### PR TITLE
Bug fix for handling multiple BaseURLs

### DIFF
--- a/app/js/dash/DashParser.js
+++ b/app/js/dash/DashParser.js
@@ -302,6 +302,9 @@ Dash.dependencies.DashParser = function () {
             if (!manifest.hasOwnProperty("BaseURL")) {
                 this.debug.log("Setting baseURL: " + baseUrl);
                 manifest.BaseURL = baseUrl;
+            } else {
+                // Setting manifest's BaseURL to the first BaseURL
+                manifest.BaseURL = manifest.BaseURL_asArray[0];
             }
             if (manifest.BaseURL.indexOf("http") !== 0) {
                 manifest.BaseURL = baseUrl + manifest.BaseURL;


### PR DESCRIPTION
Handled multiple BaseURL elements by simply choosing the first BaseURL. Fixes the issue #36.
