### PR TITLE
Fix #240

### DIFF
--- a/build/test/js/streaming/AbrControllerSpec.js
+++ b/build/test/js/streaming/AbrControllerSpec.js
@@ -74,7 +74,6 @@ describe("AbrController", function () {
 
         match = expectedBitrates.filter(function(val, idx/*, arr*/) {
             item = actualBitrates[idx];
-
             return (item && (item.qualityIndex === idx) && (item.bitrate === val) && (item.mediaType === dummyMediaInfo.type));
         });
 

--- a/build/test/js/streaming/FragmentModelSpec.js
+++ b/build/test/js/streaming/FragmentModelSpec.js
@@ -43,8 +43,8 @@ describe("FragmentModel", function () {
         });
 
         it("should detect duplicated requests", function () {
-            expect(fragmentModel.isFragmentLoadedOrPending(initRequest)).toBeTruthy();
-            expect(fragmentModel.isFragmentLoadedOrPending(mediaRequest)).toBeTruthy();
+            expect(fragmentModel.isFragmentLoadedOrPendingAndNotDiscarded(initRequest)).toBeTruthy();
+            expect(fragmentModel.isFragmentLoadedOrPendingAndNotDiscarded(mediaRequest)).toBeTruthy();
         });
 
         it("should return pending requests", function () {

--- a/build/test/js/utils/ObjectsHelper.js
+++ b/build/test/js/utils/ObjectsHelper.js
@@ -32,7 +32,7 @@
 				getMediaInfo: function() {
 					return {bitrateList:[]};
 				}
-            }
+            };
         },
 
         setup = function() {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -310,7 +310,7 @@ MediaPlayer.dependencies.AbrController = function () {
          */
         getQualityForBitrate: function(mediaInfo, bitrate) {
             var bitrateList = this.getBitrateList(mediaInfo),
-                ln = bitrateList.length,
+                ln = bitrateList ? bitrateList.length : 0,
                 bitrateInfo;
 
             for (var i = 0; i < ln; i +=1) {

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -37,6 +37,7 @@ MediaPlayer.dependencies.FragmentModel = function () {
         pendingRequests = [],
         loadingRequests = [],
         rejectedRequests = [],
+        failedRequests = [],
 
         isLoadingPostponed = false,
 
@@ -112,6 +113,9 @@ MediaPlayer.dependencies.FragmentModel = function () {
                 case MediaPlayer.dependencies.FragmentModel.states.REJECTED:
                     requests = rejectedRequests;
                     break;
+                case MediaPlayer.dependencies.FragmentModel.states.FAILED:
+                    requests = failedRequests;
+                    break;
                 default:
                     requests = [];
             }
@@ -143,6 +147,8 @@ MediaPlayer.dependencies.FragmentModel = function () {
 
             if (response && !error) {
                 executedRequests.push(request);
+            } else {
+                failedRequests.push(request);
             }
 
             addSchedulingInfoMetrics.call(this, request, error ? MediaPlayer.dependencies.FragmentModel.states.FAILED : MediaPlayer.dependencies.FragmentModel.states.EXECUTED);
@@ -270,7 +276,7 @@ MediaPlayer.dependencies.FragmentModel = function () {
                     return isLoaded;
                 };
 
-            return (check(pendingRequests) || check(loadingRequests) || (check(executedRequests) && !isDiscarded.call(this)));
+            return (check(pendingRequests) || check(loadingRequests) || check(failedRequests) || (check(executedRequests) && !isDiscarded.call(this)));
         },
 
         /**

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -230,8 +230,25 @@ MediaPlayer.dependencies.FragmentModel = function () {
                 },
 
                 isDiscarded = function() {
-                    var buffer = this.videoModel.getElement();
-                    return this.sourceBufferExt.getBufferRange(buffer, request.availabilityStartTime) === null;
+                    var buffer = this.videoModel.getElement(),
+                        inBuffer = this.sourceBufferExt.getBufferRange(buffer, request.availabilityStartTime) !== null,
+                        req,
+                        d;
+
+                    // It can take a few moments to get into the buffer
+                    if (!inBuffer) {
+                        d = new Date();
+                        d.setSeconds(d.getSeconds() + 3);
+                        for (var i = 0; i < executedRequests.length; i += 1) {
+                            req = executedRequests[i];
+
+                            if (isEqualMedia(request, req) && req.requestEndDate <= d) {
+                                return false;
+                            }
+                        }
+                    }
+
+                    return !inBuffer;
                 },
 
                 check = function(arr) {

--- a/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
+++ b/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
@@ -118,7 +118,7 @@ MediaPlayer.rules.PlaybackTimeRule = function () {
                 request = this.adapter.getFragmentRequestForTime(streamProcessor, representationInfo, rejected.startTime + (rejected.duration / 2) + EPSILON, {keepIdx: keepIdx, timeThreshold: 0});
             }
 
-            while (request && streamProcessor.getFragmentModel().isFragmentLoadedOrPending(request)) {
+            while (request && streamProcessor.getFragmentModel().isFragmentLoadedOrPendingAndNotDiscarded(request)) {
                 if (request.action === "complete") {
                     request = null;
                     streamProcessor.setIndexHandlerTime(NaN);


### PR DESCRIPTION
This PR is a workaround issue #240. For more detail, see @LloydW93's comments on #633.

It's not perfect and in the long run we would expect there to be a better solution when a general clean up of fragment loading occurs, but at least seeking actually works when this patch is applied which we think is important for v1.5.