### PR TITLE
Resolve HTTPS BaseURLs correctly

### DIFF
--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -41,6 +41,7 @@ Dash.dependencies.DashParser = function () {
         durationRegex = /^([-])?P(([\d.]*)Y)?(([\d.]*)M)?(([\d.]*)D)?T?(([\d.]*)H)?(([\d.]*)M)?(([\d.]*)S)?/,
         datetimeRegex = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(?::([0-9]*)(\.[0-9]*)?)?(?:([+-])([0-9]{2})([0-9]{2}))?/,
         numericRegex = /^[-+]?[0-9]+[.]?[0-9]*([eE][-+]?[0-9]+)?$/,
+        httpOrHttpsRegex = /^https?:\/\//i,
         matchers = [
             {
                 type: "duration",
@@ -286,7 +287,7 @@ Dash.dependencies.DashParser = function () {
                         var mergedValue;
 
                         // child is absolute, don't merge
-                        if (childValue.indexOf("http://") === 0) {
+                        if (httpOrHttpsRegex.test(childValue)) {
                             mergedValue = childValue;
                         } else {
                             mergedValue = parentValue + childValue;


### PR DESCRIPTION
Currently, BaseURL resolution is performed with a hardcoded test for `BaseURL.indexOf("http://") === 0`. URLs returning true are deemed to be absolute and all others relative

When serving media from an absolute HTTPS BaseURL, these BaseURLs are therefore deemed to be relative and are resolved incorrectly.

This PR replaces the string comparison with a regex testing for (case insensitive) http or https.