### PR TITLE
ManifestLoader: Initialize baseUrl to "" instead of null.

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -34,7 +34,7 @@ MediaPlayer.dependencies.ManifestLoader = function () {
     var RETRY_ATTEMPTS = 3,
         RETRY_INTERVAL = 500,
         parseBaseUrl = function (url) {
-            var base = null;
+            var base = "";
 
             if (url.indexOf("/") !== -1)
             {


### PR DESCRIPTION
Initialize baseUrl to "" instead of null so that if the Manifest
URL is relative without a "/", then we return an empty baseUrl
rather than null. Without this change, if a manifest url is
relative without a "/", then the media URL will be resolved as
null + media_url. Where as the correct media URL will be
"" + media_url.