### PR TITLE
commenting out log lines in limitswitchrule

### DIFF
--- a/app/js/streaming/rules/ABRRules/LimitSwitchesRule.js
+++ b/app/js/streaming/rules/ABRRules/LimitSwitchesRule.js
@@ -37,11 +37,11 @@ MediaPlayer.rules.LimitSwitchesRule = function () {
                 now = new Date().getTime(),
                 delay;
 
-            self.debug.log("Checking limit switches rule...");
+            //self.debug.log("Checking limit switches rule...");
             delay = now - lastCheckTime;
 
             if (delay < qualitySwitchThreshold /*&& rs !== undefined && (now - rs.t.getTime()) < qualitySwitchThreshold*/) {
-                self.debug.log("Wait some time before allowing another switch.");
+                //self.debug.log("Wait some time before allowing another switch unless with default priority");
                 callback(new MediaPlayer.rules.SwitchRequest(current, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT));
                 return;
             }


### PR DESCRIPTION
Too much chatter in logs that is not needed.