### PR TITLE
Fixed TTML HTML rendering after clip reload in Safari fullscreen

### DIFF
--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -346,6 +346,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             textTrackQueue = [];
             if (videoSizeCheckInterval){
                 clearInterval(videoSizeCheckInterval);
+                videoSizeCheckInterval = null;
             }
 
         },


### PR DESCRIPTION
TTML HTML Resizing stopped working when entering fullscreen after clip had been reloaded, since the videoSizeCheckInterval never got initialized a second time.