### PR TITLE
Ensure TTML captions are clipped to sample boundaries

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -52,6 +52,13 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                     break;
                 }
              }
+        },
+
+        trimCaptionsToSampleLimits = function (cArr, start, end) {
+            cArr.forEach(function (c) {
+                c.start = Math.max(start, c.start);
+                c.end   = Math.min(end, c.end);
+            });
         };
 
     return {
@@ -87,7 +94,9 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                 ccContent,
                 mediaInfo = chunk.mediaInfo,
                 mediaType = mediaInfo.type,
-                mimeType = mediaInfo.mimeType;
+                mimeType = mediaInfo.mimeType,
+                sampleStart = 0,
+                sampleEnd = Infinity;
 
             function createTextTrackFromMediaInfo(captionData, mediaInfo) {
                 var textTrackInfo = new MediaPlayer.vo.TextTrackInfo();
@@ -117,8 +126,11 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                         if(!this.firstSubtitleStart){
                             this.firstSubtitleStart = samplesInfo[0].cts-chunk.start*this.timescale;
                         }
-                        samplesInfo[i].cts -= this.firstSubtitleStart;
-                        this.buffered.add(samplesInfo[i].cts/this.timescale,(samplesInfo[i].cts+samplesInfo[i].duration)/this.timescale);
+
+                        sampleStart = samplesInfo[i].cts / this.timescale;
+                        sampleEnd = (samplesInfo[i].cts + samplesInfo[i].duration) / this.timescale;
+
+                        this.buffered.add(sampleStart, sampleEnd);
 
                         //TODO: If do not block here captions will render even though all tracks are hidden.
                         // If I block above this line we get errors in Virtual Buffer. Ideally I need to figure
@@ -130,6 +142,7 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                         parser = parser !== null ? parser : self.getParser(mimeType); //store locally for fragmented text so we do not fetch from dijon over and over again.
                         try{
                             result = parser.parse(ccContent);
+                            trimCaptionsToSampleLimits(result, sampleStart, sampleEnd);
                             this.textTrackExtensions.addCaptions(this.firstSubtitleStart/this.timescale,result);
                         } catch(e) {
                             //empty cue ?


### PR DESCRIPTION
To ease encoding and packaging of TTML segments, captions which span segment boundaries may appear in two segments with identical start and end times.

When an ISOBMFF segment becomes inactive (ie sample DTS plus duration has passed), anything related to that sample should be removed.

This PR ensures that captions in an ISOBMFF sample are clipped to the sample start and end times of that sample.

With our test asset http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd, this stops captions spanning a segment boundary appearing twice.

Note 1: In theory, the TTML parser should compute the intermediate synchronic document between each sample and determine that nothing has changed, but we do not currently have a full-featured TTML parser.

Note 2: sample CTS is used here to maintain existing functionality, though this has been previously been discussed (https://github.com/Dash-Industry-Forum/dash.js/pull/691#discussion_r36537984) and should be DTS.