### PR TITLE
Add BBC Testcard and EBU-TT-D reference streams

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -299,6 +299,16 @@
                     }
                 }
             }
+        },
+        {
+            "name": "BBC R&D Testcard",
+            "url": "http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd",
+            "browsers": ""
+        },
+        {
+            "name": "BBC R&D EBU-TT-D Subtitling Test",
+            "url": "http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd",
+            "browsers": ""
         }
     ]
 }


### PR DESCRIPTION
Add main manifests from http://rdmedia.bbc.co.uk/dash/ondemand/testcard/ and http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/ to test stream drop down.

Note that these streams are delivered on a best efforts basis and are subject to change so we recommend they are always accessed through the index page.