### PR TITLE
Feature to make auto selecting a starting bit rate a little more intelligent.

### DIFF
--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -45,7 +45,7 @@
     <script src="../../src/streaming/Context.js"></script>
     <script src="../../src/streaming/ErrorHandler.js"></script>
     <script src="../../src/streaming/utils/Capabilities.js"></script>
-    <script src="../../src/streaming/utils/LocalStorage.js"></script>
+    <script src="../../src/streaming/utils/DOMStorage.js"></script>
     <script src="../../src/streaming/utils/EventBus.js"></script>
     <script src="../../src/streaming/utils/Debug.js"></script>
     <script src="../../src/streaming/utils/CustomTimeRanges.js"></script>

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -45,6 +45,7 @@
     <script src="../../src/streaming/Context.js"></script>
     <script src="../../src/streaming/ErrorHandler.js"></script>
     <script src="../../src/streaming/utils/Capabilities.js"></script>
+    <script src="../../src/streaming/utils/LocalStorage.js"></script>
     <script src="../../src/streaming/utils/EventBus.js"></script>
     <script src="../../src/streaming/utils/Debug.js"></script>
     <script src="../../src/streaming/utils/CustomTimeRanges.js"></script>

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -207,13 +207,14 @@ Dash.dependencies.RepresentationController = function () {
             if (e.data.mediaType !== self.streamProcessor.getType() || self.streamProcessor.getStreamInfo().id !== e.data.streamInfo.id) return;
 
             currentRepresentation = self.getRepresentationForQuality(e.data.newQuality);
-            setLocalStorage(e.data.mediaType, currentRepresentation.bandwidth);
+            setLocalStorage.call(self, e.data.mediaType, currentRepresentation.bandwidth);
             addRepresentationSwitch.call(self);
         },
 
         setLocalStorage = function(type, bitrate) {
-            if (!window.localStorage || (type !== "video" && type !== "audio")) return;
-            localStorage.setItem(MediaPlayer.utils.LocalStorage["LOCAL_STORAGE_"+type.toUpperCase()+"_BITRATE_KEY"], JSON.stringify({bitrate:bitrate/1000, timestamp:new Date().getTime()}));
+            if (this.DOMStorage.isSupported(MediaPlayer.utils.DOMStorage.STORAGE_TYPE_LOCAL) && (type === "video" || type === "audio")) {
+                localStorage.setItem(MediaPlayer.utils.DOMStorage["LOCAL_STORAGE_"+type.toUpperCase()+"_BITRATE_KEY"], JSON.stringify({bitrate:bitrate/1000, timestamp:new Date().getTime()}));
+            }
         };
 
     return {
@@ -228,6 +229,7 @@ Dash.dependencies.RepresentationController = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        DOMStorage:undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.AbrController.eventList.ENAME_QUALITY_CHANGED] = onQualityChanged;

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -207,7 +207,13 @@ Dash.dependencies.RepresentationController = function () {
             if (e.data.mediaType !== self.streamProcessor.getType() || self.streamProcessor.getStreamInfo().id !== e.data.streamInfo.id) return;
 
             currentRepresentation = self.getRepresentationForQuality(e.data.newQuality);
+            setLocalStorage(e.data.mediaType, currentRepresentation.bandwidth);
             addRepresentationSwitch.call(self);
+        },
+
+        setLocalStorage = function(type, bitrate) {
+            if (!window.localStorage || (type !== "video" && type !== "audio")) return;
+            localStorage.setItem(MediaPlayer["LOCAL_STORAGE_"+type.toUpperCase()+"_BITRATE_KEY"], JSON.stringify({bitrate:bitrate/1000, timestamp:new Date().getTime()}));
         };
 
     return {

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -213,7 +213,7 @@ Dash.dependencies.RepresentationController = function () {
 
         setLocalStorage = function(type, bitrate) {
             if (!window.localStorage || (type !== "video" && type !== "audio")) return;
-            localStorage.setItem(MediaPlayer["LOCAL_STORAGE_"+type.toUpperCase()+"_BITRATE_KEY"], JSON.stringify({bitrate:bitrate/1000, timestamp:new Date().getTime()}));
+            localStorage.setItem(MediaPlayer.utils.LocalStorage["LOCAL_STORAGE_"+type.toUpperCase()+"_BITRATE_KEY"], JSON.stringify({bitrate:bitrate/1000, timestamp:new Date().getTime()}));
         };
 
     return {

--- a/src/dash/extensions/DashManifestExtensions.js
+++ b/src/dash/extensions/DashManifestExtensions.js
@@ -363,6 +363,10 @@ Dash.dependencies.DashManifestExtensions.prototype = {
                 representation.id = r.id;
             }
 
+            if (r.hasOwnProperty('bandwidth')){
+                representation.bandwidth = r.bandwidth;
+            }
+
             if (r.hasOwnProperty("SegmentBase")) {
                 segmentInfo = r.SegmentBase;
                 representation.segmentInfoType = "SegmentBase";

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -45,6 +45,7 @@ Dash.vo.Representation = function () {
     this.MSETimeOffset = NaN;
     this.segmentAvailabilityRange = null;
     this.availableSegmentsNumber = 0;
+    this.bandwidth = NaN;
 };
 
 Dash.vo.Representation.prototype = {

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -56,6 +56,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapSingleton('debug', MediaPlayer.utils.Debug);
             this.system.mapSingleton('eventBus', MediaPlayer.utils.EventBus);
             this.system.mapSingleton('capabilities', MediaPlayer.utils.Capabilities);
+            this.system.mapSingleton('localStorage', MediaPlayer.utils.LocalStorage);
             this.system.mapClass('customTimeRanges', MediaPlayer.utils.CustomTimeRanges);
 
             this.system.mapSingleton('textTrackExtensions', MediaPlayer.utils.TextTrackExtensions);

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -56,7 +56,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapSingleton('debug', MediaPlayer.utils.Debug);
             this.system.mapSingleton('eventBus', MediaPlayer.utils.EventBus);
             this.system.mapSingleton('capabilities', MediaPlayer.utils.Capabilities);
-            this.system.mapSingleton('localStorage', MediaPlayer.utils.LocalStorage);
+            this.system.mapSingleton('DOMStorage', MediaPlayer.utils.DOMStorage);
             this.system.mapClass('customTimeRanges', MediaPlayer.utils.CustomTimeRanges);
 
             this.system.mapSingleton('textTrackExtensions', MediaPlayer.utils.TextTrackExtensions);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -75,7 +75,7 @@ MediaPlayer = function (context) {
         metricsExt,
         metricsModel,
         videoModel,
-        localStorage,
+        DOMStorage,
         initialized = false,
         playing = false,
         autoPlay = true,
@@ -102,7 +102,6 @@ MediaPlayer = function (context) {
 
             playing = true;
             this.debug.log("Playback initiated!");
-
             streamController = system.getObject("streamController");
             streamController.subscribe(MediaPlayer.dependencies.StreamController.eventList.ENAME_STREAMS_COMPOSED, manifestUpdater);
             manifestLoader.subscribe(MediaPlayer.dependencies.ManifestLoader.eventList.ENAME_MANIFEST_LOADED, streamController);
@@ -111,11 +110,8 @@ MediaPlayer = function (context) {
             streamController.setVideoModel(videoModel);
             streamController.setAutoPlay(autoPlay);
             streamController.setProtectionData(protectionData);
-
-            localStorage.checkInitialBitrate();
-
+            DOMStorage.checkInitialBitrate();
             streamController.load(source);
-
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
             system.mapOutlet("scheduleWhilePaused", "stream");
             system.mapOutlet("scheduleWhilePaused", "scheduleController");
@@ -273,7 +269,7 @@ MediaPlayer = function (context) {
             abrController = system.getObject("abrController");
             rulesController = system.getObject("rulesController");
             metricsModel = system.getObject("metricsModel");
-            localStorage = system.getObject("localStorage");
+            DOMStorage = system.getObject("DOMStorage");
         },
 
         /**
@@ -352,7 +348,7 @@ MediaPlayer = function (context) {
          *
          */
         enableLastBitrateCaching: function (enable, ttl) {
-            localStorage.enableLastBitrateCaching(enable, ttl);
+            DOMStorage.enableLastBitrateCaching(enable, ttl);
         },
 
         /**

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -81,15 +81,7 @@ MediaPlayer.dependencies.AbrController = function () {
         },
 
         getInitialBitrate = function(type) {
-            var initialBitrate;
-
-            if (!bitrateDict.hasOwnProperty(type)) {
-                bitrateDict[type] = (type === "video") ? MediaPlayer.dependencies.AbrController.DEFAULT_VIDEO_BITRATE : MediaPlayer.dependencies.AbrController.DEFAULT_AUDIO_BITRATE;
-            }
-
-            initialBitrate = bitrateDict[type];
-
-            return initialBitrate;
+            return bitrateDict[type];
         },
 
         setInitialBitrate = function(type, value) {
@@ -292,7 +284,8 @@ MediaPlayer.dependencies.AbrController = function () {
             topQualities = {};
             qualityDict = {};
             confidenceDict = {};
-            bitrateDict = {};
+            //bitrateDict = {}; // We should let this setting persist over multiple sources. If we empty the object each time we
+            //attach source in media player then there is no way to set initial bit rate for the second media source and so on...
         }
     };
 };

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -132,7 +132,7 @@
         },
 
         /*
-         * Called when current playback positon is changed.
+         * Called when current playback position is changed.
          * Used to determine the time current stream is finished and we should switch to the next stream.
          * TODO move to ???Extensions class
          */
@@ -157,7 +157,7 @@
         },
 
         /*
-         * Called when Seeking event is occured.
+         * Called when Seeking event is occurred.
          * TODO move to ???Extensions class
          */
         onSeeking = function(e) {

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-MediaPlayer.utils.LocalStorage = function () {
+MediaPlayer.utils.DOMStorage = function () {
 
     var enableLastBitrateCaching = true,
         checkInitialBitrate = function() {
@@ -38,10 +38,10 @@ MediaPlayer.utils.LocalStorage = function () {
                     //Checks local storage to see if there is valid, non-expired bit rate
                     //hinting from the last play session to use as a starting bit rate. if not,
                     // it uses the default video and audio value in MediaPlayer.dependencies.AbrController
-                    if (window.localStorage && enableLastBitrateCaching) {
-                        var key = MediaPlayer.utils.LocalStorage["LOCAL_STORAGE_"+value.toUpperCase()+"_BITRATE_KEY"],
+                    if (this.isSupported(MediaPlayer.utils.DOMStorage.STORAGE_TYPE_LOCAL) && enableLastBitrateCaching) {
+                        var key = MediaPlayer.utils.DOMStorage["LOCAL_STORAGE_"+value.toUpperCase()+"_BITRATE_KEY"],
                             obj = JSON.parse(localStorage.getItem(key)) || {},
-                            isExpired = (new Date().getTime() - parseInt(obj.timestamp)) >= MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION || false,
+                            isExpired = (new Date().getTime() - parseInt(obj.timestamp)) >= MediaPlayer.utils.DOMStorage.LOCAL_STORAGE_BITRATE_EXPIRATION || false,
                             bitrate = parseInt(obj.bitrate);
 
                         if (!isNaN(bitrate) && !isExpired) {
@@ -68,7 +68,17 @@ MediaPlayer.utils.LocalStorage = function () {
         enableLastBitrateCaching: function(enable, ttl) {
             enableLastBitrateCaching = enable;
             if (ttl !== undefined && !isNaN(ttl) && typeof(ttl) === "number"){
-                MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = ttl;
+                MediaPlayer.utils.DOMStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = ttl;
+            }
+        },
+        //type can be local, session
+        isSupported: function(type) {
+            if (type === MediaPlayer.utils.DOMStorage.STORAGE_TYPE_LOCAL) {
+                return window.localStorage || false;
+            } else if (type === MediaPlayer.utils.DOMStorage.STORAGE_TYPE_SESSION) {
+                return window.sessionStorage || false;
+            } else {
+                return false;
             }
         }
 
@@ -76,10 +86,12 @@ MediaPlayer.utils.LocalStorage = function () {
 };
 
 
-MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_VIDEO_BITRATE_KEY = "dashjs_vbitrate";
-MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_AUDIO_BITRATE_KEY = "dashjs_abitrate";
-MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = 360000;
+MediaPlayer.utils.DOMStorage.LOCAL_STORAGE_VIDEO_BITRATE_KEY = "dashjs_vbitrate";
+MediaPlayer.utils.DOMStorage.LOCAL_STORAGE_AUDIO_BITRATE_KEY = "dashjs_abitrate";
+MediaPlayer.utils.DOMStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = 360000;
+MediaPlayer.utils.DOMStorage.STORAGE_TYPE_LOCAL = "local";
+MediaPlayer.utils.DOMStorage.STORAGE_TYPE_SESSION = "session";
 
-MediaPlayer.utils.LocalStorage.prototype = {
-    constructor: MediaPlayer.utils.LocalStorage
+MediaPlayer.utils.DOMStorage.prototype = {
+    constructor: MediaPlayer.utils.DOMStorage
 };

--- a/src/streaming/utils/LocalStorage.js
+++ b/src/streaming/utils/LocalStorage.js
@@ -1,0 +1,85 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+MediaPlayer.utils.LocalStorage = function () {
+
+    var enableLastBitrateCaching = true,
+        checkInitialBitrate = function() {
+            ['video', 'audio'].forEach(function(value) {
+                //first make sure player has not explicitly set a starting bit rate
+                if (this.abrController.getInitialBitrateFor(value) === undefined) {
+                    //Checks local storage to see if there is valid, non-expired bit rate
+                    //hinting from the last play session to use as a starting bit rate. if not,
+                    // it uses the default video and audio value in MediaPlayer.dependencies.AbrController
+                    if (window.localStorage && enableLastBitrateCaching) {
+                        var key = MediaPlayer.utils.LocalStorage["LOCAL_STORAGE_"+value.toUpperCase()+"_BITRATE_KEY"],
+                            obj = JSON.parse(localStorage.getItem(key)) || {},
+                            isExpired = (new Date().getTime() - parseInt(obj.timestamp)) >= MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION || false,
+                            bitrate = parseInt(obj.bitrate);
+
+                        if (!isNaN(bitrate) && !isExpired) {
+                            this.abrController.setInitialBitrateFor(value, bitrate);
+                            this.log("Last bitrate played for "+value+" was "+bitrate);
+                        } else if (isExpired){
+                            localStorage.removeItem(key);
+                        }
+                    }
+                    //check again to see if local storage value was set, if not set default value for startup.
+                    if (this.abrController.getInitialBitrateFor(value) === undefined) {
+                        this.abrController.setInitialBitrateFor(value, MediaPlayer.dependencies.AbrController["DEFAULT_"+value.toUpperCase()+"_BITRATE"]);
+                    }
+                }
+
+            }, this);
+        };
+
+    return {
+        system: undefined,
+        log:undefined,
+        abrController: undefined,
+        checkInitialBitrate:checkInitialBitrate,
+        enableLastBitrateCaching: function(enable, ttl) {
+            enableLastBitrateCaching = enable;
+            if (ttl !== undefined && !isNaN(ttl) && typeof(ttl) === "number"){
+                MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = ttl;
+            }
+        }
+
+    };
+};
+
+
+MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_VIDEO_BITRATE_KEY = "dashjs_vbitrate";
+MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_AUDIO_BITRATE_KEY = "dashjs_abitrate";
+MediaPlayer.utils.LocalStorage.LOCAL_STORAGE_BITRATE_EXPIRATION = 360000;
+
+MediaPlayer.utils.LocalStorage.prototype = {
+    constructor: MediaPlayer.utils.LocalStorage
+};


### PR DESCRIPTION
During playback when a quality level changes it is recorded into local storage now. 
Upon starting a stream this information is retrieved and if it not expired (< 1 hour old) then it is used to pick the starting quality for playback. If it is not present or expired we default back to the bit rate nearest 1000kpbs