### PR TITLE
Make HTTP Metrics more spec compliant

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -135,6 +135,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     var converter = new MetricsTreeConverter();
     $scope.videoMetrics = null;
     $scope.audioMetrics = null;
+    $scope.streamMetrics = null;
 
     $scope.getVideoTreeMetrics = function () {
         var metrics = player.getMetricsFor("video");
@@ -144,6 +145,11 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     $scope.getAudioTreeMetrics = function () {
         var metrics = player.getMetricsFor("audio");
         $scope.audioMetrics = converter.toTreeViewDataSource(metrics);
+    }
+
+    $scope.getStreamTreeMetrics = function () {
+        var metrics = player.getMetricsFor("stream");
+        $scope.streamMetrics = converter.toTreeViewDataSource(metrics);
     }
 
     // from: https://gist.github.com/siongui/4969449

--- a/samples/dash-if-reference-player/app/metrics.js
+++ b/samples/dash-if-reference-player/app/metrics.js
@@ -229,6 +229,8 @@ MetricsTreeConverter = function () {
 
                 treeMetrics.push(treeMetric);
             }
+
+            return treeMetrics;
         },
 
         httpRequestToTreeMetric = function (httpRequest) {

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -460,6 +460,7 @@
                                 <ul class="dropdown-menu" role="menu" aria-labelledby="metricsDropdown">
                                     <li><a href="#video-metrics" tabindex="-1" data-toggle="tab">Video</a></li>
                                     <li><a href="#audio-metrics" tabindex="-1" data-toggle="tab">Audio</a></li>
+                                    <li><a href="#stream-metrics" tabindex="-1" data-toggle="tab">Stream</a></li>
                                 </ul>
                             </li>
                             <li><a href="#notes" data-toggle="tab">Release Notes</a></li>
@@ -491,6 +492,21 @@
                                     class="tree"
                                     data-angular-treeview="true"
                                     data-tree-model="audioMetrics"
+                                    data-node-label="text"
+                                    data-node-children="items">
+                                </div>
+                            </div>
+                            <div class="tab-pane" id="stream-metrics">
+                                <button
+                                    type="button"
+                                    class="btn btn-default"
+                                    ng-click="getStreamTreeMetrics()">
+                                    Stream - Update
+                                </button>
+                                <div
+                                    class="tree"
+                                    data-angular-treeview="true"
+                                    data-tree-model="streamMetrics"
                                     data-node-label="text"
                                     data-node-children="items">
                                 </div>

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -155,7 +155,7 @@ Dash.dependencies.DashHandler = function () {
             period = representation.adaptation.period;
 
             request.mediaType = mediaType;
-            request.type = "Initialization Segment";
+            request.type = MediaPlayer.vo.metrics.HTTPRequest.INIT_SEGMENT_TYPE;
             request.url = getRequestUrl(representation.initialization, representation);
             request.range = representation.range;
             presentationStartTime = period.start;
@@ -419,7 +419,7 @@ Dash.dependencies.DashHandler = function () {
             else {
                 representation.availableSegmentsNumber = Math.ceil((availabilityWindow.end - availabilityWindow.start) / duration);
             }
-            
+
             return segments;
         },
 
@@ -779,7 +779,7 @@ Dash.dependencies.DashHandler = function () {
             url = unescapeDollarsInTemplate(url);
 
             request.mediaType = type;
-            request.type = "Media Segment";
+            request.type = MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE;
             request.url = url;
             request.range = segment.mediaRange;
             request.startTime = segment.presentationStartTime;

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -332,10 +332,8 @@ Dash.dependencies.DashMetricsExtensions = function () {
                 httpRequest = httpRequestList[httpRequestList.length-1],
                 headers;
 
-            if (httpRequest.type === 'MPD')
-            {
+            if (httpRequest.type === MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE) {
                 headers = parseResponseHeaders(httpRequest.responseHeaders);
-
             }
 
             return headers[id] === undefined ? null :  headers[id];

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -37,7 +37,7 @@ MediaPlayer.dependencies.FragmentLoader = function () {
 
         doLoad = function (request, remainingAttempts) {
             var req = new XMLHttpRequest(),
-                httpRequestMetrics = null,
+                traces = [],
                 firstProgress = true,
                 needFailureReport = true,
                 lastTraceTime = null,
@@ -48,7 +48,14 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                     var currentTime = new Date(),
                         bytes = req.response,
                         latency,
-                        download;
+                        download,
+                        httpRequestMetrics = null;
+
+                    traces.push({
+                        s: currentTime,
+                        d: currentTime.getTime() - lastTraceTime.getTime(),
+                        b: [bytes ? bytes.byteLength : 0]
+                    });
 
                     if (!requestVO.firstByteDate) {
                         requestVO.firstByteDate = requestVO.requestStartDate;
@@ -60,39 +67,41 @@ MediaPlayer.dependencies.FragmentLoader = function () {
 
                     self.log((succeeded ? "loaded " : "failed ") + requestVO.mediaType + ":" + requestVO.type + ":" + requestVO.startTime + " (" + req.status + ", " + latency + "ms, " + download + "ms)");
 
-                    httpRequestMetrics.tresponse = requestVO.firstByteDate;
-                    httpRequestMetrics.tfinish = requestVO.requestEndDate;
-                    httpRequestMetrics.responsecode = req.status;
-                    httpRequestMetrics.responseHeaders = req.getAllResponseHeaders();
+                    httpRequestMetrics = self.metricsModel.addHttpRequest(
+                        request.mediaType,
+                        null,
+                        request.type,
+                        request.url,
+                        req.responseURL || null,
+                        request.range,
+                        request.requestStartDate,
+                        requestVO.firstByteDate,
+                        requestVO.requestEndDate,
+                        req.status,
+                        request.duration,
+                        req.getAllResponseHeaders()
+                    );
 
-                    self.metricsModel.appendHttpTrace(httpRequestMetrics,
-                        currentTime,
-                        currentTime.getTime() - lastTraceTime.getTime(),
-                        [bytes ? bytes.byteLength : 0]);
-                    lastTraceTime = currentTime;
+                    if (succeeded) {
+                        // trace is only for successful requests
+                        traces.forEach(function (trace) {
+                            self.metricsModel.appendHttpTrace(httpRequestMetrics,
+                                                              trace.s,
+                                                              trace.d,
+                                                              trace.b);
+                        });
+                    }
                 };
 
                 xhrs.push(req);
                 request.requestStartDate = new Date();
 
-                httpRequestMetrics = self.metricsModel.addHttpRequest(request.mediaType,
-                                                                      null,
-                                                                      request.type,
-                                                                      request.url,
-                                                                      null,
-                                                                      request.range,
-                                                                      request.requestStartDate,
-                                                                      null,
-                                                                      null,
-                                                                      null,
-                                                                      null,
-                                                                      request.duration,
-                                                                      null);
+                traces.push({
+                    s: request.requestStartDate,
+                    d: 0,
+                    b: [0]
+                });
 
-                self.metricsModel.appendHttpTrace(httpRequestMetrics,
-                                                  request.requestStartDate,
-                                                  request.requestStartDate.getTime() - request.requestStartDate.getTime(),
-                                                  [0]);
                 lastTraceTime = request.requestStartDate;
 
                 req.open("GET", self.requestModifierExt.modifyRequestURL(request.url), true);
@@ -113,7 +122,6 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                         firstProgress = false;
                         if (!event.lengthComputable || (event.lengthComputable && event.total != event.loaded)) {
                             request.firstByteDate = currentTime;
-                            httpRequestMetrics.tresponse = currentTime;
                         }
                     }
 
@@ -122,10 +130,12 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                         request.bytesTotal = event.total;
                     }
 
-                    self.metricsModel.appendHttpTrace(httpRequestMetrics,
-                                                      currentTime,
-                                                      currentTime.getTime() - lastTraceTime.getTime(),
-                                                      [req.response ? req.response.byteLength : 0]);
+                    traces.push({
+                        s: currentTime,
+                        d: currentTime.getTime() - lastTraceTime.getTime(),
+                        b: [req.response ? req.response.byteLength : 0]
+                    });
+
                     lastTraceTime = currentTime;
                     self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, {request: request});
                 };

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -76,6 +76,13 @@ MediaPlayer.vo.metrics.HTTPRequest.Trace.prototype = {
     constructor : MediaPlayer.vo.metrics.HTTPRequest.Trace
 };
 
-MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE = 'Media Segment';
-MediaPlayer.vo.metrics.HTTPRequest.INIT_SEGMENT_TYPE = 'Initialization Segment';
+// these should possibly be MPD, XLinkExpansion, InitializationSegment,
+// MediaSegment, IndexSegment, BitstreamSwitchingSegment, other. See
+// ISO 23009-1 D.4.3
 MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE = 'MPD';
+MediaPlayer.vo.metrics.HTTPRequest.XLINK_EXPANSION_TYPE = 'XLink Expansion';
+MediaPlayer.vo.metrics.HTTPRequest.INIT_SEGMENT_TYPE = 'Initialization Segment';
+MediaPlayer.vo.metrics.HTTPRequest.INDEX_SEGMENT_TYPE = 'Index Segment';
+MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE = 'Media Segment';
+MediaPlayer.vo.metrics.HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'Bitstream Switching Segment';
+MediaPlayer.vo.metrics.HTTPRequest.OTHER_TYPE = 'other';


### PR DESCRIPTION
Recently I have been looking a Metrics Reporting and noticed that there were a few disparities between the DASH spec and the client implementation, notably redirect reporting and HTTP trace reporting and a few other things as well.

I have also enabled viewing of stream-related (manifest loading, xlink resolving) metrics in the sample player, as well as viewing traces for all metrics types.

The same fix as requested in #597 is in here which I had already spotted.