### PR TITLE
Check protectionController is not null when resetting StreamController

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -598,8 +598,10 @@
                 protectionController.protectionModel.subscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE, teardownComplete, undefined, true);
                 protectionController.teardown();
             } else {
-                protectionController.setMediaElement(null);
-                protectionController = null;
+                if (protectionController) {
+                    protectionController.setMediaElement(null);
+                    protectionController = null;
+                }
                 protectionData = null;
                 this.notify(MediaPlayer.dependencies.StreamController.eventList.ENAME_TEARDOWN_COMPLETE);
             }


### PR DESCRIPTION
A race condition exists where streamController.reset can be called a second time before the first has completed. In the instance protectionController may be null (if ownProtectionController was previously true), so check before calling any methods on it.