### PR TITLE
Fixes for multi-period protected content

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -278,6 +278,27 @@
                     }
                 }
             }
+        },
+        {
+            "name": "CableLabs Cenc PR/WV (2-Period, 2-Key)",
+            "url": "http://html5.cablelabs.com:8100/cenc/prwv_mp/dash.mpd",
+            "browsers": "",
+            "protData": {
+                "com.widevine.alpha": {
+                    "drmtoday": true,
+                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
+                    "httpRequestHeaders": {
+                        "dt-custom-data": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
+                    }
+                },
+                "com.microsoft.playready": {
+                    "drmtoday": true,
+                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
+                    "httpRequestHeaders": {
+                        "http-header-CustomData": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
+                    }
+                }
+            }
         }
     ]
 }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -39,7 +39,6 @@ MediaPlayer.dependencies.Stream = function () {
         isUpdating = false,
         isInitialized = false,
         protectionController,
-        ownProtectionController = false,
 
         eventController = null,
 
@@ -288,20 +287,10 @@ MediaPlayer.dependencies.Stream = function () {
             this[MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR] = onProtectionError.bind(this);
         },
 
-        initialize: function(strmInfo, protectionCtrl, protectionData) {
+        initialize: function(strmInfo, protectionCtrl) {
             streamInfo = strmInfo;
-            if (this.capabilities.supportsEncryptedMedia()) {
-                if (!protectionCtrl) {
-                    protectionCtrl = this.system.getObject("protectionController");
-                    ownProtectionController = true;
-                }
-                protectionController = protectionCtrl;
-                protectionController.subscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR, this);
-                protectionController.setMediaElement(this.videoModel.getElement());
-                if (protectionData) {
-                    protectionController.setProtectionData(protectionData);
-                }
-            }
+            protectionController = protectionCtrl;
+            protectionController.subscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR, this);
         },
 
         /**
@@ -362,14 +351,7 @@ MediaPlayer.dependencies.Stream = function () {
             this.liveEdgeFinder.abortSearch();
             this.liveEdgeFinder.unsubscribe(MediaPlayer.dependencies.LiveEdgeFinder.eventList.ENAME_LIVE_EDGE_SEARCH_COMPLETED, this.playbackController);
 
-            if (protectionController) {
-                protectionController.unsubscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR, this);
-                if (ownProtectionController) {
-                    protectionController.teardown();
-                    protectionController = null;
-                    ownProtectionController = false;
-                }
-            }
+            protectionController.unsubscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR, this);
 
             isMediaInitialized = false;
             isStreamActivated = false;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -39,6 +39,7 @@
     var streams = [],
         activeStream,
         protectionController,
+        ownProtectionController = false,
         protectionData,
         STREAM_END_THRESHOLD = 0.2,
         autoPlay = true,
@@ -305,6 +306,17 @@
 
             streamsInfo = self.adapter.getStreamsInfo(manifest);
 
+            if (this.capabilities.supportsEncryptedMedia()) {
+                if (!protectionController) {
+                    protectionController = this.system.getObject("protectionController");
+                    ownProtectionController = true;
+                }
+                protectionController.setMediaElement(this.videoModel.getElement());
+                if (protectionData) {
+                    protectionController.setProtectionData(protectionData);
+                }
+            }
+
             try {
                 if (streamsInfo.length === 0) {
                     throw new Error("There are no streams");
@@ -406,6 +418,7 @@
 
     return {
         system: undefined,
+        capabilities: undefined,
         videoModel: undefined,
         manifestUpdater: undefined,
         manifestLoader: undefined,
@@ -532,6 +545,10 @@
             canPlay = false;
             hasMediaError = false;
 
+            if (ownProtectionController) {
+                protectionController.teardown();
+                ownProtectionController = false;
+            }
             protectionController = null;
             protectionData = null;
 

--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -39,6 +39,14 @@
 MediaPlayer.models.ProtectionModel = {
 
     /**
+     * Returns an array of all initialization data sets currently used by
+     * active sessions.
+     *
+     * @return {ArrayBuffer[]} an array of initialization data buffers
+     getAllInitData: function() {},
+     */
+
+    /**
      * Determine if the user-agent supports one of the given key systems and
      * content type configurations. Sends ENAME_KEY_SYSTEM_ACCESS_COMPLETE event
      * with a KeySystemAccess object as event data

--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -230,6 +230,17 @@ MediaPlayer.models.ProtectionModel_01b = function () {
             }
         },
 
+        getAllInitData: function() {
+            var i, retVal = [];
+            for (i = 0; i < pendingSessions.length; i++) {
+                retVal.push(pendingSessions[i].initData);
+            }
+            for (i = 0; i < sessions.length; i++) {
+                retVal.push(sessions[i].initData);
+            }
+            return retVal;
+        },
+
         requestKeySystemAccess: function(ksConfigurations) {
             var ve = videoElement;
             if (!ve) { // Must have a video element to do this capability tests
@@ -318,19 +329,6 @@ MediaPlayer.models.ProtectionModel_01b = function () {
 
             if (!this.keySystem) {
                 throw new Error("Can not create sessions until you have selected a key system");
-            }
-
-            // Check for duplicate initData.
-            var i;
-            for (i = 0; i < sessions.length; i++) {
-                if (this.protectionExt.initDataEquals(initData, sessions[i].initData)) {
-                    return;
-                }
-            }
-            for (i = 0; i < pendingSessions.length; i++) {
-                if (this.protectionExt.initDataEquals(initData, pendingSessions[i].initData)) {
-                    return;
-                }
             }
 
             // Determine if creating a new session is allowed

--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -76,8 +76,10 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
                     switch (event.type) {
 
                         case "encrypted":
-                            self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY,
-                                new MediaPlayer.vo.protection.NeedKey(event.initData, event.initDataType));
+                            if (event.initData) {
+                                self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY,
+                                        new MediaPlayer.vo.protection.NeedKey(event.initData, event.initDataType));
+                            }
                             break;
                     }
                 }
@@ -181,6 +183,14 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             }
         },
 
+        getAllInitData: function() {
+            var retVal = [];
+            for (var i = 0; i < sessions.length; i++) {
+                retVal.push(sessions[i].initData);
+            }
+            return retVal;
+        },
+
         requestKeySystemAccess: function(ksConfigurations) {
             requestKeySystemAccessInternal.call(this, ksConfigurations, 0);
         },
@@ -231,13 +241,6 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
             if (!this.keySystem || !mediaKeys) {
                 throw new Error("Can not create sessions until you have selected a key system");
-            }
-
-            // Check for duplicate initData.
-            for (var i = 0; i < sessions.length; i++) {
-                if (this.protectionExt.initDataEquals(initData, sessions[i].initData)) {
-                    return;
-                }
             }
 
             var session = mediaKeys.createSession(sessionType);

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -51,8 +51,10 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
                     switch (event.type) {
 
                         case api.needkey:
-                            self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY,
-                                new MediaPlayer.vo.protection.NeedKey(event.initData, "cenc"));
+                            if (event.initData) {
+                                self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY,
+                                        new MediaPlayer.vo.protection.NeedKey(event.initData, "cenc"));
+                            }
                             break;
                     }
                 }
@@ -150,6 +152,14 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
             }
         },
 
+        getAllInitData: function() {
+            var retVal = [];
+            for (var i = 0; i < sessions.length; i++) {
+                retVal.push(sessions[i].initData);
+            }
+            return retVal;
+        },
+
         requestKeySystemAccess: function(ksConfigurations) {
 
             // Try key systems in order, first one with supported key system configuration
@@ -242,13 +252,6 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
 
             if (!this.keySystem || !mediaKeys || !keySystemAccess) {
                 throw new Error("Can not create sessions until you have selected a key system");
-            }
-
-            // Check for duplicate initData.
-            for (var i = 0; i < sessions.length; i++) {
-                if (this.protectionExt.initDataEquals(initData, sessions[i].initData)) {
-                    return;
-                }
             }
 
             // Use the first video capability for the contentType.


### PR DESCRIPTION
ProtectionController now managed at the StreamController instead of
Stream to prevent destroying key information when changing periods

Better support for preventing session creation for initialization data
we have already seen

New multi-period, protected content added to sources list

Moved key system selection out of ProtectionExtensions.  The parts of
key system selection that apps would want to change (returning
prioritized list of keys systems, etc) are still in extensions.