### PR TITLE
Fix #226 - explicitly update buffer after seek

### DIFF
--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1352,7 +1352,7 @@ MediaPlayer.dependencies.BufferController = function () {
                     }
                 );
             } else {
-                updateBufferLevel.call(self);
+                return updateBufferLevel.call(self);
             }
         },
 

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -554,7 +554,9 @@ MediaPlayer.dependencies.Stream = function () {
             //this.debug.log("Got seeking event.");
             var time = this.videoModel.getCurrentTime();
 
-            startBuffering(time);
+            updateBuffer.call(this).then(function () {
+                startBuffering(time);
+            });
         },
 
         onSeeked = function () {
@@ -583,13 +585,17 @@ MediaPlayer.dependencies.Stream = function () {
         },
 
         updateBuffer = function() {
+            var promises = [];
+
             if (videoController) {
-                videoController.updateBufferState();
+                promises.push(videoController.updateBufferState());
             }
 
             if (audioController) {
-               audioController.updateBufferState();
+               promises.push(audioController.updateBufferState());
             }
+
+            return Q.all(promises);
         },
 
         startBuffering = function(time) {


### PR DESCRIPTION
When using MediaPlayer.seek() or setting HTMLMediaElement.currentTime, an explicit call to updateBuffer is required in the seek handler in case a progress or timeupdate event has not occurred recently which would have called it.

If the buffer level is not updated after the seek, getRequiredBufferLength continues to report the buffer level from the previous playback position and consequently BufferController.getRequiredFragmentCount returns zero (if the buffer was full), causing downloading to stop and play to stall.

The fault is intermittent because the required fragment count could be non-zero if the buffer level was not quite full.

This has been reported as issue #226.
