### PR TITLE
ProtectionModel_01b teardown throws exception on Safari

### DIFF
--- a/src/streaming/models/ProtectionModel_01b.js
+++ b/src/streaming/models/ProtectionModel_01b.js
@@ -323,15 +323,25 @@ MediaPlayer.models.ProtectionModel_01b = function () {
         },
 
         setMediaElement: function(mediaElement) {
+            if (videoElement === mediaElement) {
+                return;
+            }
+
+            // Replacing the previous element
             if (videoElement) {
                 removeEventListeners();
             }
+
             videoElement = mediaElement;
-            videoElement.addEventListener(api.keyerror, eventHandler);
-            videoElement.addEventListener(api.needkey, eventHandler);
-            videoElement.addEventListener(api.keymessage, eventHandler);
-            videoElement.addEventListener(api.keyadded, eventHandler);
-            this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_VIDEO_ELEMENT_SELECTED);
+
+            // Only if we are not detaching from the existing element
+            if (videoElement) {
+                videoElement.addEventListener(api.keyerror, eventHandler);
+                videoElement.addEventListener(api.needkey, eventHandler);
+                videoElement.addEventListener(api.keymessage, eventHandler);
+                videoElement.addEventListener(api.keyadded, eventHandler);
+                this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_VIDEO_ELEMENT_SELECTED);
+            }
         },
 
         createKeySession: function(initData /*, keySystemType */) {


### PR DESCRIPTION
The media element is set to null on teardown in ProtectionController. ProtectionModel_01b attempts to add event handlers to the new element without checking it is not null.

I simply copied the basic checks from the other ProtectionModels and it looks good now.

@greg80303 can you take a look at this patch.