### PR TITLE
Rework event message handling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
     watch: {},
     jshint: {
       all: ["app/js/*/**/*.js"],
+      samples: ["samples/*/**/*.js"],
       options: {
         jshintrc: ".jshintrc"
       }
@@ -73,15 +74,15 @@ module.exports = function(grunt) {
             './test/js/streaming/FragmentControllerSpec.js',
             './test/js/streaming/FragmentModelSpec.js',
             './test/js/streaming/AbrControllerSpec.js'
-			],
+            ],
           vendor: [
-			"./app/lib/jquery/jquery-1.10.2.min.js",
+            "./app/lib/jquery/jquery-1.10.2.min.js",
             "./app/lib/xml2json.js",
-            "./app/lib/objectiron.js",			
+            "./app/lib/objectiron.js",
             "./app/lib/Math.js",
             "./app/lib/long.js",
-            "./app/lib/kendo/kendo.web.min.js", 
-			"./app/lib/dijon.js",
+            "./app/lib/kendo/kendo.web.min.js",
+            "./app/lib/dijon.js",
             "./app/lib/base64.js"],
           template : require('grunt-template-jasmine-istanbul'),
           templateOptions: {
@@ -93,11 +94,11 @@ module.exports = function(grunt) {
         }
       }
     },
-	jsdoc: {
+    jsdoc: {
         dist: {
             options: {
                 destination: 'jsdoc/JSDoc',
-				configure : "jsdoc/jsdoc_conf.json"
+                configure : "jsdoc/jsdoc_conf.json"
             }
         }
     }

--- a/app/js/dash/DashManifestExtensions.js
+++ b/app/js/dash/DashManifestExtensions.js
@@ -11,7 +11,7 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*jslint nomen: true*/
 
 Dash.dependencies.DashManifestExtensions = function () {
     "use strict";
@@ -568,107 +568,162 @@ Dash.dependencies.DashManifestExtensions.prototype = {
         return periodEnd;
     },
 
-    getEventsForPeriod: function(manifest,period) {
+    getEventStreamsForPeriod: function (manifest, period) {
 
-        var periodArray = manifest.Period_asArray,
-            eventStreams = periodArray[period.index].EventStream_asArray,
-            events = [];
+     var periodArray = manifest.Period_asArray,
+            eventStreamsInPeriod,
+            numEventStreamsInPeriod,
+            eventStreams = [],
+            eventStream,
+            event,
+            i,
+            j;
 
-        if(eventStreams) {
-            for(var i = 0; i < eventStreams.length; i += 1) {
-                var eventStream = new Dash.vo.EventStream();
-                eventStream.period = period;
-                eventStream.timescale = 1;
+        if (!manifest || !period) {
+            return eventStreams;
+        }
 
-                if(eventStreams[i].hasOwnProperty("schemeIdUri")) {
-                    eventStream.schemeIdUri = eventStreams[i].schemeIdUri;
+        eventStreamsInPeriod = periodArray[period.index].EventStream_asArray;
+
+        if (eventStreamsInPeriod) {
+            numEventStreamsInPeriod = eventStreamsInPeriod.length;
+
+            for (i = 0; i < numEventStreamsInPeriod; i += 1) {
+                eventStream = new Dash.vo.EventStream();
+
+                if (eventStreamsInPeriod[i].hasOwnProperty("schemeIdUri")) {
+                    eventStream.schemeIdUri = eventStreamsInPeriod[i].schemeIdUri;
                 } else {
                     throw "Invalid EventStream. SchemeIdUri has to be set";
                 }
-                if(eventStreams[i].hasOwnProperty("timescale")) {
-                    eventStream.timescale = eventStreams[i].timescale;
-                }
-                if(eventStreams[i].hasOwnProperty("value")) {
-                    eventStream.value = eventStreams[i].value;
-                }
-                for(var j = 0; j < eventStreams[i].Event_asArray.length; j += 1) {
-                    var event = new Dash.vo.Event();
-                    event.presentationTime = 0;
-                    event.eventStream = eventStream;
 
-                    if(eventStreams[i].Event_asArray[j].hasOwnProperty("presentationTime")) {
-                        event.presentationTime = eventStreams[i].Event_asArray[j].presentationTime;
-                    }
-                    if(eventStreams[i].Event_asArray[j].hasOwnProperty("duration")) {
-                        event.duration = eventStreams[i].Event_asArray[j].duration;
-                    }
-                    if(eventStreams[i].Event_asArray[j].hasOwnProperty("id")) {
-                        event.id = eventStreams[i].Event_asArray[j].id;
-                    }
-                    events.push(event);
+                if (eventStreamsInPeriod[i].hasOwnProperty("timescale")) {
+                    eventStream.timescale = eventStreamsInPeriod[i].timescale;
                 }
+
+                // this is (incorrectly) interpreted as a number - schema
+                // defines it as a string
+                if (eventStreamsInPeriod[i].hasOwnProperty("value")) {
+                    eventStream.value = eventStreamsInPeriod[i].value.toString();
+                }
+
+                for (j = 0; j < eventStreamsInPeriod[i].Event_asArray.length; j += 1) {
+                    event = new Dash.vo.Event();
+
+                    if (eventStreamsInPeriod[i].Event_asArray[j].hasOwnProperty("presentationTime")) {
+                        event.presentationTime = eventStreamsInPeriod[i].Event_asArray[j].presentationTime;
+                    }
+
+                    if (eventStreamsInPeriod[i].Event_asArray[j].hasOwnProperty("duration")) {
+                        event.duration = eventStreamsInPeriod[i].Event_asArray[j].duration;
+                    }
+
+                    if (eventStreamsInPeriod[i].Event_asArray[j].hasOwnProperty("id")) {
+                        event.id = eventStreamsInPeriod[i].Event_asArray[j].id;
+                    }
+
+                    event.messageData = eventStreamsInPeriod[i].Event_asArray[j].__text;
+
+                    eventStream.events.push(event);
+                }
+
+                eventStreams.push(eventStream);
             }
         }
 
-        return events;
+        return eventStreams;
     },
 
-    getEventStreamForAdaptationSet : function (manifest, adaptation) {
+    getEventStreamsForAdaptationSet : function (manifest, adaptation) {
 
-        var eventStreams = [],
-            inbandStreams = manifest.Period_asArray[adaptation.period.index].
-                AdaptationSet_asArray[adaptation.index].InbandEventStream_asArray;
+        var inbandStreams,
+            numInbandStreams,
+            eventStreams = [],
+            eventStream,
+            i;
+
+        if (!manifest || !adaptation) {
+            return eventStreams;
+        }
+
+        inbandStreams = manifest.
+            Period_asArray[adaptation.period.index].
+            AdaptationSet_asArray[adaptation.index].
+            InbandEventStream_asArray;
 
         if(inbandStreams) {
-            for(var i = 0; i < inbandStreams.length ; i += 1 ) {
-                var eventStream = new Dash.vo.EventStream();
-                eventStream.timescale = 1;
+            numInbandStreams = inbandStreams.length;
 
-                if(inbandStreams[i].hasOwnProperty("schemeIdUri")) {
+            for(i = 0; i < numInbandStreams; i += 1) {
+                eventStream = new Dash.vo.EventStream();
+
+                if (inbandStreams[i].hasOwnProperty("schemeIdUri")) {
                     eventStream.schemeIdUri = inbandStreams[i].schemeIdUri;
                 } else {
                     throw "Invalid EventStream. SchemeIdUri has to be set";
                 }
-                if(inbandStreams[i].hasOwnProperty("timescale")) {
+
+                if (inbandStreams[i].hasOwnProperty("timescale")) {
                     eventStream.timescale = inbandStreams[i].timescale;
                 }
-                if(inbandStreams[i].hasOwnProperty("value")) {
-                    eventStream.value = inbandStreams[i].value;
+
+                // this is (incorrectly) interpreted as a number - schema
+                // defines it as a string
+                if (inbandStreams[i].hasOwnProperty("value")) {
+                    eventStream.value = inbandStreams[i].value.toString();
                 }
+
                 eventStreams.push(eventStream);
             }
         }
+
         return eventStreams;
     },
 
-    getEventStreamForRepresentation : function (manifest, representation) {
+    getEventStreamsForRepresentation: function (manifest, representation) {
 
-        var eventStreams = [],
-            inbandStreams = manifest.Period_asArray[representation.adaptation.period.index].
-                AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].InbandEventStream_asArray;
+        var inbandStreams,
+            numInbandStreams,
+            eventStreams = [],
+            eventStream,
+            i;
 
-        if(inbandStreams) {
-            for(var i = 0; i < inbandStreams.length ; i++ ) {
-                var eventStream = new Dash.vo.EventStream();
-                eventStream.timescale = 1;
-                eventStream.representation = representation;
+        if (!manifest || !representation) {
+            return eventStreams;
+        }
 
-                if(inbandStreams[i].hasOwnProperty("schemeIdUri")) {
+        inbandStreams = manifest.
+            Period_asArray[representation.adaptation.period.index].
+            AdaptationSet_asArray[representation.adaptation.index].
+            Representation_asArray[representation.index].
+            InbandEventStream_asArray;
+
+        if (inbandStreams) {
+            numInbandStreams = inbandStreams.length;
+
+            for (i = 0; i < numInbandStreams; i += 1) {
+                eventStream = new Dash.vo.EventStream();
+
+                if (inbandStreams[i].hasOwnProperty("schemeIdUri")) {
                     eventStream.schemeIdUri = inbandStreams[i].schemeIdUri;
                 } else {
                     throw "Invalid EventStream. SchemeIdUri has to be set";
                 }
-                if(inbandStreams[i].hasOwnProperty("timescale")) {
+
+                if (inbandStreams[i].hasOwnProperty("timescale")) {
                     eventStream.timescale = inbandStreams[i].timescale;
                 }
-                if(inbandStreams[i].hasOwnProperty("value")) {
-                    eventStream.value = inbandStreams[i].value;
+
+                // this is (incorrectly) interpreted as a number - schema
+                // defines it as a string
+                if (inbandStreams[i].hasOwnProperty("value")) {
+                    eventStream.value = inbandStreams[i].value.toString();
                 }
+
                 eventStreams.push(eventStream);
             }
         }
-        return eventStreams;
 
+        return eventStreams;
     }
-
 };

--- a/app/js/dash/vo/Event.js
+++ b/app/js/dash/vo/Event.js
@@ -13,13 +13,10 @@
  */
 Dash.vo.Event = function () {
     "use strict";
-    this.duration = NaN;
-    this.presentationTime = NaN;
-    this.id = NaN;
+    this.duration = Number.MAX_VALUE;
+    this.presentationTime = 0;
+    this.id = undefined;
     this.messageData = "";
-    this.eventStream = null;
-    this.presentationTimeDelta = NaN; // Specific EMSG Box paramater
-
 };
 
 Dash.vo.Event.prototype = {

--- a/app/js/dash/vo/EventStream.js
+++ b/app/js/dash/vo/EventStream.js
@@ -13,12 +13,10 @@
  */
 Dash.vo.EventStream = function () {
     "use strict";
-    this.adaptionSet = null;
-    this.representation = null;
-    this.period = null;
     this.timescale = 1;
     this.value = "";
     this.schemeIdUri = "";
+    this.events = [];
 };
 
 Dash.vo.EventStream.prototype = {

--- a/app/js/dash/vo/InbandEvent.js
+++ b/app/js/dash/vo/InbandEvent.js
@@ -1,0 +1,32 @@
+/**
+ * @copyright The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2014, British Broadcasting Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the British Broadcasting Corporation nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * @license THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global Dash*/
+
+Dash.vo.InbandEvent = function () {
+    "use strict";
+    this.duration = Number.MAX_VALUE;
+    this.presentationTime = 0;
+    this.id = undefined;
+    this.messageData = "";
+
+    // these are unique to the InbandEvent
+    this.schemeIdUri = "";
+    this.value = "";
+    this.timescale = 0;
+};
+
+Dash.vo.InbandEvent.prototype = {
+    constructor: Dash.vo.InbandEvent
+};

--- a/app/js/streaming/EventController.js
+++ b/app/js/streaming/EventController.js
@@ -1,108 +1,108 @@
-/*
- * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
+/**
+ * @copyright The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
  *
  * Copyright (c) 2013, Fraunhofer Fokus
+ * Copyright (c) 2014, British Broadcasting Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
- * •  Neither the name of the Digital Primates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * @license THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-MediaPlayer.dependencies.EventController = function(){
+/*globals MediaPlayer, TrackEvent*/
+MediaPlayer.dependencies.EventController = function () {
     "use strict";
 
+    var EventCue = window.DataCue || window.VTTCue,
+        mediaElement,
 
-    var inlineEvents = [], // Holds all Inline Events not triggered yet
-        inbandEvents = [], // Holds all Inband Events not triggered yet
-        activeEvents = [], // Holds all Events currently running
-        eventInterval = null, // variable holding the setInterval
-        refreshDelay = 100, // refreshTime for the setInterval
-        presentationTimeThreshold = refreshDelay / 1000,
-        MPD_RELOAD_SCHEME = "urn:mpeg:dash:event:2012",
-        MPD_RELOAD_VALUE = 1,
+        // HBBTV profiles a few additional constraints. this decides whether
+        // we should adhere to them. on the whole, it doesn't really matter
+        HBBTV_COMPLIANT = true,
 
-        reset = function() {
-            if(eventInterval !== null) {
-                clearInterval(eventInterval);
-                eventInterval = null;
+        /**
+         * to ensure all cues become active, they must have a duration at least
+         * as long as time it takes for the user agent to raise them
+         *
+         * @param event
+         */
+        ensureSensibleDuration = function (event) {
+            var MINIMUM_DURATION_S = HBBTV_COMPLIANT ? 0.250 : 0,
+                duration = event.duration === 0xFFFF ?
+                        Number.MAX_VALUE :
+                        event.duration / (event.timescale || 1);
+
+            event.duration = duration;
+
+            if (duration < MINIMUM_DURATION_S) {
+                event.duration = MINIMUM_DURATION_S;
             }
-            inlineEvents = null;
-            inbandEvents = null;
-            activeEvents = null;
-        },
 
-        clear = function() {
-            if(eventInterval !== null) {
-                clearInterval(eventInterval);
-                eventInterval = null;
+            if (event.schemeIdUri === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_SCHEME_ID_URI &&
+                    (event.value === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_UPDATE ||
+                    event.value === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_PATCH ||
+                    event.value === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_INBAND)) {
+                // in this special case, the duration isn't a duration.
+                // however, we still don't handle this case. even so, we still
+                // need a non-zero length duration so the cue ends up in the
+                // activeCues list.
+                event.duration = MINIMUM_DURATION_S;
             }
-        },
 
-        start = function () {
-            var self = this;
-
-            self.debug.log("Start Event Controller");
-            if (!isNaN(refreshDelay)) {
-                eventInterval = setInterval(onEventTimer.bind(this), refreshDelay);
-            }
+            return event.duration;
         },
 
         /**
-         * Add events to the eventList. Events that are not in the mpd anymore but not triggered yet will still be deleted
-         * @param values
+         * search the cue list for a cue with the same id (and, by definition,
+         * same schemeIdUri and value). deliberately do not use getCueById
+         * since that method returns the first instance - we may want another.
+         *
+         * @param cues  - a TextTrackCueList object
+         * @param cue   - a TextTrackCue/VTTCue
          */
-        addInlineEvents = function(values) {
-            var self = this;
-            inlineEvents = [];
+        findExistingCue = function (cues, cue) {
+            var numCues = cues.length,
+                i = 0;
 
-            if(values && values.length > 0){
-                inlineEvents = values;
-            }
-            self.debug.log("Added "+values.length+ " inline events");
-        },
+            while (i < numCues) {
+                if (cues[i].id === cue.id) {
+                    if ((cue.startTime >= cues[i].startTime) &&
+                            (cue.startTime < cues[i].endTime)) {
+                        return cues[i];
+                    }
+                }
 
-        /**
-         * i.e. processing of any one event message box with the same id is sufficient
-         * @param values
-         */
-        addInbandEvents = function(values) {
-            var self = this;
-            for(var i=0;i<values.length;i++) {
-                var event = values[i];
-                inbandEvents[event.id] = event;
-                self.debug.log("Add inband event with id "+event.id);
+                i += 1;
             }
         },
-
         /**
-         * Itereate through the eventList and trigger/remove the events
+         * given a schemeIdUri and value, find a matching TextTrack
+         *
+         * @param schemeIdUri
+         * @param value
+         * @param includeDisabled - should search disabled tracks too
          */
-        onEventTimer = function () {
-            triggerEvents.call(this,inbandEvents);
-            triggerEvents.call(this,inlineEvents);
-            removeEvents.call(this);
-        },
+        findTrackBySchemeAndValue = function (schemeIdUri, value, includeDisabled) {
+            var tracks = mediaElement.textTracks,
+                numTracks,
+                track,
+                trackLabel = schemeIdUri + ' ' + value,
+                i;
 
-        triggerEvents = function(events) {
-            var self = this,
-                currentVideoTime = this.videoModel.getCurrentTime(),
-                presentationTime;
+            if (tracks) {
+                numTracks = tracks.length;
 
-            /* == Trigger events that are ready == */
-            if(events) {
-                for (var j = 0; j < events.length; j++) {
-                    var curr = events[j];
+                for (i = 0; i < numTracks; i += 1) {
+                    track = tracks[i];
 
-                    if (curr !== undefined) {
-                        presentationTime = curr.presentationTime / curr.eventStream.timescale;
-                        if (presentationTime === 0 || (presentationTime <= currentVideoTime && presentationTime + presentationTimeThreshold > currentVideoTime)) {
-                            self.debug.log("Start Event at " + currentVideoTime);
-                            if (curr.duration > 0) activeEvents.push(curr);
-                            if (curr.eventStream.schemeIdUri == MPD_RELOAD_SCHEME && curr.eventStream.value == MPD_RELOAD_VALUE) refreshManifest.call(this);
-                            events.splice(j, 1);
+                    if (track.label === trackLabel) {
+                        if (includeDisabled || track.mode !== 'disabled') {
+                            return track;
+                        } else {
+                            return undefined;
                         }
                     }
                 }
@@ -110,61 +110,336 @@ MediaPlayer.dependencies.EventController = function(){
         },
 
         /**
-         * Remove events from the list that are over
+         * create a track on the media element
+         * if there is already a text track with the same schemeIduri and value
+         * they are equivalent. just return the original one, re-enabling it if
+         * necessary.
+         *
+         * @param schemeIdUri
+         * @param value
          */
-        removeEvents = function() {
-            var self = this;
+        createTrack = function (schemeIdUri, value) {
+            var self = this,
+                track = findTrackBySchemeAndValue.call(
+                    self,
+                    schemeIdUri,
+                    value,
+                    true
+                ),
+                label = schemeIdUri + ' ' + value;
 
-            if(activeEvents) {
-                var currentVideoTime = this.videoModel.getCurrentTime();
+            if (!track) {
+                track = mediaElement.addTextTrack('metadata', label, '');
+                if (track) {
+                    track.mode = 'hidden';
+                }
+            } else {
+                if (track.mode === 'disabled') {
+                    track.mode = 'hidden';
 
-                for (var i = 0; i < activeEvents.length; i++) {
-                    var curr = activeEvents[i];
-                    if (curr !== null && (curr.duration + curr.presentationTime) / curr.eventStream.timescale < currentVideoTime) {
-                        self.debug.log("Remove Event at time " + currentVideoTime);
-                        curr = null;
-                        activeEvents.splice(i, 1);
-                    }
+                    // when calling addTextTrack above, this event will be
+                    // dispatched automatically. in the reenabling case, we
+                    // must do it ourselves.
+                    mediaElement.textTracks.dispatchEvent(
+                        new TrackEvent('addtrack', { track: track })
+                    );
                 }
             }
 
+            this.eventBus.dispatchEvent({
+                type:   'addtrack',
+                track:  track
+            });
+
+            return track;
         },
 
-        refreshManifest = function () {
-            var self = this,
-                manifest = self.manifestModel.getValue(),
-                url = manifest.url;
+        /**
+         * 'remove' the track from the media element
+         * (there's no API call to removeTextTrack, so just delete all
+         * the cues and set the mode to disabled.)
+         *
+         * @param track - the TextTrack object
+         */
+        removeTrack = function (track) {
 
-            if (manifest.hasOwnProperty("Location")) {
-                url = manifest.Location;
+            if (track && track.mode !== 'disabled') {
+
+                while (track.cues.length) {
+                    track.removeCue(track.cues[0]);
+                }
+
+                track.mode = 'disabled';
+
+                this.eventBus.dispatchEvent({
+                    type:   'removetrack',
+                    track:  track
+                });
+
+                // note that, by explicitly dispatching here, this event may
+                // be dispatched twice when the media resource is torn down.
+                // this may need to be considered in handlers. unfortunately
+                // there isn't really a way around this. since the media
+                // element persists across sessions, hopefully it shouldn't be
+                // an issue.
+                mediaElement.textTracks.dispatchEvent(
+                    new TrackEvent('removetrack', { track: track })
+                );
             }
-            self.debug.log("Refresh manifest @ " + url);
-            self.manifestLoader.load(url);
+        },
+
+        /**
+         * given a schemeIdUri and value, remove track from the media element
+         *
+         * @param schemeIdUri
+         * @param value
+         */
+        removeTrackBySchemeAndValue = function (schemeIdUri, value) {
+            var track = findTrackBySchemeAndValue.call(
+                this,
+                schemeIdUri,
+                value
+            );
+
+            removeTrack.call(this, track);
+        },
+
+        /**
+         * iterate accross the tracklist, 'removing' each track
+         */
+        removeAllTracks = function () {
+            var tracks = mediaElement.textTracks,
+                numTracks,
+                i;
+
+            if (tracks) {
+                numTracks = tracks.length;
+
+                for (i = 0; i < numTracks; i += 1) {
+                    removeTrack.call(this, tracks[i]);
+                }
+            }
+        },
+
+        /**
+         * add Events and InbandEvents to Track, modifying existing cues if
+         * necessary. uses Cue objects to represent Events
+         *
+         * @param track - TextTrack object
+         * @param events - array of Event/InbandEvent objects
+         * @param timescale - timescale for all events in [events]
+         */
+        addEventsToTrack = function (track, events, timescale) {
+            var numEvents = events.length,
+                event,
+                startTime,
+                duration,
+                endTime,
+                cue,
+                existingCue,
+                i,
+                key;
+
+            if (track) {
+                for (i = 0; i < numEvents; i += 1) {
+                    event = events[i];
+
+                    startTime = (event.presentationTime || 0) / (timescale || 1);
+                    duration = ensureSensibleDuration(event);
+                    endTime = startTime + duration;
+
+                    cue = new EventCue(
+                        startTime,
+                        endTime,
+                        JSON.stringify(event)
+                    );
+                    cue.id = event.id;
+
+                    existingCue = findExistingCue(track.cues, cue);
+                    if (existingCue) {
+                        // update the existing cue in place with deep copy
+                        // probably only need endTime and text, but be safe
+                        for (key in cue) {
+                            if (cue.hasOwnProperty(key)) {
+                                existingCue[key] = cue[key];
+                            }
+                        }
+                    } else {
+                        track.addCue(cue);
+                    }
+                }
+            }
+        },
+
+        /**
+         * add EventStreams and Events, creating Tracks if necessary
+         *
+         * @param eventStreams - array of EventStream objects
+         * @param clearEvents - optionally remove all existing EventStreams
+         */
+        addEventStreams = function (eventStreams, clearEvents) {
+            var numEventStreams,
+                eventStream,
+                track,
+                i;
+
+            if (clearEvents) {
+                removeAllTracks.call(this);
+            }
+
+            numEventStreams = eventStreams.length;
+
+            for (i = 0; i < numEventStreams; i += 1) {
+                eventStream = eventStreams[i];
+                if (eventStream) {
+
+                    // will return the track if it already exists
+                    track = createTrack.call(
+                        this,
+                        eventStream.schemeIdUri,
+                        eventStream.value
+                    );
+
+                    if (track) {
+                        addEventsToTrack.call(
+                            this,
+                            track,
+                            eventStream.events,
+                            eventStream.timescale
+                        );
+                    }
+                }
+            }
+        },
+
+        /**
+         * remove Tracks associated with EventStream objects
+         *
+         * @param eventStreams - array of EventStream objects
+         */
+        removeEventStreams = function (eventStreams) {
+            var self = this,
+                numEventStreams,
+                eventStream,
+                track,
+                i;
+
+            numEventStreams = eventStreams.length;
+
+            for (i = 0; i < numEventStreams; i += 1) {
+                eventStream = eventStreams[i];
+                if (eventStream) {
+                    track = removeTrackBySchemeAndValue.call(
+                        self,
+                        eventStream.schemeIdUri,
+                        eventStream.value
+                    );
+                }
+            }
+        },
+
+        /**
+         * Handles the switch between Representations or AdaptationSets by
+         * taking arrays of old and new EventStreams and managing the TextTrack
+         * according to their contents: entries which exist in both will remain
+         * unchanged, old entries only will be removed, new only added.
+         *
+         * @param oldEventStreams - the previous list of EventStreams
+         * @param newEventStreams - the list of new EventStreams
+         */
+        handleSwitch = function (oldEventStreams, newEventStreams) {
+            var compareEventStreams = function (l, r) {
+                    return ((l.schemeIdUri === r.schemeIdUri) &&
+                        (l.value === r.value) &&
+                        (l.id === r.id));
+                },
+
+                // there is certainly a more efficient way of acheiving this,
+                // but the number of entries should be small.
+                getOnlyInLNotR = function (l, r) {
+                    return l.filter(function (l1) {
+                        return !r.some(function (r1) {
+                            return compareEventStreams(l1, r1);
+                        });
+                    });
+                },
+
+                onlyInOld = getOnlyInLNotR(oldEventStreams, newEventStreams),
+                onlyInNew = getOnlyInLNotR(newEventStreams, oldEventStreams);
+
+            removeEventStreams.call(this, onlyInOld);
+            addEventStreams.call(this, onlyInNew);
+        },
+
+        /**
+         * adds an Event object to the associated Track
+         *
+         * @param events - array of Event/InbandEvent objects
+         */
+        addInbandEvents = function (events) {
+            var numEvents = events.length,
+                event,
+                track,
+                i;
+
+            for (i = 0; i < numEvents; i += 1) {
+                event = events[i];
+
+                track = findTrackBySchemeAndValue.call(
+                    this,
+                    event.schemeIdUri,
+                    event.value
+                );
+
+                if (track) {
+                    addEventsToTrack.call(
+                        this,
+                        track,
+                        [event],
+                        event.timescale
+                    );
+                }
+            }
+        },
+
+        /**
+         * reset this controller, disabling all tracks
+         */
+        reset = function () {
+            removeAllTracks.call(this);
+        },
+
+        /**
+         * associates the media element
+         *
+         * @param HTMLMediaElement
+         */
+        setMediaElement = function (value) {
+            mediaElement = value;
         };
 
     return {
-        manifestModel: undefined,
-        manifestLoader:undefined,
-        debug: undefined,
-        system: undefined,
-        errHandler: undefined,
-        videoModel:undefined,
-        addInlineEvents : addInlineEvents,
-        addInbandEvents : addInbandEvents,
-        reset : reset,
-        clear : clear,
-        start: start,
-        getVideoModel: function() {
-            return this.videoModel;
-        },
-        setVideoModel:function(value) {
-            this.videoModel = value;
-        },
-        initialize:function(videoModel) {
-            this.setVideoModel(videoModel);
+        // external dependencies
+        eventBus: undefined,
+
+        // currently, these handlers all do the same, but they may not always
+        handleRepresentationSwitch: handleSwitch,
+        handleAdaptationSetSwitch: handleSwitch,
+        handlePeriodSwitch: handleSwitch,
+        reset: reset,
+        addInbandEvents: addInbandEvents,
+        addEventStreams: addEventStreams,
+
+        /**
+         * initialises the eventController
+         * currently, this is just a case of setting the media object
+         *
+         * @param videoModel
+         */
+        initialize: function (videoModel) {
+            setMediaElement(videoModel.getElement());
         }
     };
-
 };
 
 MediaPlayer.dependencies.EventController.prototype = {

--- a/app/js/streaming/ManifestUpdater.js
+++ b/app/js/streaming/ManifestUpdater.js
@@ -1,14 +1,14 @@
 /*
  * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
- * 
+ *
  * Copyright (c) 2013, Digital Primates
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
  * •  Neither the name of the Digital Primates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 MediaPlayer.dependencies.ManifestUpdater = function () {
@@ -18,6 +18,17 @@ MediaPlayer.dependencies.ManifestUpdater = function () {
         refreshTimer = null,
         isStopped = false,
         isUpdating = false,
+        updateByEventMessageOnly = false,
+
+        setIgnoreMinimumUpdatePeriod = function (doIt) {
+            updateByEventMessageOnly = !!doIt;
+
+            this.debug.log("Disable minimumUpdatePeriod: " + !!doIt);
+        },
+
+        getIgnoreMinimumUpdatePeriod = function () {
+            return updateByEventMessageOnly;
+        },
 
         clear = function () {
             if (refreshTimer !== null) {
@@ -91,6 +102,38 @@ MediaPlayer.dependencies.ManifestUpdater = function () {
         onStreamsComposed = function(/*sender, error*/) {
             // When streams are ready we can consider manifest update completed. Resolve the update promise.
             isUpdating = false;
+        },
+
+        onEventStreamsChanged = function (event) {
+            var self = this,
+                trackEventHandler = function (event) {
+                    var track = event.target;
+
+                    // this assumes that there is only one active update
+                    // message at a time.
+                    if (track.activeCues.length) {
+                        self.debug.log("ManifestUpdater: refreshing manifest due to event message");
+                        onRefreshTimer.call(this);
+                    }
+                },
+                siu = event.track.label.split(" ")[0],
+                val = event.track.label.split(" ")[1];
+
+            // check this is an event handler we are interested in
+            if ((siu === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_SCHEME_ID_URI) &&
+                    ((val === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_UPDATE) ||
+                     (val === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_PATCH) ||
+                     (val === MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_INBAND))) {
+                if (event.type === "addtrack") {
+                    setIgnoreMinimumUpdatePeriod.call(self, true);
+                    this.stop();
+                    event.track.addEventListener('cuechange', trackEventHandler.bind(this));
+                } else if (event.type === "removetrack") {
+                    setIgnoreMinimumUpdatePeriod.call(self, false);
+                    this.start();
+                    event.track.removeEventListener('cuechange', trackEventHandler.bind(this));
+                }
+            }
         };
 
     return {
@@ -99,6 +142,7 @@ MediaPlayer.dependencies.ManifestUpdater = function () {
         manifestModel: undefined,
         manifestExt: undefined,
         manifestLoader: undefined,
+        eventBus: undefined,
 
         setup: function () {
             // Listen to streamsComposed event to be aware that the streams have been composed
@@ -106,6 +150,10 @@ MediaPlayer.dependencies.ManifestUpdater = function () {
             this.manifestLoaded = onManifestLoaded;
             this.playbackStarted = onPlaybackStarted;
             this.playbackPaused = onPlaybackPaused;
+
+            // listen for TextTrack changes, there may be something for us
+            this.eventBus.addEventListener("addtrack", onEventStreamsChanged.bind(this));
+            this.eventBus.addEventListener("removetrack", onEventStreamsChanged.bind(this));
         },
 
         start: function () {
@@ -114,11 +162,18 @@ MediaPlayer.dependencies.ManifestUpdater = function () {
         },
 
         stop: function() {
-            isStopped = true;
-            clear.call(this);
+            if (!getIgnoreMinimumUpdatePeriod()) {
+                isStopped = false;
+                update.call(this);
+            }
         }
     };
 };
+
+MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_SCHEME_ID_URI = "urn:mpeg:dash:event:2012";
+MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_UPDATE = "1";
+MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_PATCH = "2";
+MediaPlayer.dependencies.ManifestUpdater.MANIFEST_UPDATE_EMSG_VALUE_INBAND = "3";
 
 MediaPlayer.dependencies.ManifestUpdater.prototype = {
     constructor: MediaPlayer.dependencies.ManifestUpdater

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -209,7 +209,6 @@
 
             play();
             from.resetEventController();
-            activeStream.startEventController();
             isStreamSwitchingInProgress = false;
         },
 
@@ -219,6 +218,7 @@
                 metrics = self.metricsModel.getMetricsFor("stream"),
                 manifestUpdateInfo = self.metricsExt.getCurrentManifestUpdate(metrics),
                 playbackCtrl,
+                eventCtrl,
                 streamInfo,
                 pLen,
                 sLen,
@@ -254,9 +254,11 @@
                     if (!stream) {
                         stream = self.system.getObject("stream");
                         playbackCtrl = self.system.getObject("playbackController");
+                        eventCtrl = self.system.getObject("eventController");
                         stream.setStreamInfo(streamInfo);
                         stream.setVideoModel(pIdx === 0 ? self.videoModel : createVideoModel.call(self));
                         stream.setPlaybackController(playbackCtrl);
+                        stream.setEventController(eventCtrl);
                         playbackCtrl.subscribe(playbackCtrl.eventList.ENAME_PLAYBACK_ERROR, stream);
                         playbackCtrl.subscribe(playbackCtrl.eventList.ENAME_PLAYBACK_METADATA_LOADED, stream);
                         stream.initProtection();

--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
     <script src="app/js/dash/vo/Representation.js"></script>
     <script src="app/js/dash/vo/Segment.js"></script>
     <script src="app/js/dash/vo/Event.js"></script>
+    <script src="app/js/dash/vo/InbandEvent.js"></script>
     <script src="app/js/dash/vo/EventStream.js"></script>
     <script src="app/js/dash/DashParser.js"></script>
     <script src="app/js/dash/DashHandler.js"></script>

--- a/samples/emsg/css/style.css
+++ b/samples/emsg/css/style.css
@@ -1,0 +1,7 @@
+video, canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1920px;
+    height: 1080px;
+}

--- a/samples/emsg/index.html
+++ b/samples/emsg/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>emsg ball position demo</title>
+    <link rel="icon" href="http://www.bbc.co.uk/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="css/style.css">
+
+    <script src="../../app/lib/dijon.js"></script>
+    <script src="../../app/lib/base64.js"></script>
+    <script src="../../app/lib/xml2json.js"></script>
+    <script src="../../app/lib/objectiron.js"></script>
+    <script src="../../app/lib/long.js"></script>
+    <script src="../../app/lib/Math.js"></script>
+    <script src="../../app/lib/jquery/jquery-1.10.2.min.js"></script>
+    <script src="../../app/js/streaming/MediaPlayer.js"></script>
+    <script src="../../app/js/streaming/Context.js"></script>
+    <script src="../../app/js/streaming/ErrorHandler.js"></script>
+    <script src="../../app/js/streaming/Capabilities.js"></script>
+    <script src="../../app/js/streaming/EventBus.js"></script>
+    <script src="../../app/js/streaming/Debug.js"></script>
+    <script src="../../app/js/streaming/TokenAuthentication.js"></script>
+    <script src="../../app/js/streaming/VideoModel.js"></script>
+    <script src="../../app/js/streaming/vo/FragmentRequest.js"></script>
+    <script src="../../app/js/streaming/vo/TrackInfo.js"></script>
+    <script src="../../app/js/streaming/vo/MediaInfo.js"></script>
+    <script src="../../app/js/streaming/vo/StreamInfo.js"></script>
+    <script src="../../app/js/streaming/vo/ManifestInfo.js"></script>
+    <script src="../../app/js/streaming/ManifestLoader.js"></script>
+    <script src="../../app/js/streaming/ManifestUpdater.js"></script>
+    <script src="../../app/js/streaming/ManifestModel.js"></script>
+    <script src="../../app/js/streaming/MediaSourceExtensions.js"></script>
+    <script src="../../app/js/streaming/SourceBufferExtensions.js"></script>
+    <script src="../../app/js/streaming/VideoModelExtensions.js"></script>
+    <script src="../../app/js/streaming/PlaybackController.js"></script>
+    <script src="../../app/js/streaming/FragmentController.js"></script>
+    <script src="../../app/js/streaming/AbrController.js"></script>
+    <script src="../../app/js/streaming/FragmentLoader.js"></script>
+    <script src="../../app/js/streaming/FragmentModel.js"></script>
+    <script src="../../app/js/streaming/StreamController.js"></script>
+    <script src="../../app/js/streaming/StreamProcessor.js"></script>
+    <script src="../../app/js/streaming/ScheduleController.js"></script>
+    <script src="../../app/js/streaming/Stream.js"></script>
+    <script src="../../app/js/streaming/BufferController.js"></script>
+    <script src="../../app/js/streaming/LiveEdgeFinder.js"></script>
+    <script src="../../app/js/streaming/ProtectionModel.js"></script>
+    <script src="../../app/js/streaming/ProtectionController.js"></script>
+    <script src="../../app/js/streaming/ProtectionExtensions.js"></script>
+    <script src="../../app/js/streaming/Notifier.js"></script>
+    <script src="../../app/js/streaming/rules/SwitchRequest.js"></script>
+    <script src="../../app/js/streaming/rules/RulesContext.js"></script>
+    <script src="../../app/js/streaming/rules/ABRRules/DownloadRatioRule.js"></script>
+    <script src="../../app/js/streaming/rules/ABRRules/InsufficientBufferRule.js"></script>
+    <script src="../../app/js/streaming/rules/ABRRules/LimitSwitchesRule.js"></script>
+    <script src="../../app/js/streaming/rules/ABRRules/ABRRulesCollection.js"></script>
+    <script src="../../app/js/streaming/EventController.js"></script>
+    <script src="../../app/js/streaming/URIQueryAndFragmentModel.js"></script>
+    <script src="../../app/js/streaming/vo/URIFragmentData.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/RulesController.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/ScheduleRulesCollection.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/BufferLevelRule.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/PendingRequestsRule.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/SameTimeRequestRule.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/PlaybackTimeRule.js"></script>
+    <script src="../../app/js/streaming/rules/SchedulingRules/LiveEdgeBinarySearchRule.js"></script>
+    <script src="../../app/js/streaming/captioning/VTTParser.js"></script>
+    <script src="../../app/js/streaming/captioning/TTMLParser.js"></script>
+    <script src="../../app/js/streaming/captioning/TextTrackExtensions.js"></script>
+    <script src="../../app/js/streaming/captioning/TextSourceBuffer.js"></script>
+    <script src="../../app/js/streaming/captioning/TextController.js"></script>
+    <script src="../../app/js/streaming/vo/MetricsList.js"></script>
+    <script src="../../app/js/streaming/MetricsModel.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/BufferLevel.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/HTTPRequest.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/PlayList.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/RepresentationSwitch.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/DroppedFrames.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/SchedulingInfo.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/ManifestUpdate.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/DVRInfo.js"></script>
+    <script src="../../app/js/dash/Dash.js"></script>
+    <script src="../../app/js/dash/DashContext.js"></script>
+    <script src="../../app/js/dash/vo/Mpd.js"></script>
+    <script src="../../app/js/dash/vo/Period.js"></script>
+    <script src="../../app/js/dash/vo/AdaptationSet.js"></script>
+    <script src="../../app/js/dash/vo/Representation.js"></script>
+    <script src="../../app/js/dash/vo/Segment.js"></script>
+    <script src="../../app/js/dash/vo/Event.js"></script>
+    <script src="../../app/js/dash/vo/InbandEvent.js"></script>
+    <script src="../../app/js/dash/vo/EventStream.js"></script>
+    <script src="../../app/js/dash/DashParser.js"></script>
+    <script src="../../app/js/dash/DashHandler.js"></script>
+    <script src="../../app/js/dash/RepresentationController.js"></script>
+    <script src="../../app/js/dash/BaseURLExtensions.js"></script>
+    <script src="../../app/js/dash/FragmentExtensions.js"></script>
+    <script src="../../app/js/dash/DashManifestExtensions.js"></script>
+    <script src="../../app/js/dash/DashMetricsExtensions.js"></script>
+    <script src="../../app/js/dash/TimelineConverter.js"></script>
+    <script src="../../app/js/dash/DashAdapter.js"></script>
+
+    <!-- this is where the magic happens -->
+    <script src="js/emsg.js"></script>
+</head>
+<body>
+    <div id="container">
+        <video id="v"></video>
+        <canvas id="overlay"></canvas>
+    </div>
+</body>
+</html>

--- a/samples/emsg/js/emsg.js
+++ b/samples/emsg/js/emsg.js
@@ -1,0 +1,192 @@
+/**
+ * @copyright The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2014, British Broadcasting Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the British Broadcasting Corporation nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * @license THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @param $ - jquery
+ * @param d - the document
+ *
+ */
+
+/*global $, jQuery, Dash, MediaPlayer, document */
+
+var emsg = (function ($, d) {
+    "use strict";
+
+    // keep these global to emsg to save passing them around all over the place
+    var canvas,
+        ctx,
+
+        /**
+         * clear the canvas by drawing a rectangle over the whole canvas
+         */
+        clear = function () {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        },
+
+        /**
+         * Draw an X shape made up of two stroked paths
+         * note the coordinates provided are based on the origin at bottom left
+         * @param data - the contents of the emsg message_data
+         */
+        drawCross = function (data) {
+            ctx.strokeStyle = data.colour;
+            ctx.beginPath();
+            ctx.moveTo(data.x1, canvas.height - data.y1);
+            ctx.lineTo(data.x2, canvas.height - data.y2);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(data.x2, canvas.height - data.y1);
+            ctx.lineTo(data.x1, canvas.height - data.y2);
+            ctx.stroke();
+        },
+
+        /**
+         * Draw a stroked rectangle
+         * note the coordinates provided are based on the origin at bottom left
+         * @param data - the contents of the emsg message_data
+         */
+        drawSquare = function (data) {
+            ctx.strokeStyle = data.colour;
+            ctx.strokeRect(
+                data.x1,
+                canvas.height - data.y2,
+                data.x2 - data.x1,
+                data.y2 - data.y1
+            );
+        },
+
+        // LUT for known shape drawing methods
+        shapeMethods = {
+            "cross":    drawCross,
+            "square":   drawSquare
+        },
+
+        /**
+         * callback is called on cuechange by the track on the video
+         * @param event - a js Event object
+         */
+        cueChangeHandler = function (event) {
+            var track = event.target,
+                cues = track.activeCues,
+                numCues = cues.length,
+                cue,
+                messageData,
+                method,
+                i;
+
+            // clear everything and redraw the active shapes each time
+            // not the most efficient way, but probably the easiest
+            clear();
+
+            // loop through the active cues and make sense of them
+            for (i = 0; i < numCues; i += 1) {
+                cue = JSON.parse(cues[i].text);
+                messageData = JSON.parse(cue.messageData);
+                method = shapeMethods[messageData.shape];
+
+                if (method) {
+                    method(messageData);
+                }
+            }
+        },
+
+        /**
+         * listen for TrackEvent-like events signalling that new tracks have
+         * been added to the player.
+         * @param event - a JS Event object
+         */
+        tracksChanged = function (event) {
+            var type = event.type,
+                track = event.track,
+                siu = event.track.label.split(" ")[0],
+                val = event.track.label.split(" ")[1];
+
+            // is the track for a schemeIdUri and value we are interested in?
+            if (siu === "tag:rdmedia.bbc.co.uk,2014:events/ballposition" &&
+                    val === "1") {
+                // yes, so add a cuechange event handler
+                if (type === "addtrack") {
+                    track.addEventListener("cuechange", cueChangeHandler);
+                }
+                // it's no longer around so don't listen for cuechanges
+                if (type === "removetrack") {
+                    track.removeEventListener("cuechange", cueChangeHandler);
+                }
+            }
+        },
+
+        /**
+         * configure the canvas for drawing
+         */
+        setupOverlay = function () {
+            // the canvas is in front of the video
+            canvas = d.getElementById("overlay");
+            ctx = canvas.getContext("2d");
+
+            // set the actual height to the styled height
+            canvas.width = $("#overlay").width();
+            canvas.height = $("#overlay").height();
+        };
+
+    return {
+
+        /**
+         * create the player object and attach video and manifest
+         */
+        start: function () {
+            var useEventBus = false,
+                dashCtx = new Dash.di.DashContext(),
+                player = new MediaPlayer(dashCtx),
+                video = d.getElementById("v"),
+                url = "http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd";
+
+            setupOverlay();
+
+            // configure the DASH player
+            player.startup();
+            player.debug.setLogToBrowserConsole(false);
+            player.setAutoPlay(true);
+
+            // track events are dispatched on both eventBus and the
+            // mediaelement. the main reason is that this does not require
+            // knowledge of the video element if you have access to the
+            // eventBus - this is good for internal use. it doesn't really
+            // matter which is used. this demo uses the Video.TextTrackList.
+            if (!useEventBus) {
+                video.textTracks.addEventListener("addtrack", tracksChanged);
+                video.textTracks.addEventListener("removetrack", tracksChanged);
+            } else {
+                player.addEventListener("addtrack", tracksChanged);
+                player.addEventListener("removetrack", tracksChanged);
+            }
+
+            // the test content contains a high (8Mbps) representation and is
+            // "longform" and on-demand. that combination makes this a problem:
+            // https://code.google.com/p/chromium/issues/detail?id=421694
+            // this can cause the buffer to stall when the top rate is selected
+            // https://github.com/Dash-Industry-Forum/dash.js/issues/283 gives
+            // more info - see my comments there if you are interested.
+            // work around: forcably limit buffer size to minimum.
+            player.setBufferMax("min");
+
+            player.attachView(video);
+            player.attachSource(url);
+        }
+    };
+}(jQuery, document));
+
+$(function () {
+    "use strict";
+
+    // once the page has loaded, start the player
+    emsg.start();
+});

--- a/test/js/utils/ObjectsHelper.js
+++ b/test/js/utils/ObjectsHelper.js
@@ -28,6 +28,11 @@
                 },
                 getStreamInfo: function() {
                     return {};
+                },
+                getEventController: function () {
+                    return {
+                        handleRepresentationSwitch: function () {}
+                    };
                 }
             }
         },


### PR DESCRIPTION
This PR enhances both in- and out-of-band event message handling functionality available in dash.js.

It does this following as closely as possible the HBBTV v1.3.1 specification, using the TextTrack and TextTrackCue interfaces on the HTMLMediaElement for management and dispatch of events.

There is one deviation from the spec as it stands, but which in practice seems unlikely to cause an issue: when an identical EventStream is available on more than Representation, the code is currently unable to differentiate between the source of each message and hence will process both. This therefore ignores the recommendation in the MPEG-DASH spec that processing one Representation per `@schemeIdUri/@value` pair is sufficient.

A simple sample application which exercises the API is provided - see /samples/emsg/index.html. The existing Fraunhofer sample application continues to work, as does manifest updating.

All existing tests and JSHint continue to pass.

I welcome review and comment of this change-set.
