### PR TITLE
Fix #688 - specify a valid icon for sample pages

### DIFF
--- a/contrib/webmjs/example.html
+++ b/contrib/webmjs/example.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
 
     <link rel="stylesheet" href="../../samples/dash-if-reference-player/app/lib/bootstrap/css/bootstrap.min.css">
@@ -24,7 +24,7 @@
     <!-- https://github.com/eu81273/angular.treeview -->
     <script src="../../samples/dash-if-reference-player/app/lib/angular.treeview/angular.treeview.min.js"></script>
 
-	<script src="dash.webm.debug.js"></script>
+    <script src="dash.webm.debug.js"></script>
 
     <!-- App -->
     <script src="../../samples/dash-if-reference-player/app/metrics.js"></script>

--- a/samples/ad-insertion/adinsertion_inband.html
+++ b/samples/ad-insertion/adinsertion_inband.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
     <script src="../../dist/dash.debug.js"></script>

--- a/samples/ad-insertion/adinsertion_inline.html
+++ b/samples/ad-insertion/adinsertion_inline.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
-	<script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.debug.js"></script>
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
 
 </head>

--- a/samples/ad-insertion/xlink.html
+++ b/samples/ad-insertion/xlink.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
-	<script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.debug.js"></script>
 
 </head>
 <body ng-controller="DashController">

--- a/samples/captioning/caption_vtt.html
+++ b/samples/captioning/caption_vtt.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>WebVTT Dash Demo</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
 
     <script src="../../dist/dash.debug.js"></script>
 

--- a/samples/dash-if-reference-player/eme.html
+++ b/samples/dash-if-reference-player/eme.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
 
     <link rel="stylesheet" href="app/lib/bootstrap/css/bootstrap.min.css">

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>Dash JavaScript Player</title>
     <meta name="description" content="" />
-    <link rel="icon" type="image/png" href="http://dashpg.com/w/2012/09/dashif.ico" />
+    <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
 
     <link rel="stylesheet" href="app/lib/bootstrap/css/bootstrap.min.css">


### PR DESCRIPTION
Sounds pointless but, as reported in #688, requests for the DASH-IF icon return 403. This is annoying as it sticks a red entry in the console which confuses debugging.

Replace with a URL for what I assume is the same icon but which returns 200.