### PR TITLE
Added API and ability to set maximum bitrate cap

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -41,7 +41,8 @@ Dash.dependencies.RepresentationController = function () {
             var self = this,
                 bitrate = null,
                 streamInfo = self.streamProcessor.getStreamInfo(),
-                quality;
+                quality,
+                maxQuality = self.abrController.getTopQualityIndexFor(type, streamInfo.id),
 
             updating = true;
             self.notify(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_STARTED);
@@ -53,6 +54,10 @@ Dash.dependencies.RepresentationController = function () {
                 quality = self.abrController.getQualityForBitrate(self.streamProcessor.getMediaInfo(), bitrate);
             } else {
                 quality = self.abrController.getQualityFor(type, streamInfo);
+            }
+
+            if (quality > maxQuality) {
+                quality = maxQuality;
             }
 
             currentRepresentation = getRepresentationForQuality.call(self, quality);

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -86,30 +86,6 @@ Dash.dependencies.DashMetricsExtensions = function () {
             return null;
         },
 
-        adaptationIsType = function (adaptation, bufferType) {
-            return this.manifestExt.getIsTypeOf(adaptation, bufferType);
-        },
-
-        findMaxBufferIndex = function (period, bufferType) {
-            var adaptationSet,
-                adaptationSetArray,
-                representationArray,
-                adaptationSetArrayIndex;
-
-            if (!period || !bufferType) return -1;
-
-            adaptationSetArray = period.AdaptationSet_asArray;
-            for (adaptationSetArrayIndex = 0; adaptationSetArrayIndex < adaptationSetArray.length; adaptationSetArrayIndex = adaptationSetArrayIndex + 1) {
-                adaptationSet = adaptationSetArray[adaptationSetArrayIndex];
-                representationArray = adaptationSet.Representation_asArray;
-                if (adaptationIsType.call(this, adaptationSet, bufferType)) {
-                    return representationArray.length;
-                }
-            }
-
-            return -1;
-        },
-
         getBandwidthForRepresentation = function (representationId) {
             var self = this,
                 manifest = self.manifestModel.getValue(),
@@ -135,14 +111,15 @@ Dash.dependencies.DashMetricsExtensions = function () {
             return representationIndex;
         },
 
-        getMaxIndexForBufferType = function (bufferType, periodIdx) {
-            var self = this,
-                manifest = self.manifestModel.getValue(),
-                maxIndex,
-                period = manifest.Period_asArray[periodIdx];
+        getMaxIndexForBufferType = function (bufferType, periodId) {
+            var abrController = this.system.getObject("abrController"),
+                idx=0;
 
-            maxIndex = findMaxBufferIndex.call(this, period, bufferType);
-            return maxIndex;
+            if (abrController) {
+                idx = abrController.getTopQualityIndexFor(bufferType, periodId);
+            }
+
+            return idx;
         },
 
         getCurrentRepresentationSwitch = function (metrics) {
@@ -374,6 +351,7 @@ Dash.dependencies.DashMetricsExtensions = function () {
     return {
         manifestModel: undefined,
         manifestExt: undefined,
+        system:undefined,
         getBandwidthForRepresentation : getBandwidthForRepresentation,
         getIndexForRepresentation : getIndexForRepresentation,
         getMaxIndexForBufferType : getMaxIndexForBufferType,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -352,6 +352,34 @@ MediaPlayer = function (context) {
         },
 
         /**
+         * When switching multi-bitrate content (auto or manual mode) this property specifies the maximum bitrate allowed.
+         * If you set this property to a value lower than that currently playing, the switching engine will switch down to
+         * satisfy this requirement. If you set it to a value that is lower than the lowest bitrate, it will still play
+         * that lowest bitrate.
+         *
+         * You can set or remove this bitrate cap at anytime before or during playback.  To clear this setting you must use the API
+         * and set the value param to NaN.
+         *
+         * This feature is typically used to reserve higher bitrates for playback only when the player is in large or full-screen format.
+         *
+         * @param type String 'video' or 'audio' are the type options.
+         * @param value int value in kbps representing the maximum bitrate allowed.
+         * @memberof MediaPlayer#
+         */
+        setMaxAllowedBitrateFor:function(type, value) {
+            abrController.setMaxAllowedBitrateFor(type, value);
+        },
+
+        /**
+         * @param type String 'video' or 'audio' are the type options.
+         * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#setMaxAllowedBitrateFor setMaxAllowedBitrateFor()}
+         */
+        getMaxAllowedBitrateFor:function(type) {
+            return abrController.getMaxAllowedBitrateFor(type);
+        },
+
+        /**
          * @param value
          * @memberof MediaPlayer#
          */

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -146,6 +146,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             indexHandler.initialize(this);
             bufferController.initialize(type, buffer, mediaSource, self);
             scheduleController.initialize(type, this);
+            abrController.initialize(type, this);
 
             fragmentModel = this.getFragmentModel();
             fragmentModel.setLoader(fragmentLoader);


### PR DESCRIPTION
- When switching multi-bitrate content (auto or manual mode) this property specifies the maximum bitrate allowed.  

- If you set this property to a value lower than that currently playing, the switching engine will switch down to  satisfy this requirement. 
- If you set it to a value that is lower than the lowest bitrate, it will still play that lowest bitrate.
- If you set this property lower than the initial bitrate value it will start on the lower value of the two.
- You can set or remove this bitrate cap at anytime before or during playback.  
- To clear this setting you must use the API and set the value param to NaN. 

- This feature is typically used to reserve higher bitrates for playback only when the player is in large or full-screen format.