### PR TITLE
Fix for unsafe constructs

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -149,13 +149,13 @@ var ControlBar = function(dashjsMediaPlayer) {
 
         setDuration = function(value){
             if (!isNaN(value)) {
-                durationDisplay.innerHTML = player.convertToTimeCode(value);
+                durationDisplay.textContent = player.convertToTimeCode(value);
             }
         },
 
         setTime = function(value){
             if (!isNaN(value)) {
-                timeDisplay.innerHTML = player.convertToTimeCode(value);
+                timeDisplay.textContent = player.convertToTimeCode(value);
             }
         },
 
@@ -284,7 +284,7 @@ var ControlBar = function(dashjsMediaPlayer) {
                 captionItem.id = "captionItem_"+i
                 captionItem.index = i;
                 captionItem.selected = false;
-                captionItem.innerHTML = i === 0 ? tracks[i].kind +" off" : tracks[i-1].lang + " : " + tracks[i-1].kind; //subtract to offset for off button.
+                captionItem.textContent = i === 0 ? tracks[i].kind +" off" : tracks[i-1].lang + " : " + tracks[i-1].kind; //subtract to offset for off button.
                 captionItem.onmouseover = function(e){
                     if (this.selected !== true){
                         this.classList.add("caption-item-over");

--- a/src/dash/extensions/DashManifestExtensions.js
+++ b/src/dash/extensions/DashManifestExtensions.js
@@ -123,7 +123,8 @@ Dash.dependencies.DashManifestExtensions.prototype = {
         var lang = "";
 
         if (adaptation.hasOwnProperty("lang")) {
-            lang = adaptation.lang;
+            //Filter out any other characters not allowed according to RFC5646
+            lang = adaptation.lang.replace(/[^A-Za-z0-9-]/g,"");
         }
 
         return lang;

--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -726,7 +726,7 @@ MediaPlayer.utils.TTMLParser = function() {
                 else if (el.hasOwnProperty('#text')) {
                     // Add the text to an individual span element (to add line padding if it is defined).
                     var textNode = document.createElement('span');
-                    textNode.innerHTML = el['#text'];
+                    textNode.textContent = el['#text'];
 
                     // We append the element to the cue container.
                     cue.appendChild(textNode);


### PR DESCRIPTION
Replacement of unsafe constructs (innerHTML) with textContent, and filtering of characters in lang attribute in manifest to allowed ones.

Fixes #787.

Test content:
http://async5.org/dash/ED_OnDemand_5SecSeg_Subtitles.mpd
http://streamtest.eu/dash/vod/testpic_2s/bug_subs.mpd

The first one is from #787 for the "lang" attribute. The second is for TTML subtitle text.


