### PR TITLE
Time text merge ie fix

### DIFF
--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -2,21 +2,20 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>WebVTT Dash Demo</title>
+    <title>Multiple Text Track Sample</title>
     <meta name="description" content="" />
 
     <script src="../../dist/dash.debug.js"></script>
 
-
     <script>
         var EXTERNAL_CAPTION_URL = "http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd", // need to manually seek to get stream to start... issue with MPD but only sample with multi adaptations for external sidecar caption text xml
             FRAGMENTED_CAPTION_URL = "http://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd",
-            videoElement;
+            videoElement,
+            player;
 
         function startVideo() {
             var url = FRAGMENTED_CAPTION_URL,
                 context,
-                player,
                 TTMLRenderingDiv;
 
             videoElement = document.querySelector(".dash-video-player video");
@@ -40,7 +39,7 @@
                 var track = tracks[i],
                     option = document.createElement("option");
 
-                option.text = track.language;
+                option.text = track.language.toUpperCase() + " : " + track.kind;
                 option.value = i;
                 selectMenu.add(option);
             }
@@ -49,15 +48,9 @@
         }
 
         function onCaptionMenuChange(e){
-            var tracks = videoElement.textTracks,
-                ln = tracks.length,
-                idx = e.currentTarget.selectedIndex - 1;
-
-            for(var i=0; i<ln; i++){
-                var track = tracks[i];
-                track.mode = idx === i ? "showing" : "hidden";
-            }
+            player.setTextTrack(e.currentTarget.selectedIndex - 1);
         }
+
     </script>
 
     <style>

--- a/samples/captioning/ttml-ebutt-sample.html
+++ b/samples/captioning/ttml-ebutt-sample.html
@@ -2,26 +2,28 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Multiple Language Timed Text Sample</title>
+    <title>Multiple Language EBU Timed Text Sample</title>
     <meta name="description" content="" />
 
     <script src="../../dist/dash.debug.js"></script>
 
     <script>
-        var EXTERNAL_CAPTION_URL = "http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd", // need to manually seek to get stream to start... issue with MPD but only sample with multi adaptations for external sidecar caption text xml
-            FRAGMENTED_CAPTION_URL = "http://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd",
+        var CAPTION_URL = "a",
             videoElement,
             player;
 
         function startVideo() {
-            var url = FRAGMENTED_CAPTION_URL,
-                context;
+            var url = CAPTION_URL,
+                context,
+                TTMLRenderingDiv;
 
             videoElement = document.querySelector(".dash-video-player video");
+            TTMLRenderingDiv = document.querySelector("#ttml-rendering-div");
             context = new Dash.di.DashContext();
             player = new MediaPlayer(context);
             player.startup();
             player.attachView(videoElement);
+            player.attachTTMLRenderingDiv(TTMLRenderingDiv);
             player.setAutoPlay(true);
             player.attachSource(url);
             player.addEventListener(MediaPlayer.events.TEXT_TRACK_ADDED, onTrackAdded);
@@ -60,6 +62,7 @@
     <body onload="startVideo()">
         <div class="dash-video-player">
             <video controls="true"></video>
+            <div id="ttml-rendering-div"></div>
         </div>
         <div>
             <select id="caption-menu">

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -79,6 +79,7 @@ MediaPlayer = function (context) {
         metricsExt,
         metricsModel,
         videoModel,
+        textSourceBuffer,
         DOMStorage,
         initialized = false,
         resetting = false,
@@ -595,6 +596,37 @@ MediaPlayer = function (context) {
          */
         setQualityFor: function (type, value) {
             abrController.setPlaybackQuality(type, streamController.getActiveStreamInfo(), value);
+        },
+
+
+        /**
+         * Use this method to change the current text track for both external time text files and fragmented text tracks. There is no need to
+         * set the track mode on the video object to switch a track when using this method.
+         *
+         * @param idx - Index of track based on the order of the order the tracks are added.  Use MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED.
+         * @see {@link MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED}
+         * @memberof MediaPlayer#
+         */
+        setTextTrack: function (idx) {
+            if (textSourceBuffer === undefined){
+                textSourceBuffer = system.getObject("textSourceBuffer");
+            }
+
+            var tracks = element.textTracks,
+                ln = tracks.length;
+
+            for(var i=0; i < ln; i++ ){
+                var track = tracks[i],
+                    mode = idx === i ? "showing" : "hidden";
+
+                if (track.mode !== mode){ //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent events.
+                    track.mode = mode;
+                }
+            }
+
+            if (textSourceBuffer.isFragmented) {
+                textSourceBuffer.setTextTrack();
+            }
         },
 
         /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -590,6 +590,8 @@ MediaPlayer = function (context) {
         },
 
         /**
+         * Sets the current quality for media type instead of letting the ABR Herstics automatically selecting it..
+         *
          * @param type
          * @param value
          * @memberof MediaPlayer#
@@ -603,11 +605,13 @@ MediaPlayer = function (context) {
          * Use this method to change the current text track for both external time text files and fragmented text tracks. There is no need to
          * set the track mode on the video object to switch a track when using this method.
          *
-         * @param idx - Index of track based on the order of the order the tracks are added.  Use MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED.
+         * @param idx - Index of track based on the order of the order the tracks are added Use -1 to disable all tracks. (turn captions off).  Use MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED.
          * @see {@link MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED}
          * @memberof MediaPlayer#
          */
         setTextTrack: function (idx) {
+            //For external time text file,  the only action needed to change a track is marking the track mode to showing.
+            // Fragmented text tracks need the additional step of calling textSourceBuffer.setTextTrack();
             if (textSourceBuffer === undefined){
                 textSourceBuffer = system.getObject("textSourceBuffer");
             }
@@ -619,12 +623,12 @@ MediaPlayer = function (context) {
                 var track = tracks[i],
                     mode = idx === i ? "showing" : "hidden";
 
-                if (track.mode !== mode){ //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent events.
+                if (track.mode !== mode){ //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
                     track.mode = mode;
                 }
             }
 
-            if (textSourceBuffer.isFragmented) {
+            if (textSourceBuffer.isFragmented && idx >= 0) {
                 textSourceBuffer.setTextTrack();
             }
         },
@@ -1082,16 +1086,10 @@ MediaPlayer = function (context) {
          * @memberof MediaPlayer#
          */
         attachTTMLRenderingDiv: function (div) {
-            if (!initialized) {
-                throw "MediaPlayer not initialized!";
+            if (!videoModel) {
+                throw "Must call attachView with video element before you attach TTML Rendering Div";
             }
-
-
-            videoModel = null;
-            if (div) {
-                videoModel = system.getObject("videoModel");
-                videoModel.setTTMLRenderingDiv(div);
-            }
+            videoModel.setTTMLRenderingDiv(div);
         },
 
         /**

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -33,20 +33,27 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
         allTracksAreDisabled = false,
         parser = null,
 
-        onTextTrackChange = function(evt) {
-            for (var i = 0; i < evt.srcElement.length; i++ ) {
-                var t = evt.srcElement[i],
-                    el = this.videoModel.getElement();
 
-                allTracksAreDisabled = t.mode !== "showing";
-                if (t.mode === "showing" && el.currentTime > 0) { //TODO find a better way to block function when event is triggered at startup when listener is added.  Tried to delay adding listener.
-                    if (currentTrackIdx !== i) { // do not reset track if already the current track.  This happens when all captions get turned off via UI and then turned on again.
+        onTextTrackChange = function(/*evt*/) {
+            var el = this.videoModel.getElement(),
+                tracks = el.textTracks,
+                ln = tracks.length;
+
+            for (var i = 0; i < ln; i++ ) {
+                var track = tracks[i];
+
+                allTracksAreDisabled = track.mode !== "showing";
+
+                if (track.mode === "showing" && el.currentTime > 0) { //TODO find a better way to block function when event is triggered at startup when listener is added.  Tried to delay adding listener.
+                    if (currentTrackIdx !== i) { // do not reset track if already the current track.  This happens when all captions get turned off via UI and then turned on again and with videojs.
+
                         var previousTextTrack = this.textTrackExtensions.getCurrentTextTrack();
                         this.textTrackExtensions.deleteTrackCues(previousTextTrack);
                         if (previousTextTrack.renderingType === "html") {
                             this.textTrackExtensions.removeCueStyle();
                             this.textTrackExtensions.clearCues();
                         }
+
                         currentTrackIdx = i;
                         this.textTrackExtensions.setCurrentTrackIdx(i);
                         this.textTrackExtensions.deleteTrackCues(this.textTrackExtensions.getCurrentTextTrack());
@@ -117,7 +124,6 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                     for (i = 0; i < this.mediaInfos.length; i++){
                         createTextTrackFromMediaInfo(null, this.mediaInfos[i]);
                     }
-                    self.videoModel.getElement().textTracks.addEventListener('change', onTextTrackChange.bind(self));
                     this.timescale = fragmentExt.getMediaTimescaleFromMoov(bytes);
                 }else {
                     samplesInfo = fragmentExt.getSamplesInfo(bytes);
@@ -188,7 +194,9 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
 
         removeEventListener: function (type, listener, useCapture) {
             this.eventBus.removeEventListener(type, listener, useCapture);
-        }
+        },
+
+        setTextTrack: onTextTrackChange,
     };
 };
 

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -188,8 +188,6 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             var track = this.getCurrentTextTrack();
             track.mode = "showing";//make sure tracks are showing to be able to add the cue...
 
-
-
             for(var item in captionData) {
                 var cue,
                     currentItem = captionData[item];


### PR DESCRIPTION
This PR rebases the IE Timed Text fix on all the recent merges as well as pulls in the Big EBUTT additions.  

IE Changes include. 

Detection of IE11 - May need to include Edge in this. Need to test. 
If IE11 use the addTextTrack method and have poor cleanup of tracks between sessions. 
Also remove event driven text track changes since IE fails here as well and breaks the HTML spec for track events.  

API added to make changing tracks clean and simple. 