### PR TITLE
Call clearCues as part of deleteAllTextTracks(). Fixes issue #770.

### DIFF
--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -348,7 +348,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
                 clearInterval(videoSizeCheckInterval);
                 videoSizeCheckInterval = null;
             }
-
+            this.clearCues();
         },
 
         deleteTextTrack: function(idx) {
@@ -389,8 +389,10 @@ MediaPlayer.utils.TextTrackExtensions = function () {
         },
 
         clearCues: function() {
-            while(captionContainer.firstChild) {
-                captionContainer.removeChild(captionContainer.firstChild);
+            if (captionContainer) {
+                while(captionContainer.firstChild) {
+                    captionContainer.removeChild(captionContainer.firstChild);
+                }
             }
         }
     };


### PR DESCRIPTION
This fixes #770. Should get into an update of 1.5 release.