### PR TITLE
Fixes bug: 437:TTML Subtitles are non-functional

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -37,7 +37,7 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
 
             try {
                 result = self.getParser().parse(ccContent);
-                label = mediaInfo.id;
+                label = mediaInfo.index;
                 lang = mediaInfo.lang;
 
                 self.getTextTrackExtensions().addTextTrack(self.videoModel.getElement(), result, label, lang, true);

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -33,17 +33,19 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             for(var item in captionData) {
                 var currentItem = captionData[item];
                 var cue = new Cue(currentItem.start, currentItem.end, currentItem.data);
-                if (currentItem.styles.align !== undefined && cue.hasOwnProperty("align")) {
-                    cue.align = currentItem.styles.align;
-                }
-                if (currentItem.styles.line !== undefined && cue.hasOwnProperty("line")) {
-                    cue.line = currentItem.styles.line;
-                }
-                if (currentItem.styles.position !== undefined && cue.hasOwnProperty("position")) {
-                    cue.position = currentItem.styles.position ;
-                }
-                if (currentItem.styles.size !== undefined && cue.hasOwnProperty("size")) {
-                    cue.size = currentItem.styles.size;
+                if (currentItem.styles !== null) {
+                    if (currentItem.styles.align !== undefined && cue.hasOwnProperty("align")) {
+                        cue.align = currentItem.styles.align;
+                    }
+                    if (currentItem.styles.line !== undefined && cue.hasOwnProperty("line")) {
+                        cue.line = currentItem.styles.line;
+                    }
+                    if (currentItem.styles.position !== undefined && cue.hasOwnProperty("position")) {
+                        cue.position = currentItem.styles.position ;
+                    }
+                    if (currentItem.styles.size !== undefined && cue.hasOwnProperty("size")) {
+                        cue.size = currentItem.styles.size;
+                    }
                 }
                 track.addCue(cue);
             }


### PR DESCRIPTION
Adds a null check & changes label to use mediaInfo.index instead of ID as ID is null for ttml. There are most likely better ways to fix these issues, as ttml subtitles are created as VTTCues with the current code. However this code yields functional ttml subtitles with the "Insertion of Timed Text 2" source content.

Bug https://github.com/Dash-Industry-Forum/dash.js/issues/437
