### PR TITLE
Seek bug in InsufficientBufferRule

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -130,6 +130,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
                 playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, scheduleController);
                 playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_STARTED, scheduleController);
                 playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, scheduleController.scheduleRulesCollection.playbackTimeRule);
+                playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, abrController.abrRulesCollection.insufficientBufferRule);
 
                 if (isDynamic) {
                     playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_WALLCLOCK_TIME_UPDATED, trackController);

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -293,6 +293,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_WALLCLOCK_TIME_UPDATED, bufferController);
             playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_WALLCLOCK_TIME_UPDATED, scheduleController);
             playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, scheduleController.scheduleRulesCollection.playbackTimeRule);
+            playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, abrController.abrRulesCollection.insufficientBufferRule);
 
             baseUrlExt.unsubscribe(Dash.dependencies.BaseURLExtensions.eventList.ENAME_INITIALIZATION_LOADED, indexHandler);
             baseUrlExt.unsubscribe(Dash.dependencies.BaseURLExtensions.eventList.ENAME_SEGMENTS_LOADED, indexHandler);

--- a/src/streaming/rules/ABRRules/InsufficientBufferRule.js
+++ b/src/streaming/rules/ABRRules/InsufficientBufferRule.js
@@ -46,14 +46,22 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
         setBufferInfo = function (type, state) {
             bufferStateDict[type] = bufferStateDict[type] || {};
             bufferStateDict[type].state = state;
-            if (state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED) {
+            if (state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED && !bufferStateDict[type].firstBufferLoadedEvent) {
                 bufferStateDict[type].firstBufferLoadedEvent = true;
             }
+        },
+
+        onPlaybackSeeking = function (evt) {
+            bufferStateDict = {}
         };
 
     return {
         log: undefined,
         metricsModel: undefined,
+
+        setup: function() {
+            this[MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING] = onPlaybackSeeking;
+        },
 
         execute: function (context, callback) {
             var self = this,
@@ -62,12 +70,14 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
                 current = context.getCurrentValue(),
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
                 streamInfo = context.getStreamInfo(),
+                trackInfo = context.getTrackInfo(),
                 duration = streamInfo.duration,
                 currentTime = context.getStreamProcessor().getPlaybackController().getTime(),
                 sp = context.getStreamProcessor(),
                 isDynamic = sp.isDynamic(),
                 lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
                 lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null,
+                lowBufferMark = Math.min(trackInfo.fragmentDuration, MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD),
                 switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
 
             if (now - lastSwitchTime < waitToSwitchTime ||
@@ -81,12 +91,12 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
             if (lastBufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_EMPTY && bufferStateDict[mediaType].firstBufferLoadedEvent !== undefined) {
                 switchRequest = new MediaPlayer.rules.SwitchRequest(0, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
 
-            } else if ( !isDynamic && //TODO Need to make LOW_BUFFER_THRESHOLD dynamic maybe use fragment duration ? may work better for dynamic content as well. Once fragment abandonment
+            } else if ( !isDynamic &&
                         bufferStateDict[mediaType].state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
-                        lastBufferLevelVO.level < (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD * 2) &&
-                        currentTime < (duration - MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD * 2)) {
+                        lastBufferLevelVO.level < (lowBufferMark * 2) &&
+                        currentTime < (duration - lowBufferMark * 2)) {
 
-                var p = lastBufferLevelVO.level > MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD ?
+                var p = lastBufferLevelVO.level > lowBufferMark ?
                     MediaPlayer.rules.SwitchRequest.prototype.DEFAULT : MediaPlayer.rules.SwitchRequest.prototype.STRONG;
 
                 switchRequest = new MediaPlayer.rules.SwitchRequest(Math.max(current - 1, 0), p);

--- a/src/streaming/rules/ABRRules/InsufficientBufferRule.js
+++ b/src/streaming/rules/ABRRules/InsufficientBufferRule.js
@@ -51,8 +51,8 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
             }
         },
 
-        onPlaybackSeeking = function (evt) {
-            bufferStateDict = {}
+        onPlaybackSeeking = function () {
+            bufferStateDict = {};
         };
 
     return {


### PR DESCRIPTION
reset the value of bufferStateDict[type].firstBufferLoadedEvent each
time seeking occurs.

Also use fragment duration to detect lowBuferMark.