### PR TITLE
Refactor common license request code out of extensions

### DIFF
--- a/src/streaming/models/ProtectionModel.js
+++ b/src/streaming/models/ProtectionModel.js
@@ -270,13 +270,6 @@ MediaPlayer.models.ProtectionModel.eventList = {
      * @constant
      */
     ENAME_TEARDOWN_COMPLETE: "protectionTeardownComplete",
-    /**
-     * Event ID for events delivered when a license request procedure
-     * has completed
-     *
-     * @constant
-     */
-    ENAME_LICENSE_REQUEST_COMPLETE: "licenseRequestComplete"
 };
 
 /**


### PR DESCRIPTION
Moved most of the license request code into ProtectionController.  This
leaves ProtectionExtensions with a much cleaner set of functions for
applications to override.