### PR TITLE
Allow range in SegmentList's Initialization

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -81,6 +81,16 @@ Dash.dependencies.DashHandler = function () {
                 }
             } else if (representation.hasOwnProperty("SegmentList") &&
                        representation.SegmentList.hasOwnProperty("Initialization") &&
+                       representation.SegmentList.Initialization.hasOwnProperty("range")) {
+                if (representation.SegmentList.Initialization.hasOwnProperty("sourceURL")) {
+                    initialization = representation.SegmentList.Initialization.sourceURL;
+                } else {
+                    initialization = representation.BaseURL;
+                }
+
+                range = representation.SegmentList.Initialization.range;
+            } else if (representation.hasOwnProperty("SegmentList") &&
+                       representation.SegmentList.hasOwnProperty("Initialization") &&
                        representation.SegmentList.Initialization.hasOwnProperty("sourceURL")) {
                 initialization = representation.SegmentList.Initialization.sourceURL;
             } else if (representation.hasOwnProperty("SegmentBase") &&


### PR DESCRIPTION
I have a single-file segment list which looks like this:

```
<SegmentList duration="2020" timescale="1000">
  <Initialization range="28-619" sourceURL="audio.mp4"/>
  <SegmentURL media="audio.mp4" mediaRange="620-31006"/>
   ...
</SegmentList>
```

dash.js did not take account of the `range` attribute in the `Initialization` element and downloaded the whole video instead.

Here is a small fix for this issue.
