### PR TITLE
Exclude certain nodes from the 'ironing'

### DIFF
--- a/app/lib/objectiron.js
+++ b/app/lib/objectiron.js
@@ -181,28 +181,31 @@ function ObjectIron(map) {
             }
 
             // iterate over the objects and look for any of the items we care about
-            for (pp in source) {
-                if (source.hasOwnProperty(pp)) {
-                    pi = lookup.indexOf(pp);
-                    if (pi !== -1) {
-                        item = map[pi];
+            if ( pp != 'SegmentList') {
+                for (pp in source) {
+                    if (source.hasOwnProperty(pp)) {
+                        pi = lookup.indexOf(pp);
+                        if (pi !== -1) {
+                            item = map[pi];
 
-                        if (item.isArray) {
-                            array = source[pp + "_asArray"];
-                            for (i = 0, len = array.length; i < len; i += 1) {
-                                node = array[i];
+                            if (item.isArray) {
+                                array = source[pp + "_asArray"];
+                                for (i = 0, len = array.length; i < len; i += 1) {
+                                    node = array[i];
+                                    mapItem(item, node);
+                                }
+                            } else {
+                                node = source[pp];
                                 mapItem(item, node);
                             }
-                        } else {
-                            node = source[pp];
-                            mapItem(item, node);
+                        }
+                        if (pp != "__cnt" && pp != 'media' && pp != 'SegmentURL' && pp != 'SegmentURL_asArray' && pp != '__text') {
+                            // now check this to see if he has any of the properties we care about
+                            performMapping(source[pp]);
                         }
                     }
-                    // now check this to see if he has any of the properties we care about
-                    performMapping(source[pp]);
                 }
             }
-
             return source;
         };
 


### PR DESCRIPTION
My manifest (http://54.241.9.147//new-fandor/vod/40/4032/captain_video_FILM_v14_chromecast.smil/manifest_mpm4sav_mvlist.mpd) fails to load within the 10 seconds that my Android sender requires.  I get a timeout and the video won't play.  I have very little idea on what's actually going on in the ironing code other than it seems to be merging certain properties down the manifest's json tree.  I'm not sure why that's required.  My manifest has a ton of segments(it's over 4 hours), so I stopped doing some of the work at the Segment level.  I'm not sure if this breaks anything, but it puts the parsing performance under 10 seconds and the video starts playing without a timeout.  

I would love to understand what's going on here so I could possibly improve the code further.
