### PR TITLE
fix jshint error introduced during fixing issue #119

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,5 +27,7 @@
         "MSMediaKeys",
         "MediaKeys",
         "Caster",
-        "TextTrackCue"]
+        "TextTrackCue",
+        "HTMLMediaElement"
+    ]
 }


### PR DESCRIPTION
Turns out jshint doesn't know about HTMLMediaElement so this needs to be add to the rc file. I didn't notice this as I wasn't using grunt at the time - sorry!
