### PR TITLE
This fixes Dash-Industry-Forum/dash.js#207

### DIFF
--- a/app/js/streaming/URIQueryAndFragmentModel.js
+++ b/app/js/streaming/URIQueryAndFragmentModel.js
@@ -23,8 +23,7 @@ MediaPlayer.models.URIQueryAndFragmentModel = function () {
                 testQuery = new RegExp(/[?]/),
                 testFragment = new RegExp(/[#]/),
                 isQuery = testQuery.test(uri),
-                isFragment = testFragment.test(uri),
-                mappedArr;
+                isFragment = testFragment.test(uri);
 
             function reduceArray(previousValue, currentValue, index, array) {
                 var arr =  array[0].split(/[=]/);
@@ -45,8 +44,6 @@ MediaPlayer.models.URIQueryAndFragmentModel = function () {
 
                 return array;
             }
-
-            mappedArr = uri.split(/[?#]/).map(mapArray);
 
             if (URIQueryData.length > 0) {
                 URIQueryData = URIQueryData.reduce(reduceArray, null);


### PR DESCRIPTION
This code is not referenced anywhere else, and appears to do nothing. This is why it has been removed. It was causing a null reference exception on the uri.split().

According to @JGRennison `mapArray` is used in TimelineConverter.js.
