### PR TITLE
Proper check for absolute url's

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -19,6 +19,7 @@ Dash.dependencies.DashHandler = function () {
         isDynamic,
         type,
         currentTime = 0,
+		absUrl = new RegExp('^(?:(?:[a-z]+:)?\/)?\/', 'i'),
 
         zeroPadToLength = function (numStr, minStrLength) {
             while (numStr.length < minStrLength) {
@@ -119,7 +120,7 @@ Dash.dependencies.DashHandler = function () {
 
             if (destination === baseURL) {
                 url = destination;
-            } else if (destination.indexOf("http://") !== -1) {
+            } else if (absUrl.test(destination)) {
                 url = destination;
             } else {
                 url = baseURL + destination;


### PR DESCRIPTION
There are two places were url's are being checked against the string `http://`.  This fixes that so that absolute url's of any sort will be correctly detected.

I tried to add a unit test for this but it seems like that whole file would have to be refactored to give access to that function.  If there is another way I would be happy to add a test for this.

Also, there is a second place where the `http` is being hardcoded but I could not find a way to get it to run, so I left it.  That is here https://github.com/Dash-Industry-Forum/dash.js/blob/development/app/js/dash/DashParser.js#L254

And here is my signed agreement:
![dash-if-feedback-agreement-3-7-2014](https://cloud.githubusercontent.com/assets/1027776/5109506/49aee298-6fd7-11e4-9759-9c83d7cbdc84.jpg)
