### PR TITLE
Bug fix for seek error

### DIFF
--- a/app/js/streaming/BufferExtensions.js
+++ b/app/js/streaming/BufferExtensions.js
@@ -20,7 +20,7 @@ MediaPlayer.dependencies.BufferExtensions = function () {
         decideBufferLength: function (minBufferTime) {
             bufferTime = 4;
 
-            if (isNaN(minBufferTime) || minBufferTime <= 0) {
+            if (isNaN(minBufferTime) || minBufferTime <= bufferTime) {
                 bufferTime = 4;
             } else {
                 bufferTime = minBufferTime;


### PR DESCRIPTION
This fixes issue #75.  This bug shows up when minBufferTime is low and the duration of segments/subsegments is small.  The video element is still in the seeking state waiting for more buffers whereas dash.js thinks it has buffered enough.  Fixed it by setting the minBufferTime threshold correctly.
