### PR TITLE
include requests queue to metrics

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -178,6 +178,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             movingDownload = {},
             movingRatio = {},
             droppedFramesValue = 0,
+            requestsQueue,
             fillmoving = function(type, Requests){
                 var requestWindow,
                     downloadTimes,
@@ -224,6 +225,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
             httpRequests = metricsExt.getHttpRequests(metrics);
             droppedFramesMetrics = metricsExt.getCurrentDroppedFrames(metrics);
+            requestsQueue = metricsExt.getRequestsQueue(metrics);
 
             fillmoving("video", httpRequests);
             fillmoving("audio", httpRequests);
@@ -274,7 +276,8 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                 droppedFramesValue: droppedFramesValue,
                 movingLatency: movingLatency,
                 movingDownload: movingDownload,
-                movingRatio: movingRatio
+                movingRatio: movingRatio,
+                requestsQueue: requestsQueue
             }
         }
         else {
@@ -391,7 +394,14 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     function metricChanged(e) {
         var metrics,
             point,
-            treeData;
+            treeData,
+            bufferedRanges = [];
+
+        // get current buffered ranges of video element and keep them up to date
+        for (var i = 0, len = video.buffered.length; i < len; i += 1) {
+            bufferedRanges.push(video.buffered.start(i) + ' - ' + video.buffered.end(i));
+        }
+        $scope.bufferedRanges = bufferedRanges;
 
         if (e.data.stream == "video") {
             metrics = getCribbedMetricsFor("video");
@@ -402,6 +412,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                 $scope.videoMaxIndex = metrics.numBitratesValue;
                 $scope.videoBufferLength = metrics.bufferLengthValue;
                 $scope.videoDroppedFrames = metrics.droppedFramesValue;
+                $scope.videoRequestsQueue = metrics.requestsQueue;
                 if (metrics.movingLatency["video"]) {
                     $scope.videoLatencyCount = metrics.movingLatency["video"].count;
                     $scope.videoLatency = metrics.movingLatency["video"].low.toFixed(3) + " < " + metrics.movingLatency["video"].average.toFixed(3) + " < " + metrics.movingLatency["video"].high.toFixed(3);
@@ -433,6 +444,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                 $scope.audioMaxIndex = metrics.numBitratesValue;
                 $scope.audioBufferLength = metrics.bufferLengthValue;
                 $scope.audioDroppedFrames = metrics.droppedFramesValue;
+                $scope.audioRequestsQueue = metrics.requestsQueue;
                 if (metrics.movingLatency["audio"]) {
                     $scope.audioLatencyCount = metrics.movingLatency["audio"].count;
                     $scope.audioLatency = metrics.movingLatency["audio"].low.toFixed(3) + " < " + metrics.movingLatency["audio"].average.toFixed(3) + " < " + metrics.movingLatency["audio"].high.toFixed(3);

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -167,6 +167,7 @@
     <script src="../../src/streaming/vo/metrics/TCPConnection.js"></script>
     <script src="../../src/streaming/vo/metrics/DroppedFrames.js"></script>
     <script src="../../src/streaming/vo/metrics/SchedulingInfo.js"></script>
+    <script src="../../src/streaming/vo/metrics/RequestsQueue.js"></script>
     <script src="../../src/streaming/vo/metrics/ManifestUpdate.js"></script>
     <script src="../../src/streaming/vo/metrics/DVRInfo.js"></script>
 
@@ -521,6 +522,7 @@
                                     <li><a href="#stream-metrics" tabindex="-1" data-toggle="tab">Stream</a></li>
                                 </ul>
                             </li>
+                            <li><a href="#requests" data-toggle="tab">Requests</a></li>
                             <li><a href="#notes" data-toggle="tab">Release Notes</a></li>
                         </ul>
                         <div id="debugTabContent" class="tab-content">
@@ -568,6 +570,53 @@
                                     data-node-label="text"
                                     data-node-children="items">
                                 </div>
+                            </div>
+                            <div class="tab-pane" id="requests">
+                                <div class="video-requests col-md-4">
+                                    <div>Pending Requests (Video)</div>
+                                    <ul ng-repeat = "request in videoRequestsQueue.pendingRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Loading Requests (Video)</div>
+                                    <ul ng-repeat = "request in videoRequestsQueue.loadingRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Executed Requests (Video)</div>
+                                    <ul ng-repeat = "request in videoRequestsQueue.executedRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Rejected Requests (Video)</div>
+                                    <ul ng-repeat = "request in videoRequestsQueue.rejectedRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                </div>
+
+                                <div class="audio-requests col-md-4">
+                                    <div>Pending Requests (Audio)</div>
+                                    <ul ng-repeat = "request in audioRequestsQueue.pendingRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Loading Requests (Audio)</div>
+                                    <ul ng-repeat = "request in audioRequestsQueue.loadingRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Executed Requests (Audio)</div>
+                                    <ul ng-repeat = "request in audioRequestsQueue.executedRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                    <div>Rejected Requests (Audio)</div>
+                                    <ul ng-repeat = "request in audioRequestsQueue.rejectedRequests">
+                                        <li>{{request.startTime}}</li>
+                                    </ul>
+                                </div>
+
+                                <div class="buffered-ranges col-md-4">
+                                    <div>Buffered Ranges (Video + Audio)</div>
+                                    <ul ng-repeat = "bufferedRange in bufferedRanges">
+                                        <li>{{bufferedRange}}</li>
+                                    </ul>
+                                </div>
+
                             </div>
                             <div class="tab-pane" id="notes">
                                 <div ng-repeat="note in releaseNotes" class="note-box">

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -318,6 +318,7 @@ Dash.dependencies.DashAdapter = function () {
             DVR_INFO: "DVRInfo",
             DROPPED_FRAMES: "DroppedFrames",
             SCHEDULING_INFO: "SchedulingInfo",
+            REQUESTS_QUEUE: "RequestsQueue",
             MANIFEST_UPDATE: "ManifestUpdate",
             MANIFEST_UPDATE_STREAM_INFO: "ManifestUpdatePeriodInfo",
             MANIFEST_UPDATE_TRACK_INFO: "ManifestUpdateRepresentationInfo",

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -188,6 +188,10 @@ Dash.dependencies.DashMetricsExtensions = function () {
             return currentBufferLevel;
         },
 
+        getRequestsQueue = function (metrics) {
+            return metrics.RequestsQueue;
+        },
+
         getCurrentPlaybackRate = function (metrics) {
             if (metrics === null) {
                 return null;
@@ -409,7 +413,8 @@ Dash.dependencies.DashMetricsExtensions = function () {
         getCurrentDVRInfo : getCurrentDVRInfo,
         getCurrentManifestUpdate: getCurrentManifestUpdate,
         getLatestFragmentRequestHeaderValueByID:getLatestFragmentRequestHeaderValueByID,
-        getLatestMPDRequestHeaderValueByID:getLatestMPDRequestHeaderValueByID
+        getLatestMPDRequestHeaderValueByID:getLatestMPDRequestHeaderValueByID,
+        getRequestsQueue: getRequestsQueue
     };
 };
 

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -132,6 +132,7 @@ MediaPlayer.dependencies.FragmentModel = function () {
                 range = request.range;
 
             this.metricsModel.addSchedulingInfo(mediaType, now, type, startTime, availabilityStartTime, duration, quality, range, state);
+            this.metricsModel.addRequestsQueue(mediaType, pendingRequests, loadingRequests, executedRequests, rejectedRequests);
         },
 
         onLoadingCompleted = function(e) {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -268,6 +268,19 @@ MediaPlayer.models.MetricsModel = function () {
             return vo;
         },
 
+        addRequestsQueue: function(mediaType, pendingRequests, loadingRequests, executedRequests, rejectedRequests) {
+            var vo = new MediaPlayer.vo.metrics.RequestsQueue();
+
+            vo.pendingRequests = pendingRequests;
+            vo.loadingRequests = loadingRequests;
+            vo.executedRequests = executedRequests;
+            vo.rejectedRequests = rejectedRequests;
+
+            this.getMetricsFor(mediaType).RequestsQueue = vo;
+
+            this.metricAdded(mediaType, this.adapter.metricsList.REQUESTS_QUEUE, vo);
+        },
+
         addManifestUpdate: function(mediaType, type, requestTime, fetchTime, availabilityStartTime, presentationStartTime, clientTimeOffset, currentTime, buffered, latency) {
             var vo = new MediaPlayer.vo.metrics.ManifestUpdate(),
                 metrics = this.getMetricsFor("stream");

--- a/src/streaming/vo/metrics/RequestsQueue.js
+++ b/src/streaming/vo/metrics/RequestsQueue.js
@@ -28,24 +28,15 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-MediaPlayer.models.MetricsList = function () {
+MediaPlayer.vo.metrics.RequestsQueue = function () {
     "use strict";
 
-    return {
-        TcpList: [],
-        HttpList: [],
-        RepSwitchList: [],
-        BufferLevel: [],
-        BufferState: [],
-        PlayList: [],
-        DroppedFrames: [],
-        SchedulingInfo: [],
-        DVRInfo: [],
-        ManifestUpdate: [],
-        RequestsQueue: null
-    };
+    this.pendingRequests = [];
+    this.loadingRequests = [];
+    this.executedRequests = [];
+    this.rejectedRequests = [];
 };
 
-MediaPlayer.models.MetricsList.prototype = {
-    constructor: MediaPlayer.models.MetricsList
+MediaPlayer.vo.metrics.RequestsQueue.prototype = {
+    constructor: MediaPlayer.vo.metrics.RequestsQueue
 };


### PR DESCRIPTION
add new metric 'RequestsQueue' and show it in debug area at the bottom of dash-if-reference-player index.html in new tab 'Requests'

this helps understanding the algorithm in combination with the visual documentation mentioned in https://groups.google.com/forum/#!topic/dashjs/pQRlJLVyEo4