### PR TITLE
Fix #665 - don't wait on seeking event which may never come

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -111,7 +111,7 @@ MediaPlayer.dependencies.PlaybackController = function () {
 
             var initialSeekTime = getStreamStartTime.call(this, streamInfo);
             this.log("Starting playback at offset: " + initialSeekTime);
-            this.seek(initialSeekTime);
+            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_SEEKING, {seekTime: initialSeekTime});
         },
 
         updateCurrentTime = function() {


### PR DESCRIPTION
Startup used to attempt to seek to an time which was not initially seekable. As documented in #665, this is not compliant with the spec.

Rather than setting the currentTime on the media element, send a ENAME_PLAYBACK_SEEKING event to all interested parties and wait for segments to be downloaded and appended to the sourcebuffers. Once this has occured for all streams, *then* seek the media element (since the start time is now seekable).

The code to do the seeking after the first segments were appended was already there since it is used for syncing audio and video which don't have identical start times.