### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-script: cd build && npm install && npm test
+before_install: cd build && npm install -g grunt-cli
+install: npm install

--- a/build/package.json
+++ b/build/package.json
@@ -13,6 +13,9 @@
     "grunt-template-jasmine-istanbul": "=0.3.0",
     "jasmine-sinon": "~0.3.1"
   },
+  "scripts": {
+    "test": "grunt"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Dash-Industry-Forum/dash.js.git"


### PR DESCRIPTION
The current travis builds doesn't actually run any tests. In fact the .11 nodejs build even writes "Error: no test specified"

The only reason they are marked as passed, is that "cd build" makes them return 0. This fixes it, so it actually testes the builds.