### PR TITLE
Stop TypeError when chunk.mediaType === fragmentedText

### DIFF
--- a/src/streaming/extensions/SourceBufferExtensions.js
+++ b/src/streaming/extensions/SourceBufferExtensions.js
@@ -205,13 +205,14 @@ MediaPlayer.dependencies.SourceBufferExtensions.prototype = {
     append: function (buffer, chunk) {
         var self = this,
             bytes = chunk.bytes,
-            appendMethod = ("append" in buffer) ? "append" : (("appendBuffer" in buffer) ? "appendBuffer" : null);
+            appendMethod = ("append" in buffer) ? "append" : (("appendBuffer" in buffer) ? "appendBuffer" : null),
+            acceptsChunk = buffer.hasOwnProperty("getTextTrackExtensions");
 
         if (!appendMethod) return;
 
         try {
             self.waitForUpdateEnd(buffer, function() {
-                if (self.manifestExt.getIsTextTrack(chunk.mediaType)) {
+                if (acceptsChunk) {
                     // chunk.start is used in calculations by TextSourceBuffer
                     buffer[appendMethod](bytes, chunk);
                 } else {

--- a/src/streaming/extensions/SourceBufferExtensions.js
+++ b/src/streaming/extensions/SourceBufferExtensions.js
@@ -206,7 +206,10 @@ MediaPlayer.dependencies.SourceBufferExtensions.prototype = {
         var self = this,
             bytes = chunk.bytes,
             appendMethod = ("append" in buffer) ? "append" : (("appendBuffer" in buffer) ? "appendBuffer" : null),
-            acceptsChunk = buffer.hasOwnProperty("getTextTrackExtensions");
+            // our user-defined sourcebuffer-like object has Object as its
+            // prototype whereas built-in SourceBuffers will have something
+            // more sensible. do not pass chunk to built-in append.
+            acceptsChunk = Object.prototype.toString.call(buffer).slice(8, -1) === "Object";
 
         if (!appendMethod) return;
 


### PR DESCRIPTION
2ff50a0 in #674 did not fix the case where chunk is required to be passed to TextSourceBuffer.append - getIsTextTrack did not resolve correctly for fragmentedText and TypeError was thrown in append since chunk was not passed correctly.

I chose to fix this using hasOwnProperty to search for a property which should never appear on the native version. The other option I considered was using Function.length to determine the number of arguments append would accept. Both seem smelly, but it seems unlikely a native SourceBuffer will ever have a getTextTrackExtensions method.

This fix enables playback of http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd which used to work and was subsequently broken.

EDIT: checking for fragmentedText in getIsTextTrack isn't really an option since getIsTextTrack expects a mimeType and the mimeType is not know at this point. The ideal fix is not to vary the number of arguments to supposedly identical methods.