### PR TITLE
Fix for Issue #619 & Partial fix for #601

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -404,13 +404,24 @@
         onManifestUpdated = function(e) {
             if (!e.error) {
                 this.log("Manifest has loaded.");
-                //self.log(self.manifestModel.getValue());
-                // before composing streams, attempt to synchronize with some
-                // time source (if there are any available)
-                var manifestUTCTimingSources = this.manifestExt.getUTCTimingSources(e.data.manifest),
-                    allUTCTimingSources = manifestUTCTimingSources.concat(UTCTimingSources); //manifest utc time source(s) take precedence over default or explicitly added sources.
+                //Since streams are not composed yet , need to manually look up useCalculatedLiveEdgeTime to detect if stream
+                //is SegmentTimeline to avoid using time source
+                var manifest = e.data.manifest,
+                    streamInfo = this.adapter.getStreamsInfo(manifest)[0],
+                    mediaInfo  = this.adapter.getMediaInfoForType(manifest, streamInfo, "video"),
+                    adaptation = this.adapter.getDataForMedia(mediaInfo),
+                    useCalculatedLiveEdgeTime = this.manifestExt.getRepresentationsForAdaptation(manifest, adaptation)[0].useCalculatedLiveEdgeTime;
 
-                this.timeSyncController.initialize(allUTCTimingSources, useManifestDateHeaderTimeSource);
+                if (useCalculatedLiveEdgeTime) {
+                    this.log("SegmentTimeline detected using calculated Live Edge Time");
+                    useManifestDateHeaderTimeSource = false;
+                }
+
+                var manifestUTCTimingSources = this.manifestExt.getUTCTimingSources(e.data.manifest),
+                    allUTCTimingSources = (!this.manifestExt.getIsDynamic(manifest) || useCalculatedLiveEdgeTime ) ?  manifestUTCTimingSources :  manifestUTCTimingSources.concat(UTCTimingSources);
+
+                this.timeSyncController.initialize(useCalculatedLiveEdgeTime ? manifestUTCTimingSources : allUTCTimingSources, useManifestDateHeaderTimeSource);
+
             } else {
                 this.reset();
             }

--- a/src/streaming/rules/SynchronizationRules/LiveEdgeWithTimeSynchronizationRule.js
+++ b/src/streaming/rules/SynchronizationRules/LiveEdgeWithTimeSynchronizationRule.js
@@ -55,7 +55,6 @@ MediaPlayer.rules.LiveEdgeWithTimeSynchronizationRule = function () {
                 // Thus, we need to switch an expected live edge and actual live edge for SegmentTimelne streams.
                 var actualLiveEdge = this.timelineConverter.getExpectedLiveEdge();
                 this.timelineConverter.setExpectedLiveEdge(liveEdgeInitialSearchPosition);
-                this.timelineConverter.setTimeSyncCompleted(false);
                 callback(new MediaPlayer.rules.SwitchRequest(actualLiveEdge, p));
             } else {
                 callback(new MediaPlayer.rules.SwitchRequest(liveEdgeInitialSearchPosition, p));


### PR DESCRIPTION
Fix for issue #619 - Will not make time source attempt for static streams unless UTC timing in manifest advise to do so.

Partial Fix for issue #601
* Avoids using "utc timing sources or date header if SegmentTimeline is present.  
* Maintains the same live edge detection steps as 1.4 if not SegmentTimeline.
* Will still use MPD  based time sources if present (same functionality as 1.3) 