### PR TITLE
Cleaned up the setting of style on native cue on Chrome. 

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -47,7 +47,7 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                         if (previousTextTrack !== null) {
                             self.textTrackExtensions.deleteTrackCues(previousTextTrack);
                             if (previousTextTrack.renderingType === "html") {
-                                self.textTrackExtensions.removeCueStyle();
+                                self.textTrackExtensions.removeNativeCueStyle();
                                 self.textTrackExtensions.clearCues();
                             }
                         }


### PR DESCRIPTION
Fixes #795 and #796.

The styling is needed since empty native cues are visible on Chrome, and we only use them to trigger our own HTML-rendered subtitles.

Now we also only do this for Chrome.