### PR TITLE
removeAllListeners does not remove all listeners

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -147,6 +147,7 @@ MediaPlayer.dependencies.PlaybackController = function () {
         removeAllListeners = function() {
             if (!videoModel) return;
 
+            videoModel.unlisten("canplay", onCanPlay);
             videoModel.unlisten("play", onPlaybackStart);
             videoModel.unlisten("playing", onPlaybackPlaying);
             videoModel.unlisten("pause", onPlaybackPaused);


### PR DESCRIPTION
PlaybackController.removeAllListeners does not stop listening for canplay. For symmetry, unlisten for this event.