### PR TITLE
Bug # 623 Async Protection teardown

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -80,6 +80,7 @@ MediaPlayer = function (context) {
         videoModel,
         DOMStorage,
         initialized = false,
+        resetting = false,
         playing = false,
         autoPlay = true,
         scheduleWhilePaused = false,
@@ -90,7 +91,7 @@ MediaPlayer = function (context) {
         usePresentationDelay = false,
 
         isReady = function () {
-            return (!!element && !!source);
+            return (!!element && !!source && !resetting);
         },
 
         play = function () {
@@ -235,28 +236,32 @@ MediaPlayer = function (context) {
 
         resetAndPlay = function() {
             if (playing && streamController) {
-                playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, streamController);
-                playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, streamController);
-                playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_CAN_PLAY, streamController);
-                playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
+                if (!resetting) {
+                    resetting = true;
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, streamController);
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, streamController);
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_CAN_PLAY, streamController);
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
 
-                var teardownComplete = {},
-                    self = this;
-                teardownComplete[MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE] = function () {
+                    var teardownComplete = {},
+                            self = this;
+                    teardownComplete[MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE] = function () {
 
-                    // Finish rest of shutdown process
-                    abrController.reset();
-                    rulesController.reset();
-                    playbackController.reset();
-                    streamController = null;
-                    playing = false;
+                        // Finish rest of shutdown process
+                        abrController.reset();
+                        rulesController.reset();
+                        playbackController.reset();
+                        streamController = null;
+                        playing = false;
 
-                    if (isReady.call(self)) {
-                        doAutoPlay.call(self);
-                    }
-                };
-                streamController.subscribe(MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE, teardownComplete, undefined, true);
-                streamController.reset();
+                        resetting = false;
+                        if (isReady.call(self)) {
+                            doAutoPlay.call(self);
+                        }
+                    };
+                    streamController.subscribe(MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE, teardownComplete, undefined, true);
+                    streamController.reset();
+                }
             } else {
                 if (isReady.call(this)) {
                     doAutoPlay.call(this);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -242,7 +242,7 @@ MediaPlayer = function (context) {
 
                 var teardownComplete = {},
                     self = this;
-                teardownComplete[MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE] = function (event) {
+                teardownComplete[MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE] = function () {
 
                     // Finish rest of shutdown process
                     abrController.reset();

--- a/src/streaming/controllers/ProtectionController.js
+++ b/src/streaming/controllers/ProtectionController.js
@@ -320,6 +320,8 @@ MediaPlayer.dependencies.ProtectionController = function () {
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_CREATED, this);
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_CLOSED, this);
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED, this);
+            this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_MESSAGE, this);
+            this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY, this);
             this.keySystem = undefined;
 
             this.protectionModel.teardown();

--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -167,5 +167,6 @@ MediaPlayer.models.ProtectionModel.eventList = {
     ENAME_KEY_SESSION_CREATED: "keySessionCreated",
     ENAME_KEY_SESSION_REMOVED: "keySessionRemoved",
     ENAME_KEY_SESSION_CLOSED: "keySessionClosed",
-    ENAME_KEY_STATUSES_CHANGED: "keyStatusesChanged"
+    ENAME_KEY_STATUSES_CHANGED: "keyStatusesChanged",
+    ENAME_TEARDOWN_COMPLETE: "teardownComplete"
 };

--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -188,7 +188,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             var numSessions = sessions.length,
                 session,
                 self = this;
-            if (numSessions != 0) {
+            if (numSessions !== 0) {
                 // Called when we are done closing a session.  Success or fail
                 var done = function(session) {
                     removeSession(session);
@@ -197,8 +197,6 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
                             videoElement.removeEventListener("encrypted", eventHandler);
                             videoElement.setMediaKeys(null).then(function () {
                                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE);
-                            }).catch(function (error) {
-                                var x = 1;
                             });
                         }
                     }

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -144,11 +144,18 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
         },
 
         teardown: function() {
-            if (videoElement) {
-                videoElement.removeEventListener(api.needkey, eventHandler);
-            }
-            for (var i = 0; i < sessions.length; i++) {
-                this.closeKeySession(sessions[i]);
+            try {
+                for (var i = 0; i < sessions.length; i++) {
+                    this.closeKeySession(sessions[i]);
+                }
+                if (videoElement) {
+                    videoElement.removeEventListener(api.needkey, eventHandler);
+                    videoElement.setMediaKeys(null);
+                }
+                this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE);
+            } catch (error) {
+                this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE,
+                        null, "Error tearing down key sessions and MediaKeys! -- " + error.message);
             }
         },
 

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -66,15 +66,17 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
         // readyState, so we need this logic to ensure we don't set the keys
         // too early
         setMediaKeys = function() {
-            // IE11 does not allow setting of media keys until
+            var boundDoSetKeys = null;
             var doSetKeys = function() {
+                videoElement.removeEventListener("loadedmetadata", boundDoSetKeys);
                 videoElement[api.setMediaKeys](mediaKeys);
                 this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_VIDEO_ELEMENT_SELECTED);
             };
             if (videoElement.readyState >= 1) {
                 doSetKeys.call(this);
             } else {
-                videoElement.addEventListener("loadedmetadata", doSetKeys.bind(this));
+                boundDoSetKeys = doSetKeys.bind(this);
+                videoElement.addEventListener("loadedmetadata", boundDoSetKeys);
             }
 
         },


### PR DESCRIPTION
Added events to allow the protection system to be torn down asynchronously.  Since the latest EME APIs are mostly asynchronous, this is necessary to ensure proper shutdown prior to changing streams.

Shutdown the media source before shutting down the protection system.  On Chrome, this is necessary because MediaKeys can not be set to null until the src has been cleared.