### PR TITLE
Address issues #345, #283 - unrecoverable video stall

### DIFF
--- a/src/streaming/rules/SchedulingRules/BufferLevelRule.js
+++ b/src/streaming/rules/SchedulingRules/BufferLevelRule.js
@@ -35,7 +35,7 @@ MediaPlayer.rules.BufferLevelRule = function () {
                 minBufferTarget = decideBufferLength.call(this, scheduleController.bufferController.getMinBufferTime(), duration),
                 currentBufferTarget = minBufferTarget,
                 bufferMax = scheduleController.bufferController.bufferMax,
-                isLongFormContent = (duration >= MediaPlayer.dependencies.BufferController.LONG_FORM_CONTENT_DURATION_THRESHOLD),
+                //isLongFormContent = (duration >= MediaPlayer.dependencies.BufferController.LONG_FORM_CONTENT_DURATION_THRESHOLD),
                 requiredBufferLength = 0;
 
 
@@ -45,8 +45,8 @@ MediaPlayer.rules.BufferLevelRule = function () {
                 requiredBufferLength = duration;
             } else if (bufferMax === MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED) {
                 if (!isDynamic && self.abrController.isPlayingAtTopQuality(scheduleController.streamProcessor.getStreamInfo())) {
-                    currentBufferTarget = isLongFormContent ?
-                        MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM :
+                    currentBufferTarget = /*isLongFormContent ?
+                        MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM :*/
                         MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY;
                 }
                 requiredBufferLength = currentBufferTarget + Math.max(getCurrentHttpRequestLatency.call(self, vmetrics),


### PR DESCRIPTION
#283 and #345 relate to a problem with presentations longer than 600s. When long presentations are detected, the player allows buffering much further ahead (300s vs 30s) which can fill the source buffer if the representation bit-rate is high.

It has been observed that, as the buffer becomes full, Chrome does not appear to follow correctly the coded frame eviction algorithm which can cause frames at the current play head to be evicted, leading to playback stalling unrecoverably. I am not sure if IE is affected.

Whilst this is clearly a UA issue, I believe that dash.js needs to work around this type of problem until it is fixed. Limiting the buffer length to thirty seconds regardless of presentation duration solves this in the short term.

Our research suggests that it is not sensible to buffer very far into the future in any case, but that is a question for another time.

I hope this PR can be accepted in to v1.3.