### PR TITLE
Never create a native SourceBuffer for fragmented text

### DIFF
--- a/src/streaming/extensions/SourceBufferExtensions.js
+++ b/src/streaming/extensions/SourceBufferExtensions.js
@@ -46,10 +46,20 @@ MediaPlayer.dependencies.SourceBufferExtensions.prototype = {
         var self = this,
             codec = mediaInfo.codec,
             buffer = null;
+
         try {
+            // Safari claims to support anything starting 'application/mp4'.
+            // it definitely doesn't understand 'application/mp4;codecs="stpp"'
+            // - currently no browser does, so check for it and use our own
+            // implementation.
+            if (codec.match(/application\/mp4;\s*codecs="stpp"/i)) {
+                throw new Error("not really supported");
+            }
+
             buffer = mediaSource.addSourceBuffer(codec);
-        } catch(ex) {
-            if ((mediaInfo.isText)||(codec.indexOf('codecs="stpp"')!=-1)) {
+
+        } catch (ex) {
+            if ((mediaInfo.isText) || (codec.indexOf('codecs="stpp"') !== -1)) {
                 buffer = self.system.getObject("textSourceBuffer");
             } else {
                 throw ex;


### PR DESCRIPTION
Safari makes some dubious claims about codec support in both HTMLMediaElement.canPlayType and Mediasource.isTypeSupported. Presumably based on the same logic, it will allow SourceBuffers to be created for types it does not actually understand.

A native SourceBuffer is created for type application/mp4;codecs="stpp", but when the initialisation segment for that stream is appended the browser crashes with SIGSEGV.

This patch checks the codec type and ensures the native addSourceBuffer is never called for application/mp4;codecs="stpp". No current UA supports this type so this change should not affect any UA other than Safari (I am happy to be corrected if I have this wrong). I have verified this with IE11, Edge, FF (Nightly), Chrome and Safari.

Currently attempting to play http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd shows the fault. On applying this patch, Safari will no longer crash but will still not play anything because Safari does not support AVC3 video (despite claiming it does, similar to above).

EDIT: Clearly it would be preferable not to require this workaround, and that all UAs respond correctly with the types of sourcebuffer they can support. I am also aware that should any UA choose to support TTML via MSE in the future this patch will need to be revisited.

Additionally I am filing a bug with Apple relating to this.