### PR TITLE
SegmentURL: Default to baseUrl when "media" attribute absent

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -517,6 +517,8 @@ Dash.dependencies.DashHandler = function () {
                 segments = [],
                 list = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
                     AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentList,
+                baseURL = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
+                    AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].BaseURL,
                 len = list.SegmentURL_asArray.length,
                 periodSegIdx,
                 seg,
@@ -541,7 +543,7 @@ Dash.dependencies.DashHandler = function () {
                     periodSegIdx);
 
                 seg.replacementTime = (start + periodSegIdx - 1) * representation.segmentDuration;
-                seg.media = s.media;
+                seg.media = s.media ? s.media : baseURL;
                 seg.mediaRange = s.mediaRange;
                 seg.index = s.index;
                 seg.indexRange = s.indexRange;


### PR DESCRIPTION
This was breaking for SegmentList manifests with SegmentURLs missing a
"media" attribute (e.g. MP4Box may produce these). Section 5.3.9.3.2 of
the dash spec says that the media element should default to any BaseURL
element in this case.