### PR TITLE
Fix for crash caused by uninitialized currentTrackInfo in onLiveEdgeSearchCompleted

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -341,7 +341,10 @@ MediaPlayer.dependencies.ScheduleController = function () {
 
         onLiveEdgeSearchCompleted = function(e) {
             if (e.error) return;
-
+            
+            if(!currentTrackInfo)
+                return;
+            
             // step back from a found live edge time to be able to buffer some data
             var self = this,
                 liveEdgeTime = e.data.liveEdge,


### PR DESCRIPTION
In a case when attempt to playback live content immediately as a live service starts, onLiveEdgeSearchCompleted is called before currentTrackInfo is initialized. A check here fixes this. Should not have any side effects as this method should not proceed uninitialized anyway.