### PR TITLE
changed API to not return system but object based on context string name.

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -356,11 +356,11 @@ MediaPlayer = function (context) {
         },
 
         /**
-         * @returns {Object} the current dijon instance for DI.
+         * @returns {Object} An instance of system object based on the string name in Context.js or DashContext.js
          * @memberof MediaPlayer#
          */
-        getSystem: function () {
-            return system;
+        getObjectByContextName: function (name) {
+            return system.getObject(name);
         },
 
         /**


### PR DESCRIPTION
Per @greg80303 comments in PR #653 making this a little more abstracted so you can not access system externally. 