### PR TITLE
send event to Stream.js to stop player if the keySystem access is den…

### DIFF
--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -237,7 +237,7 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
                     protCtrl.selectKeySystem(keySystemAccess);
                 } else {
                     self.log(event.error);
-					protCtrl.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR,
+                    protCtrl.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR,
                         "[DRM] KeySystem Access Denied! -- " + event.error);
                 }
             };

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -237,6 +237,8 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
                     protCtrl.selectKeySystem(keySystemAccess);
                 } else {
                     self.log(event.error);
+					protCtrl.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR,
+                        "[DRM] KeySystem Access Denied! -- " + event.error);
                 }
             };
 


### PR DESCRIPTION
…ied. To test this point, we can, in chrome, disable CDM widevine plugin.