### PR TITLE
Bug fix for incorrect audio/video total index bug.

### DIFF
--- a/app/js/dash/DashManifestExtensions.js
+++ b/app/js/dash/DashManifestExtensions.js
@@ -57,6 +57,9 @@ Dash.dependencies.DashManifestExtensions.prototype = {
             }
         }
 
+        if (result) {
+            adaptation.type = "audio";
+        }
         return Q.when(result);
     },
 
@@ -99,6 +102,9 @@ Dash.dependencies.DashManifestExtensions.prototype = {
             }
         }
 
+        if (result) {
+            adaptation.type = "video";
+        }
         return Q.when(result);
     },
 

--- a/app/js/dash/DashMetricsExtensions.js
+++ b/app/js/dash/DashMetricsExtensions.js
@@ -73,10 +73,23 @@ Dash.dependencies.DashMetricsExtensions = function () {
             var found = false;
 
             if (bufferType === "video") {
-                found = this.manifestExt.getIsVideo(adaptation);
+                if (adaptation.hasOwnProperty("type")) {
+                    if (adaptation.type === "video") {
+                        found = true;    
+                    }
+                } else {
+                    this.manifestExt.getIsVideo(adaptation);
+                }
             }
             else if (bufferType === "audio") {
-                found = this.manifestExt.getIsAudio(adaptation); // TODO : Have to be sure it's the *active* audio track.
+                // TODO : Have to be sure it's the *active* audio track.
+                if (adaptation.hasOwnProperty("type")) {
+                    if (adaptation.type === "audio") {
+                        found = true;    
+                    }
+                } else {
+                    this.manifestExt.getIsAudio(adaptation);
+                }
             }
             else {
                 found = false;


### PR DESCRIPTION
This bug #58 was due to the fact that getIsAudio function in DashManifestExtensions.js returns a promise while the calling function in DashMetricsExtensions.js was incorrectly treating the return value as boolean value.  Same is the case for getIsVideo.  Fixed it by adding a type field to the adaptation structure.  Please let me know if there is any other better way to achieve the same.  
