### PR TITLE
Resubmit: Adding support for Widevine (merged changes by @colde)

### DIFF
--- a/app/js/streaming/Context.js
+++ b/app/js/streaming/Context.js
@@ -25,6 +25,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapSingleton('textTrackExtensions', MediaPlayer.utils.TextTrackExtensions);
             this.system.mapSingleton('vttParser', MediaPlayer.utils.VTTParser);
             this.system.mapSingleton('ttmlParser', MediaPlayer.utils.TTMLParser);
+            this.system.mapSingleton('stringMethods', MediaPlayer.utils.StringMethods);
 
             this.system.mapClass('videoModel', MediaPlayer.models.VideoModel);
             this.system.mapSingleton('manifestModel', MediaPlayer.models.ManifestModel);

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -50,7 +50,6 @@ MediaPlayer = function (aContext) {
         abrController,
         element,
         source,
-        protectionData = null,
         streamController,
         rulesController,
         manifestUpdater,
@@ -58,6 +57,7 @@ MediaPlayer = function (aContext) {
         metricsExt,
         metricsModel,
         videoModel,
+        protectionData,
         initialized = false,
         playing = false,
         autoPlay = true,
@@ -89,8 +89,8 @@ MediaPlayer = function (aContext) {
             manifestLoader.subscribe(MediaPlayer.dependencies.ManifestLoader.eventList.ENAME_MANIFEST_LOADED, streamController);
             manifestLoader.subscribe(MediaPlayer.dependencies.ManifestLoader.eventList.ENAME_MANIFEST_LOADED, manifestUpdater);
             streamController.setVideoModel(videoModel);
-            streamController.setAutoPlay(autoPlay);
             streamController.setProtectionData(protectionData);
+            streamController.setAutoPlay(autoPlay);
             streamController.load(source);
 
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
@@ -216,6 +216,7 @@ MediaPlayer = function (aContext) {
                 abrController.reset();
                 rulesController.reset();
                 streamController = null;
+                protectionData = null;
                 playing = false;
             }
         };
@@ -303,6 +304,14 @@ MediaPlayer = function (aContext) {
          */
         getVideoModel: function () {
             return videoModel;
+        },
+
+        /**
+         * @param value
+         * @memberof MediaPlayer#
+         */
+        setProtectionData: function (value) {
+            protectionData = value;
         },
 
         /**

--- a/app/js/streaming/ProtectionModel.js
+++ b/app/js/streaming/ProtectionModel.js
@@ -21,11 +21,9 @@ MediaPlayer.models.ProtectionModel = function () {
         keySystems = [],
 
         onKeySystemUpdateCompleted = function(e) {
-            var hasWebkitGenerateKeyRequest = ('webkitGenerateKeyRequest' in document.createElement('video'));
-
             if (e.error) return;
 
-            if (!hasWebkitGenerateKeyRequest) {
+            if ('update' in session) {
                 session.update(e.data.data);
             }
         };
@@ -33,6 +31,7 @@ MediaPlayer.models.ProtectionModel = function () {
     return {
         system : undefined,
         protectionExt : undefined,
+        stringMethods : undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.ProtectionExtensions.eventList.ENAME_KEY_SYSTEM_UPDATE_COMPLETED] = onKeySystemUpdateCompleted;
@@ -44,18 +43,13 @@ MediaPlayer.models.ProtectionModel = function () {
         },
 
         addKeySession: function (kid, mediaCodec, initData) {
-            var session = null,
-                hasWebkitGenerateKeyRequest = ('webkitGenerateKeyRequest' in document.createElement('video'));
+            var session = null;
 
-            if (!hasWebkitGenerateKeyRequest) {
-                session = this.protectionExt.createSession(keySystems[kid].keys, mediaCodec, initData, keySystems[kid].keySystem.cdmData());
+            session = this.protectionExt.createSession(keySystems[kid].keys, mediaCodec, initData, keySystems[kid].keySystem.cdmData());
 
-                this.protectionExt.listenToKeyAdded(session, keyAddedListener);
-                this.protectionExt.listenToKeyError(session, keyErrorListener);
-                this.protectionExt.listenToKeyMessage(session, keyMessageListener);
-            } else {
-                this.protectionExt.listenToKeyMessage(this.videoModel.getElement(), keyMessageListener);
-            }
+            this.protectionExt.listenToKeyAdded(session, keyAddedListener);
+            this.protectionExt.listenToKeyError(session, keyErrorListener);
+            this.protectionExt.listenToKeyMessage(session, keyMessageListener);
 
             keySystems[kid].initData = initData;
             keySystems[kid].keySessions.push(session);
@@ -63,12 +57,12 @@ MediaPlayer.models.ProtectionModel = function () {
             return session;
         },
 
-        addKeySystem: function (kid, contentProtectionData, keySystemDesc) {
+        addKeySystem: function (kid, contentProtectionData, keySystemDesc, initData) {
             var keysLocal = null;
 
             keysLocal = this.protectionExt.createMediaKeys(keySystemDesc.keysTypeString);
 
-            this.protectionExt.setMediaKey(element, keysLocal);
+            this.protectionExt.setMediaKey(element, keysLocal, initData);
 
             keySystems[kid] = {
                 kID : kid,
@@ -82,6 +76,8 @@ MediaPlayer.models.ProtectionModel = function () {
 
         removeKeySystem: function (kid) {
             if (kid !== null && keySystems[kid] !== undefined && keySystems[kid].keySessions.length !== 0) {
+                this.protectionExt.unlistenToVideoModelKeyMessage(this.videoModel, keyMessageListener);
+
                 var keySessions = keySystems[kid].keySessions;
 
                 for(var kss = 0; kss < keySessions.length; ++kss) {
@@ -107,9 +103,9 @@ MediaPlayer.models.ProtectionModel = function () {
             return keySystem.keySystem.getInitData(keySystem.contentProtection);
         },
 
-        updateFromMessage: function (kid, sessionValue, event) {
-            session = sessionValue;
-            keySystems[kid].keySystem.getUpdate(event);
+        updateFromMessage: function (kid, event) {
+            session = event.target;
+            keySystems[kid].keySystem.getUpdate(event, !this.stringMethods.isNullOrEmpty(keySystems[kid].keySystem.laUrl()) ? keySystems[kid].keySystem.laUrl() : event.destinationURL);
         },
 /*
         addKey: function (type, key, data, id) {
@@ -138,6 +134,8 @@ MediaPlayer.models.ProtectionModel = function () {
 
         listenToKeyMessage: function(listener) {
             keyMessageListener = listener;
+
+            this.protectionExt.listenToVideoModelKeyMessage(this.videoModel, listener);
 
             for(var ks = 0; ks < keySystems.length; ++ks) {
                 var keySessions = keySystems[ks].keySessions;

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -66,52 +66,35 @@ MediaPlayer.dependencies.Stream = function () {
         // Encrypted Media Extensions
 
         onMediaSourceNeedsKey = function (event) {
-            var self = this,
-                mediaInfo = mediaInfos.video,
-                videoCodec = mediaInfos ? mediaInfos.video.codec : null,
-                type;
+            var mediaInfo = mediaInfos ? mediaInfos.video : null,
+                videoCodec = mediaInfos && mediaInfos.video ? mediaInfos.video.codec : null;
 
-            type = (event.type !== "msneedkey") ? event.type : videoCodec;
-            initData.push({type: type, initData: event.initData});
+            initData.push({type: event.type, initData: event.initData});
 
-            this.debug.log("DRM: Key required for - " + type);
-            //this.debug.log("DRM: Generating key request...");
-            //this.protectionModel.generateKeyRequest(DEFAULT_KEY_TYPE, event.initData);
+            this.debug.log("DRM: Key required for - " + event.type);
+
             if (mediaInfo && !!videoCodec && !kid) {
                 try
                 {
-                    kid = self.protectionController.selectKeySystem(mediaInfo);
+                    kid = this.protectionController.selectKeySystem(mediaInfo, event);
                 }
                 catch (error)
                 {
-                    pause.call(self);
-                    self.debug.log(error);
-                    self.errHandler.mediaKeySystemSelectionError(error);
+                    pause.call(this);
+                    this.debug.log(error);
+                    this.errHandler.mediaKeySystemSelectionError(error);
                 }
             }
 
             if (!!kid) {
-                self.protectionController.ensureKeySession(kid, type, event);
+                this.protectionController.ensureKeySession(kid, (event.type !== 'msneedkey') ? event.type : videoCodec, event);
             }
         },
 
         onMediaSourceKeyMessage = function (event) {
-            var self = this,
-                session = null;
-
             this.debug.log("DRM: Got a key message...");
 
-            session = event.target;
-
-            self.protectionController.updateFromMessage(kid, session, event);
-
-            //if (event.keySystem !== DEFAULT_KEY_TYPE) {
-            //    this.debug.log("DRM: Key type not supported!");
-            //}
-            // else {
-                // todo : request license?
-                //requestLicense(e.message, e.sessionId, this);
-            // }
+            this.protectionController.updateFromMessage(kid, event);
         },
 
         onMediaSourceKeyAdded = function () {

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -336,16 +336,16 @@
             this[MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED] = onTimeupdate;
         },
 
+        setProtectionData: function (value) {
+            protectionData = value;
+        },
+
         setAutoPlay: function (value) {
             autoPlay = value;
         },
 
         getAutoPlay: function () {
             return autoPlay;
-        },
-
-        setProtectionData: function (value) {
-            protectionData = value;
         },
 
         getVideoModel: function () {
@@ -393,6 +393,7 @@
             this.adapter.reset();
             isStreamSwitchingInProgress = false;
             activeStream = null;
+            protectionData = null;
         },
 
         play: play,

--- a/app/js/streaming/StringMethods.js
+++ b/app/js/streaming/StringMethods.js
@@ -1,0 +1,22 @@
+/*
+ * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2014, Arkena
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * •  Neither the name of the Arkena nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ MediaPlayer.utils.StringMethods = function () {
+    'use strict';
+
+    return {
+        isNullOrEmpty: function (str) {
+            return typeof (str) === 'undefined' || str === null || str === void (0) || str === '';
+        }
+    };
+};

--- a/debug.html
+++ b/debug.html
@@ -31,6 +31,20 @@
             player = new MediaPlayer(context);
             player.startup();
             player.attachView(video);
+            player.setProtectionData({
+                licenseRequest: {
+                    'com.microsoft.playready': {
+                        cdmData: null,
+                        laUrl: null,
+                        headers: null
+                    },
+                    'com.widevine.alpha': {
+                        cdmData: null,
+                        laUrl: null,
+                        headers: null
+                    }
+                }
+            });
             player.setAutoPlay(false);
             player.attachSource(url);
         }

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
     <script src="app/js/streaming/StreamProcessor.js"></script>
     <script src="app/js/streaming/ScheduleController.js"></script>
     <script src="app/js/streaming/Stream.js"></script>
+    <script src="app/js/streaming/StringMethods.js"></script>
     <script src="app/js/streaming/BufferController.js"></script>
     <script src="app/js/streaming/LiveEdgeFinder.js"></script>
     <script src="app/js/streaming/ProtectionModel.js"></script>


### PR DESCRIPTION
* Adding Widevine support.
* Extending PlayReady support with optional CustomData.
* Adding option to override protectionData (including laUrl, cdmData &
license request headers) when instantiating the player.
* Moved parsing of CDM message into respective DRM license acquirers.