### PR TITLE
Fix broken FH link

### DIFF
--- a/samples/dash-if-reference-player/app/contributors.json
+++ b/samples/dash-if-reference-player/app/contributors.json
@@ -32,7 +32,7 @@
         {
             "name": "Fraunhofer Fokus",
             "logo": "app/img/fh_fokus.png",
-            "link": "http://www.fokus.fraunhofer.de/en/fame/index.html"
+            "link": "https://www.fokus.fraunhofer.de/go/fame"
         },
         {
             "name": "CableLabs",


### PR DESCRIPTION
Fix a broken link to the Fraunhofer page