### PR TITLE
Add jsdoc output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+# ignore any jsdoc output
+/jsdoc/**/*


### PR DESCRIPTION
The output of jsdoc should be ignored by git.

I am also planning on submitting some non-trivial code soon! :-)
