### PR TITLE
Segment Abandonment

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -263,22 +263,6 @@ Dash.dependencies.DashAdapter = function () {
             }
 
             return events;
-        },
-
-        getQulityIndexForBitrate = function (streamProcessor, targetBandwidth) {
-            var mediaInfo = streamProcessor.getMediaInfo(),
-                manifest = this.manifestModel.getValue(),
-                adaptation = this.manifestExt.getAdaptationForType(manifest, mediaInfo.streamInfo.index, mediaInfo.type),
-                max = mediaInfo.trackCount - 1;
-
-            for ( var i = max ; i > 0; i-- )
-            {
-                var repBandwidth = this.manifestExt.getRepresentationFor(i, adaptation).bandwidth;
-                if (targetBandwidth >= repBandwidth) {
-                    return i;
-                }
-            }
-            return 0;
         };
 
     return {
@@ -310,7 +294,6 @@ Dash.dependencies.DashAdapter = function () {
         getDataForTrack: getRepresentationForTrackInfo,
         getDataForMedia: getAdaptationForMediaInfo,
         getDataForStream: getPeriodForStreamInfo,
-        getQulityIndexForBitrate:getQulityIndexForBitrate,
         getStreamsInfo: getStreamsInfoFromManifest,
         getManifestInfo: getMpdInfo,
         getMediaInfoForType: getMediaInfoForType,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -263,11 +263,28 @@ Dash.dependencies.DashAdapter = function () {
             }
 
             return events;
+        },
+
+        getQulityIndexForBitrate = function (streamProcessor, targetBandwidth) {
+            var mediaInfo = streamProcessor.getMediaInfo(),
+                manifest = this.manifestModel.getValue(),
+                adaptation = this.manifestExt.getAdaptationForType(manifest, mediaInfo.streamInfo.index, mediaInfo.type),
+                max = mediaInfo.trackCount - 1;
+
+            for ( var i = max ; i > 0; i-- )
+            {
+                var repBandwidth = this.manifestExt.getRepresentationFor(i, adaptation).bandwidth;
+                if (targetBandwidth >= repBandwidth) {
+                    return i;
+                }
+            }
+            return 0;
         };
 
     return {
         system : undefined,
         manifestExt: undefined,
+        manifestModel:undefined,
         timelineConverter: undefined,
 
         metricsList: {
@@ -293,7 +310,7 @@ Dash.dependencies.DashAdapter = function () {
         getDataForTrack: getRepresentationForTrackInfo,
         getDataForMedia: getAdaptationForMediaInfo,
         getDataForStream: getPeriodForStreamInfo,
-
+        getQulityIndexForBitrate:getQulityIndexForBitrate,
         getStreamsInfo: getStreamsInfoFromManifest,
         getManifestInfo: getMpdInfo,
         getMediaInfoForType: getMediaInfoForType,

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -99,6 +99,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('pendingRequestsRule', MediaPlayer.rules.PendingRequestsRule);
             this.system.mapClass('playbackTimeRule', MediaPlayer.rules.PlaybackTimeRule);
             this.system.mapClass('sameTimeRequestRule', MediaPlayer.rules.SameTimeRequestRule);
+            this.system.mapClass('abandonRequestRule', MediaPlayer.rules.AbandonRequestsRule);
             this.system.mapSingleton('scheduleRulesCollection', MediaPlayer.rules.ScheduleRulesCollection);
 
             this.system.mapClass('liveEdgeBinarySearchRule', MediaPlayer.rules.LiveEdgeBinarySearchRule);

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -114,13 +114,20 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                         if (!event.lengthComputable || (event.lengthComputable && event.total != event.loaded)) {
                             request.firstByteDate = currentTime;
                             httpRequestMetrics.tresponse = currentTime;
+
                         }
                     }
+                    if (event.lengthComputable) {
+                        request.bytesLoaded = event.loaded;
+                        request.bytesTotal = event.total;
+                    }
+
                     self.metricsModel.appendHttpTrace(httpRequestMetrics,
                                                       currentTime,
                                                       currentTime.getTime() - lastTraceTime.getTime(),
                                                       [req.response ? req.response.byteLength : 0]);
                     lastTraceTime = currentTime;
+                    self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, {request: request});
                 };
 
                 req.onload = function () {
@@ -231,5 +238,6 @@ MediaPlayer.dependencies.FragmentLoader.prototype = {
 
 MediaPlayer.dependencies.FragmentLoader.eventList = {
     ENAME_LOADING_COMPLETED: "loadingCompleted",
+    ENAME_LOADING_PROGRESS: "loadingProgress",
     ENAME_CHECK_FOR_EXISTENCE_COMPLETED: "checkForExistenceCompleted"
 };

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -65,6 +65,7 @@ MediaPlayer = function (context) {
     var VERSION = "1.4.0",
         DEFAULT_TIME_SERVER = "http://time.akamai.com/?iso",
         DEFAULT_TIME_SOURCE_SCHEME = "urn:mpeg:dash:utc:http-xsdate:2014",
+        numOfParallelRequestAllowed = 0,
         system,
         abrController,
         element,
@@ -124,11 +125,12 @@ MediaPlayer = function (context) {
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
             system.mapOutlet("scheduleWhilePaused", "stream");
             system.mapOutlet("scheduleWhilePaused", "scheduleController");
+            system.mapValue("numOfParallelRequestAllowed", numOfParallelRequestAllowed);
+            system.mapOutlet("numOfParallelRequestAllowed", "scheduleController");
             system.mapValue("fragmentAbandonmentEnabled", fragmentAbandonmentEnabled);
             system.mapOutlet("fragmentAbandonmentEnabled", "scheduleController");
             system.mapValue("bufferMax", bufferMax);
             system.mapOutlet("bufferMax", "bufferController");
-
             rulesController.initialize();
         },
 
@@ -362,6 +364,23 @@ MediaPlayer = function (context) {
          */
         enableLastBitrateCaching: function (enable, ttl) {
             DOMStorage.enableLastBitrateCaching(enable, ttl);
+        },
+
+
+        /**
+         * Setting this value to something greater than 0 will result in that many parallel requests (per media type). Having concurrent request
+         * may help with latency but will alter client bandwidth detection. This may slow the responsiveness of the
+         * ABR heuristics.  It will also deactivate the AbandonRequestsRule, which at this time, only works accurately when parallel request are turned off.
+         *
+         * We do not suggest setting this value greater than 4.
+         *
+         * @value - Number of parallel request allowed at one time.
+         * @default 0
+         * @memberof MediaPlayer#
+         *
+         */
+        setNumOfParallelRequestAllowed: function (value){
+            numOfParallelRequestAllowed = value;
         },
 
         /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -82,6 +82,7 @@ MediaPlayer = function (context) {
         playing = false,
         autoPlay = true,
         scheduleWhilePaused = false,
+        fragmentAbandonmentEnabled = true,
         bufferMax = MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED,
         useManifestDateHeaderTimeSource = true,
         UTCTimingSources = [],
@@ -123,6 +124,8 @@ MediaPlayer = function (context) {
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
             system.mapOutlet("scheduleWhilePaused", "stream");
             system.mapOutlet("scheduleWhilePaused", "scheduleController");
+            system.mapValue("fragmentAbandonmentEnabled", fragmentAbandonmentEnabled);
+            system.mapOutlet("fragmentAbandonmentEnabled", "scheduleController");
             system.mapValue("bufferMax", bufferMax);
             system.mapOutlet("bufferMax", "bufferController");
 
@@ -757,6 +760,30 @@ MediaPlayer = function (context) {
             if (isReady.call(this)) {
                 doAutoPlay.call(this);
             }
+        },
+
+        /**
+         * Use this method to attach an already parsed manifest
+         *
+         * @param m the manifest
+         */
+        attachManifest: function (m) {
+            manifest = m;
+        },
+
+        /**
+         * Attach KeySystem-specific data to use for License Acquisition with EME
+         * @param data and object containing property names corresponding to key
+         * system name strings and associated values being instances of
+         * MediaPlayer.vo.protection.ProtectionData
+         */
+        attachProtectionData: function(data) {
+            protectionData = data;
+        },
+
+		
+        enableFragmentAbandonment: function(enable) {
+            fragmentAbandonmentEnabled = enable;
         },
 
         /**

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -157,6 +157,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
+            fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
 
             if (type === "video" || type === "audio" || type === "fragmentedText") {
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_OUTRUN, fragmentModel);

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -176,6 +176,10 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             return type;
         },
 
+        getABRController:function() {
+            return this.abrController;
+        },
+
         getFragmentLoader: function () {
             return this.fragmentLoader;
         },
@@ -315,6 +319,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
+            fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
             fragmentModel.reset();
 
             indexHandler.reset();

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -138,7 +138,7 @@ MediaPlayer.dependencies.AbrController = function () {
         initialize: function(type, streamProcessor) {
             streamProcessorDict[type] = streamProcessor;
             abandonmentStateDict[type] = abandonmentStateDict[type] || {};
-            abandonmentStateDict[type].state = MediaPlayer.rules.AbandonRequestsRule.ALLOW_LOAD;
+            abandonmentStateDict[type].state = MediaPlayer.dependencies.AbrController.ALLOW_LOAD;
         },
 
         getAutoSwitchBitrate: function () {
@@ -176,7 +176,7 @@ MediaPlayer.dependencies.AbrController = function () {
 
                     oldQuality = getInternalQuality(type, streamId);
 
-                    if (quality === oldQuality || (abandonmentStateDict[type].state === MediaPlayer.rules.AbandonRequestsRule.ABANDON_LOAD &&  quality > oldQuality)) return;
+                    if (quality === oldQuality || (abandonmentStateDict[type].state === MediaPlayer.dependencies.AbrController.ABANDON_LOAD &&  quality > oldQuality)) return;
 
                     setInternalQuality(type, streamId, quality);
                     //self.log("New quality of " + quality);
@@ -227,6 +227,10 @@ MediaPlayer.dependencies.AbrController = function () {
             abandonmentStateDict[type].state = state;
         },
 
+        getAbandonmentStateFor: function (type) {
+            return abandonmentStateDict[type].state;
+        },
+
         /**
          * @param type
          * @param {number} value A value of the initial bitrate, kbps
@@ -256,7 +260,7 @@ MediaPlayer.dependencies.AbrController = function () {
         /**
          * @param mediaInfo
          * @param bitrate A bitrate value, kbps
-         * @returns {number} A quality index for the given bitrate
+         * @returns {number} A quality index <= for the given bitrate
          * @memberof AbrController#
          */
         getQualityForBitrate: function(mediaInfo, bitrate) {
@@ -267,9 +271,10 @@ MediaPlayer.dependencies.AbrController = function () {
             for (var i = 0; i < ln; i +=1) {
                 bitrateInfo = bitrateList[i];
 
-                if (bitrate*1000 <= bitrateInfo.bitrate) return i;
+                if (bitrate*1000 <= bitrateInfo.bitrate) {
+                    return Math.max(i-1, 0);
+                }
             }
-
             return (ln-1);
         },
 
@@ -346,3 +351,8 @@ MediaPlayer.dependencies.AbrController.eventList = {
 MediaPlayer.dependencies.AbrController.DEFAULT_VIDEO_BITRATE = 1000;
 // Default initial audio bitrate, kbps
 MediaPlayer.dependencies.AbrController.DEFAULT_AUDIO_BITRATE = 100;
+
+MediaPlayer.dependencies.AbrController.ABANDON_LOAD = "abandonload";
+MediaPlayer.dependencies.AbrController.ALLOW_LOAD = "allowload";
+MediaPlayer.dependencies.AbrController.ABANDON_TIMEOUT = 10000;
+MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY = 0.9;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -37,6 +37,7 @@ MediaPlayer.dependencies.AbrController = function () {
         confidenceDict = {},
         bitrateDict = {},
         streamProcessorDict={},
+        abandonmentStateDict = {},
 
         getInternalQuality = function (type, id) {
             var quality;
@@ -136,6 +137,8 @@ MediaPlayer.dependencies.AbrController = function () {
 
         initialize: function(type, streamProcessor) {
             streamProcessorDict[type] = streamProcessor;
+            abandonmentStateDict[type] = abandonmentStateDict[type] || {};
+            abandonmentStateDict[type].state = MediaPlayer.rules.AbandonRequestsRule.ALLOW_LOAD;
         },
 
         getAutoSwitchBitrate: function () {
@@ -156,6 +159,7 @@ MediaPlayer.dependencies.AbrController = function () {
                 confidence,
 
                 callback = function(res) {
+
                     var topQualityIdx = getTopQualityIndex.call(self, type, streamId);
 
                     quality = res.value;
@@ -172,7 +176,7 @@ MediaPlayer.dependencies.AbrController = function () {
 
                     oldQuality = getInternalQuality(type, streamId);
 
-                    if (quality === oldQuality) return;
+                    if (quality === oldQuality || (abandonmentStateDict[type].state === MediaPlayer.rules.AbandonRequestsRule.ABANDON_LOAD &&  quality > oldQuality)) return;
 
                     setInternalQuality(type, streamId, quality);
                     //self.log("New quality of " + quality);
@@ -195,6 +199,7 @@ MediaPlayer.dependencies.AbrController = function () {
                 currentValue = currentValue === MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE ? 0 : currentValue;
                 return Math.max(currentValue, newValue);
             });
+
         },
 
         setPlaybackQuality: function (type, streamInfo, newPlaybackQuality) {
@@ -216,6 +221,10 @@ MediaPlayer.dependencies.AbrController = function () {
 
         getConfidenceFor: function(type, streamInfo) {
             return getInternalConfidence(type, streamInfo.id);
+        },
+
+        setAbandonmentStateFor: function (type, state) {
+            abandonmentStateDict[type].state = state;
         },
 
         /**
@@ -320,9 +329,7 @@ MediaPlayer.dependencies.AbrController = function () {
             qualityDict = {};
             confidenceDict = {};
             streamProcessorDict = {};
-            //bitrateDict = {}; // Letting this setting persist over multiple sources.
-            // There is no way to set initial bit rate on subsequent media sources in a session if we renew the object each time
-            //attachSource is called in media player.
+            abandonmentStateDict = {};
         }
     };
 };

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -44,6 +44,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
         playListTraceMetrics = null,
         playListTraceMetricsClosed = true,
         segmentAbandonmentInProgress = false,
+        abandonmentTimeout,
 
         clearPlayListTraceMetrics = function (endTime, stopreason) {
             var duration = 0,
@@ -390,7 +391,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
                             self.abrController.setPlaybackQuality("video", self.streamController.getActiveStreamInfo() , newQuality);
                             replaceCanceledRequests.call(self, requests);
 
-                            setTimeout(function () {
+                            abandonmentTimeout = setTimeout(function () {
                                 self.abrController.setAbandonmentStateFor('video', MediaPlayer.rules.AbandonRequestsRule.ALLOW_LOAD);
                                 segmentAbandonmentInProgress = false;
                             }, MediaPlayer.rules.AbandonRequestsRule.ABANDON_TIMEOUT);
@@ -496,6 +497,8 @@ MediaPlayer.dependencies.ScheduleController = function () {
             fragmentModel.abortRequests();
             self.fragmentController.detachModel(fragmentModel);
             fragmentsToLoad = 0;
+            segmentAbandonmentInProgress = false;
+            clearTimeout(abandonmentTimeout);
         },
 
         start: doStart,

--- a/src/streaming/rules/ABRRules/InsufficientBufferRule.js
+++ b/src/streaming/rules/ABRRules/InsufficientBufferRule.js
@@ -70,15 +70,15 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
                 mediaType = context.getMediaInfo().type,
                 current = context.getCurrentValue(),
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
-                streamInfo = context.getStreamInfo(),
-                trackInfo = context.getTrackInfo(),
-                duration = streamInfo.duration,
-                currentTime = self.playbackController.getTime(),
-                sp = context.getStreamProcessor(),
-                isDynamic = sp.isDynamic(),
-                lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
+                //streamInfo = context.getStreamInfo(),
+                //trackInfo = context.getTrackInfo(),
+                //duration = streamInfo.duration,
+                //currentTime = context.getStreamProcessor().getPlaybackController().getTime(),
+                //sp = context.getStreamProcessor(),
+                //isDynamic = sp.isDynamic(),
+                //lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
                 lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null,
-                lowBufferMark = Math.min(trackInfo.fragmentDuration, MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD),
+                //lowBufferMark = Math.min(trackInfo.fragmentDuration, MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD),
                 switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
 
             if (now - lastSwitchTime < waitToSwitchTime ||
@@ -92,16 +92,18 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
             if (lastBufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_EMPTY && bufferStateDict[mediaType].firstBufferLoadedEvent !== undefined) {
                 switchRequest = new MediaPlayer.rules.SwitchRequest(0, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
 
-            } else if ( !isDynamic &&
-                        bufferStateDict[mediaType].state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
-                        lastBufferLevelVO.level < (lowBufferMark * 2) &&
-                        currentTime < (duration - lowBufferMark * 2)) {
-
-                var p = lastBufferLevelVO.level > lowBufferMark ?
-                    MediaPlayer.rules.SwitchRequest.prototype.DEFAULT : MediaPlayer.rules.SwitchRequest.prototype.STRONG;
-
-                switchRequest = new MediaPlayer.rules.SwitchRequest(Math.max(current - 1, 0), p);
             }
+            //removing this for testing with new abandonment logic.  Should replace this.
+            //else if ( !isDynamic &&
+            //            bufferStateDict[mediaType].state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
+            //            lastBufferLevelVO.level < (lowBufferMark * 2) &&
+            //            currentTime < (duration - lowBufferMark * 2)) {
+            //
+            //    var p = lastBufferLevelVO.level > lowBufferMark ?
+            //        MediaPlayer.rules.SwitchRequest.prototype.DEFAULT : MediaPlayer.rules.SwitchRequest.prototype.STRONG;
+            //
+            //    switchRequest = new MediaPlayer.rules.SwitchRequest(Math.max(current - 1, 0), p);
+            //}
 
             if (switchRequest.value !== MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE && switchRequest.value !== current) {
                 self.log("InsufficientBufferRule requesting switch to index: ", switchRequest.value, "type: ",mediaType, " Priority: ",

--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -67,7 +67,7 @@ MediaPlayer.rules.ThroughputRule = function () {
                 arr.shift();
             }
 
-            return averageThroughput;
+            return averageThroughput * MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY;
         };
 
 
@@ -99,7 +99,8 @@ MediaPlayer.rules.ThroughputRule = function () {
             if (now - lastSwitchTime < waitToSwitchTime ||
                 !metrics || lastRequest === null ||
                 lastRequest.type !== MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE ||
-                bufferStateVO === null || bufferLevelVO === null) {
+                bufferStateVO === null || bufferLevelVO === null ||
+                abrController.getAbandonmentStateFor(mediaType) === MediaPlayer.dependencies.AbrController.ABANDON_LOAD) {
                 callback(switchRequest);
                 return;
             }

--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -75,7 +75,6 @@ MediaPlayer.rules.ThroughputRule = function () {
         log: undefined,
         metricsExt: undefined,
         metricsModel: undefined,
-        adapter:undefined,
 
         execute: function (context, callback) {
             var self = this,
@@ -86,6 +85,7 @@ MediaPlayer.rules.ThroughputRule = function () {
                 trackInfo = context.getTrackInfo(),
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
                 streamProcessor = context.getStreamProcessor(),
+                abrController = streamProcessor.getABRController(),
                 isDynamic= streamProcessor.isDynamic(),
                 lastRequest = self.metricsExt.getCurrentHttpRequest(metrics),
                 waitToSwitchTime = !isNaN(trackInfo.fragmentDuration) ? trackInfo.fragmentDuration / 2 : 2,
@@ -113,7 +113,7 @@ MediaPlayer.rules.ThroughputRule = function () {
             if (bufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
                 (bufferLevelVO.level >= (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD*2) || isDynamic))
             {
-                var newQuality = self.adapter.getQulityIndexForBitrate(streamProcessor, averageThroughput);
+                var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput/1000);
                 switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT);
             }
 

--- a/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
@@ -44,7 +44,7 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
     return {
         metricsExt: undefined,
         log:undefined,
-        adapter:undefined,
+
 
         setScheduleController: function(scheduleControllerValue) {
             var id = scheduleControllerValue.streamProcessor.getStreamInfo().id;
@@ -62,6 +62,7 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
                 trackInfo = context.getTrackInfo(),
                 req = progressEvent.data.request,
                 scheduleCtrl = scheduleController[streamId][mediaType],
+                abrController = context.getStreamProcessor().getABRController(),
                 fragmentModel = scheduleCtrl.getFragmentModel(),
                 concurrentReqs = fragmentModel.getRequests({state:MediaPlayer.dependencies.FragmentModel.states.LOADING}).length,
                 fragmentInfo,
@@ -101,7 +102,7 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
                         return;
                     }else if (fragmentInfo.allowToLoad !== false) {
                         fragmentInfo.allowToLoad = false;
-                        var newQuality = this.adapter.getQulityIndexForBitrate(context.getStreamProcessor(), fragmentInfo.measuredBandwidthInKbps*1000);
+                        var newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps);
                         switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
                     }
                 }

--- a/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
@@ -1,0 +1,130 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+MediaPlayer.rules.AbandonRequestsRule = function () {
+    "use strict";
+
+    var GRACE_TIME_THRESHOLD = 1000,
+        ABANDON_MULTIPLIER = 1.75,
+        fragmentDict = {},
+        scheduleController = {},
+
+        setFragmentRequestDict = function (type, id) {
+            fragmentDict[type] = fragmentDict[type] || {};
+            fragmentDict[type][id] = fragmentDict[type][id] || {};
+        };
+
+    return {
+        metricsExt: undefined,
+        log:undefined,
+        adapter:undefined,
+
+        setScheduleController: function(scheduleControllerValue) {
+            var id = scheduleControllerValue.streamProcessor.getStreamInfo().id;
+            scheduleController[id] = scheduleController[id] || {};
+            scheduleController[id][scheduleControllerValue.streamProcessor.getType()] = scheduleControllerValue;
+        },
+
+        execute: function(context, callback) {
+
+            var now = new Date().getTime(),
+                mediaInfo = context.getMediaInfo(),
+                mediaType = mediaInfo.type,
+                streamId = context.getStreamInfo().id,
+                progressEvent = context.getCurrentValue(),
+                trackInfo = context.getTrackInfo(),
+                req = progressEvent.data.request,
+                scheduleCtrl = scheduleController[streamId][mediaType],
+                fragmentModel = scheduleCtrl.getFragmentModel(),
+                concurrentReqs = fragmentModel.getRequests({state:MediaPlayer.dependencies.FragmentModel.states.LOADING}).length,
+                fragmentInfo,
+                switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
+
+            if (mediaType === 'video' && !isNaN(req.index)) { // TODO just for testing remove and make dict to store sep values for audio and video!!
+
+                setFragmentRequestDict(mediaType, req.index);
+                fragmentInfo = fragmentDict[mediaType][req.index];
+
+                if (fragmentInfo === null && req.firstByteDate === null) {
+                    callback(switchRequest);
+                    return;
+                }
+
+                //setup some init info based on first progress event
+                if (fragmentInfo.firstByteTime === undefined) {
+                    fragmentInfo.firstByteTime = req.firstByteDate.getTime();
+                    fragmentInfo.segmentDuration = req.duration;
+                    fragmentInfo.bytesTotal = req.bytesTotal;
+                    fragmentInfo.id = req.index;
+                }
+
+                //update info base on subsequent progress events until completed.
+                fragmentInfo.bytesLoaded = req.bytesLoaded;
+                fragmentInfo.elapsedTime = now - fragmentInfo.firstByteTime;
+
+
+                if (fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal &&
+                    fragmentInfo.elapsedTime >= GRACE_TIME_THRESHOLD) {
+
+                    fragmentInfo.measuredBandwidthInKbps = Math.round((fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime)) * concurrentReqs;
+                    fragmentInfo.estimatedTimeOfDownload = fragmentInfo.bytesTotal*8*0.001/fragmentInfo.measuredBandwidthInKbps;
+
+                    if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || trackInfo.quality === 0) {
+                        callback(switchRequest);
+                        return;
+                    }else if (fragmentInfo.allowToLoad !== false) {
+                        fragmentInfo.allowToLoad = false;
+                        var newQuality = this.adapter.getQulityIndexForBitrate(context.getStreamProcessor(), fragmentInfo.measuredBandwidthInKbps*1000);
+                        switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
+                    }
+                }
+                //TODO figure out way to set completed request that no longer needed to be stored in dict to null.
+            }
+
+            callback(switchRequest);
+        },
+
+        reset: function() {
+            fragmentDict = {};
+        }
+    };
+};
+
+MediaPlayer.rules.AbandonRequestsRule.ABANDON_LOAD = "abandonload";
+MediaPlayer.rules.AbandonRequestsRule.ALLOW_LOAD = "allowload";
+MediaPlayer.rules.AbandonRequestsRule.ABANDON_TIMEOUT = 10000;
+
+MediaPlayer.rules.AbandonRequestsRule.prototype = {
+    constructor: MediaPlayer.rules.AbandonRequestsRule
+};
+
+
+
+

--- a/src/streaming/rules/SchedulingRules/SameTimeRequestRule.js
+++ b/src/streaming/rules/SchedulingRules/SameTimeRequestRule.js
@@ -31,8 +31,7 @@
 MediaPlayer.rules.SameTimeRequestRule = function () {
     "use strict";
 
-    var LOADING_REQUEST_THRESHOLD = 4,
-        lastMediaRequestIdxs = {},
+    var lastMediaRequestIdxs = {},
 
         findClosestToTime = function(fragmentModels, time) {
             var req,
@@ -163,7 +162,7 @@ MediaPlayer.rules.SameTimeRequestRule = function () {
 
                 if (model.getIsPostponed() && !isNaN(req.startTime)) continue;
 
-                if (loadingLength > LOADING_REQUEST_THRESHOLD) {
+                if (loadingLength > MediaPlayer.dependencies.ScheduleController.LOADING_REQUEST_THRESHOLD) {
                     callback(new MediaPlayer.rules.SwitchRequest([], p));
                     return;
                 }

--- a/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
+++ b/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
@@ -33,13 +33,15 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
 
     var fragmentsToScheduleRules = [],
         fragmentsToExecuteRules = [],
-        nextFragmentRules = [];
+        nextFragmentRules = [],
+        adandonFragmentRules = [];
 
     return {
         bufferLevelRule: undefined,
         pendingRequestsRule: undefined,
         playbackTimeRule: undefined,
         sameTimeRequestRule: undefined,
+        abandonRequestRule:undefined,
 
         getRules: function (type) {
             switch (type) {
@@ -49,6 +51,8 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
                     return nextFragmentRules;
                 case MediaPlayer.rules.ScheduleRulesCollection.prototype.FRAGMENTS_TO_EXECUTE_RULES:
                     return fragmentsToExecuteRules;
+                case MediaPlayer.rules.ScheduleRulesCollection.prototype.ABANDON_FRAGMENT_RULES:
+                    return adandonFragmentRules;
                 default:
                     return null;
             }
@@ -59,6 +63,7 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
             fragmentsToScheduleRules.push(this.pendingRequestsRule);
             nextFragmentRules.push(this.playbackTimeRule);
             fragmentsToExecuteRules.push(this.sameTimeRequestRule);
+            adandonFragmentRules.push(this.abandonRequestRule);
         }
     };
 };
@@ -67,5 +72,6 @@ MediaPlayer.rules.ScheduleRulesCollection.prototype = {
     constructor: MediaPlayer.rules.ScheduleRulesCollection,
     FRAGMENTS_TO_SCHEDULE_RULES: "fragmentsToScheduleRules",
     NEXT_FRAGMENT_RULES: "nextFragmentRules",
-    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules"
+    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules",
+    ABANDON_FRAGMENT_RULES: "abandonFragmentRules"
 };

--- a/src/streaming/vo/FragmentRequest.js
+++ b/src/streaming/vo/FragmentRequest.js
@@ -46,6 +46,8 @@ MediaPlayer.vo.FragmentRequest = function () {
     this.availabilityStartTime = null;
     this.availabilityEndTime = null;
     this.wallStartTime = null;
+    this.bytesLoaded = NaN;
+    this.bytesTotal = NaN;
 };
 
 MediaPlayer.vo.FragmentRequest.prototype = {


### PR DESCRIPTION
This feature will abandon fragments that are going to take too long (more than fragment duration * multiplier ) to download and call for a switch to a quality that matches the real time measured bandwidth during download progress.  This feature will only work when parallel request are turned off. (off by default now)

A new API was created in MP to allow to set the number of parallel requests desired.  