### PR TITLE
Support initData in MPD for ClearKey and Widevine

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -164,7 +164,31 @@
             "browsers": ""
         },
         {
-            "name": "CableLabs Cenc WV",
+            "name": "CableLabs Cenc ClearKey",
+            "url": "http://html5.cablelabs.com:8100/cenc/ck/dash.mpd",
+            "browsers": "",
+            "protData": {
+                "org.w3.clearkey": {
+                    "clearkeys": {
+                        "IAAAACAAIAAgACAAAAAAAg" : "5t1CjnbMFURBou087OSj2w"
+                    }
+                }
+            }
+        },
+        {
+            "name": "CableLabs Cenc ClearKey (InitData in MPD)",
+            "url": "http://html5.cablelabs.com:8100/cenc/ck/dash_initdata.mpd",
+            "browsers": "",
+            "protData": {
+                "org.w3.clearkey": {
+                    "clearkeys": {
+                        "IAAAACAAIAAgACAAAAAAAg" : "5t1CjnbMFURBou087OSj2w"
+                    }
+                }
+            }
+        },
+        {
+            "name": "CableLabs Cenc Widevine",
             "url": "http://html5.cablelabs.com:8100/cenc/wv/dash.mpd",
             "browsers": "",
             "protData": {
@@ -174,7 +198,7 @@
             }
         },
         {
-            "name": "CableLabs Cenc WV/CK",
+            "name": "CableLabs Cenc Widevine/ClearKey",
             "url": "http://html5.cablelabs.com:8100/cenc/wvck/dash.mpd",
             "browsers": "",
             "protData": {
@@ -183,26 +207,35 @@
                 },
                 "org.w3.clearkey": {
                     "clearkeys": {
-                        "EAAAABAAEAAQABAAAAAAAQ": "OiobaN0r2bLusl6ExHdmaA",
-                        "EAAAABAAEAAQABAAAAAAAg": "B+TWU8+0XGYVjZP/zkIpBw",
-                        "obHB0aKyo7OktKW1xdXl9Q": "JTn6hLmHQWAJp/u6EbI5qw"
+                        "H3JbV93QV3mPNBKQON2UtQ" : "ClKhDPHMtCouEx1vLGsJsA"
                     }
                 }
             }
         },
         {
-            "name": "CableLabs Cenc PR/CK",
-            "url": "http://html5.cablelabs.com:8100/cenc/prck/dash.mpd",
+            "name": "CableLabs Cenc Widevine/ClearKey (InitData in MPD)",
+            "url": "http://html5.cablelabs.com:8100/cenc/wvck/dash_initdata.mpd",
             "browsers": "",
             "protData": {
+                "com.widevine.alpha": {
+                    "laURL": "https://html5.cablelabs.com:8025"
+                },
                 "org.w3.clearkey": {
                     "clearkeys": {
-                        "EAAAABAAEAAQABAAAAAAAQ": "OiobaN0r2bLusl6ExHdmaA",
-                        "EAAAABAAEAAQABAAAAAAAg": "B+TWU8+0XGYVjZP/zkIpBw",
-                        "obHB0aKyo7OktKW1xdXl9Q": "JTn6hLmHQWAJp/u6EbI5qw"
+                        "H3JbV93QV3mPNBKQON2UtQ" : "ClKhDPHMtCouEx1vLGsJsA"
                     }
                 }
             }
+        },
+        {
+            "name": "CableLabs Cenc PlayReady",
+            "url": "http://html5.cablelabs.com:8100/cenc/pr/dash.mpd",
+            "browsers": ""
+        },
+        {
+            "name": "CableLabs Cenc PlayReady (InitData in MPD)",
+            "url": "http://html5.cablelabs.com:8100/cenc/pr/dash_initdata.mpd",
+            "browsers": ""
         }
     ]
 }

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -80,6 +80,20 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
     },
 
     /**
+     * Parse a standard common encryption PSSH which contains a sinmple
+     * base64-encoding of the init data
+     *
+     * @param cpData the ContentProtection element
+     * @returns {ArrayBuffer} the init data or null if not found
+     */
+    parseInitDataFromContentProtection: function(cpData) {
+        if ("pssh" in cpData) {
+            return BASE64.decodeArray(cpData.pssh.__text).buffer;
+        }
+        return null;
+    },
+
+    /**
      * Parses list of PSSH boxes into keysystem-specific PSSH data
      *
      * @param data {ArrayBuffer} the concatenated list of PSSH boxes as provided by

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -118,7 +118,6 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
             }
         };
 
-
     return {
 
         system: undefined,
@@ -143,7 +142,7 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey = function() {
             requestClearKeyLicense.call(this, message, requestData);
         },
 
-        getInitData: function(/*cpData*/) { return null; }
+        getInitData: MediaPlayer.dependencies.protection.CommonEncryption.parseInitDataFromContentProtection
     };
 };
 

--- a/src/streaming/protection/drm/KeySystem_Widevine.js
+++ b/src/streaming/protection/drm/KeySystem_Widevine.js
@@ -90,16 +90,6 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
 
                 xhr.send(message);
             }
-        },
-
-        /* TODO: Implement me */
-        parseInitDataFromContentProtection = function(/*cpData*/) {
-            return null;
-        },
-
-        /* TODO: Implement me */
-        isInitDataEqual = function(/*initData1, initData2*/) {
-            return false;
         };
 
     return {
@@ -123,9 +113,7 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
 
         doLicenseRequest: requestLicense,
 
-        getInitData: parseInitDataFromContentProtection,
-
-        initDataEquals: isInitDataEqual
+        getInitData: MediaPlayer.dependencies.protection.CommonEncryption.parseInitDataFromContentProtection
     };
 };
 


### PR DESCRIPTION
Added a standard way to support initData in the MPD for both
Widevine and ClearKey.  A Widevine representative has confirmed
that this is the standard way to format their ContentProtection
element.  For ClearKey, I have chosen to use the same format,
since it is very simply and works well.

Updated the sources.json to add new test content for common encryption
with and without init data present in the MPD.

Removed PlayReady/ClearKey content from the sources.json.  IE11 does
not support PSSH version 1 (which ClearKey requires).  Just the presence
of the ClearKey PSSH in the file causes an error, so we won't be able
to test this combination of DRMs until the next version of IE (Spartan)
is released.