### PR TITLE
Add JSDocs to all protection/DRM-related code

### DIFF
--- a/build/jsdoc/jsdoc_conf.json
+++ b/build/jsdoc/jsdoc_conf.json
@@ -5,7 +5,7 @@
     "source": {
         "include": ["../src/streaming/", "../src/dash/"]
     },
-    "plugins": [],
+    "plugins": [ "plugins/markdown" ],
     "templates": {	
 		"cleverLinks"           : false,
 		"monospaceLinks"        : true,

--- a/src/dash/DashCreate.js
+++ b/src/dash/DashCreate.js
@@ -69,8 +69,8 @@ Dash.createAll = function(className, scope, context)
 
 /**
  * Returns the mime-type identifier for any source content to be accepted as a dash manifest by the Dash.create() method.
- * @type {dashManifestMimeType: string}
  */
 Dash.supportedManifestMimeTypes = {
+    /** @type string */
     mimeType: "application/dash+xml"
 };

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -28,6 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
+/**
+ * Dijon Context Object
+ *
+ * @class
+ */
 MediaPlayer.di.Context = function () {
     "use strict";
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -732,12 +732,21 @@ MediaPlayer = function (context) {
         },
 
         /**
-         * Allows application to retrieve a manifest
+         * A Callback function provided when retrieving manifests
+         *
+         * @callback MediaPlayer~retrieveManifestCallback
+         * @param {Object} manifest JSON version of the manifest XML data or null if an
+         * error was encountered
+         * @param {String} error An error string or null if the operation was successful
+         */
+
+        /**
+         * Allows application to retrieve a manifest.  Manifest loading is asynchronous and
+         * requires the app-provided callback function
          *
          * @param {string} url the manifest url
-         * @param {function} callback function that accepts two parameters.  The first is
-         * a successfully parsed manifest or null, the second is a string that contains error
-         * information in the case that the first parameter is null
+         * @param {MediaPlayer~retrieveManifestCallback} callback manifest retrieval callback
+         * @memberof MediaPlayer#
          */
         retrieveManifest: function(url, callback) {
             (function(manifestUrl) {
@@ -1046,16 +1055,64 @@ MediaPlayer.prototype = {
     constructor: MediaPlayer
 };
 
-
+/**
+ * Namespace for {@MediaPlayer} dependencies
+ * @namespace
+ */
 MediaPlayer.dependencies = {};
+
+/**
+ * Namespace for {@MediaPlayer} protection-related objects
+ * @namespace
+ */
 MediaPlayer.dependencies.protection = {};
+
+/**
+ * Namespace for {@MediaPlayer} license server implementations
+ * @namespace
+ */
 MediaPlayer.dependencies.protection.servers = {};
+
+/**
+ * Namespace for {@MediaPlayer} utility classes
+ * @namespace
+ */
 MediaPlayer.utils = {};
+
+/**
+ * Namespace for {@MediaPlayer} model classes
+ * @namespace
+ */
 MediaPlayer.models = {};
+
+/**
+ * Namespace for {@MediaPlayer} data objects
+ * @namespace
+ */
 MediaPlayer.vo = {};
+
+/**
+ * Namespace for {@MediaPlayer} metrics-related data objects
+ * @@namespace
+ */
 MediaPlayer.vo.metrics = {};
+
+/**
+ * Namespace for {@MediaPlayer} protection-related data objects
+ * @namespace
+ */
 MediaPlayer.vo.protection = {};
+
+/**
+ * Namespace for {@MediaPlayer} rules classes
+ * @namespace
+ */
 MediaPlayer.rules = {};
+
+/**
+ * Namespace for {@MediaPlayer} dependency-injection helper classes
+ * @namespace
+ */
 MediaPlayer.di = {};
 
 /**

--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -29,145 +29,256 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
 /**
  * Defines the public interface for all ProtectionModel implementations.
  *
  * ProtectionModel implementations provide access to particular versions
  * of the Encrypted Media Extensions (EME) APIs that have been implemented
- * in a user agent
+ * in a user agent.  Developers wishing to add support for a new EME version
+ * found in a target user-agent should add a new instance of this interface
+ * to the
+ *
+ * Applications should not need direct access to this object.  All interactions with
+ * the protection system should be performed with
+ * {@link MediaPlayer.dependencies.ProtectionController}
+ *
+ * @interface MediaPlayer.models.ProtectionModel
  */
-MediaPlayer.models.ProtectionModel = {
 
-    /**
-     * Returns an array of all initialization data sets currently used by
-     * active sessions.
-     *
-     * @return {ArrayBuffer[]} an array of initialization data buffers
-     getAllInitData: function() {},
-     */
+MediaPlayer.models.ProtectionModel = function() { };
 
-    /**
-     * Determine if the user-agent supports one of the given key systems and
-     * content type configurations. Sends ENAME_KEY_SYSTEM_ACCESS_COMPLETE event
-     * with a KeySystemAccess object as event data
-     *
-     * @param {Object[]} ksConfigurations - array of desired key system
-     * configurations in priority order (highest priority first)
-     * @param {MediaPlayer.dependencies.protection.KeySystem} ksConfigurations.ks -
-     * the key system
-     * @param {MediaPlayer.vo.protection.KeySystemConfiguration[]}
-     * ksConfigurations.configs - array of acceptable key system configurations
-     * for this key system in priority order (highest priority first)
-     *
-     requestKeySystemAccess: function(ksConfigurations) { },
-     */
+/**
+ * Returns an array of all initialization data currently used by
+ * active sessions.
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#getAllInitData
+ * @returns {ArrayBuffer[]} an array of initialization data buffers
+ */
 
-    /**
-     * Selects the key system to use for all future operations on this
-     * ProtectionModel.  Sends ENAME_KEY_SYSTEM_SELECTED with no data
-     *
-     * @param keySystemAccess {MediaPlayer.vo.protection.KeySystemAccess} the key
-     * system access token representing a supported key system
-     *
-     selectKeySystem: function(keySystemAccess) { },
-     */
+/**
+ * Determine if the user-agent supports one of the given key systems and
+ * content type configurations. Sends ENAME_KEY_SYSTEM_ACCESS_COMPLETE event
+ * with a KeySystemAccess object as event data
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#requestKeySystemAccess
+ * @param {Object[]} ksConfigurations array of desired key system
+ * configurations in priority order (highest priority first)
+ * @param {MediaPlayer.dependencies.protection.KeySystem} ksConfigurations.ks
+ * the key system
+ * @param {MediaPlayer.vo.protection.KeySystemConfiguration[]} ksConfigurations.configs
+ * array of acceptable key system configurations
+ * for this key system in priority order (highest priority first)
+ */
 
-    /**
-     * Associate this protection model with a HTMLMediaElement
-     *
-     * @param mediaElement {HTMLMediaElement} the media element to
-     * which we should associate this protection model and all current
-     * key sessions
-     *
-     setMediaElement: function(mediaElement) { },
-     */
+/**
+ * Selects the key system to use for all future operations on this
+ * ProtectionModel.  Sends ENAME_KEY_SYSTEM_SELECTED with no data
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#selectKeySystem
+ * @param keySystemAccess {MediaPlayer.vo.protection.KeySystemAccess} the key
+ * system access token representing a supported key system
+ */
 
-    /**
-     * Creates a new key session using the given initData and type. Sends
-     * ENAME_KEY_SESSION_CREATED event with MediaPlayer.vo.protection.SessionToken
-     * as data.
-     *
-     * @param {ArrayBuffer} initData PSSH box for the currently selected
-     * key system.
-     * @param {string} sessionType the desired session type.  One of "temporary",
-     * "persistent-license", "persistent-release-message".  CDM implementations
-     * are not required to support anything except "temporary"
-     *
-     createKeySession: function(initData, sessionType) { },
-     */
+/**
+ * Associate this protection model with a HTMLMediaElement
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#setMediaElement
+ * @param mediaElement {HTMLMediaElement} the media element to
+ * which we should associate this protection model and all current
+ * key sessions
+ */
 
-    /**
-     * Update the given key session with a key (or any other message
-     * intended for the CDM)
-     *
-     * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session
-     * token
-     * @param {ArrayBuffer} message the message that should be delivered to the CDM
-     * for this session
-     *
-     updateKeySession: function(sessionToken, message) { },
-     */
+/**
+ * Creates a new key session using the given initData and type. Sends
+ * ENAME_KEY_SESSION_CREATED event with MediaPlayer.vo.protection.SessionToken
+ * as data.
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#createKeySession
+ * @param {ArrayBuffer} initData PSSH box for the currently selected
+ * key system.
+ * @param {string} sessionType the desired session type.  One of "temporary",
+ * "persistent-license", "persistent-release-message".  CDM implementations
+ * are not required to support anything except "temporary"
+ */
 
-    /**
-     * Loads the persisted key session data associated with the given sessionID
-     * into a new session.  Sends ENAME_KEY_SESSION_CREATED event with
-     * MediaPlayer.vo.protection.SessionToken as data.
-     *
-     * @param {string} sessionID the session ID corresponding to the persisted
-     * session data to be loaded
-     *
-     loadKeySession: function(sessionID) {},
-     */
+/**
+ * Update the given key session with a key (or any other message
+ * intended for the CDM)
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#updateKeySession
+ * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session
+ * token
+ * @param {ArrayBuffer} message the message that should be delivered to the CDM
+ * for this session
+ */
 
-    /**
-     * Removes any persisted key session data associated with the given session.
-     * Also closes the session.  Sends ENAME_KEY_SESSION_REMOVED and
-     * ENAME_KEY_SESSION_CLOSED with sessionID as data
-     *
-     * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session
-     * token
-     *
-     removeKeySession: function(sessionToken) {},
-     */
+/**
+ * Loads the persisted key session data associated with the given sessionID
+ * into a new session.  Sends ENAME_KEY_SESSION_CREATED event with
+ * {@MediaPlayer.vo.protection.SessionToken} as data.
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#loadKeySession
+ * @param {string} sessionID the session ID corresponding to the persisted
+ * session data to be loaded
+ */
 
-    /**
-     * Close the given session and release all associated keys.  Following
-     * this call, the sessionToken becomes invalid.  Sends ENAME_KEY_SESSION_CLOSED
-     * with sessionID as data
-     *
-     * @param sessionToken the session token
-     *
-     closeKeySession: function(sessionToken) {},
-     */
+/**
+ * Removes any persisted key session data associated with the given session.
+ * Also closes the session.  Sends ENAME_KEY_SESSION_REMOVED and
+ * ENAME_KEY_SESSION_CLOSED with sessionID as data
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#removeKeySession
+ * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session
+ * token
+ */
 
-    /**
-     * Sets the certificate to be used by the CDM for encrypting messages
-     *
-     * @param serverCertificate
-     *
-     setServerCertificate: function(serverCertificate) {},
-     */
+/**
+ * Close the given session and release all associated keys.  Following
+ * this call, the sessionToken becomes invalid.  Sends ENAME_KEY_SESSION_CLOSED
+ * with sessionID as data
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#closeKeySession
+ * @param sessionToken the session token
+ */
 
-    /**
-     * Selected key system
-     *
-     keySystem: undefined
-     */
-};
+/**
+ * Sets the certificate to be used by the CDM for encrypting messages
+ *
+ * @function
+ * @name MediaPlayer.models.ProtectionModel#setServerCertificate
+ * @param {ArrayBuffer} serverCertificate
+ */
 
+/**
+ * Currently selected key system.  Will be null or undefined if no key
+ * system has yet been selected
+ *
+ * @instance
+ * @name keySystem
+ * @memberof MediaPlayer.models.ProtectionModel
+ * @readonly
+ * @type MediaPlayer.dependencies.protection.KeySystem
+ */
+
+
+/**
+ * Event IDs for events sent by ProtectionModel implementations. Use these
+ * event names when subscribing or unsubscribing from ProtectionModel events.
+ *
+ * @enum {String}
+ */
 MediaPlayer.models.ProtectionModel.eventList = {
+    /**
+     * Event ID for needkey/encrypted events
+     *
+     * @constant
+     */
     ENAME_NEED_KEY: "needkey",
+    /**
+     * Event ID for events delivered when a key system access procedure
+     * has completed
+     *
+     * @constant
+     */
     ENAME_KEY_SYSTEM_ACCESS_COMPLETE: "keySystemAccessComplete",
+    /**
+     * Event ID for events delivered when a key system selection procedure
+     * completes
+     *
+     * @constant
+     */
     ENAME_KEY_SYSTEM_SELECTED: "keySystemSelected",
+    /**
+     * Event ID for events delivered when a HTMLMediaElement has been
+     * associated with the protection set
+     *
+     * @constant
+     */
     ENAME_VIDEO_ELEMENT_SELECTED: "videoElementSelected",
+    /**
+     * Event ID for events delivered when a new server certificate has
+     * been delivered to the CDM
+     *
+     * @constant
+     */
     ENAME_SERVER_CERTIFICATE_UPDATED: "serverCertificateUpdated",
+    /**
+     * Event ID for events delivered when the protection set receives
+     * a key message from the CDM
+     *
+     * @constant
+     */
     ENAME_KEY_MESSAGE: "keyMessage",
+    /**
+     * Event ID for events delivered when a new key has been added
+     *
+     * @constant
+     * @deprecated The latest versions of the EME specification no longer
+     * use this event.  {@MediaPlayer.models.protectionModel.eventList.ENAME_KEY_STATUSES_CHANGED}
+     * is preferred.
+     */
     ENAME_KEY_ADDED: "keyAdded",
+    /**
+     * Event ID for events delivered when an error is encountered by the CDM
+     * while processing a license server response message
+     *
+     * @constant
+     */
     ENAME_KEY_ERROR: "keyError",
+    /**
+     * Event ID for events delivered when a new key sessions creation
+     * process has completed
+     *
+     * @constant
+     */
     ENAME_KEY_SESSION_CREATED: "keySessionCreated",
+    /**
+     * Event ID for events delivered when a key session removal
+     * process has completed
+     *
+     * @constant
+     */
     ENAME_KEY_SESSION_REMOVED: "keySessionRemoved",
+    /**
+     * Event ID for events delivered when a key session close
+     * process has completed
+     *
+     * @constant
+     */
     ENAME_KEY_SESSION_CLOSED: "keySessionClosed",
+    /**
+     * Event ID for events delivered when the status of one or more
+     * decryption keys has changed
+     *
+     * @constant
+     */
     ENAME_KEY_STATUSES_CHANGED: "keyStatusesChanged",
+    /**
+     * Event ID for events delivered when the process of shutting down
+     * a protection set has completed
+     *
+     * @constant
+     */
     ENAME_TEARDOWN_COMPLETE: "protectionTeardownComplete",
+    /**
+     * Event ID for events delivered when a license request procedure
+     * has completed
+     *
+     * @constant
+     */
     ENAME_LICENSE_REQUEST_COMPLETE: "licenseRequestComplete"
 };
+
+/**
+ * needkey/encrypted event
+ */

--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -29,6 +29,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Initial implementation of EME
+ *
+ * Implemented by Google Chrome prior to v36
+ *
+ * @implements MediaPlayer.models.ProtectionModel
+ * @class
+ */
 MediaPlayer.models.ProtectionModel_01b = function () {
 
     var videoElement = null,
@@ -334,13 +342,16 @@ MediaPlayer.models.ProtectionModel_01b = function () {
             // Determine if creating a new session is allowed
             if (moreSessionsAllowed || sessions.length === 0) {
 
-                var newSession = {
-                    prototype: (new MediaPlayer.models.SessionToken()).prototype,
+                var newSession = { // Implements MediaPlayer.vo.protection.SessionToken
                     sessionID: null,
                     initData: initData,
 
                     getSessionID: function() {
                         return this.sessionID;
+                    },
+
+                    getExpirationTime: function() {
+                        return NaN;
                     }
                 };
                 pendingSessions.push(newSession);
@@ -424,7 +435,7 @@ MediaPlayer.models.ProtectionModel_01b.APIs = [
  * @param videoElement {HTMLMediaElement} the media element that will be
  * used for detecting APIs
  * @returns an API object that is used when initializing the ProtectionModel
- * instance
+ * instance, or null if this EME version is not supported
  */
 MediaPlayer.models.ProtectionModel_01b.detect = function(videoElement) {
     var apis = MediaPlayer.models.ProtectionModel_01b.APIs;

--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -30,8 +30,12 @@
  */
 
 /**
- * Implemented in:
- *   Chrome 40 with chrome://flags -- Enable Encrypted Media Extensions
+ * Most recent EME implementation
+ *
+ * Implemented by Google Chrome v36+ (Windows, OSX, Linux)
+ *
+ * @implements MediaPlayer.models.ProtectionModel
+ * @class
  */
 MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
@@ -113,8 +117,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
         createSessionToken = function(session, initData) {
 
             var self = this;
-            var token = {
-                prototype: (new MediaPlayer.models.SessionToken()).prototype,
+            var token = { // Implements MediaPlayer.vo.protection.SessionToken
                 session: session,
                 initData: initData,
 
@@ -375,10 +378,10 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 };
 
 /**
- * Detects presence of EME v3Feb2014 APIs
+ * Detects presence of EME v21Jan2015 APIs
  *
  * @param videoElement {HTMLMediaElement} the media element that will be
- * used for detecting APIs
+ * used for detecting API support
  * @returns {Boolean} true if support was detected, false otherwise
  */
 MediaPlayer.models.ProtectionModel_21Jan2015.detect = function(videoElement) {

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -29,6 +29,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Implementation of the EME APIs as of the 3 Feb 2014 state of the specification.
+ *
+ * Implemented by Internet Explorer 11 (Windows 8.1)
+ *
+ * @implements MediaPlayer.models.ProtectionModel
+ * @class
+ */
 MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
 
     var videoElement = null,
@@ -85,8 +93,7 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
         // MediaKeySession and session-specific event handler
         createSessionToken = function(keySession, initData) {
             var self = this;
-            return {
-                prototype: (new MediaPlayer.models.SessionToken()).prototype,
+            return { // Implements MediaPlayer.vo.protection.SessionToken
                 session: keySession,
                 initData: initData,
 
@@ -121,6 +128,10 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
 
                 getSessionID: function() {
                     return this.session.sessionId;
+                },
+
+                getExpirationTime: function() {
+                    return NaN;
                 }
             };
         };
@@ -384,8 +395,8 @@ MediaPlayer.models.ProtectionModel_3Feb2014.APIs = [
  *
  * @param videoElement {HTMLMediaElement} the media element that will be
  * used for detecting APIs
- * @returns an API object that is used when initializing the ProtectionModel
- * instance
+ * @returns {Object} an API object that is used when initializing the
+ * ProtectionModel instance or null if this EME version is not supported
  */
 MediaPlayer.models.ProtectionModel_3Feb2014.detect = function(videoElement) {
     var apis = MediaPlayer.models.ProtectionModel_3Feb2014.APIs;

--- a/src/streaming/protection/drm/KeySystem.js
+++ b/src/streaming/protection/drm/KeySystem.js
@@ -30,66 +30,80 @@
  */
 
 /**
- * @file Defines the interface for Key Systems (DRMs) supported by the
- * player.
+ * Defines the public interface for all Key Systems (DRMs) supported
+ * by the player.
+ *
+ * @interface
  */
 
-MediaPlayer.dependencies.protection.KeySystem = {
+MediaPlayer.dependencies.protection.KeySystem = function() {};
 
-    /**
-     * Key system name string (e.g. 'org.w3.clearkey')
-     *
-     * {DOMString}
-     *
-     systemString: undefined,
-     */
+/**
+ * Key system name string (e.g. 'org.w3.clearkey')
+ *
+ * @instance
+ * @name systemString
+ * @memberof MediaPlayer.dependencies.protection.KeySystem
+ * @readonly
+ * @type String
+ */
 
-    /**
-     * Key system UUID in the form '01234567-89ab-cdef-0123-456789abcdef'
-     *
-     * {DOMString}
-     *
-     uuid: undefined,
-     */
+/**
+ * Key system UUID in the form '01234567-89ab-cdef-0123-456789abcdef'
+ *
+ * @instance
+ * @name uuid
+ * @memberof MediaPlayer.dependencies.protection.KeySystem
+ * @readonly
+ * @type String
+ */
 
-    /**
-     * The scheme ID URI for this key system in the form
-     * 'urn:uuid:01234567-89ab-cdef-0123-456789abcdef' as used
-     * in DASH ContentProtection elements
-     *
-     * {DOMString}
-     *
-     schemeIdURI: undefined,
-     */
+/**
+ * The scheme ID URI for this key system in the form
+ * 'urn:uuid:01234567-89ab-cdef-0123-456789abcdef' as used
+ * in DASH ContentProtection elements
+ *
+ * @instance
+ * @name schemeIdURI
+ * @memberof MediaPlayer.dependencies.protection.KeySystem
+ * @readonly
+ * @type String
+ */
 
-    /**
-     * Parse DRM-specific init data from the ContentProtection
-     * element.
-     *
-     * @param contentProtection the ContentProtection element
-     * @returns {ArrayBuffer} initialization data
-     *
-     getInitData: function(contentProtection) { return null; },
-     */
+/**
+ * Parse DRM-specific init data from the ContentProtection
+ * element.
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.KeySystem#getInitData
+ * @param {Object} contentProtection the json-style contentProtection
+ * object representing the ContentProtection element parsed from the
+ * MPD XML document.
+ * @returns {ArrayBuffer} EME initialization data
+ */
 
-    /**
-     * For some key systems, the CDM message contains HTTP headers that
-     * can be parsed by the application and attached to the license request.
-     * Returns a header object with key/value pairs as object properties/values
-     *
-     * @param {ArrayBuffer} message the CDM message
-     * @returns {Object} headers parsed from CDM message or null
-     getRequestHeadersFromMessage: function(message) { return null; },
-     */
+/**
+ * For some key systems, the CDM message contains HTTP headers that
+ * can be parsed by the application and attached to the license request.
+ * Returns a header object with key/value pairs as object properties/values
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.KeySystem#getRequestHeadersFromMessage
+ * @param {ArrayBuffer} message the CDM message
+ * @returns {Object} headers object with header names as the object property
+ * names and header values as the corresponding object property values.  Return
+ * null if no such headers were found or if the mechanism is not supported by
+ * this key system
+ */
 
-    /**
-     * For some key systems, the CDM message contains more than just the
-     * license request.  This method will pull the license request from
-     * the CDM message
-     *
-     * @param message {ArrayBuffer} the CDM message
-     * @returns {Uint8Array} the license request message
-     getLicenseRequestFromMessage: function(message) { return message; }
-     */
-};
+/**
+ * For some key systems, the CDM message contains more than just the
+ * license request data.  This method will pull the license request from
+ * the CDM message, if necessary.
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.KeySystem#getLicenseRequestFromMessage
+ * @param message {ArrayBuffer} the CDM message
+ * @returns {Uint8Array} the license request message
+ */
 

--- a/src/streaming/protection/drm/KeySystem_Access.js
+++ b/src/streaming/protection/drm/KeySystem_Access.js
@@ -29,6 +29,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Adobe Access DRM
+ *
+ * @class
+ * @implements MediaPlayer.dependencies.protection.KeySystem
+ */
 MediaPlayer.dependencies.protection.KeySystem_Access = function() {
     "use strict";
 };

--- a/src/streaming/protection/drm/KeySystem_ClearKey.js
+++ b/src/streaming/protection/drm/KeySystem_ClearKey.js
@@ -54,3 +54,35 @@ MediaPlayer.dependencies.protection.KeySystem_ClearKey.prototype = {
     constructor: MediaPlayer.dependencies.protection.KeySystem_ClearKey
 };
 
+/**
+ * Returns desired clearkeys (as specified in the CDM message) from protection data
+ *
+ * @param {MediaPlayer.vo.protection.ProtectionData} protData the protection data
+ * @param {ArrayBuffer} message the ClearKey CDM message
+ * @returns {MediaPlayer.vo.protection.ClearKeyKeySet} the key set or null if none found
+ * @throws {Error} if a keyID specified in the CDM message was not found in the
+ * protection data
+ * @memberof MediaPlayer.dependencies.protection.KeySystem_ClearKey
+ */
+MediaPlayer.dependencies.protection.KeySystem_ClearKey.getClearKeysFromProtectionData = function(protData, message) {
+    var clearkeySet = null;
+    if (protData) {
+        // ClearKey is the only system that does not require a license server URL, so we
+        // handle it here when keys are specified in protection data
+        var jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
+        var keyPairs = [];
+        for (var i = 0; i < jsonMsg.kids.length; i++) {
+            var clearkeyID = jsonMsg.kids[i],
+                    clearkey = (protData.clearkeys.hasOwnProperty(clearkeyID)) ? protData.clearkeys[clearkeyID] : null;
+            if (!clearkey) {
+                throw new Error("DRM: ClearKey keyID (" + clearkeyID + ") is not known!");
+            }
+            // KeyIDs from CDM are not base64 padded.  Keys may or may not be padded
+            keyPairs.push(new MediaPlayer.vo.protection.KeyPair(clearkeyID, clearkey));
+        }
+        clearkeySet = new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs);
+    }
+    return clearkeySet;
+};
+
+

--- a/src/streaming/protection/drm/KeySystem_PlayReady.js
+++ b/src/streaming/protection/drm/KeySystem_PlayReady.js
@@ -29,6 +29,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Microsoft PlayReady DRM
+ *
+ * @class
+ * @implements MediaPlayer.dependencies.protection.KeySystem
+ */
 MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
     "use strict";
 

--- a/src/streaming/protection/drm/KeySystem_Widevine.js
+++ b/src/streaming/protection/drm/KeySystem_Widevine.js
@@ -29,6 +29,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Google Widevine DRM
+ *
+ * @class
+ * @implements MediaPlayer.dependencies.protection.KeySystem
+ */
 MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
     "use strict";
 

--- a/src/streaming/protection/servers/ClearKey.js
+++ b/src/streaming/protection/servers/ClearKey.js
@@ -29,19 +29,20 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * CableLabs ClearKey license server implementation
+ *
+ * For testing purposes and evaluating potential uses for ClearKey, we have developed
+ * a dirt-simple API for requesting ClearKey licenses from a remote server.
+ *
+ * @implements MediaPlayer.dependencies.protection.servers.LicenseServer
+ * @class
+ */
 MediaPlayer.dependencies.protection.servers.ClearKey = function() {
     "use strict";
 
     return {
 
-        /**
-         * Returns a new or updated license server URL based on information
-         * found in the CDM message
-         *
-         * @param url the initially established URL (from ProtectionData or initData)
-         * @param message the CDM message
-         * @returns {string} the URL to use in license requests
-         */
         getServerURLFromMessage: function(url, message) {
             // Build ClearKey server query string
             var jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
@@ -53,28 +54,10 @@ MediaPlayer.dependencies.protection.servers.ClearKey = function() {
             return url;
         },
 
-        /**
-         * Returns the HTTP method to be used (i.e. "GET", "POST", etc.) in
-         * XMLHttpRequest.open().
-         *
-         * @returns {string} the HTTP method
-         */
         getHTTPMethod: function() { return 'GET'; },
 
-        /**
-         * Returns the response type to set for XMLHttpRequest.responseType
-         *
-         * @returns {string} the response type
-         */
         getResponseType: function(/*keySystemStr*/) { return 'json'; },
 
-        /**
-         * Parses the license server response to retrieve the message intended for
-         * the CDM.
-         *
-         * @param serverResponse the response as returned in XMLHttpRequest.response
-         * @returns {Object} message that will be sent to the CDM
-         */
         getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
             if (!serverResponse.hasOwnProperty("keys")) {
                 return null;
@@ -89,44 +72,8 @@ MediaPlayer.dependencies.protection.servers.ClearKey = function() {
             return new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs);
         },
 
-        /**
-         * Parses the license server response during error conditions and returns a
-         * string to display for debugging purposes
-         *
-         * @param serverResponse the server response
-         */
         getErrorResponse: function(serverResponse/*, keySystemStr*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
-        },
-
-        /**
-         * Returns desired clearkeys (as specified in the CDM message) from protection data
-         *
-         * @param protData the protection data
-         * @param message {ArrayBuffer} the ClearKey CDM message
-         * @returns {MediaPlayer.vo.protection.ClearKeyKeySet} the key set or null if none found
-         * @throws {Error} if a keyID specified in the CDM message was not found in the
-         * protection data
-         */
-        getClearKeysFromProtectionData: function(protData, message) {
-            var clearkeySet = null;
-            if (protData) {
-                // ClearKey is the only system that does not require a license server URL, so we
-                // handle it here when keys are specified in protection data
-                var jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
-                var keyPairs = [];
-                for (var i = 0; i < jsonMsg.kids.length; i++) {
-                    var clearkeyID = jsonMsg.kids[i],
-                            clearkey = (protData.clearkeys.hasOwnProperty(clearkeyID)) ? protData.clearkeys[clearkeyID] : null;
-                    if (!clearkey) {
-                        throw new Error("DRM: ClearKey keyID (" + clearkeyID + ") is not known!");
-                    }
-                    // KeyIDs from CDM are not base64 padded.  Keys may or may not be padded
-                    keyPairs.push(new MediaPlayer.vo.protection.KeyPair(clearkeyID, clearkey));
-                }
-                clearkeySet = new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs);
-            }
-            return clearkeySet;
         }
     };
 };

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -29,6 +29,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * CastLabs DRMToday License Server implementation
+ *
+ * @implements MediaPlayer.dependencies.protection.servers.LicenseServer
+ * @class
+ */
 MediaPlayer.dependencies.protection.servers.DRMToday = function() {
     "use strict";
 
@@ -55,59 +61,21 @@ MediaPlayer.dependencies.protection.servers.DRMToday = function() {
 
     return {
 
-        /**
-         * Returns a new or updated license server URL based on information
-         * found in the CDM message
-         *
-         * @param url the initially established URL (from ProtectionData or initData)
-         * @param message the CDM message
-         * @returns {string} the URL to use in license requests
-         */
         getServerURLFromMessage: function(url /*, message*/) { return url; },
 
-        /**
-         * Returns the HTTP method to be used (i.e. "GET", "POST", etc.) in
-         * XMLHttpRequest.open().
-         *
-         * @returns {string} the HTTP method
-         */
         getHTTPMethod: function() { return 'POST'; },
 
-        /**
-         * Returns the response type to set for XMLHttpRequest.responseType
-         * for a particular key system
-         *
-         * @param keySystemStr {String} the key system
-         * @returns {string} the response type
-         */
         getResponseType: function(keySystemStr) {
             return keySystems[keySystemStr].responseType;
         },
 
-        /**
-         * Parses the license server response to retrieve the message intended for
-         * the CDM.
-         *
-         * @param serverResponse the response as returned in XMLHttpRequest.response
-         * @param keySystemStr {String} the key system string
-         * @returns {Uint8Array} message that will be sent to the CDM
-         */
         getLicenseMessage: function(serverResponse, keySystemStr) {
             return keySystems[keySystemStr].getLicenseMessage(serverResponse);
         },
 
-        /**
-         * Parses the license server response during error conditions and returns a
-         * string to display for debugging purposes
-         *
-         * @param serverResponse the server response
-         * @param keySystemStr {String} the key system string
-         * @returns {String} An error message to report
-         */
         getErrorResponse: function(serverResponse, keySystemStr) {
             return keySystems[keySystemStr].getErrorResponse(serverResponse);
         }
-
     };
 };
 

--- a/src/streaming/protection/servers/LicenseServer.js
+++ b/src/streaming/protection/servers/LicenseServer.js
@@ -1,0 +1,98 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Defines the public interface for license server implementations supported
+ * by the player.
+ *
+ * Different license servers have different requirements regarding the methods
+ * used to request DRM licenses.  Things like request headers, license response
+ * formats (for both error and success cases) need to be customized for a
+ * specific server implementation
+ *
+ * @interface
+ */
+
+MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
+
+/**
+ * Returns a new or updated license server URL based on the requirements of the
+ * license server and possibly from information passed in the CDM license message
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getServerURLFromMessage
+ * @param {string} url the initially established URL (from ProtectionData or initData)
+ * @param {ArrayBuffer} message the CDM message which may be needed to generate the license
+ * requests URL
+ * @returns {string} the URL to use in license requests
+ */
+
+/**
+ * Returns the HTTP method to be used (i.e. "GET", "POST", etc.) in
+ * XMLHttpRequest.open().
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getHTTPMethod
+ * @returns {string} the HTTP method
+ */
+
+/**
+ * Returns the response type to set for XMLHttpRequest.responseType
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getResponseType
+ * @param {string} keySystemStr the key system string representing the key system
+ * associated with a license request.  Multi-DRM license servers may have different
+ * response types depending on the key system.
+ * @returns {string} the response type
+ */
+
+/**
+ * Parses the license server response to retrieve the message intended for
+ * the CDM.
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getLicenseMessage
+ * @param {Object} serverResponse the response as returned in XMLHttpRequest.response
+ * @param {string} keySystemStr the key system string representing the key system
+ * associated with a license request.
+ * @returns {Object} message that will be sent to the CDM
+ */
+
+/**
+ * Parses the license server response during error conditions and returns a
+ * string to display for debugging purposes
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getErrorResponse
+ * @param {Object} serverResponse the server response
+ * @returns {string} an error message that indicates the reason for the failure
+ */

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -29,53 +29,29 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * Microsoft PlayReady Test License Server
+ *
+ * For testing content that uses the PlayReady test server at
+ *
+ * @implements MediaPlayer.dependencies.protection.servers.LicenseServer
+ * @class
+ */
 MediaPlayer.dependencies.protection.servers.PlayReady = function() {
     "use strict";
 
     return {
 
-        /**
-         * Returns a new or updated license server URL based on information
-         * found in the CDM message
-         *
-         * @param url the initially established URL (from ProtectionData or initData)
-         * @param message the CDM message
-         * @returns {string} the URL to use in license requests
-         */
         getServerURLFromMessage: function(url /*, message*/) { return url; },
 
-        /**
-         * Returns the HTTP method to be used (i.e. "GET", "POST", etc.) in
-         * XMLHttpRequest.open().
-         *
-         * @returns {string} the HTTP method
-         */
         getHTTPMethod: function() { return 'POST'; },
 
-        /**
-         * Returns the response type to set for XMLHttpRequest.responseType
-         *
-         * @returns {string} the response type
-         */
         getResponseType: function(/*keySystemStr*/) { return 'arraybuffer'; },
 
-        /**
-         * Parses the license server response to retrieve the message intended for
-         * the CDM.
-         *
-         * @param serverResponse the response as returned in XMLHttpRequest.response
-         * @returns {Uint8Array} message that will be sent to the CDM
-         */
         getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
             return new Uint8Array(serverResponse);
         },
 
-        /**
-         * Parses the license server response during error conditions and returns a
-         * string to display for debugging purposes
-         *
-         * @param serverResponse the server response
-         */
         getErrorResponse: function(serverResponse/*, keySystemStr*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
         }

--- a/src/streaming/protection/servers/Widevine.js
+++ b/src/streaming/protection/servers/Widevine.js
@@ -34,49 +34,16 @@ MediaPlayer.dependencies.protection.servers.Widevine = function() {
 
     return {
 
-        /**
-         * Returns a new or updated license server URL based on information
-         * found in the CDM message
-         *
-         * @param url the initially established URL (from ProtectionData or initData)
-         * @param message the CDM message
-         * @returns {string} the URL to use in license requests
-         */
         getServerURLFromMessage: function(url /*, message*/) { return url; },
 
-        /**
-         * Returns the HTTP method to be used (i.e. "GET", "POST", etc.) in
-         * XMLHttpRequest.open().
-         *
-         * @returns {string} the HTTP method
-         */
         getHTTPMethod: function() { return 'POST'; },
 
-
-        /**
-         * Returns the response type to set for XMLHttpRequest.responseType
-         *
-         * @returns {string} the response type
-         */
         getResponseType: function(/*keySystemStr*/) { return 'arraybuffer'; },
 
-        /**
-         * Parses the license server response to retrieve the message intended for
-         * the CDM.
-         *
-         * @param serverResponse the response as returned in XMLHttpRequest.response
-         * @returns {Uint8Array} message that will be sent to the CDM
-         */
         getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
             return new Uint8Array(serverResponse);
         },
 
-        /**
-         * Parses the license server response during error conditions and returns a
-         * string to display for debugging purposes
-         *
-         * @param serverResponse the server response
-         */
         getErrorResponse: function(serverResponse/*, keySystemStr*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
         }

--- a/src/streaming/vo/protection/ClearKeyKeySet.js
+++ b/src/streaming/vo/protection/ClearKeyKeySet.js
@@ -36,7 +36,7 @@
  * @param keyPairs {MediaPlayer.vo.protection.KeyPair[]} array of key pairs
  * @param type the type of keys in this set.  One of either 'persistent'
  * or 'temporary'.  Can also be null or undefined.
- * @constructor
+ * @class
  */
 MediaPlayer.vo.protection.ClearKeyKeySet = function(keyPairs, type) {
     if (type && type !== "persistent" && type !== "temporary")

--- a/src/streaming/vo/protection/KeyError.js
+++ b/src/streaming/vo/protection/KeyError.js
@@ -34,7 +34,8 @@
  *
  * @param sessionToken the key session to which this error is associated
  * @param errorString an informational error message
- * @constructor
+ * @class
+ * @deprecated Newest versions of EME APIs will not use this error object
  */
 MediaPlayer.vo.protection.KeyError = function(sessionToken, errorString) {
     "use strict";

--- a/src/streaming/vo/protection/KeyMessage.js
+++ b/src/streaming/vo/protection/KeyMessage.js
@@ -38,7 +38,7 @@
  * @param [defaultURL] license acquisition URL provided by the CDM
  * @param [messageType] the message type.  One of "license-request",
  * "license-renewal", "license-release", "individualization-request"
- * @constructor
+ * @class
  */
 MediaPlayer.vo.protection.KeyMessage = function(sessionToken, message, defaultURL, messageType) {
     "use strict";

--- a/src/streaming/vo/protection/KeyPair.js
+++ b/src/streaming/vo/protection/KeyPair.js
@@ -34,7 +34,7 @@
  *
  * @param keyID {String} 128-bit key ID, base64 encoded, with no padding
  * @param key {String} 128-bit encryption key, base64 encoded, with no padding
- * @constructor
+ * @class
  */
 MediaPlayer.vo.protection.KeyPair = function(keyID, key) {
     "use strict";

--- a/src/streaming/vo/protection/KeySystemAccess.js
+++ b/src/streaming/vo/protection/KeySystemAccess.js
@@ -38,7 +38,7 @@
  * @param {MediaPlayer.vo.protection.KeySystemConfiguration} ksConfiguration the
  * subset of configurations passed to the key system access request that are supported
  * by this user agent
- * @constructor
+ * @class
  */
 MediaPlayer.vo.protection.KeySystemAccess = function(keySystem, ksConfiguration) {
     this.keySystem = keySystem;

--- a/src/streaming/vo/protection/KeySystemConfiguration.js
+++ b/src/streaming/vo/protection/KeySystemConfiguration.js
@@ -30,12 +30,20 @@
  */
 
 /**
+ * Represents a set of configurations that describe the capabilities desired for
+ * support by a given CDM
  *
- * @param {MediaPlayer.vo.protection.MediaCapability[]} audioCapabilities
- * @param {MediaPlayer.vo.protection.MediaCapability[]} videoCapabilities
- * @param {string} [distinctiveIdentifier]
- * @param {string} [persistentState]
- * @constructor
+ * @param {MediaPlayer.vo.protection.MediaCapability[]} audioCapabilities array of
+ * desired audio capabilities.  Higher preference capabilities should be placed earlier
+ * in the array.
+ * @param {MediaPlayer.vo.protection.MediaCapability[]} videoCapabilities array of
+ * desired video capabilities.  Higher preference capabilities should be placed earlier
+ * in the array.
+ * @param {string} [distinctiveIdentifier] desired use of distinctive identifiers.
+ * One of "required", "optional", or "not-allowed"
+ * @param {string} [persistentState] desired support for persistent storage of
+ * key systems.  One of "required", "optional", or "not-allowed"
+ * @class
  */
 MediaPlayer.vo.protection.KeySystemConfiguration = function(audioCapabilities, videoCapabilities, distinctiveIdentifier, persistentState) {
     this.initDataTypes = [ "cenc" ];

--- a/src/streaming/vo/protection/LicenseRequestComplete.js
+++ b/src/streaming/vo/protection/LicenseRequestComplete.js
@@ -32,14 +32,15 @@
 /**
  * Event indicating the receipt of a response from a license server
  *
- * @param message {Uint8Array} license response message
- * @param requestData a request-specific data object
+ * @param {Uint8Array} message license response message
+ * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session to
+ * which this license request is associated
  * @constructor
  */
-MediaPlayer.vo.protection.LicenseRequestComplete = function(message, requestData) {
+MediaPlayer.vo.protection.LicenseRequestComplete = function(message, sessionToken) {
     "use strict";
     this.message = message;
-    this.requestData = requestData;
+    this.sessionToken = sessionToken;
 };
 
 MediaPlayer.vo.protection.LicenseRequestComplete.prototype = {

--- a/src/streaming/vo/protection/ProtectionData.js
+++ b/src/streaming/vo/protection/ProtectionData.js
@@ -30,21 +30,53 @@
  */
 
 /**
- * Data used to customize KeySystems and override default or CDM-provided
- * values
+ * Data provided for a particular piece of content to customize license server URLs,
+ * license server HTTP request headers, clearkeys, or other content-specific data
  *
  * @param {string} laURL a license acquisition URL to use with this key system
  * @param {Object} httpRequestHeaders headers to add to the http request
  * @param {Object} clearkeys defines a set of clear keys that are available to
  * the key system.  Object properties are base64-encoded keyIDs (with no padding).
  * Corresponding property values are keys, base64-encoded (no padding).
- * @constructor
+ * @class
  */
 MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, clearkeys) {
     this.laURL = laURL;
     this.httpRequestHeaders = httpRequestHeaders;
     this.clearkeys = clearkeys;
 };
+
+/**
+ * License server URL
+ *
+ * @instance
+ * @type string
+ * @name MediaPlayer.vo.protection.ProtectionData.laURL
+ * @readonly
+ * @memberof MediaPlayer.vo.protection.ProtectionData
+ */
+
+/**
+ * HTTP Request Headers for use in license requests.  Each property name
+ * in the object is a header name with its corresponding header value being
+ * the property value
+ *
+ * @instance
+ * @type Object
+ * @name MediaPlayer.vo.protection.ProtectionData.httpRequestsHeaders
+ * @readonly
+ * @memberof MediaPlayer.vo.protection.ProtectionData
+ */
+
+/**
+ * ClearKey key-pairs that can be used to decrypt the content
+ *
+ * @instance
+ * @type Object
+ * @name MediaPlayer.vo.protection.ProtectionData.clearkeys
+ * @readonly
+ * @memberof MediaPlayer.vo.protection.ProtectionData
+ */
 
 MediaPlayer.vo.protection.ProtectionData.prototype = {
     constructor: MediaPlayer.vo.protection.ProtectionData

--- a/src/streaming/vo/protection/SessionToken.js
+++ b/src/streaming/vo/protection/SessionToken.js
@@ -29,50 +29,56 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * All session tokens returns by ProtectionModel implementations
- * are guaranteed to contain initialization data and optionally
- * session IDs
+ * All session identifiers (tokens) returned by ProtectionController as well as
+ * ProtectionModel implementations are guaranteed to contain certain properties
+ * regardless of the proprietary data each ProtectionModel will need to attach.
+ * This interface defines the common APIs for session tokens available for
+ * applications to access.
  *
- * @constructor
+ * @interface MediaPlayer.vo.protection.SessionToken
  */
-MediaPlayer.models.SessionToken = function () {
-    "use strict";
-};
 
-MediaPlayer.models.SessionToken.prototype = {
+MediaPlayer.vo.protection.SessionToken = function () { };
 
-    /**
-     * The initialization data used to create this session
-     *
-     * {Uint8Array} initialization data
-     */
-    initData: null,
+/**
+ * The initialization data used to create this session
+ *
+ * @instance
+ * @name initData
+ * @memberof MediaPlayer.vo.protection.SessionToken
+ * @type ArrayBuffer
+ * @readonly
+ */
 
-    /**
-     * The unique session ID designated to this session
-     *
-     * @return {string} the session ID or the empty string if the implementation
-     * does not support session IDs or the sessionID has not yet been established
-     */
-    getSessionID: function() { return ""; },
+/**
+ * Returns the unique session ID designated to this session
+ *
+ * @function
+ * @name MediaPlayer.vo.protection.SessionToken#getSessionID
+ * @return {string} the session ID or the empty string if the implementation
+ * does not support session IDs or the sessionID has not yet been established
+ */
 
-    /**
-     * The time, in milliseconds since 01 January, 1970 UTC, after which
-     * the key(s) in the session will no longer be usable to decrypt
-     * media data, or NaN if no such time exists
-     *
-     * @returns {Number} the expiration time
-     */
-    getExpirationTime: function() { return NaN; },
+/**
+ * The time, in milliseconds since 01 January, 1970 UTC, after which
+ * the key(s) in the session will no longer be usable to decrypt
+ * media data, or NaN if no such time exists
+ *
+ * @function
+ * @name MediaPlayer.vo.protection.SessionToken#getExpirationTime
+ * @returns {Number} the expiration time or NaN if no expiration time exists
+ * for this session
+ */
 
-    /**
-     * Returns a read-only map of key IDs known to the session to the
-     * current status of the associated key.
-     *
-     * @returns {maplike<BufferSource,MediaKeyStatus>}
-     */
-    getKeyStatuses: function() { return null; }
-};
+/**
+ * Returns a read-only map of key IDs known to the session to the
+ * current status of the associated key.
+ *
+ * @function
+ * @name MediaPlayer.vo.protection.SessionToken#getKeyStatuses
+ * @returns {"maplike<BufferSource,MediaKeyStatus>"} the map of keys
+ * in this session and their associated status
+ */
 
 
 


### PR DESCRIPTION
Most all of the protection system has decent JSDocs now.  Also updated some related MediaPlayer documentation to help fill out some of the JSDoc links

Users must update to the latest grunt-jsdoc module because the new documentation depends on JSDoc 3.3.