### PR TITLE
limit pending requests

### DIFF
--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -31,8 +31,8 @@
 MediaPlayer.dependencies.FragmentLoader = function () {
     "use strict";
 
-    var RETRY_ATTEMPTS = 3,
-        RETRY_INTERVAL = 500,
+    var RETRY_ATTEMPTS = MediaPlayer.dependencies.FragmentLoader.RETRY_ATTEMPTS,
+        RETRY_INTERVAL = MediaPlayer.dependencies.FragmentLoader.RETRY_INTERVAL,
         xhrs = [],
 
         doLoad = function (request, remainingAttempts) {
@@ -231,6 +231,9 @@ MediaPlayer.dependencies.FragmentLoader = function () {
         }
     };
 };
+
+MediaPlayer.dependencies.FragmentLoader.RETRY_ATTEMPTS = 3;
+MediaPlayer.dependencies.FragmentLoader.RETRY_INTERVAL = 500;
 
 MediaPlayer.dependencies.FragmentLoader.prototype = {
     constructor: MediaPlayer.dependencies.FragmentLoader

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -161,6 +161,11 @@ MediaPlayer.dependencies.BufferController = function () {
             // quality can be appended providing init fragment for a new required quality has not been
             // appended yet.
             if ((quality !== requiredQuality && isInit) || (quality !== currentQuality && !isInit)) {
+                self.log('reject request - required quality = ' + requiredQuality +
+                                        ' current quality = ' + currentQuality +
+                                        ' chunk media type = ' + chunk.mediaType +
+                                        ' chunk quality = ' + quality +
+                                        ' chunk index = ' + chunk.index);
                 onMediaRejected.call(self, quality, chunk.index);
                 return;
             }

--- a/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
+++ b/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
@@ -86,6 +86,12 @@ MediaPlayer.rules.PlaybackTimeRule = function () {
 
             time = hasSeekTarget ? st : ((useRejected ? (rejected.startTime) : currentTime));
 
+            // limit proceeding index handler to max buffer -> limit pending requests queue
+            if (!hasSeekTarget && !rejected && (time > playbackTime + MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY)) {
+                callback(new MediaPlayer.rules.SwitchRequest(null, p));
+                return;
+            }
+
             if (rejected) {
                 sc.getFragmentModel().removeRejectedRequest(rejected);
             }


### PR DESCRIPTION
during our long term playback tests we realized a lot of playback crashes. we realized that it always happens when there are a lot of rejected requests in parallel. therefore we limited the amount of pending requests in PlaybackTimeRule.

Additionally we made retry attempts and interval configurable. If you set the attempts to a very high number, the player now - with limiting pending requests - can resume playback correctly after lost internet connection (fixes Issue: https://github.com/Dash-Industry-Forum/dash.js/issues/599)