### PR TITLE
DashHandler.getSegments called after DashHandler.isMediaFinished + javascript fp precision hazards

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -195,7 +195,8 @@ Dash.dependencies.DashHandler = function () {
                     fTime = seg.presentationStartTime - period.start;
                     sDuration = representation.adaptation.period.duration;
                     this.log(representation.segmentInfoType + ": " + fTime + " / " + sDuration);
-                    isFinished = (fTime >= sDuration);
+                    var timescale = representation.timescale;
+                    isFinished = (Math.round(fTime*timescale)/timescale >= Math.round(sDuration*timescale)/timescale);
                 }
             } else {
                 isFinished = true;

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -890,7 +890,14 @@ Dash.dependencies.DashHandler = function () {
             //self.log("New index: " + index);
 
             finished = isMediaFinished.call(self, representation);
-
+			
+            //Recheck if there be more segments, and then recheck if finished
+            if(!finished)
+            {
+                getSegments.call(self, representation);
+                finished = isMediaFinished.call(self, representation);
+            }
+			
             //self.log("Stream finished? " + finished);
             if (finished) {
                 request = new MediaPlayer.vo.FragmentRequest();
@@ -901,7 +908,7 @@ Dash.dependencies.DashHandler = function () {
                 self.log("Signal complete.");
                 //self.log(request);
             } else {
-                getSegments.call(self, representation);
+                //getSegments.call(self, representation);   //Getting segments after checking if finished changes the state 
                 //self.log("Got segments.");
                 //self.log(segments);
                 segment = getSegmentByIndex(idx, representation);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -192,7 +192,7 @@
                 duration = activeStream.getStreamInfo().duration;
 
             return streams.filter(function(stream){
-                return (stream.getStreamInfo().start === (start + duration));
+                return (Math.round(stream.getStreamInfo().start * 1000)/1000 === Math.round((start + duration)*1000)/1000);
             })[0];
         },
 
@@ -209,7 +209,7 @@
                 stream = streams[i];
                 duration += stream.getDuration();
 
-                if (time < duration) {
+                if (Math.round(time * 1000)/1000 < Math.round(duration * 1000)/1000) {
                     return stream;
                 }
             }


### PR DESCRIPTION
In DashHandler.getNext, getSegments is being called after checking isMediaFinished; the former can potentially change the results of isMediaFinished after the call (more segments may be added). In one of the services I am testing, this locks/crashes the code down since the segment added by this call to getSegments is after period end. Hence the calls here are adjusted.

I cannot however completely verify this because when I look at the call-stack for the case when the code crashes, I cannot understand the complete call-flow (40+ calls to 26 unique methods in 12 different classes to get index for a segment). Still if I test DashHandler this seems OK; an expert should verify this.

![image](https://cloud.githubusercontent.com/assets/3089913/9831687/08f7c412-5961-11e5-8ec6-003d5928e559.png)