### PR TITLE
Live edge fix

### DIFF
--- a/src/dash/TimelineConverter.js
+++ b/src/dash/TimelineConverter.js
@@ -192,6 +192,10 @@ Dash.dependencies.TimelineConverter = function () {
             return isClientServerTimeSyncCompleted;
         },
 
+        setTimeSyncCompleted: function(value) {
+            isClientServerTimeSyncCompleted = value;
+        },
+
         getClientTimeOffset: function() {
             return clientServerTimeShift;
         },

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -86,6 +86,8 @@ MediaPlayer = function (context) {
         bufferMax = MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED,
         useManifestDateHeaderTimeSource = true,
         UTCTimingSources = [],
+        liveDelayFragmentCount = 4,
+        usePresentationDelay = false,
 
         isReady = function () {
             return (!!element && !!source);
@@ -112,6 +114,7 @@ MediaPlayer = function (context) {
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, streamController);
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_CAN_PLAY, streamController);
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
+            playbackController.setLiveDelayAttributes(liveDelayFragmentCount, usePresentationDelay);
 
             streamController.initialize(autoPlay, protectionController, protectionData);
             DOMStorage.checkInitialBitrate();
@@ -347,6 +350,33 @@ MediaPlayer = function (context) {
             return videoModel;
         },
 
+
+
+        /**
+         * <p>Changing this value will lower or increase live stream latency.  The detected segment duration will be multiplied by this value
+         * to define a time in seconds to delay a live stream from the live edge.</p>
+         * <p>Lowering this value will lower latency but may decrease the player's ability to build a stable buffer.</p>
+         *
+         * @param value {int} Represents how many segment durations to delay the live stream.
+         * @default 4
+         * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#useSuggestedPresentationDelay useSuggestedPresentationDelay()}
+         */
+        setLiveDelayFragmentCount: function(value) {
+            liveDelayFragmentCount = value;
+        },
+
+        /**
+         * <p>Set to true if you would like to override the default live delay and honor the SuggestedPresentationDelay attribute in by the manifest.</p>
+         * @param value {Boolean}
+         * @default false
+         * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#setLiveDelayFragmentCount setLiveDelayFragmentCount()}
+         */
+        useSuggestedPresentationDelay: function(value) {
+            usePresentationDelay = value;
+        },
+
         /**
          * Set to false if you would like to disable the last known bit rate from being stored during playback and used
          * to set the initial bit rate for subsequent playback within the expiration window.
@@ -371,7 +401,7 @@ MediaPlayer = function (context) {
          *
          * We do not suggest setting this value greater than 4.
          *
-         * @value - Number of parallel request allowed at one time.
+         * @value {int} Number of parallel request allowed at one time.
          * @default 0
          * @memberof MediaPlayer#
          *
@@ -391,8 +421,8 @@ MediaPlayer = function (context) {
          *
          * This feature is typically used to reserve higher bitrates for playback only when the player is in large or full-screen format.
          *
-         * @param type String 'video' or 'audio' are the type options.
-         * @param value int value in kbps representing the maximum bitrate allowed.
+         * @param type {String} 'video' or 'audio' are the type options.
+         * @param value {int} Value in kbps representing the maximum bitrate allowed.
          * @memberof MediaPlayer#
          */
         setMaxAllowedBitrateFor:function(type, value) {
@@ -400,7 +430,7 @@ MediaPlayer = function (context) {
         },
 
         /**
-         * @param type String 'video' or 'audio' are the type options.
+         * @param type {String} 'video' or 'audio' are the type options.
          * @memberof MediaPlayer#
          * @see {@link MediaPlayer#setMaxAllowedBitrateFor setMaxAllowedBitrateFor()}
          */
@@ -409,15 +439,20 @@ MediaPlayer = function (context) {
         },
 
         /**
-         * @param value
+         * <p>Set to false to prevent stream from auto-playing when the view is attached.</p>
+         *
+         * @param value {Boolean}
+         * @default true
          * @memberof MediaPlayer#
+         * @see {@link MediaPlayer#attachView attachView()}
+         *
          */
         setAutoPlay: function (value) {
             autoPlay = value;
         },
 
         /**
-         * @returns {boolean} The current autoPlay state.
+         * @returns {Boolean} The current autoPlay state.
          * @memberof MediaPlayer#
          */
         getAutoPlay: function () {
@@ -881,11 +916,9 @@ MediaPlayer = function (context) {
          * NOTE - If you do not need the raw offset value (i.e. media analytics, tracking, etc) consider using the {@link MediaPlayer#seek seek()} method
          * which will calculate this value for you and set the video element's currentTime property all in one simple call.
          *
-         * @param {number} value A relative time, in seconds, based on the return value of the {@link MediaPlayer#duration duration()} method is expected.
+         * @param value {Number} A relative time, in seconds, based on the return value of the {@link MediaPlayer#duration duration()} method is expected.
          * @returns A value that is relative the available range within the timeShiftBufferLength (DVR Window).
-         *
          * @see {@link MediaPlayer#seek seek()}
-         *
          * @memberof MediaPlayer#
          * @method
          */

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -346,7 +346,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
             var self = this,
                 liveEdgeTime = e.data.liveEdge,
                 manifestInfo = currentTrackInfo.mediaInfo.streamInfo.manifestInfo,
-                startTime = liveEdgeTime - Math.min((self.playbackController.getLiveDelay()), manifestInfo.DVRWindowSize / 2),
+                startTime = liveEdgeTime - Math.min((self.playbackController.getLiveDelay(currentTrackInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2),
                 request,
                 metrics = self.metricsModel.getMetricsFor("stream"),
                 manifestUpdateInfo = self.metricsExt.getCurrentManifestUpdate(metrics),

--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -112,18 +112,19 @@ MediaPlayer.rules.ThroughputRule = function () {
             storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
             averageThroughput = Math.round(getAverageThroughput(mediaType, isDynamic));
 
-            if (bufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
-                abrController.getAbandonmentStateFor(mediaType) !== MediaPlayer.dependencies.AbrController.ABANDON_LOAD &&
-                (bufferLevelVO.level >= (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD*2) || isDynamic))
-            {
-                var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput/1000);
-                switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT);
-            }
+            if (abrController.getAbandonmentStateFor(mediaType) !== MediaPlayer.dependencies.AbrController.ABANDON_LOAD) {
 
-            if (switchRequest.value !== MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE && switchRequest.value !== current) {
-                self.log("ThroughputRule requesting switch to index: ", switchRequest.value, "type: ",mediaType, " Priority: ",
-                    switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.DEFAULT ? "Default" :
-                        switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.STRONG ? "Strong" : "Weak", "Average throughput", Math.round(averageThroughput/1024), "kbps");
+                if (bufferStateVO.state === MediaPlayer.dependencies.BufferController.BUFFER_LOADED &&
+                    (bufferLevelVO.level >= (MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD*2) || isDynamic)) {
+                    var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput/1000);
+                    switchRequest = new MediaPlayer.rules.SwitchRequest(newQuality, MediaPlayer.rules.SwitchRequest.prototype.DEFAULT);
+                }
+
+                if (switchRequest.value !== MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE && switchRequest.value !== current) {
+                    self.log("ThroughputRule requesting switch to index: ", switchRequest.value, "type: ",mediaType, " Priority: ",
+                        switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.DEFAULT ? "Default" :
+                            switchRequest.priority === MediaPlayer.rules.SwitchRequest.prototype.STRONG ? "Strong" : "Weak", "Average throughput", Math.round(averageThroughput/1024), "kbps");
+                }
             }
 
             callback(switchRequest);

--- a/src/streaming/rules/SynchronizationRules/LiveEdgeWithTimeSynchronizationRule.js
+++ b/src/streaming/rules/SynchronizationRules/LiveEdgeWithTimeSynchronizationRule.js
@@ -35,17 +35,31 @@ MediaPlayer.rules.LiveEdgeWithTimeSynchronizationRule = function () {
     "use strict";
 
     return {
+        timelineConverter: undefined,
+
         // if the time has been synchronized correctly (which it must have been
         // to end up executing this rule), the last entry in the DVR window
         // should be the live edge. if that is incorrect for whatever reason,
         // playback will fail to start and some other action should be taken.
         execute: function (context, callback) {
-            callback(
-                new MediaPlayer.rules.SwitchRequest(
-                    context.getTrackInfo().DVRWindow.end,
-                    MediaPlayer.rules.SwitchRequest.prototype.DEFAULT
-                )
-            );
+            var trackInfo = context.getTrackInfo(),
+                liveEdgeInitialSearchPosition = trackInfo.DVRWindow.end,
+                p = MediaPlayer.rules.SwitchRequest.prototype.DEFAULT;
+
+            if (trackInfo.useCalculatedLiveEdgeTime) {
+                //By default an expected live edge is the end of the last segment.
+                // A calculated live edge ('end' property of a range returned by TimelineConverter.calcSegmentAvailabilityRange)
+                // is used as an initial point for finding the actual live edge.
+                // But for SegmentTimeline mpds (w/o a negative @r) the end of the
+                // last segment is the actual live edge. At the same time, calculated live edge is an expected live edge.
+                // Thus, we need to switch an expected live edge and actual live edge for SegmentTimelne streams.
+                var actualLiveEdge = this.timelineConverter.getExpectedLiveEdge();
+                this.timelineConverter.setExpectedLiveEdge(liveEdgeInitialSearchPosition);
+                this.timelineConverter.setTimeSyncCompleted(false);
+                callback(new MediaPlayer.rules.SwitchRequest(actualLiveEdge, p));
+            } else {
+                callback(new MediaPlayer.rules.SwitchRequest(liveEdgeInitialSearchPosition, p));
+            }
         }
     };
 };


### PR DESCRIPTION
when trackInfo.useCalculatedLiveEdgeTime = true need to use the actual live edge.  Added same code to LiveEdgeWithTimeSynchronizationRule that exists in LiveEdgeBinarySearchRule since we fork based on new live edge logic and never reach the logic in LiveEdgeBinarySearchRule unless the API is used to force binary search. 