### PR TITLE
Fix of MSETimeOffset when period.start != 0

### DIFF
--- a/app/js/dash/TimelineConverter.js
+++ b/app/js/dash/TimelineConverter.js
@@ -128,9 +128,10 @@ Dash.dependencies.TimelineConverter = function () {
         },
 
         calcMSETimeOffset = function (representation) {
+            // The MSEOffset is offset from AST for media. It is Period@start - presentationTimeOffset
             var presentationOffset = representation.presentationTimeOffset;
-
-            return (-presentationOffset);
+            var periodStart = representation.adaptation.period.start;
+            return (periodStart - presentationOffset);
         },
 
         reset = function() {


### PR DESCRIPTION
Changed MSETimeOffset calculation to handle that period.start is not 0.
See Issue #250 for an MPD to test.
