### PR TITLE
fix stalling before stream ends

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -228,10 +228,6 @@ MediaPlayer.dependencies.BufferController = function () {
             checkGapBetweenBuffers.call(self);
             checkIfSufficientBuffer.call(self);
 
-            if (bufferLevel < STALL_THRESHOLD) {
-                notifyIfSufficientBufferStateChanged.call(self, false);
-            }
-
             return true;
         },
 
@@ -410,10 +406,7 @@ MediaPlayer.dependencies.BufferController = function () {
         },
 
         checkIfSufficientBuffer = function () {
-            var timeToEnd = this.playbackController.getTimeToStreamEnd();
-                //minLevel = this.streamProcessor.isDynamic() ? minBufferTime / 2 : minBufferTime;
-
-            if (bufferLevel < STALL_THRESHOLD && (minBufferTime < timeToEnd) || (minBufferTime >= timeToEnd && !isBufferingCompleted)) {
+            if (bufferLevel < STALL_THRESHOLD && !isBufferingCompleted) {
                 notifyIfSufficientBufferStateChanged.call(this, false);
             } else {
                 notifyIfSufficientBufferStateChanged.call(this, true);


### PR DESCRIPTION
this is a fix for the issue discussed on google groups: https://groups.google.com/forum/#!topic/dashjs/ZCH-6_hI7Xs

basically we now do not take care of timeToEnd in checkIfSufficientBuffer as this is causing stalls before end of stream

tested and verified by our internal QA dep.