### PR TITLE
Segment abandonment as an ABR rule instead of Scheduling rule.

### DIFF
--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -124,6 +124,7 @@
     <script src="../../src/streaming/rules/ABRRules/ABRRulesCollection.js"></script>
     <script src="../../src/streaming/rules/ABRRules/BufferOccupancyRule.js"></script>
     <script src="../../src/streaming/rules/ABRRules/ThroughputRule.js"></script>
+    <script src="../../src/streaming/rules/ABRRules/AbandonRequestsRule.js"></script>
 
     <script src="../../src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js"></script>
     <script src="../../src/streaming/rules/SchedulingRules/BufferLevelRule.js"></script>

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -99,6 +99,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('pendingRequestsRule', MediaPlayer.rules.PendingRequestsRule);
             this.system.mapClass('playbackTimeRule', MediaPlayer.rules.PlaybackTimeRule);
             this.system.mapClass('sameTimeRequestRule', MediaPlayer.rules.SameTimeRequestRule);
+            this.system.mapClass('abandonRequestRule', MediaPlayer.rules.AbandonRequestsRule);
             this.system.mapSingleton('scheduleRulesCollection', MediaPlayer.rules.ScheduleRulesCollection);
 
             this.system.mapClass('liveEdgeBinarySearchRule', MediaPlayer.rules.LiveEdgeBinarySearchRule);

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -116,11 +116,18 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                             httpRequestMetrics.tresponse = currentTime;
                         }
                     }
+
+                    if (event.lengthComputable) {
+                        request.bytesLoaded = event.loaded;
+                        request.bytesTotal = event.total;
+                    }
+
                     self.metricsModel.appendHttpTrace(httpRequestMetrics,
                                                       currentTime,
                                                       currentTime.getTime() - lastTraceTime.getTime(),
                                                       [req.response ? req.response.byteLength : 0]);
                     lastTraceTime = currentTime;
+                    self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, {request: request});
                 };
 
                 req.onload = function () {
@@ -231,5 +238,6 @@ MediaPlayer.dependencies.FragmentLoader.prototype = {
 
 MediaPlayer.dependencies.FragmentLoader.eventList = {
     ENAME_LOADING_COMPLETED: "loadingCompleted",
+    ENAME_LOADING_PROGRESS: "loadingProgress",
     ENAME_CHECK_FOR_EXISTENCE_COMPLETED: "checkForExistenceCompleted"
 };

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -65,6 +65,7 @@ MediaPlayer = function (context) {
     var VERSION = "1.4.0",
         DEFAULT_TIME_SERVER = "http://time.akamai.com/?iso",
         DEFAULT_TIME_SOURCE_SCHEME = "urn:mpeg:dash:utc:http-xsdate:2014",
+        numOfParallelRequestAllowed = 0,
         system,
         abrController,
         element,
@@ -123,6 +124,8 @@ MediaPlayer = function (context) {
             system.mapValue("scheduleWhilePaused", scheduleWhilePaused);
             system.mapOutlet("scheduleWhilePaused", "stream");
             system.mapOutlet("scheduleWhilePaused", "scheduleController");
+            system.mapValue("numOfParallelRequestAllowed", numOfParallelRequestAllowed);
+            system.mapOutlet("numOfParallelRequestAllowed", "scheduleController");
             system.mapValue("bufferMax", bufferMax);
             system.mapOutlet("bufferMax", "bufferController");
 
@@ -359,6 +362,22 @@ MediaPlayer = function (context) {
          */
         enableLastBitrateCaching: function (enable, ttl) {
             DOMStorage.enableLastBitrateCaching(enable, ttl);
+        },
+
+        /**
+         * Setting this value to something greater than 0 will result in that many parallel requests (per media type). Having concurrent request
+         * may help with latency but will alter client bandwidth detection. This may slow the responsiveness of the
+         * ABR heuristics.  It will also deactivate the AbandonRequestsRule, which at this time, only works accurately when parallel request are turned off.
+         *
+         * We do not suggest setting this value greater than 4.
+         *
+         * @value - Number of parallel request allowed at one time.
+         * @default 0
+         * @memberof MediaPlayer#
+         *
+         */
+        setNumOfParallelRequestAllowed: function (value){
+            numOfParallelRequestAllowed = value;
         },
 
         /**

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -157,6 +157,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
+            fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
 
             if (type === "video" || type === "audio" || type === "fragmentedText") {
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_OUTRUN, fragmentModel);
@@ -173,6 +174,10 @@ MediaPlayer.dependencies.StreamProcessor = function () {
 
         getType: function() {
             return type;
+        },
+
+        getABRController:function() {
+            return this.abrController;
         },
 
         getFragmentLoader: function () {
@@ -314,6 +319,8 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
+            fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
+
             fragmentModel.reset();
 
             indexHandler.reset();

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -157,7 +157,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.subscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
-            fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
+            fragmentLoader.subscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, abrController);
 
             if (type === "video" || type === "audio" || type === "fragmentedText") {
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_OUTRUN, fragmentModel);
@@ -319,7 +319,7 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_STREAM_COMPLETED, fragmentController);
             fragmentModel.unsubscribe(MediaPlayer.dependencies.FragmentModel.eventList.ENAME_FRAGMENT_LOADING_COMPLETED, scheduleController);
             fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, fragmentModel);
-            fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, scheduleController);
+            fragmentLoader.unsubscribe(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, abrController);
 
             fragmentModel.reset();
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -139,23 +139,25 @@ MediaPlayer.dependencies.AbrController = function () {
                     fragmentModel = schduleController.getFragmentModel(),
                     callback = function (switchRequest) {
 
+                        function setupTimeout(type){
+                            abandonmentTimeout = setTimeout(function () {
+                                self.setAbandonmentStateFor(type, MediaPlayer.dependencies.AbrController.ALLOW_LOAD);
+                            }, MediaPlayer.dependencies.AbrController.ABANDON_TIMEOUT);
+                        }
+
                         if (switchRequest.confidence === MediaPlayer.rules.SwitchRequest.prototype.STRONG) {
 
                             var requests = fragmentModel.getRequests({state:MediaPlayer.dependencies.FragmentModel.states.LOADING}),
                                 newQuality = switchRequest.value,
                                 currentQuality = self.getQualityFor(type, self.streamController.getActiveStreamInfo());
 
-
-                            if (newQuality != currentQuality){
+                            if (newQuality < currentQuality){
 
                                 fragmentModel.abortRequests();
                                 self.setAbandonmentStateFor(type, MediaPlayer.dependencies.AbrController.ABANDON_LOAD);
                                 self.setPlaybackQuality(type, self.streamController.getActiveStreamInfo() , newQuality);
                                 schduleController.replaceCanceledRequests(requests);
-
-                                abandonmentTimeout = setTimeout(function () {
-                                    self.abrController.setAbandonmentStateFor('video', MediaPlayer.dependencies.AbrController.ALLOW_LOAD);
-                                }, MediaPlayer.dependencies.AbrController.ABANDON_TIMEOUT);
+                                setupTimeout(type);
                             }
                         }
                     };
@@ -379,6 +381,7 @@ MediaPlayer.dependencies.AbrController = function () {
             streamProcessorDict = {};
             abandonmentStateDict = {};
             clearTimeout(abandonmentTimeout);
+            abandonmentTimeout = null;
         }
     };
 };

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -43,6 +43,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
         playListMetrics = null,
         playListTraceMetrics = null,
         playListTraceMetricsClosed = true,
+        abandonmentTimeout,
 
         clearPlayListTraceMetrics = function (endTime, stopreason) {
             var duration = 0,
@@ -131,7 +132,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
             });
         },
 
-        replaceCanceledPendingRequests = function(canceledRequests) {
+        replaceCanceledRequests = function(canceledRequests) {
             var ln = canceledRequests.length,
             // EPSILON is used to avoid javascript floating point issue, e.g. if request.startTime = 19.2,
             // request.duration = 3.83, than request.startTime + request.startTime = 19.2 + 1.92 = 21.119999999999997
@@ -282,7 +283,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
                 throw "Unexpected error!";
             }
 
-            replaceCanceledPendingRequests.call(self, canceledReqs);
+            replaceCanceledRequests.call(self, canceledReqs);
             clearPlayListTraceMetrics(new Date(), MediaPlayer.vo.metrics.PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON);
         },
 
@@ -365,6 +366,38 @@ MediaPlayer.dependencies.ScheduleController = function () {
             if (currentTrackInfo) {
                 startOnReady.call(self);
             }
+        },
+
+        onFragmentLoadProgress = function(evt) {
+
+            var self = this,
+                rules = self.scheduleRulesCollection.getRules(MediaPlayer.rules.ScheduleRulesCollection.prototype.ABANDON_FRAGMENT_RULES),
+                callback = function (switchRequest) {
+
+                    if (switchRequest.confidence === MediaPlayer.rules.SwitchRequest.prototype.STRONG) {
+
+                        var requests = fragmentModel.getRequests({state:MediaPlayer.dependencies.FragmentModel.states.LOADING}),
+                            newQuality = switchRequest.value,
+                            currentQuality = self.abrController.getQualityFor(type, self.streamController.getActiveStreamInfo());
+
+
+                        if (newQuality != currentQuality){
+
+                            fragmentModel.abortRequests();
+                            self.abrController.setAbandonmentStateFor(type, MediaPlayer.dependencies.AbrController.ABANDON_LOAD);
+                            self.abrController.setPlaybackQuality(type, self.streamController.getActiveStreamInfo() , newQuality);
+                            replaceCanceledRequests.call(self, requests);
+
+                            abandonmentTimeout = setTimeout(function () {
+                                self.abrController.setAbandonmentStateFor('video', MediaPlayer.dependencies.AbrController.ALLOW_LOAD);
+                            }, MediaPlayer.dependencies.AbrController.ABANDON_TIMEOUT);
+                        }
+                    }
+                };
+
+            self.rulesController.applyRules(rules, self.streamProcessor, callback, evt, function(currentValue, newValue) {
+                return newValue;
+            });
         };
 
     return {
@@ -380,6 +413,8 @@ MediaPlayer.dependencies.ScheduleController = function () {
         adapter: undefined,
         scheduleRulesCollection: undefined,
         rulesController: undefined,
+        numOfParallelRequestAllowed:undefined,
+        streamController:undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.LiveEdgeFinder.eventList.ENAME_LIVE_EDGE_SEARCH_COMPLETED] = onLiveEdgeSearchCompleted;
@@ -407,6 +442,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
             this[MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING] = onPlaybackSeeking;
             this[MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_RATE_CHANGED] = onPlaybackRateChanged;
             this[MediaPlayer.dependencies.PlaybackController.eventList.ENAME_WALLCLOCK_TIME_UPDATED] = onWallclockTimeUpdated;
+            this[MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS] = onFragmentLoadProgress;
         },
 
         initialize: function(typeValue, streamProcessor) {
@@ -420,6 +456,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
             self.bufferController = streamProcessor.bufferController;
             isDynamic = streamProcessor.isDynamic();
             fragmentModel = this.fragmentController.getModel(this);
+            MediaPlayer.dependencies.ScheduleController.LOADING_REQUEST_THRESHOLD = self.numOfParallelRequestAllowed;
 
             if (self.scheduleRulesCollection.bufferLevelRule) {
                 self.scheduleRulesCollection.bufferLevelRule.setScheduleController(self);
@@ -432,6 +469,11 @@ MediaPlayer.dependencies.ScheduleController = function () {
             if (self.scheduleRulesCollection.playbackTimeRule) {
                 self.scheduleRulesCollection.playbackTimeRule.setScheduleController(self);
             }
+
+            if (self.scheduleRulesCollection.abandonRequestRule) {
+                self.scheduleRulesCollection.abandonRequestRule.setScheduleController(self);
+            }
+
         },
 
         getFragmentModel: function() {
@@ -451,6 +493,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
             fragmentModel.abortRequests();
             self.fragmentController.detachModel(fragmentModel);
             fragmentsToLoad = 0;
+            clearTimeout(abandonmentTimeout);
         },
 
         start: doStart,
@@ -461,3 +504,5 @@ MediaPlayer.dependencies.ScheduleController = function () {
 MediaPlayer.dependencies.ScheduleController.prototype = {
     constructor: MediaPlayer.dependencies.ScheduleController
 };
+
+MediaPlayer.dependencies.ScheduleController.LOADING_REQUEST_THRESHOLD = 0;

--- a/src/streaming/rules/ABRRules/ABRRulesCollection.js
+++ b/src/streaming/rules/ABRRules/ABRRulesCollection.js
@@ -31,17 +31,21 @@
 MediaPlayer.rules.ABRRulesCollection = function () {
     "use strict";
 
-    var qualitySwitchRules = [];
+    var qualitySwitchRules = [],
+        adandonFragmentRules = [];
 
     return {
         insufficientBufferRule: undefined,
         bufferOccupancyRule:undefined,
         throughputRule:undefined,
+        abandonRequestRule:undefined,
 
         getRules: function (type) {
             switch (type) {
                 case MediaPlayer.rules.ABRRulesCollection.prototype.QUALITY_SWITCH_RULES:
                     return qualitySwitchRules;
+                case MediaPlayer.rules.ABRRulesCollection.prototype.ABANDON_FRAGMENT_RULES:
+                    return adandonFragmentRules;
                 default:
                     return null;
             }
@@ -51,11 +55,13 @@ MediaPlayer.rules.ABRRulesCollection = function () {
             qualitySwitchRules.push(this.insufficientBufferRule);
             qualitySwitchRules.push(this.throughputRule);
             qualitySwitchRules.push(this.bufferOccupancyRule);
+            adandonFragmentRules.push(this.abandonRequestRule);
         }
     };
 };
 
 MediaPlayer.rules.ABRRulesCollection.prototype = {
     constructor: MediaPlayer.rules.ABRRulesCollection,
-    QUALITY_SWITCH_RULES: "qualitySwitchRules"
+    QUALITY_SWITCH_RULES: "qualitySwitchRules",
+    ABANDON_FRAGMENT_RULES: "abandonFragmentRules"
 };

--- a/src/streaming/rules/ABRRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/ABRRules/AbandonRequestsRule.js
@@ -100,7 +100,7 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
                     fragmentInfo.measuredBandwidthInKbps = Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     //fragmentInfo.measuredBandwidthInKbps = (concurrentCount > 1) ? getAggragateBandwidth.call(this, mediaType, concurrentCount) :  Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     fragmentInfo.estimatedTimeOfDownload = (fragmentInfo.bytesTotal*8*0.001/fragmentInfo.measuredBandwidthInKbps).toFixed(2);
-                   this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
+                    //this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
 
                     if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || trackInfo.quality === 0) {
                         callback(switchRequest);

--- a/src/streaming/rules/ABRRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/ABRRules/AbandonRequestsRule.js
@@ -100,7 +100,7 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
                     fragmentInfo.measuredBandwidthInKbps = Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     //fragmentInfo.measuredBandwidthInKbps = (concurrentCount > 1) ? getAggragateBandwidth.call(this, mediaType, concurrentCount) :  Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     fragmentInfo.estimatedTimeOfDownload = (fragmentInfo.bytesTotal*8*0.001/fragmentInfo.measuredBandwidthInKbps).toFixed(2);
-                   // this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
+                   this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
 
                     if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || trackInfo.quality === 0) {
                         callback(switchRequest);

--- a/src/streaming/rules/ABRRules/BufferOccupancyRule.js
+++ b/src/streaming/rules/ABRRules/BufferOccupancyRule.js
@@ -45,6 +45,8 @@ MediaPlayer.rules.BufferOccupancyRule = function () {
                 mediaType = mediaInfo.type,
                 waitToSwitchTime = !isNaN(trackInfo.fragmentDuration) ? trackInfo.fragmentDuration / 2 : 2,
                 current = context.getCurrentValue(),
+                streamProcessor = context.getStreamProcessor(),
+                abrController = streamProcessor.getABRController(),
                 metrics = this.metricsModel.getReadOnlyMetricsFor(mediaType),
                 lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
                 lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null,
@@ -52,7 +54,8 @@ MediaPlayer.rules.BufferOccupancyRule = function () {
                 maxIndex = mediaInfo.trackCount - 1,
                 switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
 
-            if (now - lastSwitchTime < waitToSwitchTime) {
+            if (now - lastSwitchTime < waitToSwitchTime ||
+                abrController.getAbandonmentStateFor(mediaType) === MediaPlayer.dependencies.AbrController.ABANDON_LOAD) {
                 callback(switchRequest);
                 return;
             }

--- a/src/streaming/rules/ABRRules/InsufficientBufferRule.js
+++ b/src/streaming/rules/ABRRules/InsufficientBufferRule.js
@@ -70,15 +70,7 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
                 mediaType = context.getMediaInfo().type,
                 current = context.getCurrentValue(),
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
-                streamInfo = context.getStreamInfo(),
-                trackInfo = context.getTrackInfo(),
-                duration = streamInfo.duration,
-                currentTime = self.playbackController.getTime(),
-                sp = context.getStreamProcessor(),
-                isDynamic = sp.isDynamic(),
-                lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
                 lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null,
-                lowBufferMark = Math.min(trackInfo.fragmentDuration, MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD),
                 switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
 
             if (now - lastSwitchTime < waitToSwitchTime ||
@@ -91,16 +83,6 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
             // After the sessions first buffer loaded event , if we ever have a buffer empty event we want to switch all the way down.
             if (lastBufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_EMPTY && bufferStateDict[mediaType].firstBufferLoadedEvent !== undefined) {
                 switchRequest = new MediaPlayer.rules.SwitchRequest(0, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
-
-            } else if ( !isDynamic &&
-                        bufferStateDict[mediaType].state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
-                        lastBufferLevelVO.level < (lowBufferMark * 2) &&
-                        currentTime < (duration - lowBufferMark * 2)) {
-
-                var p = lastBufferLevelVO.level > lowBufferMark ?
-                    MediaPlayer.rules.SwitchRequest.prototype.DEFAULT : MediaPlayer.rules.SwitchRequest.prototype.STRONG;
-
-                switchRequest = new MediaPlayer.rules.SwitchRequest(Math.max(current - 1, 0), p);
             }
 
             if (switchRequest.value !== MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE && switchRequest.value !== current) {
@@ -108,6 +90,7 @@ MediaPlayer.rules.InsufficientBufferRule = function () {
                     switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.DEFAULT ? "Default" :
                         switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.STRONG ? "Strong" : "Weak");
             }
+
             lastSwitchTime = now;
             callback(switchRequest);
         },

--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -85,12 +85,10 @@ MediaPlayer.rules.ThroughputRule = function () {
                 mediaType = mediaInfo.type,
                 current = context.getCurrentValue(),
                 trackInfo = context.getTrackInfo(),
-
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
                 streamProcessor = context.getStreamProcessor(),
                 abrController = streamProcessor.getABRController(),
                 isDynamic= streamProcessor.isDynamic(),
-
                 lastRequest = self.metricsExt.getCurrentHttpRequest(metrics),
                 waitToSwitchTime = !isNaN(trackInfo.fragmentDuration) ? trackInfo.fragmentDuration / 2 : 2,
                 downloadTime,

--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -67,7 +67,7 @@ MediaPlayer.rules.ThroughputRule = function () {
                 arr.shift();
             }
 
-            return averageThroughput;
+            return averageThroughput * MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY;
         };
 
 
@@ -85,9 +85,12 @@ MediaPlayer.rules.ThroughputRule = function () {
                 mediaType = mediaInfo.type,
                 current = context.getCurrentValue(),
                 trackInfo = context.getTrackInfo(),
-                manifest = this.manifestModel.getValue(),
+
                 metrics = self.metricsModel.getReadOnlyMetricsFor(mediaType),
-                isDynamic= context.getStreamProcessor().isDynamic(),
+                streamProcessor = context.getStreamProcessor(),
+                abrController = streamProcessor.getABRController(),
+                isDynamic= streamProcessor.isDynamic(),
+
                 lastRequest = self.metricsExt.getCurrentHttpRequest(metrics),
                 waitToSwitchTime = !isNaN(trackInfo.fragmentDuration) ? trackInfo.fragmentDuration / 2 : 2,
                 downloadTime,
@@ -100,7 +103,8 @@ MediaPlayer.rules.ThroughputRule = function () {
             if (now - lastSwitchTime < waitToSwitchTime ||
                 !metrics || lastRequest === null ||
                 lastRequest.type !== MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE ||
-                bufferStateVO === null || bufferLevelVO === null) {
+                bufferStateVO === null || bufferLevelVO === null ||
+                abrController.getAbandonmentStateFor(mediaType) === MediaPlayer.dependencies.AbrController.ABANDON_LOAD) {
                 callback(switchRequest);
                 return;
             }
@@ -111,21 +115,11 @@ MediaPlayer.rules.ThroughputRule = function () {
             storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
             averageThroughput = Math.round(getAverageThroughput(mediaType, isDynamic));
 
-            var adaptation = this.manifestExt.getAdaptationForType(manifest, mediaInfo.streamInfo.index, mediaType);
-            var max = mediaInfo.trackCount - 1;
-
             if (bufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
                 (bufferLevelVO.level >= (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD*2) || isDynamic))
             {
-                for ( var i = max ; i > 0; i-- )
-                {
-                    var repBandwidth = this.manifestExt.getRepresentationFor(i, adaptation).bandwidth;
-                    if (averageThroughput >= repBandwidth) {
-                        switchRequest = new MediaPlayer.rules.SwitchRequest(i, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT);
-                        lastSwitchTime = now;
-                        break;
-                    }
-                }
+                var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput/1000);
+                switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT);
             }
 
             if (switchRequest.value !== MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE && switchRequest.value !== current) {

--- a/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
@@ -97,16 +97,16 @@ MediaPlayer.rules.AbandonRequestsRule = function () {
                 if (fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal &&
                     fragmentInfo.elapsedTime >= GRACE_TIME_THRESHOLD) {
 
-                    fragmentInfo.measuredBandwidthInKbps = Math.round((fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime) * MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY);
+                    fragmentInfo.measuredBandwidthInKbps = Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     //fragmentInfo.measuredBandwidthInKbps = (concurrentCount > 1) ? getAggragateBandwidth.call(this, mediaType, concurrentCount) :  Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
                     fragmentInfo.estimatedTimeOfDownload = (fragmentInfo.bytesTotal*8*0.001/fragmentInfo.measuredBandwidthInKbps).toFixed(2);
-                    //this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
+                   // this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
 
                     if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || trackInfo.quality === 0) {
                         callback(switchRequest);
                         return;
                     }else if (!abandonDict.hasOwnProperty(fragmentInfo.id)) {
-                        var newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps);
+                        var newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps * MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY);
                         switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
                         abandonDict[fragmentInfo.id] = fragmentInfo;
                         delete fragmentDict[mediaType][fragmentInfo.id];

--- a/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
+++ b/src/streaming/rules/SchedulingRules/AbandonRequestsRule.js
@@ -1,0 +1,148 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+MediaPlayer.rules.AbandonRequestsRule = function () {
+    "use strict";
+
+    var GRACE_TIME_THRESHOLD = 500,
+        ABANDON_MULTIPLIER = 1.5,
+        fragmentDict = {},
+        abandonDict = {},
+        scheduleController = {},
+
+        setFragmentRequestDict = function (type, id) {
+            fragmentDict[type] = fragmentDict[type] || {};
+            fragmentDict[type][id] = fragmentDict[type][id] || {};
+        };
+
+        //getAggragateBandwidth = function(mediaType, concurrentCount){
+        //    var tbl = 0,
+        //        tet = 0;
+        //    for (var key in fragmentDict[mediaType]) {
+        //        var obj = fragmentDict[mediaType][key];
+        //        if (obj.bytesLoaded < obj.bytesTotal && obj.elapsedTime >= GRACE_TIME_THRESHOLD) { //check if obj is complete or not
+        //            tbl += obj.bytesLoaded;
+        //            tet += obj.elapsedTime;
+        //        }else{
+        //            delete fragmentDict[mediaType][key];//delete entries that are complete.
+        //        }
+        //    }
+        //    var measuredBandwidthInKbps = Math.round((tbl*8/tet) * concurrentCount);
+        //    return measuredBandwidthInKbps;
+        //};
+
+    return {
+        metricsExt: undefined,
+        log:undefined,
+
+        setScheduleController: function(scheduleControllerValue) {
+            var id = scheduleControllerValue.streamProcessor.getStreamInfo().id;
+            scheduleController[id] = scheduleController[id] || {};
+            scheduleController[id][scheduleControllerValue.streamProcessor.getType()] = scheduleControllerValue;
+        },
+
+        execute: function(context, callback) {
+
+            var now = new Date().getTime(),
+                mediaInfo = context.getMediaInfo(),
+                mediaType = mediaInfo.type,
+                streamId = context.getStreamInfo().id,
+                progressEvent = context.getCurrentValue(),
+                trackInfo = context.getTrackInfo(),
+                req = progressEvent.data.request,
+                scheduleCtrl = scheduleController[streamId][mediaType],
+                abrController = context.getStreamProcessor().getABRController(),
+                fragmentModel = scheduleCtrl.getFragmentModel(),
+                concurrentCount = fragmentModel.getRequests({state:MediaPlayer.dependencies.FragmentModel.states.LOADING}).length,
+                fragmentInfo,
+                switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
+
+            if (concurrentCount === 1  && !isNaN(req.index)) {
+                setFragmentRequestDict(mediaType, req.index);
+                fragmentInfo = fragmentDict[mediaType][req.index];
+
+                if (fragmentInfo === null || req.firstByteDate === null || abandonDict.hasOwnProperty(fragmentInfo.id)) {
+                    callback(switchRequest);
+                    return;
+                }
+
+                //setup some init info based on first progress event
+                if (fragmentInfo.firstByteTime === undefined) {
+                    fragmentInfo.firstByteTime = req.firstByteDate.getTime();
+                    fragmentInfo.segmentDuration = req.duration;
+                    fragmentInfo.bytesTotal = req.bytesTotal;
+                    fragmentInfo.id = req.index;
+                   //this.log("XXX FRAG ID : " ,fragmentInfo.id, " *****************");
+                }
+                //update info base on subsequent progress events until completed.
+                fragmentInfo.bytesLoaded = req.bytesLoaded;
+                fragmentInfo.elapsedTime = now - fragmentInfo.firstByteTime;
+
+                if (fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal &&
+                    fragmentInfo.elapsedTime >= GRACE_TIME_THRESHOLD) {
+
+                    fragmentInfo.measuredBandwidthInKbps = Math.round((fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime) * MediaPlayer.dependencies.AbrController.BANDWIDTH_SAFETY);
+                    //fragmentInfo.measuredBandwidthInKbps = (concurrentCount > 1) ? getAggragateBandwidth.call(this, mediaType, concurrentCount) :  Math.round(fragmentInfo.bytesLoaded*8/fragmentInfo.elapsedTime);
+                    fragmentInfo.estimatedTimeOfDownload = (fragmentInfo.bytesTotal*8*0.001/fragmentInfo.measuredBandwidthInKbps).toFixed(2);
+                    this.log("XXX","id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
+
+                    if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || trackInfo.quality === 0) {
+                        callback(switchRequest);
+                        return;
+                    }else if (!abandonDict.hasOwnProperty(fragmentInfo.id)) {
+                        var newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps);
+                        switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
+                        abandonDict[fragmentInfo.id] = fragmentInfo;
+                        delete fragmentDict[mediaType][fragmentInfo.id];
+                        this.log("AbandonRequestsRule ( ", mediaType, "frag id",fragmentInfo.id,") is asking to abandon and switch to quality to ", newQuality, " measured bandwidth was", fragmentInfo.measuredBandwidthInKbps);
+                    }
+                }else if (fragmentInfo.bytesLoaded === fragmentInfo.bytesTotal) {
+                    delete fragmentDict[mediaType][fragmentInfo.id];
+                }
+            }
+
+            callback(switchRequest);
+        },
+
+        reset: function() {
+            fragmentDict = {};
+            abandonDict = {};
+            scheduleController = {};
+        }
+    };
+};
+
+MediaPlayer.rules.AbandonRequestsRule.prototype = {
+    constructor: MediaPlayer.rules.AbandonRequestsRule
+};
+
+
+
+

--- a/src/streaming/rules/SchedulingRules/SameTimeRequestRule.js
+++ b/src/streaming/rules/SchedulingRules/SameTimeRequestRule.js
@@ -31,8 +31,7 @@
 MediaPlayer.rules.SameTimeRequestRule = function () {
     "use strict";
 
-    var LOADING_REQUEST_THRESHOLD = 4,
-        lastMediaRequestIdxs = {},
+    var lastMediaRequestIdxs = {},
 
         findClosestToTime = function(fragmentModels, time) {
             var req,
@@ -163,7 +162,7 @@ MediaPlayer.rules.SameTimeRequestRule = function () {
 
                 if (model.getIsPostponed() && !isNaN(req.startTime)) continue;
 
-                if (loadingLength > LOADING_REQUEST_THRESHOLD) {
+                if (loadingLength > MediaPlayer.dependencies.ScheduleController.LOADING_REQUEST_THRESHOLD) {
                     callback(new MediaPlayer.rules.SwitchRequest([], p));
                     return;
                 }

--- a/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
+++ b/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
@@ -33,15 +33,14 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
 
     var fragmentsToScheduleRules = [],
         fragmentsToExecuteRules = [],
-        nextFragmentRules = [],
-        adandonFragmentRules = [];
+        nextFragmentRules = [];
+
 
     return {
         bufferLevelRule: undefined,
         pendingRequestsRule: undefined,
         playbackTimeRule: undefined,
         sameTimeRequestRule: undefined,
-        abandonRequestRule:undefined,
 
         getRules: function (type) {
             switch (type) {
@@ -51,8 +50,6 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
                     return nextFragmentRules;
                 case MediaPlayer.rules.ScheduleRulesCollection.prototype.FRAGMENTS_TO_EXECUTE_RULES:
                     return fragmentsToExecuteRules;
-                case MediaPlayer.rules.ScheduleRulesCollection.prototype.ABANDON_FRAGMENT_RULES:
-                    return adandonFragmentRules;
                 default:
                     return null;
             }
@@ -63,7 +60,6 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
             fragmentsToScheduleRules.push(this.pendingRequestsRule);
             nextFragmentRules.push(this.playbackTimeRule);
             fragmentsToExecuteRules.push(this.sameTimeRequestRule);
-            adandonFragmentRules.push(this.abandonRequestRule);
         }
     };
 };
@@ -72,6 +68,5 @@ MediaPlayer.rules.ScheduleRulesCollection.prototype = {
     constructor: MediaPlayer.rules.ScheduleRulesCollection,
     FRAGMENTS_TO_SCHEDULE_RULES: "fragmentsToScheduleRules",
     NEXT_FRAGMENT_RULES: "nextFragmentRules",
-    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules",
-    ABANDON_FRAGMENT_RULES: "abandonFragmentRules"
+    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules"
 };

--- a/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
+++ b/src/streaming/rules/SchedulingRules/ScheduleRulesCollection.js
@@ -33,13 +33,15 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
 
     var fragmentsToScheduleRules = [],
         fragmentsToExecuteRules = [],
-        nextFragmentRules = [];
+        nextFragmentRules = [],
+        adandonFragmentRules = [];
 
     return {
         bufferLevelRule: undefined,
         pendingRequestsRule: undefined,
         playbackTimeRule: undefined,
         sameTimeRequestRule: undefined,
+        abandonRequestRule:undefined,
 
         getRules: function (type) {
             switch (type) {
@@ -49,6 +51,8 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
                     return nextFragmentRules;
                 case MediaPlayer.rules.ScheduleRulesCollection.prototype.FRAGMENTS_TO_EXECUTE_RULES:
                     return fragmentsToExecuteRules;
+                case MediaPlayer.rules.ScheduleRulesCollection.prototype.ABANDON_FRAGMENT_RULES:
+                    return adandonFragmentRules;
                 default:
                     return null;
             }
@@ -59,6 +63,7 @@ MediaPlayer.rules.ScheduleRulesCollection = function () {
             fragmentsToScheduleRules.push(this.pendingRequestsRule);
             nextFragmentRules.push(this.playbackTimeRule);
             fragmentsToExecuteRules.push(this.sameTimeRequestRule);
+            adandonFragmentRules.push(this.abandonRequestRule);
         }
     };
 };
@@ -67,5 +72,6 @@ MediaPlayer.rules.ScheduleRulesCollection.prototype = {
     constructor: MediaPlayer.rules.ScheduleRulesCollection,
     FRAGMENTS_TO_SCHEDULE_RULES: "fragmentsToScheduleRules",
     NEXT_FRAGMENT_RULES: "nextFragmentRules",
-    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules"
+    FRAGMENTS_TO_EXECUTE_RULES: "fragmentsToExecuteRules",
+    ABANDON_FRAGMENT_RULES: "abandonFragmentRules"
 };

--- a/src/streaming/vo/FragmentRequest.js
+++ b/src/streaming/vo/FragmentRequest.js
@@ -46,6 +46,8 @@ MediaPlayer.vo.FragmentRequest = function () {
     this.availabilityStartTime = null;
     this.availabilityEndTime = null;
     this.wallStartTime = null;
+    this.bytesLoaded = NaN;
+    this.bytesTotal = NaN;
 };
 
 MediaPlayer.vo.FragmentRequest.prototype = {


### PR DESCRIPTION
This feature will abandon fragments that are going to take too long (more than fragment duration * multiplier ) to download and call for a switch to a quality that matches the real time measured bandwidth during download progress. This feature will only work when parallel request are turned off. (off by default now)

A new API was created in MP to allow to set the number of parallel requests desired.