### PR TITLE
Patches to TimelineConverter.calcSegmentAvailabilityRange and DashHandler.updateRepresentation for live

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -654,7 +654,7 @@ Dash.dependencies.DashHandler = function () {
             representation.segmentAvailabilityRange = self.timelineConverter.calcSegmentAvailabilityRange(representation, isDynamic);
 
             if ((representation.segmentAvailabilityRange.end < representation.segmentAvailabilityRange.start) && !representation.useCalculatedLiveEdgeTime) {
-                error = new MediaPlayer.vo.Error(Dash.dependencies.DashHandler.SEGMENTS_UNAVAILABLE_ERROR_CODE, "no segments are available yet", {availabilityDelay: Math.abs(representation.segmentAvailabilityRange.end)});
+                error = new MediaPlayer.vo.Error(Dash.dependencies.DashHandler.SEGMENTS_UNAVAILABLE_ERROR_CODE, "no segments are available yet", {availabilityDelay: representation.segmentAvailabilityRange.start - representation.segmentAvailabilityRange.end});
                 self.notify(Dash.dependencies.DashHandler.eventList.ENAME_REPRESENTATION_UPDATED, {representation: representation}, error);
                 return;
             }

--- a/src/dash/TimelineConverter.js
+++ b/src/dash/TimelineConverter.js
@@ -118,8 +118,11 @@ Dash.dependencies.TimelineConverter = function () {
             //the Media Segment list is further restricted by the CheckTime together with the MPD attribute
             // MPD@timeShiftBufferDepth such that only Media Segments for which the sum of the start time of the
             // Media Segment and the Period start time falls in the interval [NOW- MPD@timeShiftBufferDepth - @duration, min(CheckTime, NOW)] are included.
-            start = Math.max((now - representation.adaptation.period.mpd.timeShiftBufferDepth), 0);
-            end = (isNaN(checkTime) ? now : Math.min(checkTime, now)) - d;
+            start = Math.max((now - representation.adaptation.period.mpd.timeShiftBufferDepth), representation.adaptation.period.start);
+            var timeAnchor = (isNaN(checkTime) ? now : Math.min(checkTime, now));
+            var periodEnd = representation.adaptation.period.start + representation.adaptation.period.duration;
+            end = timeAnchor >= periodEnd  && (timeAnchor - d) < periodEnd ? periodEnd : timeAnchor - d;
+            //end = (isNaN(checkTime) ? now : Math.min(checkTime, now)) - d;
             range = {start: start, end: end};
 
             return range;


### PR DESCRIPTION
Patches to:

1. TimelineConverter.calcSegmentAvailabilityRange:
a. Availability start window is from Period start and not 0.
b. Availability window end when time >= period end contains the last segment of the period, regardless how small it was. This case creates issue when the last segment of the period is smaller and time is at [period end , period end + delta] where delta is the difference of the duration of the last segment.
c. It is quite confusing why d is calculate from representation.segments[representation.segments.length-1].duration, the method is called to update the length in itself in the first place, so why access its last index? I have left it untouched.

2. DashHandler.updateRepresentation
If playback is attempted before AST, we must wait till representation.segmentAvailabilityRange.start - representation.segmentAvailabilityRange.end

Limited testing done on some on-demand and live test vectors.