### PR TITLE
add a configuration file...

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -98,7 +98,8 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         context,
         videoSeries = [],
         audioSeries = [],
-        maxGraphPoints = 50;
+        maxGraphPoints = 50,
+        config = null;
 
     ////////////////////////////////////////
     //
@@ -533,6 +534,24 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
     player.attachView(video);
     player.setAutoPlay(true);
+
+    ////////////////////////////////////////
+    //
+    // Configuration file
+    //
+    ////////////////////////////////////////
+    var reqConfig = new XMLHttpRequest();
+    reqConfig.onload = function() {
+        if (reqConfig.status === 200) {
+            config = JSON.parse(reqConfig.responseText);
+            if (player) {
+                player.setConfig(config);
+            }
+        }
+    };
+    reqConfig.open("GET", "dashplayer_config.json", true);
+    reqConfig.setRequestHeader("Content-type", "application/json");
+    reqConfig.send();
 
     ////////////////////////////////////////
     //

--- a/samples/dash-if-reference-player/dashplayer_config.json
+++ b/samples/dash-if-reference-player/dashplayer_config.json
@@ -1,0 +1,19 @@
+{
+    "//": "General parameters, applied to all media",
+    "//": "A value of '-1' is considered as an undefined value, thus default value from source code is used",
+
+    "// BufferController.lowBufferThreshold": "The minimum media buffer size (in seconds) to fill before starting playing when buffering",
+    "BufferController.lowBufferThreshold": 4,
+
+    "// BufferController.minBufferTime": "The minimum media buffer size (in seconds) to fill when playing",
+    "BufferController.defaultMinBufferTime": 12,
+
+    "// video" : "Video media parameters that override general parameters",
+    "video": {
+    },
+
+    "// audio" : "Audio media parameters that override general parameters",
+    "audio": {
+    }
+}
+

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -47,6 +47,7 @@
     <script src="../../src/streaming/utils/Capabilities.js"></script>
     <script src="../../src/streaming/utils/EventBus.js"></script>
     <script src="../../src/streaming/utils/Debug.js"></script>
+    <script src="../../src/streaming/utils/Config.js"></script>
     <script src="../../src/streaming/extensions/RequestModifierExtensions.js"></script>
     <script src="../../src/streaming/models/VideoModel.js"></script>
     <script src="../../src/streaming/vo/FragmentRequest.js"></script>

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -99,6 +99,8 @@ MediaPlayer.di.Context = function () {
             this.system.mapSingleton('timeSyncController', MediaPlayer.dependencies.TimeSyncController);
 
             this.system.mapSingleton('notifier', MediaPlayer.dependencies.Notifier);
+
+            this.system.mapSingleton('config', MediaPlayer.utils.Config);
         }
     };
 };

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -235,6 +235,7 @@ MediaPlayer = function (aContext) {
         errHandler: undefined,
         uriQueryFragModel:undefined,
         videoElementExt:undefined,
+        config: undefined,
 
         setup: function() {
             metricsExt = system.getObject("metricsExt");
@@ -508,6 +509,12 @@ MediaPlayer = function (aContext) {
         reset: function() {
             this.attachSource(null);
             this.attachView(null);
+        },
+
+        setConfig: function (params) {
+            if (this.config && params) {
+                this.config.setParams(params);
+            }
         },
 
         /**

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -560,6 +560,7 @@ MediaPlayer.dependencies.BufferController = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        config: undefined,
 
         setup: function() {
             this[Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED] = onDataUpdateCompleted;
@@ -580,6 +581,14 @@ MediaPlayer.dependencies.BufferController = function () {
             onRemoved = onRemoved.bind(this);
             this.sourceBufferExt.subscribe(MediaPlayer.dependencies.SourceBufferExtensions.eventList.ENAME_SOURCEBUFFER_APPEND_COMPLETED, this, onAppended);
             this.sourceBufferExt.subscribe(MediaPlayer.dependencies.SourceBufferExtensions.eventList.ENAME_SOURCEBUFFER_REMOVE_COMPLETED, this, onRemoved);
+
+            if (MediaPlayer.dependencies.BufferController.DEFAULT_MIN_BUFFER_TIME === undefined) {
+                MediaPlayer.dependencies.BufferController.DEFAULT_MIN_BUFFER_TIME = this.config.getParamFor(undefined, "BufferController.defaultMinBufferTime", "number", 12);
+            }
+            
+            if (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD === undefined) {
+                MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD = this.config.getParamFor(undefined, "BufferController.lowBufferThreshold", "number", 4);
+            }
         },
 
         initialize: function (typeValue, buffer, source, streamProcessor) {
@@ -664,8 +673,6 @@ MediaPlayer.dependencies.BufferController = function () {
 MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED = "required";
 MediaPlayer.dependencies.BufferController.BUFFER_SIZE_MIN = "min";
 MediaPlayer.dependencies.BufferController.BUFFER_SIZE_INFINITY = "infinity";
-MediaPlayer.dependencies.BufferController.DEFAULT_MIN_BUFFER_TIME = 12;
-MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD = 4;
 MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY = 30;
 MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 300;
 MediaPlayer.dependencies.BufferController.LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;

--- a/src/streaming/rules/ABRRules/DownloadRatioRule.js
+++ b/src/streaming/rules/ABRRules/DownloadRatioRule.js
@@ -61,6 +61,7 @@ MediaPlayer.rules.DownloadRatioRule = function () {
         debug: undefined,
         metricsExt: undefined,
         metricsModel: undefined,
+        config: undefined,
 
         execute: function (context, callback) {
             var self = this,

--- a/src/streaming/utils/Config.js
+++ b/src/streaming/utils/Config.js
@@ -1,0 +1,115 @@
+/*
+ * The copyright in this software module is being made available under the BSD License, included below. This software module may be subject to other third party and/or contributor rights, including patent rights, and no such rights are granted under this license.
+ * The whole software resulting from the execution of this software module together with its external dependent software modules from dash.js project may be subject to Orange and/or other third party rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2014, Orange
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * •  Neither the name of the Orange nor the names of its contributors may be used to endorse or promote products derived from this software module without specific prior written permission.
+ * 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+MediaPlayer.utils.Config = function () {
+    "use strict";
+
+    var paramsType = ["video", "audio"],
+
+        // Default configuration, provides list of possible parameters
+        params = {
+            // BufferController parameters
+            "BufferController.lowBufferThreshold": 4,
+            "BufferController.defaultMinBufferTime": 12,
+            // ABR parameters
+            // Video parameters
+            "video": {
+            },
+            // Audio parameters
+            "audio": {
+            },
+        },
+
+        doSetParams = function (newParams) {
+            var item,
+                typeParams,
+                typeItem;
+
+            for (item in newParams) {
+                // Check if comment
+                if (item.indexOf('//') === -1) {
+                    // Check if type parameters
+                    if (paramsType.indexOf(item) > -1) {
+                        typeParams = newParams[item];
+                        for (typeItem in typeParams) {
+                            params[item][typeItem] = newParams[item][typeItem];
+                        }
+                    } else {
+                        params[item] = newParams[item];
+                    }
+                }
+            }
+        },
+
+        getParam = function (params, name, type, def) {
+            var value = params[name];
+
+            if ((value === undefined) || (value === -1)) {
+                return def;
+            }
+
+            if ((type !== undefined) && (typeof value !== type)) {
+                switch (type) {
+                    case 'number':
+                        value = Number(value);
+                        break;
+                    case 'boolean':
+                        value = (value === 'true') ||
+                                (value === '1') ||
+                                (value === 1);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return value;
+        },
+
+        doGetParam = function (name, type, def) {
+            return getParam(params, name, type, def);
+        },
+
+        doGetParamFor = function (key, name, type, def) {
+            var typeParams = params[key];
+
+            if ((typeParams !== undefined) && (typeParams[name] !== undefined)) {
+                return getParam(typeParams, name, type, def);
+            }
+
+            return getParam(params, name, type, def);
+        };
+
+    return {
+        setup: function () {
+        },
+
+        setParams: function (newParams) {
+            doSetParams(newParams);
+        },
+
+        getParam: function (name, type, def) {
+            return doGetParam(name, type, def);
+        },
+
+        getParamFor: function (key, name, type, def) {
+            return doGetParamFor(key, name, type, def);
+        }
+    };
+};
+
+MediaPlayer.utils.Config.prototype = {
+    constructor: MediaPlayer.utils.Config
+};


### PR DESCRIPTION
 in order to evolve the behavior of the video player without build it. It could be useful to allow users to change video player parameters just using json configuration file. If the idea is accepted, we could add others parameters to this config file.

the configuration file is organized into 3 parts : 
- global parameters
- video parameters
- audio parameters

A parameter could be defined in, for instance, 2 parts. In this case, the parameter defined in the specific part will be used in place of the global one.
