### PR TITLE
Added reset in URIQueryAndFragmentModel.

### DIFF
--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -312,7 +312,9 @@ MediaPlayer = function (aContext) {
                 throw "MediaPlayer not initialized!";
             }
 
+            this.uriQueryFragModel.reset();
             source = this.uriQueryFragModel.parseURI(url);
+
             this.setQualityFor('video', 0);
             this.setQualityFor('audio', 0);
 

--- a/app/js/streaming/URIQueryAndFragmentModel.js
+++ b/app/js/streaming/URIQueryAndFragmentModel.js
@@ -17,6 +17,11 @@ MediaPlayer.models.URIQueryAndFragmentModel = function () {
     var URIFragmentDataVO = new MediaPlayer.vo.URIFragmentData(),
         URIQueryData = [],
 
+        reset = function () {
+            URIFragmentDataVO = new MediaPlayer.vo.URIFragmentData()
+            URIQueryData = []
+        },
+
         parseURI = function (uri) {
 
             var URIFragmentData = [],
@@ -64,6 +69,7 @@ MediaPlayer.models.URIQueryAndFragmentModel = function () {
 
     return {
         parseURI:parseURI,
+        reset:reset,
         getURIFragmentData:URIFragmentDataVO,
         getURIQueryData:URIQueryData
     };


### PR DESCRIPTION
Need to clear information when attachSource is called on media player.  If stream has and query or fragment info it must not persist on a new source.
