### PR TITLE
Convert XlinkController/Loader to classes

### DIFF
--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -113,8 +113,8 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('liveEdgeWithTimeSynchronizationRule', MediaPlayer.rules.LiveEdgeWithTimeSynchronizationRule);
             this.system.mapSingleton('synchronizationRulesCollection', MediaPlayer.rules.SynchronizationRulesCollection);
 
-            this.system.mapSingleton('xlinkController', MediaPlayer.dependencies.XlinkController);
-            this.system.mapSingleton('xlinkLoader', MediaPlayer.dependencies.XlinkLoader);
+            this.system.mapClass('xlinkController', MediaPlayer.dependencies.XlinkController);
+            this.system.mapClass('xlinkLoader', MediaPlayer.dependencies.XlinkLoader);
             this.system.mapClass('streamProcessor', MediaPlayer.dependencies.StreamProcessor);
             this.system.mapClass('eventController', MediaPlayer.dependencies.EventController);
             this.system.mapClass('textController', MediaPlayer.dependencies.TextController);

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -155,13 +155,14 @@ MediaPlayer.dependencies.ManifestLoader = function () {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
-        xlinkController: undefined,
+        system: undefined,
 
         load: function(url) {
             doLoad.call(this, url, RETRY_ATTEMPTS);
         },
         setup: function() {
             onXlinkReady = onXlinkReady.bind(this);
+            this.xlinkController = this.system.getObject("xlinkController");
             this.xlinkController.subscribe(MediaPlayer.dependencies.XlinkController.eventList.ENAME_XLINK_READY,this,onXlinkReady);
         }
     };


### PR DESCRIPTION
Since we've made ManifestLoader a class, we also need to make ```XlinkController```/```Loader``` classes as well.  ```ManifestModel``` is updated when xlink resolution is completed, but we don't want to update ```ManifestModel``` when we allow applications to load their own manifests (```MediaPlayer.retrieveManifest()```) with their own ```ManifestLoader``` instance.