### PR TITLE
fix getting URI fragment start time

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -42,7 +42,7 @@ MediaPlayer.dependencies.PlaybackController = function () {
 
         getStreamStartTime = function (streamInfo) {
             var presentationStartTime,
-                startTimeOffset = parseInt(this.uriQueryFragModel.getURIFragmentData.s);
+                startTimeOffset = parseInt(this.uriQueryFragModel.getURIFragmentData().s);
 
             if (isDynamic) {
 


### PR DESCRIPTION
Using a #s= URI fragment to set the start time wasn't working. See https://github.com/Dash-Industry-Forum/dash.js/commit/1b7fef1ced77e3418f2adb078a7e43894608ac52#diff-e221af84d9071cb5d32527f0192eb867.