### PR TITLE
Don't update metrics for externally loaded manifests

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -168,17 +168,19 @@ Dash.dependencies.RepresentationController = function () {
                 return;
             }
 
-            for (var i = 0; i < manifestUpdateInfo.trackInfo.length; i += 1) {
-                repInfo = manifestUpdateInfo.trackInfo[i];
-                if (repInfo.index === r.index && repInfo.mediaType === self.streamProcessor.getType()) {
-                    alreadyAdded = true;
-                    break;
+            if (manifestUpdateInfo) {
+                for (var i = 0; i < manifestUpdateInfo.trackInfo.length; i += 1) {
+                    repInfo = manifestUpdateInfo.trackInfo[i];
+                    if (repInfo.index === r.index && repInfo.mediaType === self.streamProcessor.getType()) {
+                        alreadyAdded = true;
+                        break;
+                    }
                 }
-            }
 
-            if (!alreadyAdded) {
-                self.metricsModel.addManifestUpdateTrackInfo(manifestUpdateInfo, r.id, r.index, r.adaptation.period.index,
-                    self.streamProcessor.getType(),r.presentationTimeOffset, r.startNumber, r.segmentInfoType);
+                if (!alreadyAdded) {
+                    self.metricsModel.addManifestUpdateTrackInfo(manifestUpdateInfo, r.id, r.index, r.adaptation.period.index,
+                            self.streamProcessor.getType(),r.presentationTimeOffset, r.startNumber, r.segmentInfoType);
+                }
             }
 
             if (isAllRepresentationsUpdated()) {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -258,42 +258,48 @@ MediaPlayer.models.MetricsModel = function () {
         },
 
         updateManifestUpdateInfo: function(manifestUpdate, updatedFields) {
-            for (var field in updatedFields) {
-                manifestUpdate[field] = updatedFields[field];
-            }
+            if (manifestUpdate) {
+                for (var field in updatedFields) {
+                    manifestUpdate[field] = updatedFields[field];
+                }
 
-            this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE, manifestUpdate);
+                this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE, manifestUpdate);
+            }
         },
 
         addManifestUpdateStreamInfo: function(manifestUpdate, id, index, start, duration) {
-            var vo = new MediaPlayer.vo.metrics.ManifestUpdate.StreamInfo();
+            if (manifestUpdate) {
+                var vo = new MediaPlayer.vo.metrics.ManifestUpdate.StreamInfo();
 
-            vo.id = id;
-            vo.index = index;
-            vo.start = start;
-            vo.duration = duration;
+                vo.id = id;
+                vo.index = index;
+                vo.start = start;
+                vo.duration = duration;
 
-            manifestUpdate.streamInfo.push(vo);
-            this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE_STREAM_INFO, manifestUpdate);
+                manifestUpdate.streamInfo.push(vo);
+                this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE_STREAM_INFO, manifestUpdate);
 
-            return vo;
+                return vo;
+            }
         },
 
         addManifestUpdateTrackInfo: function(manifestUpdate, id, index, streamIndex, mediaType, presentationTimeOffset, startNumber, fragmentInfoType) {
-            var vo = new MediaPlayer.vo.metrics.ManifestUpdate.TrackInfo();
+            if (manifestUpdate) {
+                var vo = new MediaPlayer.vo.metrics.ManifestUpdate.TrackInfo();
 
-            vo.id = id;
-            vo.index = index;
-            vo.streamIndex = streamIndex;
-            vo.mediaType = mediaType;
-            vo.startNumber = startNumber;
-            vo.fragmentInfoType = fragmentInfoType;
-            vo.presentationTimeOffset = presentationTimeOffset;
+                vo.id = id;
+                vo.index = index;
+                vo.streamIndex = streamIndex;
+                vo.mediaType = mediaType;
+                vo.startNumber = startNumber;
+                vo.fragmentInfoType = fragmentInfoType;
+                vo.presentationTimeOffset = presentationTimeOffset;
 
-            manifestUpdate.trackInfo.push(vo);
-            this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE_TRACK_INFO, manifestUpdate);
+                manifestUpdate.trackInfo.push(vo);
+                this.metricUpdated(manifestUpdate.mediaType, this.adapter.metricsList.MANIFEST_UPDATE_TRACK_INFO, manifestUpdate);
 
-            return vo;
+                return vo;
+            }
         },
 
         addPlayList: function (mediaType, start, mstart, starttype) {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -281,6 +281,7 @@ MediaPlayer.models.MetricsModel = function () {
 
                 return vo;
             }
+            return null;
         },
 
         addManifestUpdateTrackInfo: function(manifestUpdate, id, index, streamIndex, mediaType, presentationTimeOffset, startNumber, fragmentInfoType) {
@@ -300,6 +301,7 @@ MediaPlayer.models.MetricsModel = function () {
 
                 return vo;
             }
+            return null;
         },
 
         addPlayList: function (mediaType, start, mstart, starttype) {


### PR DESCRIPTION
Fix for issue #570 

When manifests are loaded outside the player, no metrics will be collected for those manifest updates.  Once the manifest is attached to the player for playback of the media, manifest update metrics will resume collection.

The code changes in this PR simply prevent null-reference exceptions when manifest update information is not available.