### PR TITLE
Use Event.target not Event.srcElement where possible

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -241,7 +241,9 @@ MediaPlayer.dependencies.PlaybackController = function () {
         },
 
         onPlaybackError = function(event) {
-            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, {error: event.srcElement.error});
+            var target = event.target || event.srcElement;
+
+            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, {error: target.error});
         },
 
         onWallclockTime = function() {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -117,7 +117,9 @@
             hasMediaError = true;
 
             this.log("Video Element Error: " + msg);
-            this.log(e.error);
+            if (e.error) {
+                this.log(e.error);
+            }
             this.errHandler.mediaSourceError(msg);
             this.reset();
         },


### PR DESCRIPTION
While testing Firefox MSE implementation a couple of issues were noted:

- Event.srcElement is not available in Firefox. Event.target should be preferred where available. (#590)
- I noticed that e.error was needlessly logged on video error when it was not defined, adding nothing helpful to the logs.