### PR TITLE
Proposed Clearkey DRM Support

### DIFF
--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -83,6 +83,8 @@
     <script src="../../src/streaming/models/ProtectionModel.js"></script>
     <script src="../../src/streaming/models/ProtectionModel_01b.js"></script>
     <script src="../../src/streaming/models/ProtectionModel_3Feb2014.js"></script>
+    <script src="../../src/streaming/vo/protection/ClearKeyKeySet.js"></script>
+    <script src="../../src/streaming/vo/protection/KeyPair.js"></script>
     <script src="../../src/streaming/vo/protection/SessionToken.js"></script>
 
     <script src="../../src/streaming/controllers/ProtectionController.js"></script>

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -71,7 +71,6 @@ MediaPlayer.dependencies.Stream = function () {
                 if (!this.keySystem) {
                     this.keySystem = this.protectionModel.keySystem;
                     this.protectionModel.keySystem.subscribe(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE, this);
-                    this.protectionModel.keySystem.subscribe(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE, this);
                 }
                 this.debug.log("DRM: Key required for - " + mediaInfo.codec);
                 this.protectionController.createKeySession(initData, mediaInfo.codec);
@@ -86,23 +85,15 @@ MediaPlayer.dependencies.Stream = function () {
             this.debug.log("DRM: Key added.");
         },
 
-        licenseRequestComplete = function(e, updateKeySessionFunc) {
+        onLicenseRequestComplete = function(e, updateKeySessionFunc) {
             if (e.error) {
                 pause.call(this);
                 this.debug.log(e.error);
                 this.errHandler.mediaKeyMessageError(e.error);
             } else {
                 this.debug.log("DRM: License request successful.  Session ID = " + e.data.requestData.sessionID);
-                updateKeySessionFunc.call(this.protectionController, e.data.requestData, e.data.message);
+                this.protectionController.updateKeySession(e.data.requestData, e.data.message);
             }
-        },
-
-        onClearKeyLicenseRequestComplete = function(e) {
-            licenseRequestComplete.call(this, e, this.protectionController.updateKeySessionClearKey);
-        },
-
-        onLicenseRequestComplete = function(e) {
-            licenseRequestComplete.call(this, e, this.protectionController.updateKeySession);
         },
 
         onKeyError = function (event) {
@@ -500,7 +491,6 @@ MediaPlayer.dependencies.Stream = function () {
 
             // Protection event handlers
             this[MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE] = onLicenseRequestComplete.bind(this);
-            this[MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE] = onClearKeyLicenseRequestComplete.bind(this);
             this[MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY] = onNeedKey.bind(this);
             this[MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_ADDED] = onKeyAdded.bind(this);
             this[MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_ERROR] = onKeyError.bind(this);
@@ -561,7 +551,6 @@ MediaPlayer.dependencies.Stream = function () {
                 this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_CLOSED, this);
                 if (!!this.keySystem) {
                     this.keySystem.unsubscribe(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE, this);
-                    this.keySystem.unsubscribe(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE, this);
                     this.keySystem = undefined;
                 }
 

--- a/src/streaming/controllers/ProtectionController.js
+++ b/src/streaming/controllers/ProtectionController.js
@@ -61,6 +61,10 @@ MediaPlayer.dependencies.ProtectionController = function () {
 
         updateKeySession: function(sessionToken, message) {
             this.protectionModel.updateKeySession(sessionToken, message);
+        },
+
+        updateKeySessionClearKey: function(sessionToken, message) {
+            this.protectionModel.updateKeySessionClearKey(sessionToken, message);
         }
     };
 

--- a/src/streaming/controllers/ProtectionController.js
+++ b/src/streaming/controllers/ProtectionController.js
@@ -62,10 +62,6 @@ MediaPlayer.dependencies.ProtectionController = function () {
         updateKeySession: function(sessionToken, message) {
             this.protectionModel.updateKeySession(sessionToken, message);
         },
-
-        updateKeySessionClearKey: function(sessionToken, message) {
-            this.protectionModel.updateKeySessionClearKey(sessionToken, message);
-        }
     };
 
 };

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -14,6 +14,7 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
     "use strict";
 
     var keySystems = [];
+    var clearkeyKeySystem;
 
     return {
         system: undefined,
@@ -36,6 +37,7 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
             // ClearKey
             keySystem = this.system.getObject("ksClearKey");
             keySystems.push(keySystem);
+            clearkeyKeySystem = keySystem;
         },
 
         /**
@@ -69,6 +71,20 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
          */
         getKeySystems: function() {
             return keySystems;
+        },
+
+        /**
+         * Determines whether the given key system is ClearKey.  This is
+         * necessary because the EME spec defines ClearKey and its method
+         * for providing keys to the key session; and this method has changed
+         * between the various API versions.  Our EME-specific ProtectionModels
+         * must know if the system is ClearKey so that it can format the keys
+         * according to the particular spec version.
+         *
+         * @param keySystem the key
+         */
+        isClearKey: function(keySystem) {
+            return (keySystem === clearkeyKeySystem);
         },
 
         /**

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -25,10 +25,6 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
         setup: function() {
             var keySystem;
 
-            // ClearKey
-            keySystem = this.system.getObject("ksClearKey");
-            keySystems.push(keySystem);
-
             // PlayReady
             keySystem = this.system.getObject("ksPlayReady");
             keySystems.push(keySystem);
@@ -37,6 +33,9 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
             keySystem = this.system.getObject("ksWidevine");
             keySystems.push(keySystem);
 
+            // ClearKey
+            keySystem = this.system.getObject("ksClearKey");
+            keySystems.push(keySystem);
         },
 
         /**

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -25,6 +25,10 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
         setup: function() {
             var keySystem;
 
+            // ClearKey
+            keySystem = this.system.getObject("ksClearKey");
+            keySystems.push(keySystem);
+
             // PlayReady
             keySystem = this.system.getObject("ksPlayReady");
             keySystems.push(keySystem);
@@ -33,12 +37,6 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
             keySystem = this.system.getObject("ksWidevine");
             keySystems.push(keySystem);
 
-            // ClearKey
-            //keySystem = this.system.getObject("ksClearKey");
-            //keySystems.push(keySystem);
-
-            // ClearKey
-            // TODO: Need to define a ClearKey system more completely.
         },
 
         /**
@@ -137,119 +135,5 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
 
 MediaPlayer.dependencies.ProtectionExtensions.prototype = {
     constructor: MediaPlayer.dependencies.ProtectionExtensions
-
-    /*
-    getKeySystems: function (protectionDataSet) {
-        var self = this,
-            _protectionData = protectionData,
-            getLAUrl = function (laUrl, keysystem) {
-                if (protectionData && protectionData[keysystem] !== undefined) {
-                    if (protectionData[keysystem].laUrl !== null && protectionData[keysystem].laUrl !== '') {
-                        return protectionData[keysystem].laUrl;
-                    }
-                }
-                return laUrl;
-            },
-            playReadyCdmData = function () {
-                if (protectionData && protectionData["com.microsoft.playready"] !== undefined) {
-                    if (protectionData["com.microsoft.playready"].cdmData !== null && protectionData["com.microsoft.playready"].cdmData !== '') {
-
-                        var cdmDataArray = [],
-                            charCode,
-                            cdmData = protectionData["com.microsoft.playready"].cdmData;
-                        cdmDataArray.push(239);
-                        cdmDataArray.push(187);
-                        cdmDataArray.push(191);
-                        for (var i = 0, j = cdmData.length; i < j; ++i) {
-                            charCode = cdmData.charCodeAt(i);
-                            cdmDataArray.push((charCode & 0xFF00) >> 8);
-                            cdmDataArray.push(charCode & 0xFF);
-                        }
-
-                        return new Uint8Array(cdmDataArray);
-                    }
-                }
-                return null;
-            },
-            widevineNeedToAddKeySession = function(initData, keySession, event){
-                event.target.webkitGenerateKeyRequest("com.widevine.alpha", event.initData);
-
-                return true;
-            },
-            widevineGetUpdate =  function (event) {
-            };
-
-        //
-        // order by priority. if an mpd contains more than one the first match will win.
-        // Entries with the same schemeIdUri can appear multiple times with different keysTypeStrings.
-        //
-        return [
-            {
-                schemeIdUri: "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95",
-                keysTypeString: "com.microsoft.playready",
-                isSupported: function (data) {
-                    return this.schemeIdUri === data.schemeIdUri.toLowerCase();},
-                needToAddKeySession: playReadyNeedToAddKeySession,
-                getInitData: playreadyGetInitData,
-                getUpdate: playreadyGetUpdate,
-                cdmData: playReadyCdmData
-            },
-            {
-                schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
-                keysTypeString: "com.widevine.alpha",
-                isSupported: function (data) {
-                    return this.schemeIdUri === data.schemeIdUri.toLowerCase();},
-                needToAddKeySession: widevineNeedToAddKeySession,
-                getInitData: function () {
-                    // the cenc element in mpd does not contain initdata
-                    return null;},
-                getUpdate: widevineGetUpdate,
-                cdmData: function() {return null;}
-            },
-            {
-                schemeIdUri: "urn:mpeg:dash:mp4protection:2011",
-                keysTypeString: "com.microsoft.playready",
-                isSupported: function (data) {
-                    return this.schemeIdUri === data.schemeIdUri.toLowerCase() && data.value.toLowerCase() === "cenc";},
-                needToAddKeySession: playReadyNeedToAddKeySession,
-                getInitData: function () {
-                    // the cenc element in mpd does not contain initdata
-                    return null;},
-                getUpdate: playreadyGetUpdate,
-                cdmData: playReadyCdmData
-            },
-            {
-                schemeIdUri: "urn:mpeg:dash:mp4protection:2011",
-                keysTypeString: "com.widevine.alpha",
-                isSupported: function (data) {
-                    return this.schemeIdUri === data.schemeIdUri.toLowerCase() && data.value.toLowerCase() === "cenc";},
-                needToAddKeySession: widevineNeedToAddKeySession,
-                getInitData: function () {
-                    // the cenc element in mpd does not contain initdata
-                    return null;},
-                getUpdate: widevineGetUpdate,
-                cdmData: function() {return null;}
-            },
-            {
-                schemeIdUri: "urn:uuid:00000000-0000-0000-0000-000000000000",
-                keysTypeString: "webkit-org.w3.clearkey",
-                isSupported: function (data) {
-                    return this.schemeIdUri === data.schemeIdUri.toLowerCase();},
-                needToAddKeySession: function () {
-                    return true;},
-                getInitData: function () {
-                    return null;},
-                getUpdate: function (event) {
-                    var bytes, msg;
-                    bytes = new Uint16Array(event.message.buffer);
-                    msg = String.fromCharCode.apply(null, bytes);
-                    return msg;
-                },
-                cdmData: function() {return null;}
-            }
-        ];
-    },
-     */
-
 };
 

--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -74,6 +74,15 @@ MediaPlayer.models.ProtectionModel = {
      */
 
     /**
+     * Adds the given ClearKey key set to this session
+     *
+     * @param sessionToken the session token
+     * @param keySet {MediaPlayer.vo.protection.ClearKeyKeySet} the key set
+     *
+     updateKeySessionClearKey: function(sessionToken, keySet) { },
+     */
+
+    /**
      * Close the given session and release all associated keys.  Following
      * this call, the sessionToken becomes invalid
      *

--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -74,15 +74,6 @@ MediaPlayer.models.ProtectionModel = {
      */
 
     /**
-     * Adds the given ClearKey key set to this session
-     *
-     * @param sessionToken the session token
-     * @param keySet {MediaPlayer.vo.protection.ClearKeyKeySet} the key set
-     *
-     updateKeySessionClearKey: function(sessionToken, keySet) { },
-     */
-
-    /**
      * Close the given session and release all associated keys.  Following
      * this call, the sessionToken becomes invalid
      *

--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -256,22 +256,7 @@ MediaPlayer.models.ProtectionModel_01b = function () {
                 throw new Error("Can not create sessions until you have selected a key system");
             }
 
-            // Detect duplicate init data
-            /*
-            var i;
-            for (i = 0; i < pendingSessions.length; i++) {
-                if (this.keySystem.initDataEquals(initData, pendingSessions[i].initData)) {
-                    this.debug.log("Duplicate init data detected.  No new key session created!");
-                    return;
-                }
-            }
-            for (i = 0; i < sessions.length; i++) {
-                if (this.keySystem.initDataEquals(initData, sessions[i].initData)) {
-                    this.debug.log("Duplicate init data detected.  No new key session created!");
-                    return;
-                }
-            }
-            */
+            // TODO: Detect duplicate init data
 
             // Determine if creating a new session is allowed
             if (moreSessionsAllowed || sessions.length === 0) {

--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -206,6 +206,7 @@ MediaPlayer.models.ProtectionModel_01b = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        protectionExt: undefined,
         keySystem: null,
 
         setup: function() {
@@ -280,15 +281,17 @@ MediaPlayer.models.ProtectionModel_01b = function () {
         },
 
         updateKeySession: function(sessionToken, message) {
-            // Send our request to the CDM
-            videoElement[api.addKey](this.keySystem.systemString,
-                message, sessionToken.initData, sessionToken.sessionID);
-        },
-
-        updateKeySessionClearKey: function(sessionToken, keySet) {
-            for (var i = 0; i < keySet.keyPairs.length; i++) {
+            var sessionID = sessionToken.sessionID;
+            if (!this.protectionExt.isClearKey(this.keySystem)) {
+                // Send our request to the CDM
                 videoElement[api.addKey](this.keySystem.systemString,
-                        keySet.keyPairs[i].key, keySet.keyPairs[i].keyID, sessionToken.sessionID);
+                        message, sessionToken.initData, sessionID);
+            } else {
+                // For clearkey, message is a MediaPlayer.vo.protection.ClearKeyKeySet
+                for (var i = 0; i < message.keyPairs.length; i++) {
+                    videoElement[api.addKey](this.keySystem.systemString,
+                            message.keyPairs[i].key, message.keyPairs[i].keyID, sessionID);
+                }
             }
         },
 

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -183,6 +183,11 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
             session.update(message);
         },
 
+        updateKeySessionClearKey: function(sessionToken, keySet) {
+            var session = sessionToken.session;
+            session.update(keySet.toJWKString());
+        },
+
         /**
          * Close the given session and release all associated keys.  Following
          * this call, the sessionToken becomes invalid

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -105,6 +105,7 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        protectionExt: undefined,
         keySystem: null,
 
         setup: function() {
@@ -179,13 +180,13 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
 
             var session = sessionToken.session;
 
-            // Send our request to the key session
-            session.update(message);
-        },
-
-        updateKeySessionClearKey: function(sessionToken, keySet) {
-            var session = sessionToken.session;
-            session.update(keySet.toJWKString());
+            if (!this.protectionExt.isClearKey(this.keySystem)) {
+                // Send our request to the key session
+                session.update(message);
+            } else {
+                // For clearkey, message is a MediaPlayer.vo.protection.ClearKeyKeySet
+                session.update(message.toJWKString());
+            }
         },
 
         /**

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -51,6 +51,17 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
     },
 
     /**
+     * Returns just the data portion of a single PSSH
+     *
+     * @param pssh {Uint8Array} the PSSH
+     * @return {Uint8Array} data portion of the PSSH
+     */
+    getPSSHData: function(pssh) {
+        // Data begins 32 bytes into the box
+        return new Uint8Array(pssh.buffer.slice(32));
+    },
+
+    /**
      * Parses list of PSSH boxes into keysystem-specific PSSH data
      *
      * @param data {Uint8Array} the concatenated list of PSSH boxes as provided by

--- a/src/streaming/protection/drm/KeySystem.js
+++ b/src/streaming/protection/drm/KeySystem.js
@@ -92,7 +92,6 @@ MediaPlayer.dependencies.protection.KeySystem = {
 
     eventList: {
         ENAME_LICENSE_REQUEST_COMPLETE: "licenseRequestComplete",
-        ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE: "clearkeyLicenseRequestComplete"
     }
 };
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -95,7 +95,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                     if (xhr.status == 200) {
 
                         if (!xhr.response.hasOwnProperty("keys")) {
-                            this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                            this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                                     null, new Error('DRM: ClearKey Remote update, Illegal response JSON'));
                         }
                         for (i = 0; i < xhr.reponse.keys.length; i++) {
@@ -105,19 +105,19 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                             keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyid, key));
                         }
                         var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);
-                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                                 event);
                     } else {
-                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                                 null, new Error('DRM: ClearKey Remote update, XHR aborted. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
                     }
                 };
                 xhr.onabort = function () {
-                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                             null, new Error('DRM: ClearKey update, XHR aborted. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
                 };
                 xhr.onerror = function () {
-                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                             null, new Error('DRM: ClearKey update, XHR error. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
                 };
 
@@ -141,11 +141,11 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                 }
 
                 var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);
-                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                         event);
             }
             else {
-                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                         null, new Error('DRM: Illegal ClearKey type: ' + ckType));
             }
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -33,8 +33,124 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
     "use strict";
 
     var keySystemStr = "webkit-org.w3.clearkey",
-        keySystemUUID = "00000000-0000-0000-0000-000000000001",
-        protData;
+        keySystemUUID = "10000000-0000-0000-0000-000000000000",
+        protData,
+
+        /**
+         * Request a ClearKey license using PSSH-based message format that allows
+         * multiple methodologies for retrieving/storing key information
+         *
+         * @param notifier the KeySystem notifier that will receive the ENAME_LICENSE_REQUEST_COMPLETE
+         * event once the license retrieval process is complete
+         * @param message the ClearKey PSSH
+         * @param requestData request data to be passed back in the LicenseRequestComplete event
+         */
+        requestClearKeyLicense = function(message, /*laURL,*/ requestData) {
+            var i;
+
+            /* The ClearKey PSSH data format is defined as below:
+             *
+             * clearkey_pssh_data {
+             *   unsigned int (8) type
+             *   if (type == 0) {
+             *     unsigned int(16)              url_length
+             *     unsigned int(8)[url_length]   url (base64-encoded)
+             *   }
+             *   else if (type == 1) {
+             *     unsigned int(8)               num_keys
+             *     for (i = 0; i < num_keys; i++) {
+             *       unsigned int(8)[16]         key_id
+             *       unsigned int(8)[16]         key
+             *     }
+             *   }
+             * }
+             */
+
+            var psshData = MediaPlayer.dependencies.protection.CommonEncryption.getPSSHData(message),
+                dv = new DataView(psshData.buffer),
+                byteCursor = 0,
+                ckType,
+                keyPairs = [];
+
+            /* Read the ClearKey data type (0=URL, 1=JSON) */
+            ckType = dv.getUint8(byteCursor);
+            byteCursor += 1;
+
+            /* URL -- Retrieve JWKs from remote server */
+            if (ckType === 0) {
+                var url = "",
+                        urlB64 = "",
+                        urlLen = dv.getUint16(byteCursor);
+
+                byteCursor += 2;
+
+                for (i = 0; i < urlLen; i++) {
+                    urlB64 += String.fromCharCode(dv.getUint8(byteCursor+i));
+                }
+                url = atob(urlB64);
+                url = url.replace(/&amp;/, '&');
+
+                var xhr = new XMLHttpRequest();
+                xhr.onload = function () {
+                    if (xhr.status == 200) {
+
+                        if (!xhr.response.hasOwnProperty("keys")) {
+                            this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                                    null, new Error('DRM: ClearKey Remote update, Illegal response JSON'));
+                        }
+                        for (i = 0; i < xhr.reponse.keys.length; i++) {
+                            var keypair = xhr.response.keys[i],
+                                    keyid = atob(keypair.kid),
+                                    key = atob(keypair.k);
+                            keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyid, key));
+                        }
+                        var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);
+                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                                event);
+                    } else {
+                        this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                                null, new Error('DRM: ClearKey Remote update, XHR aborted. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
+                    }
+                };
+                xhr.onabort = function () {
+                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                            null, new Error('DRM: ClearKey update, XHR aborted. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
+                };
+                xhr.onerror = function () {
+                    this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                            null, new Error('DRM: ClearKey update, XHR error. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState));
+                };
+
+                xhr.open('GET', url);
+                xhr.responseType = 'json';
+                xhr.send();
+            }
+            /* internal -- keys and keyIDs are in the PSSH itself */
+            else if (ckType === 1) {
+                var numKeys = dv.getUint8(byteCursor);
+
+                byteCursor += 1;
+
+                for (i = 0; i < numKeys; i++) {
+                    var keyid, key;
+                    keyid = new Uint8Array(psshData.buffer.slice(byteCursor, byteCursor+16));
+                    byteCursor += 16;
+                    key = new Uint8Array(psshData.buffer.slice(byteCursor, byteCursor+16));
+                    byteCursor += 16;
+                    keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyid, key));
+                }
+
+                var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);
+                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                        event);
+            }
+            else {
+                this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE,
+                        null, new Error('DRM: Illegal ClearKey type: ' + ckType));
+            }
+
+        };
+
 
     return {
 
@@ -56,11 +172,20 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
             protData = protectionData;
         },
 
-        doLicenseRequest: function() { },
+        doLicenseRequest: function(message, laURL, requestData) {
+            requestClearKeyLicense.call(this, message, requestData);
+        },
 
-        getInitData: function() { return null; },
+        getInitData: function(/*cpData*/) { return null; },
 
-        initDataEquals: function() { return false; }
+        initDataEquals: function(initData1, initData2) {
+            if (initData1.length === initData2.length) {
+                if (btoa(initData1.buffer) === btoa(initData2.buffer)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     };
 };
 

--- a/src/streaming/vo/protection/KeyPair.js
+++ b/src/streaming/vo/protection/KeyPair.js
@@ -38,9 +38,9 @@
  */
 MediaPlayer.vo.protection.KeyPair = function(keyID, key) {
     "use strict";
-    if (keyID.length !== 16)
+    if (!keyID || keyID.length !== 16)
         throw new Error("Illegal key ID length! Must be 16 bytes (128 bits)");
-    if (key.length !== 16)
+    if (!key || key.length !== 16)
         throw new Error("Illegal key length! Must be 16 bytes (128 bits)");
     this.keyID = keyID;
     this.key = key;

--- a/src/streaming/vo/protection/KeyPair.js
+++ b/src/streaming/vo/protection/KeyPair.js
@@ -29,70 +29,24 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-MediaPlayer.dependencies.protection.KeySystem = {
+/**
+ * Represents a 128-bit keyID and 128-bit encryption key
+ *
+ * @param keyID {Uint8Array} 128-bit key ID
+ * @param key {Uint8Array} 128-bit encryption key
+ * @constructor
+ */
+MediaPlayer.vo.protection.KeyPair = function(keyID, key) {
+    "use strict";
+    if (keyID.length !== 16)
+        throw new Error("Illegal key ID length! Must be 16 bytes (128 bits)");
+    if (key.length !== 16)
+        throw new Error("Illegal key length! Must be 16 bytes (128 bits)");
+    this.keyID = keyID;
+    this.key = key;
+};
 
-    /**
-     * Key system name string (e.g. 'org.w3.clearkey')
-     *
-     * {DOMString}
-     *
-     systemString: undefined,
-     */
-
-    /**
-     * Key system UUID in the form '01234567-89ab-cdef-0123-456789abcdef'
-     *
-     * {DOMString}
-     *
-     uuid: undefined,
-     */
-
-    /**
-     * The scheme ID URI for this key system in the form
-     * 'urn:uuid:01234567-89ab-cdef-0123-456789abcdef' as used
-     * in DASH ContentProtection elements
-     *
-     * {DOMString}
-     *
-     schemeIdURI: undefined,
-     */
-
-    /**
-     * Request a content key/license from a remote server
-     *
-     * @param msg the request message from the CDM
-     * @param laURL default URL provided by the CDM
-     * @param requestData object that will be returned in the
-     * ENAME_LICENSE_REQUEST_COMPLETE event
-     *
-     doLicenseRequest: function(msg, laURL, requestData) {},
-     */
-
-    /**
-     * Parse DRM-specific init data from the ContentProtection
-     * element.
-     *
-     * @param contentProtection the ContentProtection element
-     * @returns {Uint8Array} initialization data
-     *
-     getInitData: function(contentProtection) { return null; },
-     */
-
-    /**
-     * Checks for equality of initialization data.  CDMs may send "needkey"
-     * events multiple times for the same initialization data, and players may
-     * wish to avoid creating new sessions for each needkey event if the init
-     * data is the same.
-     *
-     * @param initData1
-     * @param initData2
-     *
-     initDataEquals: function(initData1, initData2) {},
-     */
-
-    eventList: {
-        ENAME_LICENSE_REQUEST_COMPLETE: "licenseRequestComplete",
-        ENAME_CLEARKEY_LICENSE_REQUEST_COMPLETE: "clearkeyLicenseRequestComplete"
-    }
+MediaPlayer.vo.protection.KeyPair.prototype = {
+    constructor: MediaPlayer.vo.protection.KeyPair
 };
 


### PR DESCRIPTION
I have developed a KeySystem implementation that will allow the playback of ClearKey DRM protected content.  ClearKey support is mandated by the W3C Encrypted Media Extensions specification, however it does not define anything except the format of the message that should be passed to add keys to a session.  Specifically, it does not define an initialization data format so that the application would know how to retrieve the keys.

I have developed a new PSSH box definition that allows the decryption keys to be retrieved from:
* The content itself (in the PSSH)
* A remote server using a simple URL with query string arguments

The PSSH format is documented in KeySystem_ClearKey.js (requestClearKeyLicense() function).  I will be posting some encrypted test content in a few days that will support this form of ClearKey decryption.

I also have a very simple test server (written in Node.js) that would support the retrieval of clear keys over http/https.  The server code can be found [here](https://github.com/cablelabs/mse-eme/tree/master/create/encrypt/clearkey/server).

I also have an open source [encryption tool chain](https://github.com/cablelabs/mse-eme/tree/master/create/encrypt) that will allow you to create your own ClearKey-encrypted content using this format.  However, the [documentation](https://html5.cablelabs.com/mse-eme/doc/creation.html#encryption) for the tools is not up-to-date.  If you would like to try creating your own content and you are having trouble using the tools, please feel free to email me.