### PR TITLE
Fix playback of representations containing both audio and video tracks

### DIFF
--- a/app/js/dash/DashManifestExtensions.js
+++ b/app/js/dash/DashManifestExtensions.js
@@ -402,7 +402,7 @@ Dash.dependencies.DashManifestExtensions.prototype = {
 
             adaptationSet.index = i;
             adaptationSet.period = period;
-            adaptationSet.type = this.getIsAudio(a) ? "audio" : (this.getIsVideo(a) ? "video" : "text");
+            adaptationSet.type = this.getIsVideo(a) ? "video" : (this.getIsAudio(a) ? "audio" : "text");
             adaptations.push(adaptationSet);
         }
 


### PR DESCRIPTION
This fixes playback of muxed representations, where there are
ContentComponent elements for both audio and video. In these
cases, the initializeMediaSource method in Stream first
initializes a stream of type "video" containing both audio
and video, and the "audio" media type isn't initialized
(with a log message "No buffer was created, skipping audio data.").

Therefore, primarily set the media type to "video", if the adaptation set contains a video track.

This fixes playback of http://albin.abo.fi/~mstorsjo/dash/ondemand-combined.mpd (which worked fine in the 1.2.0 release).

A feedback agreement has been posted at https://groups.google.com/d/msg/dashjs/GW2oc8wTG8E/cC6osFFZrDoJ.
