### PR TITLE
Persistent key session and CDM "message type" support

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -193,7 +193,7 @@
             "browsers": "",
             "protData": {
                 "com.widevine.alpha": {
-                    "laURL": "https://html5.cablelabs.com:8025"
+                    "serverURL": "https://html5.cablelabs.com:8025"
                 }
             }
         },
@@ -203,7 +203,7 @@
             "browsers": "",
             "protData": {
                 "com.widevine.alpha": {
-                    "laURL": "https://html5.cablelabs.com:8025"
+                    "serverURL": "https://html5.cablelabs.com:8025"
                 },
                 "org.w3.clearkey": {
                     "clearkeys": {
@@ -218,7 +218,7 @@
             "browsers": "",
             "protData": {
                 "com.widevine.alpha": {
-                    "laURL": "https://html5.cablelabs.com:8025"
+                    "serverURL": "https://html5.cablelabs.com:8025"
                 },
                 "org.w3.clearkey": {
                     "clearkeys": {
@@ -244,14 +244,14 @@
             "protData": {
                 "com.widevine.alpha": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
                     "httpRequestHeaders": {
                         "dt-custom-data": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }
                 },
                 "com.microsoft.playready": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
                     "httpRequestHeaders": {
                         "http-header-CustomData": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }
@@ -265,14 +265,14 @@
             "protData": {
                 "com.widevine.alpha": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
                     "httpRequestHeaders": {
                         "dt-custom-data": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }
                 },
                 "com.microsoft.playready": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
                     "httpRequestHeaders": {
                         "http-header-CustomData": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }
@@ -286,14 +286,14 @@
             "protData": {
                 "com.widevine.alpha": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
                     "httpRequestHeaders": {
                         "dt-custom-data": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }
                 },
                 "com.microsoft.playready": {
                     "drmtoday": true,
-                    "laURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
+                    "serverURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
                     "httpRequestHeaders": {
                         "http-header-CustomData": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
                     }

--- a/samples/dash-if-reference-player/eme.html
+++ b/samples/dash-if-reference-player/eme.html
@@ -175,14 +175,15 @@
                     <div class="panel-heading panel-top">
                         <span class="panel-title">SessionID: {{s.sessionToken.getSessionID()}}</span>
                         <div class="btn-group">
-                            <button type="button" ng-disabled="!s.removed" class="btn btn-default" ng-click="d.protCtrl.loadKeySession(s.sessionID)">Load</button>
-                            <button type="button" ng-disabled="s.removed" class="btn btn-default" ng-click="d.protCtrl.removeKeySession(s.sessionToken)">Remove</button>
+                            <button type="button" ng-disabled="isLoaded(s)" class="btn btn-default" ng-click="d.protCtrl.loadKeySession(s.sessionID)">Load</button>
+                            <button type="button" ng-disabled="!isLoaded(s)" class="btn btn-default" ng-click="d.protCtrl.removeKeySession(s.sessionToken)">Remove</button>
                             <button type="button" class="btn btn-default" ng-click="d.protCtrl.closeKeySession(s.sessionToken)">Close</button>
                         </div>
                     </div>
                     <div class="keymessage" ng-show="s.lastMessage">{{s.lastMessage}}</div>
+                    <div class="keymessage"><b>Session Persistence: </b><span>{{getLoadedMessage(s)}}</span></div>
                     <h5 ng-show="s.getExpirationTime()">Expiration: {{s.getExpirationTime()}}</h5>
-                    <table ng-show="s.keystatus && s.keystatus.length > 0" class="table table-bordered table-hover">
+                    <table ng-show="isLoaded(s) && s.keystatus && s.keystatus.length > 0" class="table table-bordered table-hover">
                         <tr>
                             <th>Key ID</th>
                             <th class="centered">Key Status</th>

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -282,12 +282,16 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
 
         // Determine license server URL
         var url = null;
-        if (protData && protData.serverURL) {
-            var serverURL = protData.serverURL;
-            if (typeof serverURL === "string" && serverURL !== "") {
-                url = serverURL;
-            } else if (typeof serverURL === "object" && serverURL.hasOwnProperty(messageType)) {
-                url = serverURL[messageType];
+        if (protData) {
+            if (protData.serverURL) {
+                var serverURL = protData.serverURL;
+                if (typeof serverURL === "string" && serverURL !== "") {
+                    url = serverURL;
+                } else if (typeof serverURL === "object" && serverURL.hasOwnProperty(messageType)) {
+                    url = serverURL[messageType];
+                }
+            } else if (protData.laURL && protData.laURL !== "") { // TODO: Deprecated!
+                url = protData.laURL;
             }
         } else {
             url = laURL;

--- a/src/streaming/extensions/ProtectionExtensions.js
+++ b/src/streaming/extensions/ProtectionExtensions.js
@@ -278,10 +278,21 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
 
         // All remaining key system scenarios require a request to a remote license server
         var xhr = new XMLHttpRequest(),
-            url = (protData && protData.laURL && protData.laURL !== "") ? protData.laURL : laURL,
             self = this;
 
-        // Possibly update the URL based on the message
+        // Determine license server URL
+        var url = null;
+        if (protData && protData.serverURL) {
+            var serverURL = protData.serverURL;
+            if (typeof serverURL === "string" && serverURL !== "") {
+                url = serverURL;
+            } else if (typeof serverURL === "object" && serverURL.hasOwnProperty(messageType)) {
+                url = serverURL[messageType];
+            }
+        } else {
+            url = laURL;
+        }
+        // Possibly update or override the URL based on the message
         url = licenseServerData.getServerURLFromMessage(url, message, messageType);
 
         // Ensure valid license server URL

--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -353,6 +353,10 @@ MediaPlayer.models.ProtectionModel_01b = function () {
 
                     getExpirationTime: function() {
                         return NaN;
+                    },
+
+                    getSessionType: function() {
+                        return "temporary";
                     }
                 };
                 pendingSessions.push(newSession);

--- a/src/streaming/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/models/ProtectionModel_21Jan2015.js
@@ -114,7 +114,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
         // Function to create our session token objects which manage the EME
         // MediaKeySession and session-specific event handler
-        createSessionToken = function(session, initData) {
+        createSessionToken = function(session, initData, sessionType) {
 
             var self = this;
             var token = { // Implements MediaPlayer.vo.protection.SessionToken
@@ -149,6 +149,10 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
                 getKeyStatuses: function() {
                     return this.session.keyStatuses;
+                },
+
+                getSessionType: function() {
+                    return sessionType;
                 }
             };
 
@@ -297,7 +301,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             }
 
             var session = mediaKeys.createSession(sessionType);
-            var sessionToken = createSessionToken.call(this, session, initData);
+            var sessionToken = createSessionToken.call(this, session, initData, sessionType);
 
             // Generate initial key request
             var self = this;
@@ -358,7 +362,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             session.remove().then(function () {
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED,
                         sessionToken.getSessionID());
-            }).catch(function (error) {
+            }, function (error) {
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED,
                         null, "Error removing session (" + sessionToken.getSessionID() + "). " + error.name);
             });

--- a/src/streaming/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/models/ProtectionModel_3Feb2014.js
@@ -132,6 +132,10 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
 
                 getExpirationTime: function() {
                     return NaN;
+                },
+
+                getSessionType: function() {
+                    return "temporary";
                 }
             };
         };

--- a/src/streaming/protection/servers/ClearKey.js
+++ b/src/streaming/protection/servers/ClearKey.js
@@ -43,7 +43,7 @@ MediaPlayer.dependencies.protection.servers.ClearKey = function() {
 
     return {
 
-        getServerURLFromMessage: function(url, message) {
+        getServerURLFromMessage: function(url, message/*, messageType*/) {
             // Build ClearKey server query string
             var jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
             url += "/?";
@@ -54,11 +54,11 @@ MediaPlayer.dependencies.protection.servers.ClearKey = function() {
             return url;
         },
 
-        getHTTPMethod: function() { return 'GET'; },
+        getHTTPMethod: function(/*messageType*/) { return 'GET'; },
 
         getResponseType: function(/*keySystemStr*/) { return 'json'; },
 
-        getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
+        getLicenseMessage: function(serverResponse/*, keySystemStr, messageType*/) {
             if (!serverResponse.hasOwnProperty("keys")) {
                 return null;
             }
@@ -72,7 +72,7 @@ MediaPlayer.dependencies.protection.servers.ClearKey = function() {
             return new MediaPlayer.vo.protection.ClearKeyKeySet(keyPairs);
         },
 
-        getErrorResponse: function(serverResponse/*, keySystemStr*/) {
+        getErrorResponse: function(serverResponse/*, keySystemStr, messageType*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
         }
     };

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -61,19 +61,19 @@ MediaPlayer.dependencies.protection.servers.DRMToday = function() {
 
     return {
 
-        getServerURLFromMessage: function(url /*, message*/) { return url; },
+        getServerURLFromMessage: function(url /*, message, messageType*/) { return url; },
 
-        getHTTPMethod: function() { return 'POST'; },
+        getHTTPMethod: function(/*messageType*/) { return 'POST'; },
 
-        getResponseType: function(keySystemStr) {
+        getResponseType: function(keySystemStr/*, messageType*/) {
             return keySystems[keySystemStr].responseType;
         },
 
-        getLicenseMessage: function(serverResponse, keySystemStr) {
+        getLicenseMessage: function(serverResponse, keySystemStr/*, messageType*/) {
             return keySystems[keySystemStr].getLicenseMessage(serverResponse);
         },
 
-        getErrorResponse: function(serverResponse, keySystemStr) {
+        getErrorResponse: function(serverResponse, keySystemStr/*, messageType*/) {
             return keySystems[keySystemStr].getErrorResponse(serverResponse);
         }
     };

--- a/src/streaming/protection/servers/LicenseServer.js
+++ b/src/streaming/protection/servers/LicenseServer.js
@@ -53,7 +53,7 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  *
  * @function
  * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getServerURLFromMessage
- * @param {string} url the initially established URL (from ProtectionData or initData)
+ * @param {?string} url the initially established URL (from ProtectionData or initData)
  * @param {ArrayBuffer} message the CDM message which may be needed to generate the license
  * requests URL
  * @param {String} messageType the message type associated with this request.  Supported

--- a/src/streaming/protection/servers/LicenseServer.js
+++ b/src/streaming/protection/servers/LicenseServer.js
@@ -38,6 +38,10 @@
  * formats (for both error and success cases) need to be customized for a
  * specific server implementation
  *
+ * License servers handle requests for more than just initial license retrieval.
+ * Each API takes a parameter which describes the message type as supported by
+ * the Encrypted Media Extensions.
+ *
  * @interface
  */
 
@@ -52,6 +56,8 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  * @param {string} url the initially established URL (from ProtectionData or initData)
  * @param {ArrayBuffer} message the CDM message which may be needed to generate the license
  * requests URL
+ * @param {String} messageType the message type associated with this request.  Supported
+ * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the URL to use in license requests
  */
 
@@ -61,6 +67,8 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  *
  * @function
  * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getHTTPMethod
+ * @param {String} messageType the message type associated with this request.  Supported
+ * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the HTTP method
  */
 
@@ -72,11 +80,13 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  * @param {string} keySystemStr the key system string representing the key system
  * associated with a license request.  Multi-DRM license servers may have different
  * response types depending on the key system.
+ * @param {String} messageType the message type associated with this request.  Supported
+ * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the response type
  */
 
 /**
- * Parses the license server response to retrieve the message intended for
+ * Parses the license server response for any message intended for
  * the CDM.
  *
  * @function
@@ -84,7 +94,10 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  * @param {Object} serverResponse the response as returned in XMLHttpRequest.response
  * @param {string} keySystemStr the key system string representing the key system
  * associated with a license request.
- * @returns {Object} message that will be sent to the CDM
+ * @param {String} messageType the message type associated with this request.  Supported
+ * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
+ * @returns {Object} message that will be sent to the CDM or null if no CDM message
+ * was present in the response.
  */
 
 /**
@@ -94,5 +107,7 @@ MediaPlayer.dependencies.protection.servers.LicenseServer = function() {};
  * @function
  * @name MediaPlayer.dependencies.protection.servers.LicenseServer#getErrorResponse
  * @param {Object} serverResponse the server response
+ * @param {String} messageType the message type associated with this request.  Supported
+ * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} an error message that indicates the reason for the failure
  */

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -42,17 +42,17 @@ MediaPlayer.dependencies.protection.servers.PlayReady = function() {
 
     return {
 
-        getServerURLFromMessage: function(url /*, message*/) { return url; },
+        getServerURLFromMessage: function(url /*, message, messageType*/) { return url; },
 
-        getHTTPMethod: function() { return 'POST'; },
+        getHTTPMethod: function(/*messageType*/) { return 'POST'; },
 
-        getResponseType: function(/*keySystemStr*/) { return 'arraybuffer'; },
+        getResponseType: function(/*keySystemStr, messageType*/) { return 'arraybuffer'; },
 
-        getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
+        getLicenseMessage: function(serverResponse/*, keySystemStr, messageType*/) {
             return new Uint8Array(serverResponse);
         },
 
-        getErrorResponse: function(serverResponse/*, keySystemStr*/) {
+        getErrorResponse: function(serverResponse/*, keySystemStr, messageType*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
         }
     };

--- a/src/streaming/protection/servers/Widevine.js
+++ b/src/streaming/protection/servers/Widevine.js
@@ -34,17 +34,17 @@ MediaPlayer.dependencies.protection.servers.Widevine = function() {
 
     return {
 
-        getServerURLFromMessage: function(url /*, message*/) { return url; },
+        getServerURLFromMessage: function(url /*, message, messageType*/) { return url; },
 
-        getHTTPMethod: function() { return 'POST'; },
+        getHTTPMethod: function(/*messageType*/) { return 'POST'; },
 
-        getResponseType: function(/*keySystemStr*/) { return 'arraybuffer'; },
+        getResponseType: function(/*keySystemStr, messageType*/) { return 'arraybuffer'; },
 
-        getLicenseMessage: function(serverResponse/*, keySystemStr*/) {
+        getLicenseMessage: function(serverResponse/*, keySystemStr, messageType*/) {
             return new Uint8Array(serverResponse);
         },
 
-        getErrorResponse: function(serverResponse/*, keySystemStr*/) {
+        getErrorResponse: function(serverResponse/*, keySystemStr, messageType*/) {
             return String.fromCharCode.apply(null, new Uint8Array(serverResponse));
         }
     };

--- a/src/streaming/vo/protection/KeyMessage.js
+++ b/src/streaming/vo/protection/KeyMessage.js
@@ -36,8 +36,8 @@
  * to which the key message is associated
  * @param {ArrayBuffer} message the key message
  * @param [defaultURL] license acquisition URL provided by the CDM
- * @param [messageType] the message type.  One of "license-request",
- * "license-renewal", "license-release", "individualization-request"
+ * @param [messageType="license-request"] the message type.  Supported message types can be found
+ * {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @class
  */
 MediaPlayer.vo.protection.KeyMessage = function(sessionToken, message, defaultURL, messageType) {
@@ -45,7 +45,7 @@ MediaPlayer.vo.protection.KeyMessage = function(sessionToken, message, defaultUR
     this.sessionToken = sessionToken;
     this.message = message;
     this.defaultURL = defaultURL;
-    this.messageType = messageType;
+    this.messageType = messageType ? messageType : "license-request";
 };
 
 MediaPlayer.vo.protection.KeyMessage.prototype = {

--- a/src/streaming/vo/protection/KeySystemConfiguration.js
+++ b/src/streaming/vo/protection/KeySystemConfiguration.js
@@ -39,18 +39,23 @@
  * @param {MediaPlayer.vo.protection.MediaCapability[]} videoCapabilities array of
  * desired video capabilities.  Higher preference capabilities should be placed earlier
  * in the array.
- * @param {string} [distinctiveIdentifier] desired use of distinctive identifiers.
+ * @param {string} [distinctiveIdentifier="optional"] desired use of distinctive identifiers.
  * One of "required", "optional", or "not-allowed"
- * @param {string} [persistentState] desired support for persistent storage of
+ * @param {string} [persistentState="optional"] desired support for persistent storage of
  * key systems.  One of "required", "optional", or "not-allowed"
+ * @param {string[]} [sessionTypes=["temporary"]] List of session types that must
+ * be supported by the key system
  * @class
  */
-MediaPlayer.vo.protection.KeySystemConfiguration = function(audioCapabilities, videoCapabilities, distinctiveIdentifier, persistentState) {
+MediaPlayer.vo.protection.KeySystemConfiguration = function(audioCapabilities, videoCapabilities,
+                                                            distinctiveIdentifier, persistentState,
+                                                            sessionTypes) {
     this.initDataTypes = [ "cenc" ];
     this.audioCapabilities = audioCapabilities;
     this.videoCapabilities = videoCapabilities;
     this.distinctiveIdentifier = distinctiveIdentifier;
     this.persistentState = persistentState;
+    this.sessionTypes = sessionTypes;
 };
 
 MediaPlayer.vo.protection.KeySystemConfiguration.prototype = {

--- a/src/streaming/vo/protection/LicenseRequestComplete.js
+++ b/src/streaming/vo/protection/LicenseRequestComplete.js
@@ -34,13 +34,16 @@
  *
  * @param {Uint8Array} message license response message
  * @param {MediaPlayer.vo.protection.SessionToken} sessionToken the session to
- * which this license request is associated
+ * @param {String} [messageType="license-request"] the message type that is associated
+ * with this object's response message.  Supported message types can be found
+ * {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @constructor
  */
-MediaPlayer.vo.protection.LicenseRequestComplete = function(message, sessionToken) {
+MediaPlayer.vo.protection.LicenseRequestComplete = function(message, sessionToken, messageType) {
     "use strict";
     this.message = message;
     this.sessionToken = sessionToken;
+    this.messageType = messageType ? messageType : "license-request";
 };
 
 MediaPlayer.vo.protection.LicenseRequestComplete.prototype = {

--- a/src/streaming/vo/protection/ProtectionData.js
+++ b/src/streaming/vo/protection/ProtectionData.js
@@ -33,15 +33,20 @@
  * Data provided for a particular piece of content to customize license server URLs,
  * license server HTTP request headers, clearkeys, or other content-specific data
  *
- * @param {string} laURL a license acquisition URL to use with this key system
+ * @param {string|object} serverURL a license server URL to use with this key system.
+ * When specified as a string, a single URL will be used regardless of message type.
+ * When specified as an object, the object will have property names for each message
+ * type ({@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|message
+ * types defined here)} with the corresponding property value being the URL to use for
+ * messages of that type
  * @param {Object} httpRequestHeaders headers to add to the http request
  * @param {Object} clearkeys defines a set of clear keys that are available to
  * the key system.  Object properties are base64-encoded keyIDs (with no padding).
  * Corresponding property values are keys, base64-encoded (no padding).
  * @class
  */
-MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, clearkeys) {
-    this.laURL = laURL;
+MediaPlayer.vo.protection.ProtectionData = function(serverURL, httpRequestHeaders, clearkeys) {
+    this.serverURL = serverURL;
     this.httpRequestHeaders = httpRequestHeaders;
     this.clearkeys = clearkeys;
 };
@@ -50,8 +55,8 @@ MediaPlayer.vo.protection.ProtectionData = function(laURL, httpRequestHeaders, c
  * License server URL
  *
  * @instance
- * @type string
- * @name MediaPlayer.vo.protection.ProtectionData.laURL
+ * @type string|object
+ * @name MediaPlayer.vo.protection.ProtectionData.serverURL
  * @readonly
  * @memberof MediaPlayer.vo.protection.ProtectionData
  */

--- a/src/streaming/vo/protection/SessionToken.js
+++ b/src/streaming/vo/protection/SessionToken.js
@@ -80,5 +80,14 @@ MediaPlayer.vo.protection.SessionToken = function () { };
  * in this session and their associated status
  */
 
+/**
+ * Returns the session type.  Session types are defined
+ * {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeySessionType|here}
+ *
+ * @function
+ * @name MediaPlayer.vo.protection.SessionToken#getSessionType
+ * @returns {String} The session type
+ */
+
 
 


### PR DESCRIPTION
In order to fully support persistent key sessions, we need to handle other types of CDM messages besides just "request-license".  When key sessions are closed, the CDM may generate a "license-release" message so that the license server knows that the keys associated with the license are no longer usable by the client.  In the case of a "check-out/check-in" use case where a piece of content may be played on no more than X clients simultaneously, it is the responsibility of the client to inform the license server when licenses are requested and released.  [There are other license server messages defined by EME as well](https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType).

***Note: the only platform that currently supports persistent sessions is Chrome OS, so you will need a Chromebook (or similar device) to test the functionality.***

This PR improves support for persistent key sessions and all current EME message types.
* Updated the eme.html application to display persistence information about each session (persistence state will be either **Not Persistent**, **Loaded**, or **Not Loaded**.
* In several places throughout the code, we were using the term "laURL" to describe the license server URL.  This is misleading since the license server is used for more than just "license acquisition".  Renamed these variables and properties to "serverURL".  ***Note:  The "laURL" property in ProtectionData is deprecated and support will be removed in a future release.  Users who are specifying license server URLs in ProtectionData (in sources.json or programmatically) should begin migrating their code to the new property name.***
  * The newly renamed "serverURL" property of ProtectionData can now be either a string or an object.  This allows you to specify a single URL for all message types (string) or different URLs for each message type (object, where property names are message types and property values are URLs)
* ProtectionExtensions.requestLicense() renamed to ProtectionExtensions.sendLicenseServerRequest() to once again avoid misleading name
* LICENSE_REQUEST_COMPLETE event data modified to be an object containing the session token and the message type to allow applications more visibility into the types of messages being passed to the server
* Older EME implementations do not allow anything but creating "temporary" (non-persistent) sessions
* SessionTokens now contain the associated session type