### PR TITLE
Restored image subtitle rendering functionality

### DIFF
--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -206,15 +206,26 @@ MediaPlayer.utils.TextTrackExtensions = function () {
                         img.id = 'ttmlImage_'+this.id;
                         img.src = this.image;
                         img.className = 'cue-image';
-                        captionContainer.appendChild(img);
+                        if (captionContainer) {
+                            captionContainer.appendChild(img);
+                        } else {
+                            video.parentNode.appendChild(img);
+                        }
                     };
 
                     cue.onexit =  function () {
-                        var imgs = captionContainer.childNodes;
-                        var i;
+                        var container,
+                            i,
+                            imgs;
+                        if (captionContainer) {
+                            container = captionContainer;
+                        } else {
+                            container = video.parentNode;
+                        }
+                        imgs = container.childNodes;
                         for(i=0;i<imgs.length;i++){
                             if(imgs[i].id=='ttmlImage_'+this.id){
-                                captionContainer.removeChild(imgs[i]);
+                                container.removeChild(imgs[i]);
                             }
                         }
                     };


### PR DESCRIPTION
The "SMPTE-TT" backgrounImage subtitling for non-HTML rendering got broken in PR #705.

It has now been repaired and tested with a prepared content for both html and non-html rendering.

However, both in its former and present state there are a number of issues with this implementation compared to SMPTE-TT.

* It is on the <p> level instead of <div> level. (SMPTE-TT only supports background images for full duration).
* imagetype should be imageType.
* The region parameters for placement on screen are completely neglected.