### PR TITLE
Bug in new EME version management

### DIFF
--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -158,6 +158,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        protectionExt: undefined,
         keySystem: null,
 
         setup: function() {


### PR DESCRIPTION
protectionExt parameter is used in createKeySession function, but it's not defined.