### PR TITLE
Fix #721 - get date header for last mpd request

### DIFF
--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -325,15 +325,26 @@ Dash.dependencies.DashMetricsExtensions = function () {
             return curentDVRInfo;
         },
 
-        getLatestMPDRequestHeaderValueByID = function(metrics, id) {
+        getLatestMPDRequestHeaderValueByID = function (metrics, id) {
 
-            if (metrics === null) return null;
-            var httpRequestList = getHttpRequests(metrics),
-                httpRequest = httpRequestList[httpRequestList.length-1],
-                headers;
+            var httpRequestList,
+                httpRequest,
+                headers = [],
+                i;
 
-            if (httpRequest.type === MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE) {
-                headers = parseResponseHeaders(httpRequest.responseHeaders);
+            if (metrics === null) {
+                return null;
+            }
+
+            httpRequestList = getHttpRequests(metrics);
+
+            for (i = httpRequestList.length - 1; i >= 0; i -= 1) {
+                httpRequest = httpRequestList[i];
+
+                if (httpRequest.type === MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE) {
+                    headers = parseResponseHeaders(httpRequest.responseHeaders);
+                    break;
+                }
             }
 
             return headers[id] === undefined ? null :  headers[id];

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -329,7 +329,7 @@ Dash.dependencies.DashMetricsExtensions = function () {
 
             var httpRequestList,
                 httpRequest,
-                headers = [],
+                headers = {},
                 i;
 
             if (metrics === null) {


### PR DESCRIPTION
Fixes #721 in two ways:

* ensure headers[id] is always accessible by declaring headers to be an empty Object.
* reverse iterate through the request list to find the last MPD request in case there have been subsequent requests since.

As mentioned before, this function can only return the Date header if the correct CORS headers were specified in the response.