### PR TITLE
Adding getter for system in MediaPlayer

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -356,6 +356,14 @@ MediaPlayer = function (context) {
         },
 
         /**
+         * @returns {Object} the current dijon instance for DI.
+         * @memberof MediaPlayer#
+         */
+        getSystem: function () {
+            return system;
+        },
+
+        /**
          * @memberof MediaPlayer#
          */
         startup: function () {


### PR DESCRIPTION
Adding getter for system in MediaPlayer so I can access object that I override with custom context and set properties on extension object.