### PR TITLE
Added two new steps to live edge detection

### DIFF
--- a/build/test/js/dash/TimeLineConverterSpec.js
+++ b/build/test/js/dash/TimeLineConverterSpec.js
@@ -100,7 +100,7 @@ describe("TimelineConverter", function () {
                 range = timelineConverter.calcSegmentAvailabilityRange(representation, isDynamic);
 
             expect(range.start).toEqual(expectedValue);
-            expectedValue = 10;
+            expectedValue = 9;
             expect(range.end).toEqual(expectedValue);
         });
     });

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -83,6 +83,7 @@ MediaPlayer = function (context) {
         autoPlay = true,
         scheduleWhilePaused = false,
         bufferMax = MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED,
+        useManifestDateHeaderTimeSource = true,
         UTCTimingSources = [],
 
         isReady = function () {
@@ -118,7 +119,7 @@ MediaPlayer = function (context) {
             } else {
                 streamController.loadWithManifest(source);
             }
-            streamController.setUTCTimingSources(UTCTimingSources);
+            streamController.setUTCTimingSources(UTCTimingSources, useManifestDateHeaderTimeSource);
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
             system.mapOutlet("scheduleWhilePaused", "stream");
             system.mapOutlet("scheduleWhilePaused", "scheduleController");
@@ -589,7 +590,7 @@ MediaPlayer = function (context) {
         /**
          * <p>Allows you to set a scheme and server source for UTC live edge detection for dynamic streams.
          * If UTCTiming is defined in the manifest, it will take precedence over any time source manually added.</p>
-         * <p>If you have exposed the Date header, use the method {@link MediaPlayer#clearAllUTCTimingSources clearAllUTCTimingSources()}.
+         * <p>If you have exposed the Date header, use the method {@link MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()}.
          * This will allow the date header on the manifest to be used instead of a time server</p>
          *
          * @param {string} schemeIdUri -
@@ -635,7 +636,7 @@ MediaPlayer = function (context) {
          * @param {string} schemeIdUri - see {@link MediaPlayer#addUTCTimingSource addUTCTimingSource()}
          * @param {string} value - see {@link MediaPlayer#addUTCTimingSource addUTCTimingSource()}
          * @memberof MediaPlayer#
-         * @see {@link MediaPlayer#clearAllUTCTimingSources clearAllUTCTimingSources()}
+         * @see {@link MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()}
          */
         removeUTCTimingSource: function(schemeIdUri, value) {
             UTCTimingSources.forEach(function(obj, idx){
@@ -655,17 +656,38 @@ MediaPlayer = function (context) {
          * @memberof MediaPlayer#
          * @see {@link MediaPlayer#restoreDefaultUTCTimingSources restoreDefaultUTCTimingSources()}
          */
-        clearAllUTCTimingSources: function() {
+        clearDefaultUTCTimingSources: function() {
             UTCTimingSources = [];
         },
 
         /**
-         * <p>Allows you to restore the default time sources after calling {@link MediaPlayer#clearAllUTCTimingSources clearAllUTCTimingSources()}</p>
+         * <p>Allows you to restore the default time sources after calling {@link MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()}</p>
+         *
+         * @default
+         * <ul>
+         *     <li>schemeIdUri:urn:mpeg:dash:utc:http-xsdate:2014</li>
+         *     <li>value:http://time.akamai.com</li>
+         * </ul>
+         *
          * @memberof MediaPlayer#
          * @see {@link MediaPlayer#addUTCTimingSource addUTCTimingSource()}
          */
         restoreDefaultUTCTimingSources: function() {
             this.addUTCTimingSource(DEFAULT_TIME_SOURCE_SCHEME, DEFAULT_TIME_SERVER);
+        },
+
+
+        /**
+         * <p>Allows you to enable the use of the Date Header, if exposed with CORS, as a timing source for live edge detection. The
+         * use of the date header will happen only after the other timing source that take precedence fail or are omitted as described.
+         * {@link MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()} </p>
+         *
+         * @default True
+         * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#addUTCTimingSource addUTCTimingSource()}
+         */
+        enableManifestDateHeaderTimeSource: function(value) {
+            useManifestDateHeaderTimeSource = value;
         },
 
         /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -279,7 +279,7 @@ MediaPlayer = function (context) {
             metricsModel = system.getObject("metricsModel");
             DOMStorage = system.getObject("DOMStorage");
             playbackController = system.getObject("playbackController");
-            this.addUTCTimingSource(DEFAULT_TIME_SOURCE_SCHEME, DEFAULT_TIME_SERVER);
+            this.restoreDefaultUTCTimingSources();
         },
 
         /**
@@ -653,10 +653,19 @@ MediaPlayer = function (context) {
          * to using a binary search to discover the live edge</p>
          *
          * @memberof MediaPlayer#
-         * @see {@link MediaPlayer#removeUTCTimingSource removeUTCTimingSource()}
+         * @see {@link MediaPlayer#restoreDefaultUTCTimingSources restoreDefaultUTCTimingSources()}
          */
         clearAllUTCTimingSources: function() {
             UTCTimingSources = [];
+        },
+
+        /**
+         * <p>Allows you to restore the default time sources after calling {@link MediaPlayer#clearAllUTCTimingSources clearAllUTCTimingSources()}</p>
+         * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#addUTCTimingSource addUTCTimingSource()}
+         */
+        restoreDefaultUTCTimingSources: function() {
+            this.addUTCTimingSource(DEFAULT_TIME_SOURCE_SCHEME, DEFAULT_TIME_SERVER);
         },
 
         /**

--- a/src/streaming/TimeSyncController.js
+++ b/src/streaming/TimeSyncController.js
@@ -37,7 +37,6 @@ MediaPlayer.dependencies.TimeSyncController = function () {
         // the offset between the time returned from the time source
         // and the client time at that point, in milliseconds.
         offsetToDeviceTimeMs = 0,
-
         isSynchronizing = false,
         isInitialised = false,
 
@@ -219,6 +218,32 @@ MediaPlayer.dependencies.TimeSyncController = function () {
             "urn:mpeg:dash:utc:sntp:2014":          notSupportedHandler
         },
 
+        checkForDateHeader = function(){
+            var metrics = this.metricsModel.getReadOnlyMetricsFor("stream"),
+                dateHeaderValue = this.metricsExt.getLatestMPDRequestHeaderValueByID(metrics, "Date"),
+                dateHeaderTime = dateHeaderValue !== null ? new Date(dateHeaderValue).getTime() : Number.NaN;
+
+            if (!isNaN(dateHeaderTime)) {
+                setOffsetMs(dateHeaderTime - new Date().getTime());
+                completeTimeSyncSequence.call(this, false, dateHeaderTime/1000, offsetToDeviceTimeMs);
+            }else {
+                completeTimeSyncSequence.call(this, true);
+            }
+        },
+
+        completeTimeSyncSequence = function (failed, time, offset){
+
+            setIsSynchronizing(false);
+            this.notify(
+                MediaPlayer.dependencies.TimeSyncController.eventList.ENAME_TIME_SYNCHRONIZATION_COMPLETED,
+                {
+                    time: time,
+                    offset: offset
+                },
+                failed ? new MediaPlayer.vo.Error(MediaPlayer.dependencies.TimeSyncController.TIME_SYNC_FAILED_ERROR_CODE) : null
+            );
+        },
+
         attemptSync = function (sources, sourceIndex) {
 
             var self = this,
@@ -234,17 +259,12 @@ MediaPlayer.dependencies.TimeSyncController = function () {
                 // callback to emit event to listeners
                 onComplete = function (time, offset) {
                     var failed = !time || !offset;
-
-                    setIsSynchronizing(false);
-
-                    self.notify(
-                        MediaPlayer.dependencies.TimeSyncController.eventList.ENAME_TIME_SYNCHRONIZATION_COMPLETED,
-                        {
-                            time: time,
-                            offset: offset
-                        },
-                        failed ? new MediaPlayer.vo.Error(MediaPlayer.dependencies.TimeSyncController.TIME_SYNC_FAILED_ERROR_CODE) : null
-                    );
+                    if(failed) {
+                        //Before falling back to binary search , check if date header exists on MPD. if so, use for a time source.
+                        checkForDateHeader.call(self);
+                    }else {
+                        completeTimeSyncSequence.call(self, failed, time, offset);
+                    }
                 };
 
             setIsSynchronizing(true);
@@ -292,6 +312,8 @@ MediaPlayer.dependencies.TimeSyncController = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        metricsModel:undefined,
+        metricsExt:undefined,
 
         getOffsetToDeviceTimeMs: function () {
             return getOffsetMs();

--- a/src/streaming/TimeSyncController.js
+++ b/src/streaming/TimeSyncController.js
@@ -39,6 +39,7 @@ MediaPlayer.dependencies.TimeSyncController = function () {
         offsetToDeviceTimeMs = 0,
         isSynchronizing = false,
         isInitialised = false,
+        useManifestDateHeaderTimeSource,
 
         setIsSynchronizing = function (value) {
             isSynchronizing = value;
@@ -259,7 +260,7 @@ MediaPlayer.dependencies.TimeSyncController = function () {
                 // callback to emit event to listeners
                 onComplete = function (time, offset) {
                     var failed = !time || !offset;
-                    if(failed) {
+                    if(failed && useManifestDateHeaderTimeSource) {
                         //Before falling back to binary search , check if date header exists on MPD. if so, use for a time source.
                         checkForDateHeader.call(self);
                     }else {
@@ -319,7 +320,8 @@ MediaPlayer.dependencies.TimeSyncController = function () {
             return getOffsetMs();
         },
 
-        initialize: function (timingSources) {
+        initialize: function (timingSources, useManifestDateHeader) {
+            useManifestDateHeaderTimeSource = useManifestDateHeader;
             if (!getIsSynchronizing()) {
                 attemptSync.call(this, timingSources);
                 setIsInitialised(true);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -47,6 +47,7 @@
         isUpdating = false,
         hasMediaError = false,
         mediaSource,
+        UTCTimingSources,
 
         attachEvents = function (stream) {
             stream.subscribe(MediaPlayer.dependencies.Stream.eventList.ENAME_STREAM_UPDATED, this.liveEdgeFinder);
@@ -387,10 +388,12 @@
             if (!e.error) {
                 this.log("Manifest has loaded.");
                 //self.log(self.manifestModel.getValue());
-
                 // before composing streams, attempt to synchronize with some
                 // time source (if there are any available)
-                this.timeSyncController.initialize(this.manifestExt.getUTCTimingSources(e.data.manifest));
+                var manifestUTCTimingSources = this.manifestExt.getUTCTimingSources(e.data.manifest),
+                    allUTCTimingSources = manifestUTCTimingSources.concat(UTCTimingSources); //manifest utc time source(s) take precedence over default or explicitly added sources.
+
+                this.timeSyncController.initialize(allUTCTimingSources);
             } else {
                 this.reset();
             }
@@ -446,6 +449,10 @@
 
         isStreamActive: function(streamInfo) {
             return (activeStream.getId() === streamInfo.id);
+        },
+
+        setUTCTimingSources: function(value) {
+            UTCTimingSources = value;
         },
 
         /**

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -48,6 +48,7 @@
         hasMediaError = false,
         mediaSource,
         UTCTimingSources,
+        useManifestDateHeaderTimeSource,
 
         attachEvents = function (stream) {
             stream.subscribe(MediaPlayer.dependencies.Stream.eventList.ENAME_STREAM_UPDATED, this.liveEdgeFinder);
@@ -393,7 +394,7 @@
                 var manifestUTCTimingSources = this.manifestExt.getUTCTimingSources(e.data.manifest),
                     allUTCTimingSources = manifestUTCTimingSources.concat(UTCTimingSources); //manifest utc time source(s) take precedence over default or explicitly added sources.
 
-                this.timeSyncController.initialize(allUTCTimingSources);
+                this.timeSyncController.initialize(allUTCTimingSources, useManifestDateHeaderTimeSource);
             } else {
                 this.reset();
             }
@@ -451,8 +452,9 @@
             return (activeStream.getId() === streamInfo.id);
         },
 
-        setUTCTimingSources: function(value) {
+        setUTCTimingSources: function(value, value2) {
             UTCTimingSources = value;
+            useManifestDateHeaderTimeSource = value2;
         },
 
         /**


### PR DESCRIPTION
Added two new steps to live edge detection before binary search kicks in

1. If UTCTiming is not defined in the manifest not there is a default time scheme and time server defined. There is an API to add more time servers, to remove time servers and to clear all time servers.  

2. If you clear all time servers AND have exposed the Date header that value will be used instead of calling a time server, if non of the above exist, the binary search will be used.