### PR TITLE
Replace img src attribute with ng-src when using Angular

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
                         class="footer-text"
                         href="{{item.link}}"
                         target="_blank">
-                        <img src="{{item.logo}}" alt="{{item.link}}"/>
+                        <img ng-src="{{item.logo}}" alt="{{item.link}}"/>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Using Angular markup {{item.logo}} in a src attribute doesn't work correctly: the browser will fetch from the URL with the literal text {{item.logo}}, causing a 404, until Angular replaces the expression. The ngSrc directive solves this problem.

Source: http://docs.angularjs.org/api/ng.directive:ngSrc

Apologies for the confusion/multiple pull requests.
