### PR TITLE
getVideoPlaybackQuality method is not available on HTMLAudioElement

### DIFF
--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -112,9 +112,12 @@
          * TODO move to ???Extensions class
          */
         onTimeupdate = function(e) {
-            var self = this;
+            var self = this,
+                playbackQuality = self.videoExt.getPlaybackQuality(activeStream.getVideoModel().getElement());
 
-            self.metricsModel.addDroppedFrames("video", self.videoExt.getPlaybackQuality(activeStream.getVideoModel().getElement()));
+            if (playbackQuality) {
+                self.metricsModel.addDroppedFrames("video", playbackQuality);
+            }
 
             if (!getNextStream()) return;
 


### PR DESCRIPTION
@bbcrddave: 
"When using `<audio>` instead of `<video>`, no video playback quality information is available so VideoModelExtensions.getPlaybackQuality would return null. The return value was always assumed to be good which would cause MetricsModel.addDroppedFrames to throw Uncaught TypeError: Cannot read property 'creationTime' of null.

This pr checks that getPlaybackQuality returns something useful and only calls addDroppedFrames if that is the case." 
