### PR TITLE
Fix live offset when availabilityStartTime in future

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -109,7 +109,7 @@ Dash.dependencies.RepresentationController = function () {
 
             return true;
         },
-    
+
         updateRepresentations = function(adaptation) {
             var self = this,
                 reps,
@@ -133,7 +133,7 @@ Dash.dependencies.RepresentationController = function () {
 
         postponeUpdate = function(availabilityDelay) {
             var self = this,
-                delay = (availabilityDelay + (currentRepresentation.segmentDuration * 3)) * 1000,
+                delay = (availabilityDelay + (currentRepresentation.segmentDuration * this.liveDelayFragmentCount)) * 1000,
                 update = function() {
                     if (this.isUpdating()) return;
 
@@ -257,6 +257,7 @@ Dash.dependencies.RepresentationController = function () {
         subscribe: undefined,
         unsubscribe: undefined,
         DOMStorage:undefined,
+        liveDelayFragmentCount:undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.AbrController.eventList.ENAME_QUALITY_CHANGED] = onQualityChanged;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -117,6 +117,9 @@ MediaPlayer = function (context) {
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
             playbackController.setLiveDelayAttributes(liveDelayFragmentCount, usePresentationDelay);
 
+            system.mapValue("liveDelayFragmentCount", liveDelayFragmentCount);
+            system.mapOutlet("liveDelayFragmentCount", "trackController");
+
             streamController.initialize(autoPlay, protectionController, protectionData);
             DOMStorage.checkInitialBitrate();
             if (typeof source === "string") {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -346,7 +346,8 @@ MediaPlayer.dependencies.ScheduleController = function () {
             var self = this,
                 liveEdgeTime = e.data.liveEdge,
                 manifestInfo = currentTrackInfo.mediaInfo.streamInfo.manifestInfo,
-                startTime = liveEdgeTime - Math.min((self.playbackController.getLiveDelay(currentTrackInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2),
+                // startTime should probably never be less than 0
+                startTime = Math.max(0, liveEdgeTime - Math.min((self.playbackController.getLiveDelay(currentTrackInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2)),
                 request,
                 metrics = self.metricsModel.getMetricsFor("stream"),
                 manifestUpdateInfo = self.metricsExt.getCurrentManifestUpdate(metrics),


### PR DESCRIPTION
Following 33e5a74, streams which have availabilityStartTime in the future would fail to play. This is because the live edge calculated in onLiveEdgeSearchCompleted changed to be a runtime configured value of multiples of segment duration which turned out to be more than the hardcoded delay in postponeUpdate. The outcome was that startTime would be calculated to be negative and a valid segment at which to start could never be found.

Fix by ensuring postponeUpdate waits the same amount of time as will subsequently be subtracted, and also belt and braced by ensuring that startTime can never be negative.

There are probably a ton of other magic numbers we need to weed out, but this was noticed as we are currently experimenting with publishing manifest with future aSTs and they were failing to play.

I believe this is causing the second issue in #613.