### PR TITLE
Fix unparseable package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-jsdoc": "~0.5.7",
     "grunt-template-jasmine-istanbul": "~0.3.0",
-    "jasmine-sinon": "~0.3.1",
+    "jasmine-sinon": "~0.3.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm install will fail to do anything because package.json is not valid json - there is a trailing comma in the devDependencies node. See below for error.

$ npm install
npm ERR! install Couldn't read dependencies
npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: D:\nginx\html\dash.js\package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! System Windows_NT 6.1.7601
npm ERR! command "c:\Program Files\nodejs\node.exe" "c:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js" "install"
npm ERR! cwd D:\nginx\html\dash.js
npm ERR! node -v v0.10.25
npm ERR! npm -v 1.3.24
npm ERR! file D:\nginx\html\dash.js\package.json
npm ERR! code EJSONPARSE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     D:\nginx\html\dash.js\npm-debug.log
npm ERR! not ok code 0
