### PR TITLE
Don't throw exception when attempting to play audio only stream

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -420,7 +420,10 @@
                 //is SegmentTimeline to avoid using time source
                 var manifest = e.data.manifest,
                     streamInfo = this.adapter.getStreamsInfo(manifest)[0],
-                    mediaInfo  = this.adapter.getMediaInfoForType(manifest, streamInfo, "video"),
+                    mediaInfo = (
+                        this.adapter.getMediaInfoForType(manifest, streamInfo, "video") ||
+                        this.adapter.getMediaInfoForType(manifest, streamInfo, "audio")
+                    ),
                     adaptation = this.adapter.getDataForMedia(mediaInfo),
                     useCalculatedLiveEdgeTime = this.manifestExt.getRepresentationsForAdaptation(manifest, adaptation)[0].useCalculatedLiveEdgeTime;
 


### PR DESCRIPTION
Following 5687245 (#627), streams with no video would completely fail with an uncaught TypeError. This is because video is hardcoded as the only stream type queried when determining if automatic time syncronisation is required.

This PR allows audio only streams to be played.

We have a number of audio streams for testing available from http://rdmedia.bbc.co.uk/dash/ondemand/testcard/radio/ which will play after this patch has been applied. Live audio only is also reenabled by this patch.