### PR TITLE
Set the video element's media keys to null on teardown to allow loadi…

### DIFF
--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -174,6 +174,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
         teardown: function() {
             if (videoElement) {
                 videoElement.removeEventListener("encrypted", eventHandler);
+                videoElement.setMediaKeys(null);
             }
             for (var i = 0; i < sessions.length; i++) {
                 this.closeKeySession(sessions[i]);


### PR DESCRIPTION
…ng new media keys on reset

* This fixes "DOMException: The existing MediaKeys object cannot be removed while a
   media resource is loaded" that occurs when switching from one encrypted stream
   to another one using MediaPlayer.attachSource().