### PR TITLE
Updates to Support Latest Clearkey

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -180,13 +180,29 @@
             "protData": {
                 "com.widevine.alpha": {
                     "laURL": "https://html5.cablelabs.com:8025"
+                },
+                "org.w3.clearkey": {
+                    "clearkeys": {
+                        "EAAAABAAEAAQABAAAAAAAQ": "OiobaN0r2bLusl6ExHdmaA",
+                        "EAAAABAAEAAQABAAAAAAAg": "B+TWU8+0XGYVjZP/zkIpBw",
+                        "obHB0aKyo7OktKW1xdXl9Q": "JTn6hLmHQWAJp/u6EbI5qw"
+                    }
                 }
             }
         },
         {
             "name": "CableLabs Cenc PR/CK",
             "url": "http://html5.cablelabs.com:8100/cenc/prck/dash.mpd",
-            "browsers": ""
+            "browsers": "",
+            "protData": {
+                "org.w3.clearkey": {
+                    "clearkeys": {
+                        "EAAAABAAEAAQABAAAAAAAQ": "OiobaN0r2bLusl6ExHdmaA",
+                        "EAAAABAAEAAQABAAAAAAAg": "B+TWU8+0XGYVjZP/zkIpBw",
+                        "obHB0aKyo7OktKW1xdXl9Q": "JTn6hLmHQWAJp/u6EbI5qw"
+                    }
+                }
+            }
         }
     ]
 }

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -18,16 +18,6 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
     this.keySystems = [];
 
     this.clearkeyKeySystem = undefined;
-    // hard-coded set of keys for testing ClearKey
-    this.clearkeys = {
-        // 10000000-1000-1000-1000-100000000001: 0x3A2A1B68DD2BD9B2EEB25E84C4776668
-        EAAAABAAEAAQABAAAAAAAQ: "OiobaN0r2bLusl6ExHdmaA",
-        // 10000000-1000-1000-1000-100000000002: 0x07E4D653CFB45C66158D93FFCE422907
-        EAAAABAAEAAQABAAAAAAAg: "B+TWU8+0XGYVjZP/zkIpBw",
-        // A1B1C1D1-A2B2-A3B3-A4B4-A5B5C5D5E5F5: 0x2539FA84B987416009A7FBBA11B239AB
-        obHB0aKyo7OktKW1xdXl9Q: "JTn6hLmHQWAJp/u6EbI5qw"
-    };
-
 };
 
 MediaPlayer.dependencies.ProtectionExtensions.prototype = {
@@ -85,17 +75,6 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
      */
     getKeySystems: function() {
         return this.keySystems;
-    },
-
-    /**
-     * Returns one of our hard-coded ClearKey keys
-     *
-     * @param {string} keyID the base64-encoded keyID
-     * @return {string} the base64-encoded key, or null if the given
-     * keyID is unknown
-     */
-    getClearKeyKey: function(keyID) {
-        return (this.clearkeys.hasOwnProperty(keyID)) ? this.clearkeys[keyID] : null;
     },
 
     /**

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -16,7 +16,17 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
     this.system = undefined;
     this.log = undefined;
     this.keySystems = [];
+
     this.clearkeyKeySystem = undefined;
+    // hard-coded set of keys for testing ClearKey
+    this.clearkeys = {
+        // 10000000-1000-1000-1000-100000000001: 0x3A2A1B68DD2BD9B2EEB25E84C4776668
+        EAAAABAAEAAQABAAAAAAAQ: "OiobaN0r2bLusl6ExHdmaA",
+        // 10000000-1000-1000-1000-100000000002: 0x07E4D653CFB45C66158D93FFCE422907
+        EAAAABAAEAAQABAAAAAAAg: "B+TWU8+0XGYVjZP/zkIpBw",
+        // A1B1C1D1-A2B2-A3B3-A4B4-A5B5C5D5E5F5: 0x2539FA84B987416009A7FBBA11B239AB
+        obHB0aKyo7OktKW1xdXl9Q: "JTn6hLmHQWAJp/u6EbI5qw"
+    }
 
 };
 
@@ -75,6 +85,17 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
      */
     getKeySystems: function() {
         return this.keySystems;
+    },
+
+    /**
+     * Returns one of our hard-coded ClearKey keys
+     *
+     * @param {string} keyID the base64-encoded keyID
+     * @return {string} the base64-encoded key, or null if the given
+     * keyID is unknown
+     */
+    getClearKeyKey: function(keyID) {
+        return (this.clearkeys.hasOwnProperty(keyID)) ? this.clearkeys[keyID] : null;
     },
 
     /**

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -26,7 +26,7 @@ MediaPlayer.dependencies.ProtectionExtensions = function () {
         EAAAABAAEAAQABAAAAAAAg: "B+TWU8+0XGYVjZP/zkIpBw",
         // A1B1C1D1-A2B2-A3B3-A4B4-A5B5C5D5E5F5: 0x2539FA84B987416009A7FBBA11B239AB
         obHB0aKyo7OktKW1xdXl9Q: "JTn6hLmHQWAJp/u6EbI5qw"
-    }
+    };
 
 };
 

--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -260,6 +260,9 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
             // Send our request to the key session
             var self = this;
+            if (this.protectionExt.isClearKey(this.keySystem)) {
+                message = message.toJWK();
+            }
             session.update(message).catch(function (error) {
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_ERROR,
                     new MediaPlayer.vo.protection.KeyError(sessionToken, "Error sending update() message! " + error.name));

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -278,7 +278,7 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
                 session.update(message);
             } else {
                 // For clearkey, message is a MediaPlayer.vo.protection.ClearKeyKeySet
-                session.update(message.toJWKString());
+                session.update(JSON.stringify(message.toJWK()));
             }
         },
 

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -278,7 +278,7 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
                 session.update(message);
             } else {
                 // For clearkey, message is a MediaPlayer.vo.protection.ClearKeyKeySet
-                session.update(JSON.stringify(message.toJWK()));
+                session.update(new Uint8Array(message.toJWK()));
             }
         },
 

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -119,9 +119,9 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
             }
             byteCursor += 4;
 
-            /* Version must be 0 for now */
+            /* Version must be 0 or 1 */
             version = dv.getUint8(byteCursor);
-            if (version !== 0) {
+            if (version !== 0 && version !== 1) {
                 byteCursor = nextBox;
                 continue;
             }

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -53,12 +53,12 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
     /**
      * Returns just the data portion of a single PSSH
      *
-     * @param pssh {Uint8Array} the PSSH
-     * @return {Uint8Array} data portion of the PSSH
+     * @param pssh {ArrayBuffer} the PSSH
+     * @return {ArrayBuffer} data portion of the PSSH
      */
     getPSSHData: function(pssh) {
         // Data begins 32 bytes into the box
-        return new Uint8Array(pssh.buffer.slice(32));
+        return pssh.slice(32);
     },
 
     /**
@@ -68,7 +68,7 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
      * @param {MediaPlayer.dependencies.protection.KeySystem} keySystem the desired
      * key system
      * @param {ArrayBuffer} initData 'cenc' initialization data.  Concatenated list of PSSH.
-     * @returns {Uint8Array} The PSSH box data corresponding to the given key system
+     * @returns {ArrayBuffer} The PSSH box data corresponding to the given key system
      * or null if a valid association could not be found.
      */
     getPSSHForKeySystem: function(keySystem, initData) {
@@ -86,7 +86,7 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
      * CDM as initialization data when CommonEncryption content is detected
      * @returns {object} an object that has a property named according to each of
      * the detected key system UUIDs (e.g. 00000000-0000-0000-0000-0000000000)
-     * and a Uint8Array (the entire PSSH box) as the property value
+     * and a ArrayBuffer (the entire PSSH box) as the property value
      */
     parsePSSHList: function(data) {
 
@@ -169,7 +169,7 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
             byteCursor += 4;
 
             /* PSSH Data */
-            pssh[systemID] = new Uint8Array(dv.buffer.slice(boxStart, nextBox));
+            pssh[systemID] = dv.buffer.slice(boxStart, nextBox);
             byteCursor = nextBox;
         }
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -32,7 +32,7 @@
 MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
     "use strict";
 
-    var keySystemStr = "webkit-org.w3.clearkey",
+    var keySystemStr = "org.w3.clearkey",
         keySystemUUID = "10000000-0000-0000-0000-000000000000",
         protData,
 
@@ -175,7 +175,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
             requestClearKeyLicense.call(this, message, requestData);
         },
 
-        getInitData: function(/*cpData*/) { return null; },
+        getInitData: function(/*cpData*/) { return null; }
     };
 };
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -96,12 +96,12 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                 xhr.send();
             }
             /* internal -- keys are retrieved from protectionExtensions */
-            else {
+            else if (protData.clearkeys) {
                 var keyPairs = [],
                     protectionExt = this.system.getObject("protectionExt");
                 for (i = 0; i < jsonMsg.kids.length; i++) {
                     var keyID = jsonMsg.kids[i],
-                        key = protectionExt.getClearKeyKey(keyID);
+                        key = (protData.clearkeys.hasOwnProperty(keyID)) ? protData.clearkeys[keyID] : null;
                     if (!key) {
                         this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                                 null, new Error("DRM: ClearKey keyID (" + keyID + ") is not known!"));
@@ -113,6 +113,8 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                 var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);
                 this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                         event);
+            } else {
+
             }
         };
 
@@ -120,7 +122,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
     return {
 
         system: undefined,
-        schemeIdURI: undefined,
+        schemeIdURI: "urn:uuid:" + keySystemUUID,
         systemString: keySystemStr,
         uuid: keySystemUUID,
         notify: undefined,
@@ -134,7 +136,6 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
          * default or CDM-provided values
          */
         init: function(protectionData) {
-            this.schemeIdURI = "urn:uuid:" + keySystemUUID;
             protData = protectionData;
         },
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -66,7 +66,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
              */
 
             var psshData = MediaPlayer.dependencies.protection.CommonEncryption.getPSSHData(message),
-                dv = new DataView(psshData.buffer),
+                dv = new DataView(psshData),
                 byteCursor = 0,
                 ckType,
                 keyPairs = [];
@@ -132,9 +132,9 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
 
                 for (i = 0; i < numKeys; i++) {
                     var keyid, key;
-                    keyid = new Uint8Array(psshData.buffer.slice(byteCursor, byteCursor+16));
+                    keyid = new Uint8Array(psshData.slice(byteCursor, byteCursor+16));
                     byteCursor += 16;
-                    key = new Uint8Array(psshData.buffer.slice(byteCursor, byteCursor+16));
+                    key = new Uint8Array(psshData.slice(byteCursor, byteCursor+16));
                     byteCursor += 16;
                     keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyid, key));
                 }

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -97,8 +97,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
             }
             /* internal -- keys are retrieved from protectionExtensions */
             else if (protData.clearkeys) {
-                var keyPairs = [],
-                    protectionExt = this.system.getObject("protectionExt");
+                var keyPairs = [];
                 for (i = 0; i < jsonMsg.kids.length; i++) {
                     var keyID = jsonMsg.kids[i],
                         key = (protData.clearkeys.hasOwnProperty(keyID)) ? protData.clearkeys[keyID] : null;
@@ -114,7 +113,8 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                 this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                         event);
             } else {
-
+                self.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
+                        null, new Error('DRM: ClearKey has no way (URL or protection data) to retrieve keys'));
             }
         };
 

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -70,8 +70,8 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                         }
                         for (i = 0; i < xhr.response.keys.length; i++) {
                             var keypair = xhr.response.keys[i],
-                                    keyid = (BASE64.decodeArray(keypair.kid)).buffer,
-                                    key = (BASE64.decodeArray(keypair.k)).buffer;
+                                    keyid = keypair.kid.replace(/=/g, "");
+                                    key = keypair.k.replace(/=/g, "");
                             keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyid, key));
                         }
                         var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -106,7 +106,8 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
                         this.notify(MediaPlayer.dependencies.protection.KeySystem.eventList.ENAME_LICENSE_REQUEST_COMPLETE,
                                 null, new Error("DRM: ClearKey keyID (" + keyID + ") is not known!"));
                     }
-                    keyPairs.push(new MediaPlayer.vo.protection.KeyPair((BASE64.decodeArray(keyID)).buffer, (BASE64.decodeArray(key)).buffer))
+                    // KeyIDs from CDM are not base64 padded.  Keys may or may not be padded
+                    keyPairs.push(new MediaPlayer.vo.protection.KeyPair(keyID, key));
                 }
 
                 var event = new MediaPlayer.vo.protection.LicenseRequestComplete(new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs), requestData);

--- a/src/streaming/vo/protection/ClearKeyKeySet.js
+++ b/src/streaming/vo/protection/ClearKeyKeySet.js
@@ -46,25 +46,34 @@ MediaPlayer.vo.protection.ClearKeyKeySet = function(keyPairs, type) {
 
     /**
      * Convert this key set to its JSON Web Key (JWK) representation
+     *
+     * @return {ArrayBuffer} JWK object UTF-8 encoded as ArrayBuffer
      */
     this.toJWK = function() {
         var i, numKeys = this.keyPairs.length,
-            retval = {};
-        retval.keys = [];
+            jwk = {};
+        jwk.keys = [];
         for (i = 0; i < numKeys; i++) {
             var key = {
                 kty: "oct",
-                alg: "A128KW"
+                alg: "A128KW",
+                kid: this.keyPairs[i].keyID,
+                k: this.keyPairs[i].key
             };
-            // Remove base64 padding from each
-            key.k = BASE64.encode(String.fromCharCode.apply(null, this.keyPairs[i].key)).replace(/=/g, "");
-            key.kid = BASE64.encode(String.fromCharCode.apply(null, this.keyPairs[i].keyID)).replace(/=/g, "");
-            retval.keys.push(key);
+            jwk.keys.push(key);
         }
         if (this.type) {
-            retval.type = this.type;
+            jwk.type = this.type;
         }
-        return retval;
+        var jwkString = JSON.stringify(jwk);
+        var len = jwkString.length;
+
+        // Convert JSON string to ArrayBuffer
+        var buf = new ArrayBuffer(len);
+        var bView = new Uint8Array(buf);
+        for (i = 0; i < len; i++)
+            bView[i] = jwkString.charCodeAt(i);
+        return buf;
     };
 };
 

--- a/src/streaming/vo/protection/ClearKeyKeySet.js
+++ b/src/streaming/vo/protection/ClearKeyKeySet.js
@@ -47,7 +47,7 @@ MediaPlayer.vo.protection.ClearKeyKeySet = function(keyPairs, type) {
     /**
      * Convert this key set to its JSON Web Key (JWK) representation
      */
-    this.toJWKString = function() {
+    this.toJWK = function() {
         var i, numKeys = this.keyPairs.length,
             retval = {};
         retval.keys = [];
@@ -64,7 +64,7 @@ MediaPlayer.vo.protection.ClearKeyKeySet = function(keyPairs, type) {
         if (this.type) {
             retval.type = this.type;
         }
-        return JSON.stringify(retval);
+        return retval;
     };
 };
 

--- a/src/streaming/vo/protection/KeyPair.js
+++ b/src/streaming/vo/protection/KeyPair.js
@@ -32,16 +32,12 @@
 /**
  * Represents a 128-bit keyID and 128-bit encryption key
  *
- * @param keyID {Uint8Array} 128-bit key ID
- * @param key {Uint8Array} 128-bit encryption key
+ * @param keyID {String} 128-bit key ID, base64 encoded, with no padding
+ * @param key {String} 128-bit encryption key, base64 encoded, with no padding
  * @constructor
  */
 MediaPlayer.vo.protection.KeyPair = function(keyID, key) {
     "use strict";
-    if (!keyID || keyID.length !== 16)
-        throw new Error("Illegal key ID length! Must be 16 bytes (128 bits)");
-    if (!key || key.length !== 16)
-        throw new Error("Illegal key length! Must be 16 bytes (128 bits)");
     this.keyID = keyID;
     this.key = key;
 };

--- a/src/streaming/vo/protection/ProtectionData.js
+++ b/src/streaming/vo/protection/ProtectionData.js
@@ -33,15 +33,19 @@
  * Data used to customize KeySystems and override default or CDM-provided
  * values
  *
- * @param laURL
- * @param httpRequestHeaders
- * @param bearerToken
+ * @param {string} laURL a license acquisition URL to use with this key system
+ * @param {Object} httpRequestHeaders headers to add to the http request
+ * @param {Object} bearerToken
+ * @param {Object} clearkeys defines a set of clear keys that are available to
+ * the key system.  Object properties are base64-encoded keyIDs (with no padding).
+ * Corresponding property values are keys, base64-encoded (no padding).
  * @constructor
  */
-MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, bearerToken) {
+MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, bearerToken, clearkeys) {
     this.laURL = laURL;
     this.httpRequestHeaders = httpRequestHeaders;
     this.bearerToken = bearerToken;
+    this.clearkeys = clearkeys
 };
 
 MediaPlayer.vo.protection.ProtectionData.prototype = {

--- a/src/streaming/vo/protection/ProtectionData.js
+++ b/src/streaming/vo/protection/ProtectionData.js
@@ -45,7 +45,7 @@ MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, b
     this.laURL = laURL;
     this.httpRequestHeaders = httpRequestHeaders;
     this.bearerToken = bearerToken;
-    this.clearkeys = clearkeys
+    this.clearkeys = clearkeys;
 };
 
 MediaPlayer.vo.protection.ProtectionData.prototype = {


### PR DESCRIPTION
[The EME spec has been updated to add much more detail to the ClearKey key system.](https://w3c.github.io/encrypted-media/#clear-key)  This includes a newly defined [PSSH format](https://w3c.github.io/encrypted-media/cenc-format.html#common-system) for ClearKey.  With the release of Chrome 41, this makes the previous version of ClearKey incompatible.  This PR updates dash.js to support the latest ClearKey on Chrome 41+.

One caveat of having the PSSH defined in the spec is that we are no longer free to come up with our own formats.  Previously, this freedom was used to define a format that allowed carriage of keys within the PSSH itself.  Since this is no longer possible, and since we do not want to require an external ClearKey license server for testing purposes, there is now a set of hard-coded keys in the ProtectionExtensions object.  This allows the test content to playback successfully.

The test content (available in the index.html Streams pulldown) has been updated to support the new PSSH format and should playback (with this PR) successfully on Chrome 41+.