### PR TITLE
Follow redirects for the manifest file

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -81,6 +81,12 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                                                  null,
                                                  request.getAllResponseHeaders());
 
+                // Handle redirects for the MPD - as per RFC3986 Section 5.1.3
+                if (request.responseURL) {
+                    baseUrl = parseBaseUrl(request.responseURL);
+                    url = request.responseURL;
+                }
+
                 manifest = self.parser.parse(request.responseText, baseUrl);
 
                 if (manifest) {


### PR DESCRIPTION
Fixes issue #481 - see that for more details.

- IE does not currently provide a responseURL property for requests. Instead, it will currently continue to have the same behaviour it does now.
- This covered all requests it needed to from what I can see, but if I missed any out, let me know