### PR TITLE
Gracefully handle multiple MPD.Location elements

### DIFF
--- a/app/js/dash/DashParser.js
+++ b/app/js/dash/DashParser.js
@@ -348,6 +348,12 @@ Dash.dependencies.DashParser = function () {
                     }
                 }
 
+                if (manifest.hasOwnProperty("Location")) {
+                    // for now, do not support multiple Locations -
+                    // just set Location to the first Location.
+                    manifest.Location = manifest.Location_asArray[0];
+                }
+
                 //this.debug.log("Flatten manifest properties.");
                 iron.run(manifest);
                 ironed = new Date();


### PR DESCRIPTION
MPD.Location elements can occur 0..N times but, when present, only the case where N === 1 was handled correctly.

Whilst not providing a full solution (which would be application specific), this workaround ensures that at least the manifest updater can continue to operate when N > 1.
