### PR TITLE
Remove unuseful New Date call.

### DIFF
--- a/src/dash/TimelineConverter.js
+++ b/src/dash/TimelineConverter.js
@@ -96,7 +96,7 @@ Dash.dependencies.TimelineConverter = function () {
             }
 
             checkTime = representation.adaptation.period.mpd.checkTime;
-            now = calcPresentationTimeFromWallTime(new Date((new Date().getTime())), representation.adaptation.period);
+            now = calcPresentationTimeFromWallTime(new Date(), representation.adaptation.period);
             //the Media Segment list is further restricted by the CheckTime together with the MPD attribute
             // MPD@timeShiftBufferDepth such that only Media Segments for which the sum of the start time of the
             // Media Segment and the Period start time falls in the interval [NOW- MPD@timeShiftBufferDepth - @duration, min(CheckTime, NOW)] are included.


### PR DESCRIPTION
use new Date, only one time. getTime is done in calcPresentationTimeFromWallTime function.