### PR TITLE
Fixes problem with subtitles overlapping menu in reference player.

### DIFF
--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -1046,7 +1046,7 @@ MediaPlayer.utils.TTMLParser = function() {
                         var finalCue = document.createElement("div");
                         finalCue.appendChild(cueParagraph);
                         finalCue.id = "subtitle_" + cueID;
-                        finalCue.style.cssText = "position: absolute; z-index: 2147483647; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;" + cueRegionProperties;
+                        finalCue.style.cssText = "position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;" + cueRegionProperties;
 
                         if(Object.keys(fontSize).length === 0) {
                             fontSize.defaultFontSize = '100';

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -40,6 +40,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
         captionContainer = null,
         videoSizeCheckInterval = null,
         isIE11 = false,// Temp solution for the addCue InvalidStateError..
+        fullscreenAttribute = null,
 
         createTrackForUserAgent = function(i){
             var kind = textTrackQueue[i].kind;
@@ -68,6 +69,15 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             // https://connect.microsoft.com/IE/feedbackdetail/view/1660701/text-tracks-do-not-fire-change-addtrack-or-removetrack-events
             // https://connect.microsoft.com/IE/feedback/details/1573380/htmltrackelement-track-addcue-throws-invalidstateerror-when-adding-new-cue
             isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./);
+            if (document.fullscreenElement !== undefined) {
+                fullscreenAttribute = "fullscreenElement"; // Standard and Edge
+            } else if (document.webkitIsFullScreen !== undefined) {
+                fullscreenAttribute = "webkitIsFullScreen"; // Chrome and Safari (and Edge)
+            } else if (document.msFullScreenElement) { // IE11
+                fullscreenAttribute = "msFullScreenElement";
+            } else if (document.mozFullScreen) { // Firefox
+                fullscreenAttribute = "mozFullScreen";
+            }
         },
 
         addTextTrack: function(textTrackInfoVO, totalTextTracks) {
@@ -119,6 +129,12 @@ MediaPlayer.utils.TextTrackExtensions = function () {
                     for (var i = 0; i < track.activeCues.length; ++i) {
                         var cue = track.activeCues[i];
                             cue.scaleCue(cue);
+                    }
+                    
+                    if (fullscreenAttribute && document[fullscreenAttribute]) {
+                        captionContainer.style.zIndex = 2147483647;
+                    } else {
+                        captionContainer.style.zIndex = null;
                     }
                 }
             }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -163,7 +163,6 @@ MediaPlayer.models.VideoModel = function () {
             TTMLRenderingDiv.style.position = 'absolute';
             TTMLRenderingDiv.style.display = 'flex';
             TTMLRenderingDiv.style.overflow = 'hidden';
-            TTMLRenderingDiv.style.zIndex = 2147483647;
             TTMLRenderingDiv.style.pointerEvents = 'none';
             TTMLRenderingDiv.style.top = 0;
             TTMLRenderingDiv.style.left = 0;


### PR DESCRIPTION
Changed the z-index for the caption area to only take to the maximal value in fullscreen mode. Otherwise, it is not set.
Fixes #776.