### PR TITLE
Fix ThroughputRule broken by #675

### DIFF
--- a/src/streaming/rules/ABRRules/ThroughputRule.js
+++ b/src/streaming/rules/ABRRules/ThroughputRule.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -107,9 +107,12 @@ MediaPlayer.rules.ThroughputRule = function () {
             }
 
             downloadTime = (lastRequest.tfinish.getTime() - lastRequest.tresponse.getTime()) / 1000;
-            lastRequestThroughput = Math.round((lastRequest.trace[lastRequest.trace.length - 1].b * 8 ) / downloadTime);
 
-            storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
+            if (lastRequest.trace.length) {
+                lastRequestThroughput = Math.round((lastRequest.trace[lastRequest.trace.length - 1].b * 8 ) / downloadTime);
+                storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
+            }
+
             averageThroughput = Math.round(getAverageThroughput(mediaType, isDynamic));
 
             if (abrController.getAbandonmentStateFor(mediaType) !== MediaPlayer.dependencies.AbrController.ABANDON_LOAD) {


### PR DESCRIPTION
My recent changes to HTTPMetrics (#675) broke ThroughputRule if the last request resulted in a non-2xx response code since no trace would be appended. There was no test of trace since it was (correctly) always assumed to be there, but this now causes an unhandled exception.

Traces appended to these requests would almost certainly be meaningless in terms of throughput measurement so fix is to ignore requests which do not have a trace.