### PR TITLE
Further template substitution fixes

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -98,7 +98,7 @@ Dash.dependencies.DashHandler = function () {
             }
         },
 
-        escapeDollarsInTemplate = function (url) {
+        unescapeDollarsInTemplate = function (url) {
             return url.split("$$").join("$");
         },
 
@@ -830,7 +830,7 @@ Dash.dependencies.DashHandler = function () {
             url = replaceTokenForTemplate(url, "Time", segment.replacementTime);
             url = replaceTokenForTemplate(url, "Bandwidth", bandwidth);
             url = replaceIDForTemplate(url, representation.id);
-            url = escapeDollarsInTemplate(url);
+            url = unescapeDollarsInTemplate(url);
 
             request.streamType = type;
             request.type = "Media Segment";


### PR DESCRIPTION
Further to my comments this morning on pr #186, here are some more fixes for template substitution. This includes:
- allow format tags to be used in $Time$ and $Bandwidth$ substitutions
- better compliance of format tag testing with 23009-1
- escape $$ in URL
