### PR TITLE
Fix npm install warnings [low priority]

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "readme": "../README.md",
   "devDependencies": {
     "grunt": "~0.4.2",

--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dashjs",
   "version": "1.1.1",
+  "readme": "../README.md",
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-connect": "~0.7.1",


### PR DESCRIPTION
See #368.

tl;dr it's nicer not to see warnings when installing the package, and the right version number.