### PR TITLE
Initialized the audio/video quality to zero when a new manifest is loaded.

### DIFF
--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -183,6 +183,8 @@ MediaPlayer = function (aContext) {
             }
 
             source = url;
+            this.setQualityFor('video', 0);
+            this.setQualityFor('audio', 0);
 
             // TODO : update
 


### PR DESCRIPTION
This fixes issue #72.
