### PR TITLE
Metrics Reporting

### DIFF
--- a/build/test/js/utils/Main.js
+++ b/build/test/js/utils/Main.js
@@ -213,11 +213,11 @@ function populateMetricsFor(type, bitrateValue, bitrateIndex, pendingIndex, numB
         numBitratesValue = metricsExt.getMaxIndexForBufferType(type);
 
         if (bufferLevel !== null) {
-            bufferLengthValue = bufferLevel.level.toPrecision(5);
+            bufferLengthValue = (bufferLevel.level / 1000).toPrecision(5);
         }
 
         if (httpRequest !== null) {
-            lastFragmentDuration = httpRequest.mediaduration;
+            lastFragmentDuration = httpRequest._mediaduration;
             lastFragmentDownloadTime = httpRequest.tresponse.getTime() - httpRequest.trequest.getTime();
 
             // convert milliseconds to seconds

--- a/build/test/js/utils/VOHelper.js
+++ b/build/test/js/utils/VOHelper.js
@@ -79,7 +79,7 @@
             req.startTime = NaN;
             req.duration = NaN;
 
-            if (type === "Media Segment") {
+            if (type === "MediaSegment") {
                 req.url = "http://dash.edgesuite.net/envivio/dashpr/clear/video4/0.m4s";
                 req.startTime = 0;
                 req.duration = 4;
@@ -107,11 +107,11 @@
         },
 
         getMediaRequest: function() {
-            return createRequest("Media Segment");
+            return createRequest("MediaSegment");
         },
 
         getInitRequest: function() {
-            return createRequest("Initialization Segment");
+            return createRequest("InitializationSegment");
         },
 
         getCompleteRequest: function() {

--- a/contrib/webmjs/app/main.js
+++ b/contrib/webmjs/app/main.js
@@ -187,27 +187,27 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                     latencyTimes = requestWindow.map(function (req){ return Math.abs(req.tresponse.getTime() - req.trequest.getTime()) / 1000;});
 
                     movingLatency[type] = {
-                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length, 
-                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length,
+                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: latencyTimes.length
                     };
 
                     downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
-                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length, 
-                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
+                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: downloadTimes.length
                     };
 
                     durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
 
                     movingRatio[type] = {
-                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average, 
-                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low, 
-                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high, 
+                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
+                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low,
+                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high,
                         count: durationTimes.length
                     };
                 }
@@ -232,7 +232,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = bufferLevel.level.toPrecision(5);
+                bufferLengthValue = (bufferLevel.level / 1000).toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {
@@ -535,28 +535,28 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     }
 
     // Get initial stream if it was passed in.
-	var paramUrl = null;
+    var paramUrl = null;
 
     if (vars && vars.hasOwnProperty("url")) {
-    	paramUrl = vars.url;
+        paramUrl = vars.url;
     }
 
     if (vars && vars.hasOwnProperty("mpd")) {
-    	paramUrl = vars.mpd;
+        paramUrl = vars.mpd;
     }
 
     if (paramUrl !== null) {
-    	var startPlayback = true;
-    
-    	$scope.selectedItem = {};
+        var startPlayback = true;
+
+        $scope.selectedItem = {};
         $scope.selectedItem.url = paramUrl;
 
         if (vars.hasOwnProperty("autoplay")) {
-        	startPlayback = (vars.autoplay === 'true');
+            startPlayback = (vars.autoplay === 'true');
         }
 
-    	if (startPlayback) {
-	    	$scope.doLoad();
-		}
+        if (startPlayback) {
+            $scope.doLoad();
+        }
     }
 });

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -141,17 +141,23 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
     $scope.getVideoTreeMetrics = function () {
         var metrics = player.getMetricsFor("video");
-        $scope.videoMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.videoMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     $scope.getAudioTreeMetrics = function () {
         var metrics = player.getMetricsFor("audio");
-        $scope.audioMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.audioMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     $scope.getStreamTreeMetrics = function () {
         var metrics = player.getMetricsFor("stream");
-        $scope.streamMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.streamMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     // from: https://gist.github.com/siongui/4969449
@@ -196,27 +202,27 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                     latencyTimes = requestWindow.map(function (req){ return Math.abs(req.tresponse.getTime() - req.trequest.getTime()) / 1000;});
 
                     movingLatency[type] = {
-                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length, 
-                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length,
+                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: latencyTimes.length
                     };
 
                     downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
-                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length, 
-                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
+                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: downloadTimes.length
                     };
 
                     durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
 
                     movingRatio[type] = {
-                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average, 
-                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low, 
-                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high, 
+                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
+                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low,
+                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high,
                         count: durationTimes.length
                     };
                 }
@@ -244,7 +250,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type, streamIdx);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = bufferLevel.level.toPrecision(5);
+                bufferLengthValue = (bufferLevel.level / 1000).toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {
@@ -700,28 +706,28 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     }
 
     // Get initial stream if it was passed in.
-	var paramUrl = null;
+    var paramUrl = null;
 
     if (vars && vars.hasOwnProperty("url")) {
-    	paramUrl = vars.url;
+        paramUrl = vars.url;
     }
 
     if (vars && vars.hasOwnProperty("mpd")) {
-    	paramUrl = vars.mpd;
+        paramUrl = vars.mpd;
     }
 
     if (paramUrl !== null) {
-    	var startPlayback = true;
-    
-    	$scope.selectedItem = {};
+        var startPlayback = true;
+
+        $scope.selectedItem = {};
         $scope.selectedItem.url = paramUrl;
 
         if (vars.hasOwnProperty("autoplay")) {
-        	startPlayback = (vars.autoplay === 'true');
+            startPlayback = (vars.autoplay === 'true');
         }
 
-    	if (startPlayback) {
-	    	$scope.doLoad();
-		}
+        if (startPlayback) {
+            $scope.doLoad();
+        }
     }
 });

--- a/samples/dash-if-reference-player/app/metrics.js
+++ b/samples/dash-if-reference-player/app/metrics.js
@@ -21,7 +21,7 @@ MetricsTreeConverter = function () {
                 tMetric.text = "t: " + bufferMetric.t;
 
                 levelMetric = {};
-                levelMetric.text = "level: " + bufferMetric.level;
+                levelMetric.text = "level: " + bufferMetric.level / 1000;
 
                 treeMetric.items.push(tMetric);
                 treeMetric.items.push(levelMetric);
@@ -39,6 +39,7 @@ MetricsTreeConverter = function () {
                 representationidMetric,
                 subreplevelMetric,
                 startMetric,
+                mstartMetric,
                 durationMetric,
                 playbackspeedMetric,
                 stopreasonMetric,
@@ -54,27 +55,32 @@ MetricsTreeConverter = function () {
 
                 representationidMetric = {};
                 representationidMetric.text = "representationid: " + bufferMetric.representationid;
+                treeMetric.items.push(representationidMetric);
 
-                subreplevelMetric = {};
-                subreplevelMetric.text = "subreplevel: " + bufferMetric.subreplevel;
+                if (bufferMetric.subreplevel) {
+                    subreplevelMetric = {};
+                    subreplevelMetric.text = "subreplevel: " + bufferMetric.subreplevel;
+                    treeMetric.items.push(subreplevelMetric);
+                }
 
                 startMetric = {};
                 startMetric.text = "start: " + bufferMetric.start;
+                treeMetric.items.push(startMetric);
+
+                mstartMetric = {};
+                mstartMetric.text = "mstart: " + (bufferMetric.mstart / 1000);
+                treeMetric.items.push(mstartMetric);
 
                 durationMetric = {};
                 durationMetric.text = "duration: " + bufferMetric.duration;
+                treeMetric.items.push(durationMetric);
 
                 playbackspeedMetric = {};
                 playbackspeedMetric.text = "playbackspeed: " + bufferMetric.playbackspeed;
+                treeMetric.items.push(playbackspeedMetric);
 
                 stopreasonMetric = {};
                 stopreasonMetric.text = "stopreason: " + bufferMetric.stopreason;
-
-                treeMetric.items.push(representationidMetric);
-                treeMetric.items.push(subreplevelMetric);
-                treeMetric.items.push(startMetric);
-                treeMetric.items.push(durationMetric);
-                treeMetric.items.push(playbackspeedMetric);
                 treeMetric.items.push(stopreasonMetric);
 
                 treeMetrics.push(treeMetric);
@@ -91,6 +97,7 @@ MetricsTreeConverter = function () {
                 mstartMetric,
                 startTypeMetric,
                 traceMetric,
+                traceMetrics,
                 i;
 
             for (i = 0; i < playListMetrics.length; i += 1) {
@@ -103,21 +110,27 @@ MetricsTreeConverter = function () {
 
                 startMetric = {};
                 startMetric.text = "start: " + bufferMetric.start;
+                treeMetric.items.push(startMetric);
 
                 mstartMetric = {};
-                mstartMetric.text = "mstart: " + bufferMetric.mstart;
+                mstartMetric.text = "mstart: " + (bufferMetric.mstart / 1000);
+                treeMetric.items.push(mstartMetric);
 
                 startTypeMetric = {};
                 startTypeMetric.text = "starttype: " + bufferMetric.starttype;
-
-                traceMetric = {};
-                traceMetric.text = "trace";
-                traceMetric.items = playListTraceMetricsToTreeMetrics(bufferMetric.trace);
-
-                treeMetric.items.push(startMetric);
-                treeMetric.items.push(mstartMetric);
                 treeMetric.items.push(startTypeMetric);
-                treeMetric.items.push(traceMetric);
+
+                traceMetrics = playListTraceMetricsToTreeMetrics(bufferMetric.trace);
+
+                if (traceMetrics) {
+                    traceMetric = {};
+                    traceMetric.text = "trace";
+                    traceMetric.items = traceMetrics;
+                }
+
+                if (traceMetric.items.length) {
+                    treeMetric.items.push(traceMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }
@@ -128,7 +141,7 @@ MetricsTreeConverter = function () {
         representationSwitchToTreeMetrics = function (representationSwitch) {
             var treeMetrics = [],
                 treeMetric,
-                bufferMetric,
+                switchMetric,
                 tMetric,
                 mtMetric,
                 toMetric,
@@ -136,7 +149,7 @@ MetricsTreeConverter = function () {
                 i;
 
             for (i = 0; i < representationSwitch.length; i += 1) {
-                bufferMetric = representationSwitch[i];
+                switchMetric = representationSwitch[i];
 
                 treeMetric = {};
                 treeMetric.text = "Representation Switch: " + (i + 1);
@@ -144,21 +157,22 @@ MetricsTreeConverter = function () {
                 treeMetric.collapsed = true;
 
                 tMetric = {};
-                tMetric.text = "t: " + bufferMetric.t;
+                tMetric.text = "t: " + switchMetric.t;
+                treeMetric.items.push(tMetric);
 
                 mtMetric = {};
-                mtMetric.text = "mt: " + bufferMetric.mt;
+                mtMetric.text = "mt: " + (switchMetric.mt / 1000);
+                treeMetric.items.push(mtMetric);
 
                 toMetric = {};
-                toMetric.text = "to: " + bufferMetric.to;
-
-                ltoMetric = {};
-                ltoMetric.text = "lto: " + bufferMetric.lto;
-
-                treeMetric.items.push(tMetric);
-                treeMetric.items.push(mtMetric);
+                toMetric.text = "to: " + switchMetric.to;
                 treeMetric.items.push(toMetric);
-                treeMetric.items.push(ltoMetric);
+
+                if (switchMetric.lto) {
+                    ltoMetric = {};
+                    ltoMetric.text = "lto: " + switchMetric.lto;
+                    treeMetric.items.push(ltoMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }
@@ -260,49 +274,52 @@ MetricsTreeConverter = function () {
 
                 tcpidMetric = {};
                 tcpidMetric.text = "tcpid: " + bufferMetric.tcpid;
+                treeMetric.items.push(tcpidMetric);
 
                 typeMetric = {};
                 typeMetric.text = "type: " + bufferMetric.type;
+                treeMetric.items.push(typeMetric);
 
                 urlMetric = {};
                 urlMetric.text = "url: " + bufferMetric.url;
+                treeMetric.items.push(urlMetric);
 
                 actualurlMetric = {};
                 actualurlMetric.text = "actualurl: " + bufferMetric.actualurl;
+                treeMetric.items.push(actualurlMetric);
 
                 rangeMetric = {};
                 rangeMetric.text = "range: " + bufferMetric.range;
+                treeMetric.items.push(rangeMetric);
 
                 trequestMetric = {};
                 trequestMetric.text = "trequest: " + bufferMetric.trequest;
+                treeMetric.items.push(trequestMetric);
 
                 tresponseMetric = {};
                 tresponseMetric.text = "tresponse: " + bufferMetric.tresponse;
+                treeMetric.items.push(tresponseMetric);
 
                 responsecodeMetric = {};
                 responsecodeMetric.text = "responsecode: " + bufferMetric.responsecode;
+                treeMetric.items.push(responsecodeMetric);
 
-                intervalMetric = {};
-                intervalMetric.text = "interval: " + bufferMetric.interval;
+                if (bufferMetric.interval) {
+                    intervalMetric = {};
+                    intervalMetric.text = "interval: " + bufferMetric.interval;
+                    treeMetric.items.push(intervalMetric);
+                }
 
                 mediadurationMetric = {};
-                mediadurationMetric.text = "mediaduration: " + bufferMetric.mediaduration;
-
-                traceMetric = {};
-                traceMetric.text = "trace";
-                traceMetric.items = httpRequestTraceToTreeMetric(bufferMetric.trace);
-
-                treeMetric.items.push(tcpidMetric);
-                treeMetric.items.push(typeMetric);
-                treeMetric.items.push(urlMetric);
-                treeMetric.items.push(actualurlMetric);
-                treeMetric.items.push(rangeMetric);
-                treeMetric.items.push(trequestMetric);
-                treeMetric.items.push(tresponseMetric);
-                treeMetric.items.push(responsecodeMetric);
-                treeMetric.items.push(intervalMetric);
+                mediadurationMetric.text = "mediaduration: " + bufferMetric._mediaduration;
                 treeMetric.items.push(mediadurationMetric);
-                treeMetric.items.push(traceMetric);
+
+                if (bufferMetric.trace) {
+                    traceMetric = {};
+                    traceMetric.text = "trace";
+                    traceMetric.items = httpRequestTraceToTreeMetric(bufferMetric.trace);
+                    treeMetric.items.push(traceMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -56,6 +56,7 @@
     <script src="../../src/streaming/utils/VirtualBuffer.js"></script>
     <script src="../../src/streaming/utils/BoxParser.js"></script>
     <script src="../../src/streaming/utils/IsoFile.js"></script>
+    <script src="../../src/streaming/utils/RNG.js"></script>
     <script src="../../src/streaming/extensions/RequestModifierExtensions.js"></script>
     <script src="../../src/streaming/models/VideoModel.js"></script>
     <script src="../../src/streaming/vo/FragmentRequest.js"></script>
@@ -172,6 +173,27 @@
     <script src="../../src/streaming/vo/metrics/RequestsQueue.js"></script>
     <script src="../../src/streaming/vo/metrics/ManifestUpdate.js"></script>
     <script src="../../src/streaming/vo/metrics/DVRInfo.js"></script>
+    <script src="../../src/streaming/vo/metrics/DVBErrors.js"></script>
+
+    <!-- Reporting -->
+    <script src="../../src/streaming/controllers/MetricsController.js"></script>
+    <script src="../../src/streaming/controllers/MetricsCollectionController.js"></script>
+    <script src="../../src/streaming/metrics/RangeController.js"></script>
+    <script src="../../src/streaming/metrics/MetricsHandlersController.js"></script>
+    <script src="../../src/streaming/metrics/ReportingController.js"></script>
+
+    <script src="../../src/streaming/metrics/reporting/ReportingFactory.js"></script>
+    <script src="../../src/streaming/metrics/reporting/reporters/DVBReporting.js"></script>
+
+    <script src="../../src/streaming/metrics/metrics/MetricsHandlerFactory.js"></script>
+    <script src="../../src/streaming/metrics/metrics/handlers/BufferLevel.js"></script>
+    <script src="../../src/streaming/metrics/metrics/handlers/DVBErrors.js"></script>
+    <script src="../../src/streaming/metrics/metrics/handlers/GenericMetricHandler.js"></script>
+    <script src="../../src/streaming/metrics/metrics/handlers/HttpList.js"></script>
+    <script src="../../src/streaming/metrics/metrics/handlers/PlayList.js"></script>
+
+    <script src="../../src/streaming/metrics/utils/MetricSerialiser.js"></script>
+    <script src="../../src/streaming/metrics/utils/HandlerHelpers.js"></script>
 
     <!-- Dash -->
     <script src="../../src/dash/Dash.js"></script>
@@ -184,6 +206,9 @@
     <script src="../../src/dash/vo/Event.js"></script>
     <script src="../../src/dash/vo/EventStream.js"></script>
     <script src="../../src/dash/vo/UTCTiming.js"></script>
+    <script src="../../src/dash/vo/Metrics.js"></script>
+    <script src="../../src/dash/vo/Range.js"></script>
+    <script src="../../src/dash/vo/Reporting.js"></script>
     <script src="../../src/dash/DashParser.js"></script>
     <script src="../../src/dash/DashHandler.js"></script>
     <script src="../../src/dash/controllers/RepresentationController.js"></script>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -22,7 +22,7 @@
             var     metrics = player.getMetricsFor('video'),
                     metricsExt = player.getMetricsExt(),
                     bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
-            document.querySelector("#stats").innerHTML = "Buffer level " + bufferLevel.level.toPrecision(3) + "s";
+            document.querySelector("#stats").innerHTML = "Buffer level " + (bufferLevel.level / 1000).toPrecision(3) + "s";
         }
     </script>
     <style>

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -309,10 +309,9 @@ Dash.dependencies.DashAdapter = function () {
         timelineConverter: undefined,
 
         metricsList: {
-            TCP_CONNECTION: "TcpConnection",
-            HTTP_REQUEST: "HttpRequest",
-            HTTP_REQUEST_TRACE: "HttpRequestTrace",
-            TRACK_SWITCH : "RepresentationSwitch",
+            TCP_CONNECTION: "TcpList",
+            HTTP_REQUEST: "HttpList",
+            TRACK_SWITCH : "RepSwitchList",
             BUFFER_LEVEL: "BufferLevel",
             BUFFER_STATE: "BufferState",
             DVR_INFO: "DVRInfo",
@@ -322,8 +321,7 @@ Dash.dependencies.DashAdapter = function () {
             MANIFEST_UPDATE: "ManifestUpdate",
             MANIFEST_UPDATE_STREAM_INFO: "ManifestUpdatePeriodInfo",
             MANIFEST_UPDATE_TRACK_INFO: "ManifestUpdateRepresentationInfo",
-            PLAY_LIST: "PlayList",
-            PLAY_LIST_TRACE: "PlayListTrace"
+            PLAY_LIST: "PlayList"
         },
 
         convertDataToTrack: convertRepresentationToTrackInfo,

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -79,9 +79,9 @@ Dash.dependencies.RepresentationController = function () {
         addRepresentationSwitch = function() {
             var now = new Date(),
                 currentRepresentation = this.getCurrentRepresentation(),
-                currentVideoTime = this.streamProcessor.playbackController.getTime();
+                currentVideoTimeMs = this.streamProcessor.playbackController.getTime() * 1000;
 
-            this.metricsModel.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTime, currentRepresentation.id);
+            this.metricsModel.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTimeMs, currentRepresentation.id);
         },
 
         addDVRMetric = function() {

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -192,29 +192,37 @@ Dash.dependencies.DashMetricsExtensions = function () {
             return metrics.RequestsQueue;
         },
 
-        getCurrentPlaybackRate = function (metrics) {
+        getLatestPlayList = function (metrics) {
             if (metrics === null) {
                 return null;
             }
 
-            var playList = metrics.PlayList,
-                trace,
-                currentRate;
+            var playList = metrics.PlayList;
 
             if (playList === null || playList.length <= 0) {
                 return null;
             }
 
-            trace = playList[playList.length - 1].trace;
+            return playList[playList.length - 1];
+        },
+/*
+        getLatestPlayListTrace = function (metrics) {
+            var playList = getLatestPlayList(metrics),
+                trace;
+
+            if (playList === null) {
+                return null;
+            }
+
+            trace = playList.trace;
 
             if (trace === null || trace.length <= 0) {
                 return null;
             }
 
-            currentRate = trace[trace.length - 1].playbackspeed;
-            return currentRate;
+            return trace[trace.length - 1];
         },
-
+*/
         getCurrentHttpRequest = function (metrics) {
             if (metrics === null) {
                 return null;
@@ -361,9 +369,12 @@ Dash.dependencies.DashMetricsExtensions = function () {
             var httpRequest = getCurrentHttpRequest(metrics),
                 headers;
 
-            if (httpRequest === null || httpRequest.responseHeaders === null) return null;
+            if (httpRequest === null || httpRequest._responseHeaders === null) {
+                return null;
+            }
 
-            headers = parseResponseHeaders(httpRequest.responseHeaders);
+            headers = parseResponseHeaders(httpRequest._responseHeaders);
+
             return headers[id] === undefined ? null :  headers[id];
         },
 
@@ -416,7 +427,6 @@ Dash.dependencies.DashMetricsExtensions = function () {
         getMaxAllowedIndexForBufferType : getMaxAllowedIndexForBufferType,
         getCurrentRepresentationSwitch : getCurrentRepresentationSwitch,
         getCurrentBufferLevel : getCurrentBufferLevel,
-        getCurrentPlaybackRate: getCurrentPlaybackRate,
         getCurrentHttpRequest : getCurrentHttpRequest,
         getHttpRequests : getHttpRequests,
         getCurrentDroppedFrames : getCurrentDroppedFrames,
@@ -425,7 +435,8 @@ Dash.dependencies.DashMetricsExtensions = function () {
         getCurrentManifestUpdate: getCurrentManifestUpdate,
         getLatestFragmentRequestHeaderValueByID:getLatestFragmentRequestHeaderValueByID,
         getLatestMPDRequestHeaderValueByID:getLatestMPDRequestHeaderValueByID,
-        getRequestsQueue: getRequestsQueue
+        getRequestsQueue: getRequestsQueue,
+        getLatestPlayList: getLatestPlayList
     };
 };
 

--- a/src/dash/vo/Metrics.js
+++ b/src/dash/vo/Metrics.js
@@ -1,0 +1,43 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/*globals Dash */
+
+Dash.vo.Metrics = function () {
+    "use strict";
+
+    this.metrics = "";
+    this.Range = [];
+    this.Reporting = [];
+};
+
+Dash.vo.Metrics.prototype = {
+    constructor: Dash.vo.Metrics
+};

--- a/src/dash/vo/Range.js
+++ b/src/dash/vo/Range.js
@@ -1,0 +1,44 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/*globals Dash */
+
+Dash.vo.Range = function () {
+    "use strict";
+
+    this.starttime = 0;
+    this.duration = Infinity;
+
+    this.useWallClockTime = false;
+};
+
+Dash.vo.Range.prototype = {
+    constructor: Dash.vo.Range
+};

--- a/src/dash/vo/Reporting.js
+++ b/src/dash/vo/Reporting.js
@@ -1,0 +1,43 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/*globals Dash */
+
+Dash.vo.Reporting = function () {
+    "use strict";
+
+    // Reporting is a DescriptorType
+    this.schemeIdUri = "";
+    this.value = "";
+};
+
+Dash.vo.Reporting.prototype = {
+    constructor: Dash.vo.Reporting
+};

--- a/src/streaming/Context.js
+++ b/src/streaming/Context.js
@@ -64,6 +64,7 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('customTimeRanges', MediaPlayer.utils.CustomTimeRanges);
             this.system.mapSingleton('virtualBuffer', MediaPlayer.utils.VirtualBuffer);
             this.system.mapClass('isoFile', MediaPlayer.utils.IsoFile);
+            this.system.mapSingleton('randomNumberGenerator', MediaPlayer.utils.RNG);
 
             this.system.mapSingleton('textTrackExtensions', MediaPlayer.utils.TextTrackExtensions);
             this.system.mapSingleton('vttParser', MediaPlayer.utils.VTTParser);
@@ -133,6 +134,25 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('stream', MediaPlayer.dependencies.Stream);
             this.system.mapClass('scheduleController', MediaPlayer.dependencies.ScheduleController);
             this.system.mapSingleton('timeSyncController', MediaPlayer.dependencies.TimeSyncController);
+
+            this.system.mapSingleton('metricsCollectionController', MediaPlayer.dependencies.MetricsCollectionController);
+            this.system.mapClass('metricsController', MediaPlayer.dependencies.MetricsController);
+            this.system.mapClass('rangeController', MediaPlayer.dependencies.RangeController);
+            this.system.mapClass('reportingController', MediaPlayer.dependencies.ReportingController);
+            this.system.mapClass('metricsHandlersController', MediaPlayer.dependencies.MetricsHandlersController);
+
+            this.system.mapSingleton('reportingFactory', MediaPlayer.metrics.ReportingFactory);
+            this.system.mapClass('dvbReporting', MediaPlayer.metrics.reporting.DVBReporting);
+
+            this.system.mapSingleton('metricsHandlerFactory', MediaPlayer.metrics.MetricsHandlerFactory);
+            this.system.mapClass('bufferLevelHandler', MediaPlayer.metrics.handlers.BufferLevel);
+            this.system.mapClass('dVBErrorsHandler', MediaPlayer.metrics.handlers.DVBErrors);
+            this.system.mapClass('httpListHandler', MediaPlayer.metrics.handlers.HttpList);
+            this.system.mapClass('playListHandler', MediaPlayer.metrics.handlers.PlayList);
+            this.system.mapClass('genericMetricHandler', MediaPlayer.metrics.handlers.GenericMetricHandler);
+
+            this.system.mapSingleton('metricSerialiser', MediaPlayer.metrics.utils.MetricSerialiser);
+            this.system.mapSingleton('handlerHelpers', MediaPlayer.metrics.utils.HandlerHelpers);
 
             this.system.mapSingleton('notifier', MediaPlayer.dependencies.Notifier);
         }

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -41,21 +41,14 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                 firstProgress = true,
                 needFailureReport = true,
                 lastTraceTime = null,
+                lastTraceReceivedCount = 0,
                 self = this,
-                handleLoaded = function(requestVO, succeeded) {
+                handleLoaded = function (requestVO, succeeded) {
                     needFailureReport = false;
 
                     var currentTime = new Date(),
-                        bytes = req.response,
                         latency,
-                        download,
-                        httpRequestMetrics = null;
-
-                    traces.push({
-                        s: currentTime,
-                        d: currentTime.getTime() - lastTraceTime.getTime(),
-                        b: [bytes ? bytes.byteLength : 0]
-                    });
+                        download;
 
                     if (!requestVO.firstByteDate) {
                         requestVO.firstByteDate = requestVO.requestStartDate;
@@ -67,7 +60,7 @@ MediaPlayer.dependencies.FragmentLoader = function () {
 
                     self.log((succeeded ? "loaded " : "failed ") + requestVO.mediaType + ":" + requestVO.type + ":" + requestVO.startTime + " (" + req.status + ", " + latency + "ms, " + download + "ms)");
 
-                    httpRequestMetrics = self.metricsModel.addHttpRequest(
+                    self.metricsModel.addHttpRequest(
                         request.mediaType,
                         null,
                         request.type,
@@ -79,102 +72,87 @@ MediaPlayer.dependencies.FragmentLoader = function () {
                         requestVO.requestEndDate,
                         req.status,
                         request.duration,
-                        req.getAllResponseHeaders()
+                        req.getAllResponseHeaders(),
+                        succeeded ? traces : null
                     );
-
-                    if (succeeded) {
-                        // trace is only for successful requests
-                        traces.forEach(function (trace) {
-                            self.metricsModel.appendHttpTrace(httpRequestMetrics,
-                                                              trace.s,
-                                                              trace.d,
-                                                              trace.b);
-                        });
-                    }
                 };
 
-                xhrs.push(req);
-                request.requestStartDate = new Date();
+            xhrs.push(req);
+            request.requestStartDate = new Date();
+            lastTraceTime = request.requestStartDate;
 
-                traces.push({
-                    s: request.requestStartDate,
-                    d: 0,
-                    b: [0]
-                });
-
-                lastTraceTime = request.requestStartDate;
-
-                req.open("GET", self.requestModifierExt.modifyRequestURL(request.url), true);
-                req.responseType = "arraybuffer";
-                req = self.requestModifierExt.modifyRequestHeader(req);
+            req.open("GET", self.requestModifierExt.modifyRequestURL(request.url), true);
+            req.responseType = "arraybuffer";
+            req = self.requestModifierExt.modifyRequestHeader(req);
 /*
-                req.setRequestHeader("Cache-Control", "no-cache");
-                req.setRequestHeader("Pragma", "no-cache");
-                req.setRequestHeader("If-Modified-Since", "Sat, 1 Jan 2000 00:00:00 GMT");
+            req.setRequestHeader("Cache-Control", "no-cache");
+            req.setRequestHeader("Pragma", "no-cache");
+            req.setRequestHeader("If-Modified-Since", "Sat, 1 Jan 2000 00:00:00 GMT");
 */
-                if (request.range) {
-                    req.setRequestHeader("Range", "bytes=" + request.range);
+            if (request.range) {
+                req.setRequestHeader("Range", "bytes=" + request.range);
+            }
+
+            req.onprogress = function (event) {
+                var currentTime = new Date();
+
+                if (firstProgress) {
+                    firstProgress = false;
+                    if (!event.lengthComputable || (event.lengthComputable && event.total !== event.loaded)) {
+                        request.firstByteDate = currentTime;
+                    }
                 }
 
-                req.onprogress = function (event) {
-                    var currentTime = new Date();
-                    if (firstProgress) {
-                        firstProgress = false;
-                        if (!event.lengthComputable || (event.lengthComputable && event.total != event.loaded)) {
-                            request.firstByteDate = currentTime;
-                        }
-                    }
+                traces.push({
+                    s: lastTraceTime,
+                    d: currentTime.getTime() - lastTraceTime.getTime(),
+                    b: [event.loaded ? event.loaded - lastTraceReceivedCount : 0]
+                });
 
-                    if (event.lengthComputable) {
-                        request.bytesLoaded = event.loaded;
-                        request.bytesTotal = event.total;
-                    }
+                lastTraceTime = currentTime;
+                lastTraceReceivedCount = event.loaded;
+                self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, {request: request});
+            };
 
-                    traces.push({
-                        s: currentTime,
-                        d: currentTime.getTime() - lastTraceTime.getTime(),
-                        b: [req.response ? req.response.byteLength : 0]
-                    });
+            req.onload = function () {
+                if (req.status < 200 || req.status > 299) {
+                    return;
+                }
 
-                    lastTraceTime = currentTime;
-                    self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_PROGRESS, {request: request});
-                };
+                handleLoaded(request, true);
+                self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, {request: request, response: req.response});
+            };
 
-                req.onload = function () {
-                    if (req.status < 200 || req.status > 299) return;
+            req.onloadend = req.onerror = function () {
+                if (xhrs.indexOf(req) === -1) {
+                    return;
+                } else {
+                    xhrs.splice(xhrs.indexOf(req), 1);
+                }
 
-                    handleLoaded(request, true);
-                    self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, {request: request, response: req.response});
-                };
+                if (!needFailureReport) {
+                    return;
+                }
 
-                req.onloadend = req.onerror = function () {
-                    if (xhrs.indexOf(req) === -1) {
-                        return;
-                    } else {
-                        xhrs.splice(xhrs.indexOf(req), 1);
-                    }
+                handleLoaded(request, false);
 
-                    if (!needFailureReport) return;
+                if (remainingAttempts > 0) {
+                    self.log("Failed loading fragment: " + request.mediaType + ":" + request.type + ":" + request.startTime + ", retry in " + RETRY_INTERVAL + "ms" + " attempts: " + remainingAttempts);
+                    remainingAttempts--;
+                    setTimeout(function () {
+                        doLoad.call(self, request, remainingAttempts);
+                    }, RETRY_INTERVAL);
+                } else {
+                    self.log("Failed loading fragment: " + request.mediaType + ":" + request.type + ":" + request.startTime + " no retry attempts left");
+                    self.errHandler.downloadError("content", request.url, req);
+                    self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, {request: request, bytes: null}, new MediaPlayer.vo.Error(null, "failed loading fragment", null));
+                }
+            };
 
-                    handleLoaded(request, false);
-
-                    if (remainingAttempts > 0) {
-                        self.log("Failed loading fragment: " + request.mediaType + ":" + request.type + ":" + request.startTime + ", retry in " + RETRY_INTERVAL + "ms" + " attempts: " + remainingAttempts);
-                        remainingAttempts--;
-                        setTimeout(function() {
-                            doLoad.call(self, request, remainingAttempts);
-                        }, RETRY_INTERVAL);
-                    } else {
-                        self.log("Failed loading fragment: " + request.mediaType + ":" + request.type + ":" + request.startTime + " no retry attempts left");
-                        self.errHandler.downloadError("content", request.url, req);
-                        self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_LOADING_COMPLETED, {request: request, bytes: null}, new MediaPlayer.vo.Error(null, "failed loading fragment", null));
-                    }
-                };
-
-                req.send();
+            req.send();
         },
 
-        checkForExistence = function(request) {
+        checkForExistence = function (request) {
             var self = this,
                 req = new XMLHttpRequest(),
                 isSuccessful = false;
@@ -182,7 +160,9 @@ MediaPlayer.dependencies.FragmentLoader = function () {
             req.open("HEAD", request.url, true);
 
             req.onload = function () {
-                if (req.status < 200 || req.status > 299) return;
+                if (req.status < 200 || req.status > 299) {
+                    return;
+                }
 
                 isSuccessful = true;
 
@@ -190,7 +170,9 @@ MediaPlayer.dependencies.FragmentLoader = function () {
             };
 
             req.onloadend = req.onerror = function () {
-                if (isSuccessful) return;
+                if (isSuccessful) {
+                    return;
+                }
 
                 self.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_CHECK_FOR_EXISTENCE_COMPLETED, {request: request, exists: false});
             };
@@ -202,7 +184,7 @@ MediaPlayer.dependencies.FragmentLoader = function () {
         metricsModel: undefined,
         errHandler: undefined,
         log: undefined,
-        requestModifierExt:undefined,
+        requestModifierExt: undefined,
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
@@ -216,7 +198,7 @@ MediaPlayer.dependencies.FragmentLoader = function () {
             }
         },
 
-        checkForExistence: function(req) {
+        checkForExistence: function (req) {
             if (!req) {
                 this.notify(MediaPlayer.dependencies.FragmentLoader.eventList.ENAME_CHECK_FOR_EXISTENCE_COMPLETED, {request: req, exists: false});
                 return;
@@ -225,12 +207,12 @@ MediaPlayer.dependencies.FragmentLoader = function () {
             checkForExistence.call(this, req);
         },
 
-        abort: function() {
+        abort: function () {
             var i,
                 req,
                 ln = xhrs.length;
 
-            for (i = 0; i < ln; i +=1) {
+            for (i = 0; i < ln; i += 1) {
                 req = xhrs[i];
                 xhrs[i] = null;
                 req.abort();

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -115,6 +115,8 @@ MediaPlayer = function (context) {
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, streamController);
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_CAN_PLAY, streamController);
             playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
+            playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_STARTED, streamController);
+            playbackController.subscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_PAUSED, streamController);
             playbackController.setLiveDelayAttributes(liveDelayFragmentCount, usePresentationDelay);
 
             system.mapValue("liveDelayFragmentCount", liveDelayFragmentCount);
@@ -263,6 +265,8 @@ MediaPlayer = function (context) {
                     playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, streamController);
                     playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_CAN_PLAY, streamController);
                     playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_ERROR, streamController);
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_STARTED, streamController);
+                    playbackController.unsubscribe(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_PAUSED, streamController);
 
                     var teardownComplete = {},
                             self = this;
@@ -1386,6 +1390,15 @@ MediaPlayer.vo.protection = {};
  * @namespace
  */
 MediaPlayer.rules = {};
+
+/**
+ * Namespace for {@MediaPlayer} reporting classes
+ * @namespace
+ */
+MediaPlayer.metrics = {};
+MediaPlayer.metrics.reporting = {};
+MediaPlayer.metrics.handlers = {};
+MediaPlayer.metrics.utils = {};
 
 /**
  * Namespace for {@MediaPlayer} dependency-injection helper classes

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -501,7 +501,8 @@ MediaPlayer.dependencies.Stream = function () {
             return isInitialized;
         },
 
-        updateData: updateData
+        updateData: updateData,
+        getProcessors: getProcessors
     };
 };
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -110,7 +110,6 @@ MediaPlayer.dependencies.StreamProcessor = function () {
 
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_STATE_CHANGED, playbackController);
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_CLEARED, scheduleController);
-                bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BYTES_APPENDED, scheduleController);
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_UPDATED, scheduleController);
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_UPDATED, representationController);
                 bufferController.subscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_STATE_CHANGED, scheduleController);
@@ -316,7 +315,6 @@ MediaPlayer.dependencies.StreamProcessor = function () {
 
             bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_STATE_CHANGED, playbackController);
             bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_CLEARED, scheduleController);
-            bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BYTES_APPENDED, scheduleController);
             bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_UPDATED, scheduleController);
             bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_UPDATED, representationController);
             bufferController.unsubscribe(MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_STATE_CHANGED, scheduleController);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -123,7 +123,7 @@ MediaPlayer.dependencies.BufferController = function () {
             switchInitData.call(self);
         },
 
-		onMediaLoaded = function (e) {
+        onMediaLoaded = function (e) {
             if (e.data.fragmentModel !== this.streamProcessor.getFragmentModel()) return;
 
             var events,
@@ -147,7 +147,7 @@ MediaPlayer.dependencies.BufferController = function () {
             this.virtualBuffer.append(chunk);
 
             appendNext.call(this);
-		},
+        },
 
         appendToBuffer = function(chunk) {
             isAppendingInProgress = true;
@@ -335,7 +335,7 @@ MediaPlayer.dependencies.BufferController = function () {
                 leastLevel = Math.min(audioBufferLevel.level, videoBufferLevel.level);
             }
 
-            return leastLevel;
+            return leastLevel / 1000;
         },
 
         hasEnoughSpaceToAppend = function() {
@@ -492,7 +492,7 @@ MediaPlayer.dependencies.BufferController = function () {
                 level += virtualLevel;
             }
 
-            this.metricsModel.addBufferLevel(type, new Date(), level);
+            this.metricsModel.addBufferLevel(type, new Date(), level * 1000);
         },
 
         getStreamId = function() {
@@ -819,7 +819,7 @@ MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED = "required";
 MediaPlayer.dependencies.BufferController.BUFFER_SIZE_MIN = "min";
 MediaPlayer.dependencies.BufferController.BUFFER_SIZE_INFINITY = "infinity";
 MediaPlayer.dependencies.BufferController.DEFAULT_MIN_BUFFER_TIME = 12;
-MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD = 4;
+MediaPlayer.dependencies.BufferController.LOW_BUFFER_THRESHOLD_MS = 4000;
 MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY = 30;
 MediaPlayer.dependencies.BufferController.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 300;
 MediaPlayer.dependencies.BufferController.LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;

--- a/src/streaming/controllers/MetricsCollectionController.js
+++ b/src/streaming/controllers/MetricsCollectionController.js
@@ -1,0 +1,67 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.dependencies.MetricsCollectionController = function () {
+    "use strict";
+
+    var metricsControllers = [];
+
+    return {
+        system: undefined,
+
+        initialize: function (metrics) {
+            var self = this;
+
+            metrics.forEach(function (m) {
+                try {
+                    var controller = self.system.getObject("metricsController");
+                    controller.initialize(m);
+                    metricsControllers.push(controller);
+                } catch (e) {
+                    // fail quietly
+                }
+            });
+        },
+
+        reset: function () {
+            metricsControllers.forEach(function (metricsController) {
+                metricsController.reset();
+            });
+
+            metricsControllers = [];
+        }
+    };
+};
+
+MediaPlayer.dependencies.MetricsCollectionController.prototype = {
+    constructor: MediaPlayer.dependencies.MetricsCollectionController
+};

--- a/src/streaming/controllers/MetricsController.js
+++ b/src/streaming/controllers/MetricsController.js
@@ -1,0 +1,77 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.dependencies.MetricsController = function () {
+    "use strict";
+
+    var metricsHandlersController,
+        reportingController,
+        rangeController;
+
+    return {
+        system: undefined,
+
+        initialize: function (metricsEntry) {
+            try {
+                rangeController = this.system.getObject("rangeController");
+                rangeController.initialize(metricsEntry.Range);
+
+                reportingController = this.system.getObject("reportingController");
+                reportingController.initialize(metricsEntry.Reporting, rangeController);
+
+                metricsHandlersController = this.system.getObject("metricsHandlersController");
+                metricsHandlersController.initialize(metricsEntry.metrics, reportingController);
+            } catch (e) {
+                this.reset();
+                throw e;
+            }
+        },
+
+        reset: function () {
+            if (metricsHandlersController) {
+                metricsHandlersController.reset();
+            }
+
+            if (reportingController) {
+                reportingController.reset();
+            }
+
+            if (rangeController) {
+                rangeController.reset();
+            }
+        }
+    };
+};
+
+MediaPlayer.dependencies.MetricsController.prototype = {
+    constructor: MediaPlayer.dependencies.MetricsController
+};

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -179,7 +179,7 @@ MediaPlayer.dependencies.PlaybackController = function () {
 
         onPlaybackPaused = function() {
             this.log("<video> pause");
-            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_PAUSED);
+            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_PAUSED, {ended: videoModel.hasEnded()});
         },
 
         onPlaybackSeeking = function() {
@@ -200,7 +200,7 @@ MediaPlayer.dependencies.PlaybackController = function () {
             if (time === currentTime) return;
 
             currentTime = time;
-            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, {timeToEnd: this.getTimeToStreamEnd()});
+            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_TIME_UPDATED, {timeToEnd: this.getTimeToStreamEnd(), time: time});
         },
 
         onPlaybackProgress = function() {
@@ -220,8 +220,10 @@ MediaPlayer.dependencies.PlaybackController = function () {
         },
 
         onPlaybackRateChanged = function() {
-            this.log("<video> ratechange: ", this.getPlaybackRate());
-            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_RATE_CHANGED);
+            var rate = this.getPlaybackRate();
+
+            this.log("<video> ratechange: ", rate);
+            this.notify(MediaPlayer.dependencies.PlaybackController.eventList.ENAME_PLAYBACK_RATE_CHANGED, {playbackRate: rate});
         },
 
         onPlaybackMetaDataLoaded = function() {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -44,24 +44,29 @@ MediaPlayer.dependencies.ScheduleController = function () {
         playListTraceMetrics = null,
         playListTraceMetricsClosed = true,
 
-
         clearPlayListTraceMetrics = function (endTime, stopreason) {
             var duration = 0,
                 startTime = null;
 
-            if (playListTraceMetricsClosed === false) {
+            if (playListMetrics && playListTraceMetricsClosed === false) {
                 startTime = playListTraceMetrics.start;
                 duration = endTime.getTime() - startTime.getTime();
 
                 playListTraceMetrics.duration = duration;
                 playListTraceMetrics.stopreason = stopreason;
 
+                playListMetrics.trace.push(playListTraceMetrics);
+
                 playListTraceMetricsClosed = true;
             }
         },
 
         doStart = function () {
-            if (!ready) return;
+            if (!ready) {
+                return;
+            }
+
+            addPlaylistTraceMetrics.call(this);
 
             isStopped = false;
 
@@ -78,7 +83,6 @@ MediaPlayer.dependencies.ScheduleController = function () {
         startOnReady = function() {
             if (initialPlayback) {
                 getInitRequest.call(this, currentRepresentationInfo.quality);
-                addPlaylistMetrics.call(this, MediaPlayer.vo.metrics.PlayList.INITIAL_PLAY_START_REASON);
             }
 
             doStart.call(this);
@@ -94,8 +98,6 @@ MediaPlayer.dependencies.ScheduleController = function () {
             if (cancelPending) {
                 fragmentModel.cancelPendingRequests();
             }
-
-            clearPlayListTraceMetrics(new Date(), MediaPlayer.vo.metrics.PlayList.Trace.USER_REQUEST_STOP_REASON);
         },
 
         getNextFragment = function (callback) {
@@ -214,7 +216,6 @@ MediaPlayer.dependencies.ScheduleController = function () {
             if (e.data.fragmentModel !== this.streamProcessor.getFragmentModel()) return;
 
             this.log("Stream is complete");
-            clearPlayListTraceMetrics(new Date(), MediaPlayer.vo.metrics.PlayList.Trace.END_OF_CONTENT_STOP_REASON);
         },
 
         onMediaFragmentLoadingStart = function(e) {
@@ -229,10 +230,6 @@ MediaPlayer.dependencies.ScheduleController = function () {
             if (!e.error) return;
 
             doStop.call(this);
-        },
-
-        onBytesAppended = function(/*e*/) {
-            addPlaylistTraceMetrics.call(this);
         },
 
         onDataUpdateStarted = function(/*e*/) {
@@ -258,7 +255,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
 
             if (!e.data.hasSufficientBuffer && !self.playbackController.isSeeking()) {
                 self.log("Stalling Buffer");
-                clearPlayListTraceMetrics(new Date(), MediaPlayer.vo.metrics.PlayList.Trace.REBUFFERING_REASON);
+                clearPlayListTraceMetrics.call(this, new Date(), MediaPlayer.vo.metrics.PlayList.Trace.REBUFFERING_REASON);
             }
         },
 
@@ -284,25 +281,19 @@ MediaPlayer.dependencies.ScheduleController = function () {
             }
 
             replaceCanceledRequests.call(self, canceledReqs);
-            clearPlayListTraceMetrics(new Date(), MediaPlayer.vo.metrics.PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON);
-        },
-
-        addPlaylistMetrics = function(stopReason) {
-            var currentTime = new Date(),
-                presentationTime = this.playbackController.getTime();
-            clearPlayListTraceMetrics(currentTime, MediaPlayer.vo.metrics.PlayList.Trace.USER_REQUEST_STOP_REASON);
-            playListMetrics = this.metricsModel.addPlayList(type, currentTime, presentationTime, stopReason);
+            clearPlayListTraceMetrics.call(self, new Date(), MediaPlayer.vo.metrics.PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON);
+            addPlaylistTraceMetrics.call(self);
         },
 
         addPlaylistTraceMetrics = function() {
-            var self = this,
-                currentVideoTime = self.playbackController.getTime(),
-                rate = self.playbackController.getPlaybackRate(),
-                currentTime = new Date();
-
-            if (playListTraceMetricsClosed === true && currentRepresentationInfo && playListMetrics) {
+            if (playListMetrics && playListTraceMetricsClosed === true && currentRepresentationInfo) {
                 playListTraceMetricsClosed = false;
-                playListTraceMetrics = self.metricsModel.appendPlayListTrace(playListMetrics, currentRepresentationInfo.id, null, currentTime, currentVideoTime, null, rate, null);
+
+                playListTraceMetrics = new MediaPlayer.vo.metrics.PlayList.Trace();
+                playListTraceMetrics.representationid = currentRepresentationInfo.id;
+                playListTraceMetrics.start = new Date();
+                playListTraceMetrics.mstart = this.playbackController.getTime() * 1000;
+                playListTraceMetrics.playbackspeed = this.playbackController.getPlaybackRate().toString();
             }
         },
 
@@ -326,13 +317,14 @@ MediaPlayer.dependencies.ScheduleController = function () {
                 manifestUpdateInfo = this.metricsExt.getCurrentManifestUpdate(metrics);
 
             this.log("seek: " + e.data.seekTime);
-            addPlaylistMetrics.call(this, MediaPlayer.vo.metrics.PlayList.SEEK_START_REASON);
 
             this.metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {latency: currentRepresentationInfo.DVRWindow.end - this.playbackController.getTime()});
         },
 
-        onPlaybackRateChanged = function(/*e*/) {
-            addPlaylistTraceMetrics.call(this);
+        onPlaybackRateChanged = function(e) {
+            if (playListTraceMetrics) {
+                playListTraceMetrics.playbackspeed = e.data.playbackRate.toString();
+            }
         },
 
         onWallclockTimeUpdated = function(/*e*/) {
@@ -383,6 +375,7 @@ MediaPlayer.dependencies.ScheduleController = function () {
         scheduleRulesCollection: undefined,
         rulesController: undefined,
         numOfParallelRequestAllowed:undefined,
+        streamController: undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.LiveEdgeFinder.eventList.ENAME_LIVE_EDGE_SEARCH_COMPLETED] = onLiveEdgeSearchCompleted;
@@ -398,7 +391,6 @@ MediaPlayer.dependencies.ScheduleController = function () {
             this[MediaPlayer.dependencies.FragmentController.eventList.ENAME_STREAM_COMPLETED] = onStreamCompleted;
 
             this[MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_CLEARED] = onBufferCleared;
-            this[MediaPlayer.dependencies.BufferController.eventList.ENAME_BYTES_APPENDED] = onBytesAppended;
             this[MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_STATE_CHANGED] = onBufferLevelStateChanged;
             this[MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_UPDATED] = onBufferLevelUpdated;
             this[MediaPlayer.dependencies.BufferController.eventList.ENAME_INIT_REQUESTED] = onInitRequested;
@@ -457,6 +449,16 @@ MediaPlayer.dependencies.ScheduleController = function () {
             fragmentModel.abortRequests();
             self.fragmentController.detachModel(fragmentModel);
             fragmentsToLoad = 0;
+            playListMetrics = null;
+        },
+
+        setPlayList: function (playList) {
+            playListMetrics = playList;
+        },
+
+        finalisePlayList: function (time, reason) {
+            clearPlayListTraceMetrics.call(this, time, reason);
+            playListMetrics = null;
         },
 
         start: doStart,

--- a/src/streaming/metrics/MetricsHandlersController.js
+++ b/src/streaming/metrics/MetricsHandlersController.js
@@ -1,0 +1,121 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.dependencies.MetricsHandlersController = function () {
+    "use strict";
+
+    // in the future, we may want to support more than one reporter.
+    // to do this, simply change the 'some' below to 'forEach'
+    var handlers = [],
+
+        handle = function (e) {
+            var data = e.data;
+
+            handlers.forEach(function (handler) {
+                handler.handleNewMetric(data.metric, data.value);
+            });
+        };
+
+    return {
+        metricsHandlerFactory: undefined,
+        eventBus: undefined,
+
+        initialize: function (metrics, reportingController) {
+            var self = this;
+
+            metrics.split(",").forEach(
+                function (m, midx, ms) {
+                    var handler,
+                        nextm;
+
+                    // there is a bug in ISO23009-1 where the metrics attribute
+                    // is a comma-seperated list but HttpList key can contain a
+                    // comma enclosed by ().
+                    if ((m.indexOf("(") !== -1) && m.indexOf(")") === -1) {
+                        nextm = ms[midx + 1];
+
+                        if (nextm &&
+                                (nextm.indexOf("(") === -1) &&
+                                (nextm.indexOf(")") !== -1)) {
+                            m += "," + nextm;
+
+                            // delete the next metric so forEach does not visit.
+                            // nextm is unqualified -> strict-mode violation
+                            delete ms[midx + 1];
+                        }
+                    }
+
+                    handler = self.metricsHandlerFactory.create(
+                        m,
+                        reportingController
+                    );
+
+                    if (handler) {
+                        handlers.push(handler);
+                    }
+                }
+            );
+
+            this.eventBus.addEventListener(
+                MediaPlayer.events.METRIC_ADDED,
+                handle
+            );
+
+            this.eventBus.addEventListener(
+                MediaPlayer.events.METRIC_UPDATED,
+                handle
+            );
+        },
+
+        reset: function () {
+            this.eventBus.removeEventListener(
+                MediaPlayer.events.METRIC_ADDED,
+                handle
+            );
+
+            this.eventBus.removeEventListener(
+                MediaPlayer.events.METRIC_UPDATED,
+                handle
+            );
+
+            handlers.forEach(function (handler) {
+                handler.reset();
+            });
+
+            handlers = [];
+        }
+    };
+};
+
+MediaPlayer.dependencies.MetricsHandlersController.prototype = {
+    constructor: MediaPlayer.dependencies.MetricsHandlersController
+};

--- a/src/streaming/metrics/RangeController.js
+++ b/src/streaming/metrics/RangeController.js
@@ -1,0 +1,97 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.dependencies.RangeController = function () {
+    "use strict";
+    var ranges,
+        useWallClockTime = false;
+
+    return {
+        log: undefined,
+        system: undefined,
+        videoModel: undefined,
+
+        initialize: function (rs) {
+            if (rs && rs.length) {
+                rs.forEach(function (r) {
+                    var start = r.starttime,
+                        end = start + r.duration;
+
+                    ranges.add(start, end);
+                });
+
+                useWallClockTime = !!rs[0].useWallClockTime;
+            }
+        },
+
+        reset: function () {
+            ranges.clear();
+        },
+
+        setup: function () {
+            ranges = this.system.getObject("customTimeRanges");
+        },
+
+        isEnabled: function () {
+            var i,
+                numRanges = ranges.length,
+                time,
+                start,
+                end;
+
+            if (!numRanges) {
+                return true;
+            }
+
+            // When not present, DASH Metrics reporting is requested
+            // for the whole duration of the content.
+            time = useWallClockTime ?
+                    (new Date().getTime() / 1000) :
+                    this.videoModel.getCurrentTime();
+
+            for (i = 0; i < numRanges; i += 1) {
+                start = ranges.start(i);
+                end = ranges.end(i);
+
+                if ((start <= time) && (time < end)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    };
+};
+
+MediaPlayer.dependencies.RangeController.prototype = {
+    constructor: MediaPlayer.dependencies.RangeController
+};

--- a/src/streaming/metrics/ReportingController.js
+++ b/src/streaming/metrics/ReportingController.js
@@ -1,0 +1,76 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.dependencies.ReportingController = function () {
+    "use strict";
+
+    var reporters = [];
+
+    return {
+        reportingFactory: undefined,
+
+        initialize: function (reporting, rangeController) {
+            var self = this;
+
+            // "if multiple Reporting elements are present, it is expected that
+            // the client processes one of the recognized reporting schemes."
+            // to ignore this, and support multiple Reporting per Metric,
+            // simply change the 'some' below to 'forEach'
+            reporting.some(function (r) {
+                var reporter = self.reportingFactory.create(r, rangeController);
+
+                if (reporter) {
+                    reporters.push(reporter);
+                    return true;
+                }
+            });
+        },
+
+        reset: function () {
+            reporters.forEach(function (reporter) {
+                reporter.reset();
+            });
+
+            reporters = [];
+        },
+
+        report: function (type, vos) {
+            reporters.forEach(function (r) {
+                r.report(type, vos);
+            });
+        }
+    };
+};
+
+MediaPlayer.dependencies.ReportingController.prototype = {
+    constructor: MediaPlayer.dependencies.ReportingController
+};

--- a/src/streaming/metrics/metrics/MetricsHandlerFactory.js
+++ b/src/streaming/metrics/metrics/MetricsHandlerFactory.js
@@ -1,0 +1,101 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.MetricsHandlerFactory = function () {
+    "use strict";
+
+    // group 1: key, [group 3: n [, group 5: type]]
+    var keyRegex = /([a-zA-Z]*)(\(([0-9]*)(\,\s*([a-zA-Z]*))?\))?/,
+
+        knownFactoryProducts = {
+            BufferLevel:    "bufferLevelHandler",
+            DVBErrors:      "dVBErrorsHandler",
+            HttpList:       "httpListHandler",
+            PlayList:       "playListHandler",
+            RepSwitchList:  "genericMetricHandler",
+            TcpList:        "genericMetricHandler"
+        };
+
+    return {
+        system: undefined,
+        log: undefined,
+
+        create: function (listType, reportingController) {
+            var matches = listType.match(keyRegex),
+                handler;
+
+            if (!matches) {
+                return;
+            }
+
+            try {
+                handler = this.system.getObject(
+                    knownFactoryProducts[matches[1]]
+                );
+                handler.initialize(
+                    matches[1],
+                    reportingController,
+                    matches[3],
+                    matches[5]
+                );
+            } catch (e) {
+                handler = null;
+
+                this.log(
+                    "MetricsHandlerFactory: Could not create handler for type " +
+                        matches[1] +
+                        " with args " +
+                        matches[3] +
+                        ", " +
+                        matches[5] +
+                        " (" +
+                        e.message +
+                        ")"
+                );
+            }
+
+            return handler;
+        },
+
+        register: function (key, handler) {
+            knownFactoryProducts[key] = handler;
+        },
+
+        unregister: function (key) {
+            delete knownFactoryProducts[key];
+        }
+    };
+};
+
+MediaPlayer.metrics.MetricsHandlerFactory.prototype = {
+    constructor: MediaPlayer.metrics.MetricsHandlerFactory
+};

--- a/src/streaming/metrics/metrics/handlers/BufferLevel.js
+++ b/src/streaming/metrics/metrics/handlers/BufferLevel.js
@@ -1,0 +1,103 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.handlers.BufferLevel = function () {
+    "use strict";
+    var reportingController,
+        n,
+        name,
+        interval,
+
+        getLowestBufferLevel = function () {
+            var self = this;
+
+            // get the BufferLevel metric for each interesting stream type
+            return ["video", "audio", "fragmentedText"].map(
+                function (type) {
+                    return self.metricsExt.getCurrentBufferLevel(
+                        self.metricsModel.getReadOnlyMetricsFor(type)
+                    );
+                },
+                this
+            // filter out any which returned undefined/null etc
+            ).filter(
+                function (el) {
+                    return el;
+                }
+            // of the valid entries, which had the lowest level
+            ).reduce(
+                function (a, b) {
+                    return ((a.level < b.level) ? a : b);
+                }
+            );
+        },
+
+        intervalCallback = function () {
+            reportingController.report(name, getLowestBufferLevel.call(this));
+        };
+
+    return {
+        metricsModel: undefined,
+        metricsExt: undefined,
+        handlerHelpers: undefined,
+
+        setup: function () {
+            intervalCallback = intervalCallback.bind(this);
+        },
+
+        initialize: function (diName, rc, n_ms) {
+            if (rc) {
+                // this will throw if n is invalid, to be
+                // caught by the initialize caller.
+                n = this.handlerHelpers.validateN(n_ms);
+                reportingController = rc;
+                name = this.handlerHelpers.getMetricName(diName, n_ms);
+                interval = setInterval(intervalCallback, n);
+            }
+        },
+
+        reset: function () {
+            clearInterval(interval);
+            interval = null;
+            n = 0;
+            reportingController = null;
+        },
+
+        handleNewMetric: function () {
+            // do nothing
+        }
+    };
+};
+
+MediaPlayer.metrics.handlers.BufferLevel.prototype = {
+    constructor: MediaPlayer.metrics.handlers.BufferLevel
+};

--- a/src/streaming/metrics/metrics/handlers/DVBErrors.js
+++ b/src/streaming/metrics/metrics/handlers/DVBErrors.js
@@ -1,0 +1,118 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.handlers.DVBErrors = function () {
+    "use strict";
+    var reportingController,
+
+        report = function (vo) {
+            var key,
+                mpd = this.manifestModel.getValue(),
+                o = new MediaPlayer.vo.metrics.DVBErrors();
+
+            for (key in vo) {
+                if (vo.hasOwnProperty(key)) {
+                    o[key] = vo[key];
+                }
+            }
+
+            if (!o.mpdurl) {
+                o.mpdurl = mpd.url;
+            }
+
+            if (!o.servicelocation) {
+                o.servicelocation = mpd.BaseURL.serviceLocation;
+            }
+
+            if (!o.terror) {
+                o.terror = new Date();
+            }
+
+            if (reportingController) {
+                reportingController.report("DVBErrors", o);
+            }
+        },
+
+        httpMetric = function (vo) {
+            if ((vo.responsecode === 0) ||      // connection failure - unknown
+                    (vo.responsecode >= 400) || // HTTP error status code
+                    (vo.responsecode < 100) ||  // unknown status codes
+                    (vo.responsecode >= 600)) { // unknown status codes
+                report.call(this, {
+                    errorcode:  vo.responsecode || MediaPlayer.vo.metrics.DVBErrors.CONNECTION_ERROR,
+                    url:        vo.url,
+                    terror:     vo.tresponse
+                });
+            }
+        },
+
+        dvbMetric = function (vo) {
+            report.call(this, vo);
+        };
+
+    return {
+        manifestModel: undefined,
+
+        initialize: function (diName, rc) {
+            if (rc) {
+                reportingController = rc;
+
+                // Note: A Player becoming a reporting Player is itself
+                // something which is recorded by the DVBErrors metric.
+                report.call(this, {
+                    errorcode: MediaPlayer.vo.metrics.DVBErrors.BECAME_REPORTER
+                });
+            }
+        },
+
+        reset: function () {
+            reportingController = null;
+        },
+
+        handleNewMetric: function (metric, vo) {
+            switch (metric) {
+            case "DVBErrors":
+                dvbMetric.call(this, vo);
+                break;
+            case "HttpList":
+                httpMetric.call(this, vo);
+                break;
+            default:
+                break;
+            }
+        }
+    };
+};
+
+MediaPlayer.metrics.handlers.DVBErrors.prototype = {
+    constructor: MediaPlayer.metrics.handlers.DVBErrors
+};

--- a/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
+++ b/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
@@ -1,0 +1,62 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.handlers.GenericMetricHandler = function () {
+    "use strict";
+    var metricName,
+        reportingController;
+
+    return {
+        initialize: function (diName, rc) {
+            metricName = diName;
+            reportingController = rc;
+        },
+
+        reset: function () {
+            reportingController = null;
+            metricName = undefined;
+        },
+
+        handleNewMetric: function (metric, vo) {
+            // simply pass metric straight through
+            if (metric === metricName) {
+                if (reportingController) {
+                    reportingController.report(metricName, vo);
+                }
+            }
+        }
+    };
+};
+
+MediaPlayer.metrics.handlers.GenericMetricHandler.prototype = {
+    constructor: MediaPlayer.metrics.handlers.GenericMetricHandler
+};

--- a/src/streaming/metrics/metrics/handlers/HttpList.js
+++ b/src/streaming/metrics/metrics/handlers/HttpList.js
@@ -1,0 +1,101 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.handlers.HttpList = function () {
+    "use strict";
+
+    var reportingController,
+        n,
+        type,
+        name,
+        storedVos = [],
+        interval,
+
+        intervalCallback = function () {
+            var vos = storedVos;
+
+            if (vos.length) {
+                if (reportingController) {
+                    reportingController.report(name, vos);
+                }
+            }
+
+            storedVos = [];
+        };
+
+    return {
+        handlerHelpers: undefined,
+
+        setup: function () {
+            intervalCallback = intervalCallback.bind(this);
+        },
+
+        initialize: function (diName, rc, n_ms, requestType) {
+            if (rc) {
+
+                // this will throw if n is invalid, to be
+                // caught by the initialize caller.
+                n = this.handlerHelpers.validateN(n_ms);
+
+                reportingController = rc;
+
+                if (requestType && requestType.length) {
+                    type = requestType;
+                }
+
+                name = this.handlerHelpers.getMetricName(diName, n_ms, requestType);
+                interval = setInterval(intervalCallback, n);
+            }
+        },
+
+        reset: function () {
+            clearInterval(interval);
+            interval = null;
+            n = null;
+            type = null;
+            storedVos = [];
+            reportingController = null;
+        },
+
+        handleNewMetric: function (metric, vo) {
+            if (metric === "HttpList") {
+                if (!type || (type === vo.type)) {
+                    storedVos.push(vo);
+                }
+            }
+        }
+    };
+};
+
+MediaPlayer.metrics.handlers.HttpList.prototype = {
+    constructor: MediaPlayer.metrics.handlers.HttpList
+};

--- a/src/streaming/metrics/metrics/handlers/PlayList.js
+++ b/src/streaming/metrics/metrics/handlers/PlayList.js
@@ -1,0 +1,62 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.handlers.PlayList = function () {
+    "use strict";
+    var reportingController;
+
+    return {
+        initialize: function (unused, rc) {
+            reportingController = rc;
+        },
+
+        reset: function () {
+            reportingController = null;
+        },
+
+        handleNewMetric: function (metric, vo) {
+            switch (metric) {
+            case "PlayList":
+                if (reportingController) {
+                    reportingController.report("PlayList", vo);
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    };
+};
+
+MediaPlayer.metrics.handlers.PlayList.prototype = {
+    constructor: MediaPlayer.metrics.handlers.PlayList
+};

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -1,0 +1,79 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.ReportingFactory = function () {
+    "use strict";
+
+    var knownReportingSchemeIdUris = {
+        "urn:dvb:dash:reporting:2014": "dvbReporting"
+    };
+
+    return {
+        system: undefined,
+
+        create: function (entry, rangeController) {
+            var reporting;
+
+            try {
+                reporting = this.system.getObject(
+                    knownReportingSchemeIdUris[entry.schemeIdUri]
+                );
+
+                reporting.initialize(entry, rangeController);
+            } catch (e) {
+                reporting = null;
+
+                this.log(
+                    "ReportingFactory: could not create Reporting with schemeIdUri " +
+                        entry.schemeIdUri +
+                        " (" +
+                        e.message +
+                        ")"
+                );
+            }
+
+            return reporting;
+        },
+
+        register: function (schemeIdUri, moduleName) {
+            knownReportingSchemeIdUris[schemeIdUri] = moduleName;
+        },
+
+        unregister: function (schemeIdUri) {
+            delete knownReportingSchemeIdUris[schemeIdUri];
+        }
+    };
+};
+
+MediaPlayer.metrics.ReportingFactory.prototype = {
+    constructor: MediaPlayer.metrics.ReportingFactory
+};

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -1,0 +1,184 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.reporting.DVBReporting = function () {
+    "use strict";
+
+    var USE_DRAFT_DVB_SPEC = true,
+        isReportingPlayer = false,
+        reportingPlayerStatusDecided = false,
+        reportingUrl = null,
+        rangeController = null,
+        allowPendingRequestsToCompleteOnReset = true,
+        pendingRequests = [],
+
+        doGetRequest = function (url, successCB, failureCB) {
+            var req = new XMLHttpRequest(),
+                oncomplete = function () {
+                    var reqIndex = pendingRequests.indexOf(req);
+
+                    if (reqIndex === -1) {
+                        return;
+                    } else {
+                        pendingRequests.splice(reqIndex, 1);
+                    }
+
+                    if ((req.status >= 200) && (req.status < 300)) {
+                        if (successCB) {
+                            successCB();
+                        }
+                    } else {
+                        if (failureCB) {
+                            failureCB();
+                        }
+                    }
+                };
+
+            pendingRequests.push(req);
+
+            try {
+                req.open("GET", url);
+                req.onloadend = oncomplete;
+                req.onerror = oncomplete;
+                req.send();
+            } catch (e) {
+                req.onerror();
+            }
+        },
+
+        report = function (type, vos) {
+            var self = this;
+
+            if (!Array.isArray(vos)) {
+                vos = [vos];
+            }
+
+            // If the Player is not a reporting Player, then the Player shall
+            // not report any errors.
+            // ... In addition to any time restrictions specified by a Range
+            // element within the Metrics element.
+            if (isReportingPlayer && rangeController.isEnabled()) {
+
+                // This reporting mechanism operates by creating one HTTP GET
+                // request for every entry in the top level list of the metric.
+                vos.forEach(function (vo) {
+                    var url = self.metricSerialiser.serialise(vo);
+
+                    // this has been proposed for errata
+                    if (USE_DRAFT_DVB_SPEC && (type !== "DVBErrors")) {
+                        url = "metricname=" + type + "&" + url;
+                    }
+
+                    // Take the value of the @reportingUrl attribute, append a
+                    // question mark ('?') character and then append the string
+                    // created in the previous step.
+                    url = reportingUrl + "?" + url;
+
+                    // Make an HTTP GET request to the URL contained within the
+                    // string created in the previous step.
+                    doGetRequest(url, null, function () {
+                        // If the Player is unable to make the report, for
+                        // example because the @reportingUrl is invalid, the
+                        // host cannot be reached, or an HTTP status code other
+                        // than one in the 200 series is received, the Player
+                        // shall cease being a reporting Player for the
+                        // duration of the MPD.
+                        isReportingPlayer = false;
+                    });
+                });
+            }
+        };
+
+    return {
+        log: undefined,
+        eventBus: undefined,
+        metricSerialiser: undefined,
+        randomNumberGenerator: undefined,
+
+        initialize: function (entry, rc) {
+            var probability;
+
+            rangeController = rc;
+
+            reportingUrl = entry["dvb:reportingUrl"];
+
+            // If a required attribute is missing, the Reporting descriptor may
+            // be ignored by the Player
+            if (!reportingUrl) {
+                throw new Error(
+                    "required parameter missing (dvb:reportingUrl)"
+                );
+            }
+
+            // A Player's status, as a reporting Player or not, shall remain
+            // static for the duration of the MPD, regardless of MPD updates.
+            // (i.e. only calling reset (or failure) changes this state)
+            if (!reportingPlayerStatusDecided) {
+                // NOTE: DVB spec has a typo where it incorrectly references the
+                // priority attribute, which should be probability
+                probability = entry["dvb:probability"] || entry["dvb:priority"] || 0;
+                // If the @priority attribute is set to 1000, it shall be a reporting Player.
+                // If the @priority attribute is missing, the Player shall not be a reporting Player.
+                // For any other value of the @probability attribute, it shall decide at random whether to be a
+                // reporting Player, such that the probability of being one is @probability/1000.
+                if (probability && (probability === 1000 || ((probability / 1000) >= this.randomNumberGenerator.random()))) {
+                    this.log("DVBReporting: became a reporting player!");
+
+                    isReportingPlayer = true;
+                }
+
+                reportingPlayerStatusDecided = true;
+            }
+        },
+
+        reset: function () {
+            if (!allowPendingRequestsToCompleteOnReset) {
+                pendingRequests.forEach(function (req) {
+                    req.abort();
+                });
+
+                pendingRequests = [];
+            }
+
+            reportingPlayerStatusDecided = false;
+            isReportingPlayer = false;
+            reportingUrl = null;
+            rangeController = null;
+        },
+
+        report: report
+    };
+};
+
+MediaPlayer.metrics.reporting.DVBReporting.prototype = {
+    constructor: MediaPlayer.metrics.reporting.DVBReporting
+};

--- a/src/streaming/metrics/utils/HandlerHelpers.js
+++ b/src/streaming/metrics/utils/HandlerHelpers.js
@@ -1,0 +1,75 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.utils.HandlerHelpers = function () {
+    "use strict";
+    return {
+
+        getMetricName: function (key, n, type) {
+            var mn = key;
+
+            if (n) {
+                mn += "(" + n;
+
+                if (type && type.length) {
+                    mn += "," + type;
+                }
+
+                mn += ")";
+            }
+
+            return mn;
+        },
+
+        validateN: function (n_ms) {
+            if (!n_ms) {
+                throw "missing n";
+            }
+
+            if (isNaN(n_ms)) {
+                throw "n is NaN";
+            }
+
+            // n is a positive integer is defined to refer to the metric
+            // in which the buffer level is recorded every n ms.
+            if (n_ms < 0) {
+                throw "n must be positive";
+            }
+
+            return n_ms;
+        }
+    };
+};
+
+MediaPlayer.metrics.utils.HandlerHelpers.prototype = {
+    constructor: MediaPlayer.metrics.utils.HandlerHelpers
+};

--- a/src/streaming/metrics/utils/MetricSerialiser.js
+++ b/src/streaming/metrics/utils/MetricSerialiser.js
@@ -1,0 +1,100 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer*/
+MediaPlayer.metrics.utils.MetricSerialiser = function () {
+    "use strict";
+
+    // For each entry in the top level list within the metric (in the case
+    // of the DVBErrors metric each entry corresponds to an "error event"
+    // described in clause 10.8.4) the Player shall:
+    var serialise = function (metric) {
+            var pairs = [],
+                key,
+                value,
+                obj = [];
+
+            // Take each (key, value) pair from the metric entry and create a
+            // string consisting of the name of the key, followed by an equals
+            // ('=') character, followed by the string representation of the
+            // value. The string representation of the value is created based
+            // on the type of the value following the instructions in Table 22.
+            for (key in metric) {
+                if (metric.hasOwnProperty(key) && (key.indexOf("_") !== 0)) {
+                    value = metric[key];
+
+                    // we want to ensure that keys still end up in the report
+                    // even if there is no value
+                    if ((value === undefined) || (value === null)) {
+                        value = "";
+                    }
+
+                    // DVB A168 10.12.4 Table 22
+                    if (Array.isArray(value)) {
+                        // if trace or similar is null, do not include in output
+                        if (!value.length) {
+                            continue;
+                        }
+
+                        obj = [];
+
+                        value.forEach(function (v) {
+                            var isBuiltIn = Object.prototype.toString.call(v).slice(8, -1) !== "Object";
+
+                            obj.push(isBuiltIn ? v : serialise(v));
+                        });
+
+                        value = encodeURIComponent(obj.join(","));
+                    } else if (typeof value === "string") {
+                        value = encodeURIComponent(value);
+                    } else if (value instanceof Date) {
+                        value = value.toISOString();
+                    } else if (typeof value === "number") {
+                        value = Math.round(value);
+                    }
+
+                    pairs.push(key + "=" + value);
+                }
+            }
+
+            // Concatenate the strings created in the previous step with an
+            // ampersand ('&') character between each one.
+            return pairs.join("&");
+        };
+
+    return {
+        serialise: serialise
+    };
+};
+
+MediaPlayer.metrics.utils.MetricSerialiser.prototype = {
+    constructor: MediaPlayer.metrics.utils.MetricSerialiser
+};

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -31,6 +31,28 @@
 MediaPlayer.models.MetricsModel = function () {
     "use strict";
 
+    var appendHttpTrace = function (httpRequest, s, d, b) {
+        var vo = new MediaPlayer.vo.metrics.HTTPRequest.Trace();
+
+        vo.s = s;
+        vo.d = d;
+        vo.b = b;
+
+        if (!httpRequest.trace) {
+            httpRequest.trace = [];
+        }
+
+        httpRequest.trace.push(vo);
+
+        if (!httpRequest.interval) {
+            httpRequest.interval = 0;
+        }
+
+        httpRequest.interval += d;
+
+        return vo;
+    };
+
     return {
         system : undefined,
         eventBus: undefined,
@@ -114,7 +136,7 @@ MediaPlayer.models.MetricsModel = function () {
             return vo;
         },
 
-        addHttpRequest: function (mediaType, tcpid, type, url, actualurl, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders) {
+        addHttpRequest: function (mediaType, tcpid, type, url, actualurl, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders, traces) {
             var vo = new MediaPlayer.vo.metrics.HTTPRequest();
 
             // ISO 23009-1 D.4.3 NOTE 2:
@@ -139,45 +161,39 @@ MediaPlayer.models.MetricsModel = function () {
                     null, // unknown
                     null, // unknown, probably a 302
                     mediaduration,
+                    null,
                     null
                 );
 
                 vo.actualurl = actualurl;
             }
 
-            vo.stream = mediaType;
             vo.tcpid = tcpid;
             vo.type = type;
             vo.url = url;
             vo.range = range;
             vo.trequest = trequest;
             vo.tresponse = tresponse;
-            vo.tfinish = tfinish;
             vo.responsecode = responsecode;
-            vo.mediaduration = mediaduration;
-            vo.responseHeaders = responseHeaders;
+
+            vo._tfinish = tfinish;
+            vo._stream = mediaType;
+            vo._mediaduration = mediaduration;
+            vo._responseHeaders = responseHeaders;
+
+            if (traces) {
+                traces.forEach(function (trace) {
+                    appendHttpTrace(vo, trace.s, trace.d, trace.b);
+                });
+            } else {
+                // The interval and trace shall be absent for redirect and failure records.
+                delete vo.interval;
+                delete vo.trace;
+            }
+
             this.getMetricsFor(mediaType).HttpList.push(vo);
 
             this.metricAdded(mediaType, this.adapter.metricsList.HTTP_REQUEST, vo);
-            return vo;
-        },
-
-        appendHttpTrace: function (httpRequest, s, d, b) {
-            var vo = new MediaPlayer.vo.metrics.HTTPRequest.Trace();
-
-            vo.s = s;
-            vo.d = d;
-            vo.b = b;
-
-            httpRequest.trace.push(vo);
-
-            if (!httpRequest.interval) {
-                httpRequest.interval = 0;
-            }
-
-            httpRequest.interval += d;
-
-            this.metricUpdated(httpRequest.stream, this.adapter.metricsList.HTTP_REQUEST_TRACE, httpRequest);
             return vo;
         },
 
@@ -187,7 +203,12 @@ MediaPlayer.models.MetricsModel = function () {
             vo.t = t;
             vo.mt = mt;
             vo.to = to;
-            vo.lto = lto;
+
+            if (lto) {
+                vo.lto = lto;
+            } else {
+                delete vo.lto;
+            }
 
             this.getMetricsFor(mediaType).RepSwitchList.push(vo);
 
@@ -349,34 +370,22 @@ MediaPlayer.models.MetricsModel = function () {
             return null;
         },
 
-        addPlayList: function (mediaType, start, mstart, starttype) {
-            var vo = new MediaPlayer.vo.metrics.PlayList();
+        addPlayList: function (vo) {
+            var type = "stream";
 
-            vo.stream = mediaType;
-            vo.start = start;
-            vo.mstart = mstart;
-            vo.starttype = starttype;
+            if (vo.trace) {
+                vo.trace.forEach(function (trace) {
+                    if (trace.hasOwnProperty("subreplevel") && !trace.subreplevel) {
+                        delete trace.subreplevel;
+                    }
+                });
+            } else {
+                delete vo.trace;
+            }
 
-            this.getMetricsFor(mediaType).PlayList.push(vo);
+            this.getMetricsFor(type).PlayList.push(vo);
 
-            this.metricAdded(mediaType, this.adapter.metricsList.PLAY_LIST, vo);
-            return vo;
-        },
-
-        appendPlayListTrace: function (playList, trackId, subreplevel, start, mstart, duration, playbackspeed, stopreason) {
-            var vo = new MediaPlayer.vo.metrics.PlayList.Trace();
-
-            vo.representationid = trackId;
-            vo.subreplevel = subreplevel;
-            vo.start = start;
-            vo.mstart = mstart;
-            vo.duration = duration;
-            vo.playbackspeed = playbackspeed;
-            vo.stopreason = stopreason;
-
-            playList.trace.push(vo);
-
-            this.metricUpdated(playList.stream, this.adapter.metricsList.PLAY_LIST_TRACE, playList);
+            this.metricAdded(type, this.adapter.metricsList.PLAY_LIST, vo);
             return vo;
         }
     };

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -97,6 +97,10 @@ MediaPlayer.models.VideoModel = function () {
             return element.paused;
         },
 
+        hasEnded: function () {
+            return element.ended;
+        },
+
         getPlaybackRate:  function () {
             return element.playbackRate;
         },

--- a/src/streaming/rules/ABRRules/BufferOccupancyRule.js
+++ b/src/streaming/rules/ABRRules/BufferOccupancyRule.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -51,6 +51,7 @@ MediaPlayer.rules.BufferOccupancyRule = function () {
                 lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null,
                 lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null,
                 isBufferRich = false,
+                level,
                 maxIndex = mediaInfo.representationCount - 1,
                 switchRequest = new MediaPlayer.rules.SwitchRequest(MediaPlayer.rules.SwitchRequest.prototype.NO_CHANGE, MediaPlayer.rules.SwitchRequest.prototype.WEAK);
 
@@ -61,10 +62,11 @@ MediaPlayer.rules.BufferOccupancyRule = function () {
             }
 
             if (lastBufferLevelVO !== null && lastBufferStateVO !== null) {
+                level = lastBufferLevelVO.level / 1000;
                 // This will happen when another rule tries to switch from top to any other.
                 // If there is enough buffer why not try to stay at high level.
-                if (lastBufferLevelVO.level > lastBufferStateVO.target) {
-                    isBufferRich = (lastBufferLevelVO.level - lastBufferStateVO.target) > MediaPlayer.dependencies.BufferController.RICH_BUFFER_THRESHOLD;
+                if (level > lastBufferStateVO.target) {
+                    isBufferRich = (level - lastBufferStateVO.target) > MediaPlayer.dependencies.BufferController.RICH_BUFFER_THRESHOLD;
                     if (isBufferRich && mediaInfo.representationCount > 1) {
                         switchRequest = new MediaPlayer.rules.SwitchRequest(maxIndex, MediaPlayer.rules.SwitchRequest.prototype.STRONG);
                     }

--- a/src/streaming/rules/SchedulingRules/BufferLevelRule.js
+++ b/src/streaming/rules/SchedulingRules/BufferLevelRule.js
@@ -124,6 +124,7 @@ MediaPlayer.rules.BufferLevelRule = function () {
         playbackController: undefined,
         mediaController: undefined,
         virtualBuffer: undefined,
+        videoModel: undefined,
 
         setup: function() {
             this[MediaPlayer.dependencies.BufferController.eventList.ENAME_BUFFER_LEVEL_OUTRUN] = onBufferLevelOutrun;
@@ -150,7 +151,7 @@ MediaPlayer.rules.BufferLevelRule = function () {
 
             var metrics = this.metricsModel.getReadOnlyMetricsFor(mediaType),
                 switchMode = this.mediaController.getSwitchMode(),
-                bufferLevel = this.metricsExt.getCurrentBufferLevel(metrics) ? this.metricsExt.getCurrentBufferLevel(metrics).level : 0,
+                bufferLevel = (this.metricsExt.getCurrentBufferLevel(metrics) ? this.metricsExt.getCurrentBufferLevel(metrics).level : 0) / 1000,
                 currentTime = this.playbackController.getTime(),
                 appendedChunks = this.virtualBuffer.getChunks({streamId: streamId, mediaType: mediaType, appended: true, mediaInfo: mediaInfo, forRange: {start: currentTime, end: (currentTime + bufferLevel)}}),
                 appendedLevel = (appendedChunks && appendedChunks.length > 0) ? (appendedChunks[appendedChunks.length-1].bufferedRange.end - currentTime) : null,
@@ -158,9 +159,9 @@ MediaPlayer.rules.BufferLevelRule = function () {
                 scheduleCtrl = scheduleController[streamId][mediaType],
                 representationInfo = scheduleCtrl.streamProcessor.getCurrentRepresentationInfo(),
                 isDynamic = scheduleCtrl.streamProcessor.isDynamic(),
-                rate = this.metricsExt.getCurrentPlaybackRate(metrics),
+                rate = this.videoModel.getPlaybackRate(),
                 duration = streamInfo.manifestInfo.duration,
-                bufferedDuration = actualBufferLevel / Math.max(rate, 1),
+                bufferedDuration = actualBufferLevel / Math.max(Math.abs(rate), 1),
                 fragmentDuration = representationInfo.fragmentDuration,
                 timeToEnd = isDynamic ? Number.POSITIVE_INFINITY : duration - currentTime,
                 requiredBufferLength = Math.min(getRequiredBufferLength.call(this, isDynamic, duration, scheduleCtrl), timeToEnd),

--- a/src/streaming/utils/RNG.js
+++ b/src/streaming/utils/RNG.js
@@ -1,0 +1,94 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*global MediaPlayer, Uint32Array*/
+MediaPlayer.utils.RNG = function () {
+    "use strict";
+
+    // check whether secure random numbers are available. if not, revert to
+    // using Math.random
+    var crypto = window.crypto || window.msCrypto,
+
+        // could just as easily use any other array type by changing line below
+        ArrayType = Uint32Array,
+        MAX_VALUE = Math.pow(2, ArrayType.BYTES_PER_ELEMENT * 8) - 1,
+
+        // currently there is only one client for this code, and that only uses
+        // a single random number per initialisation. may want to increase this
+        // number if more consumers in the future
+        NUM_RANDOM_NUMBERS = 10,
+        randomNumbers,
+        index,
+
+        initialise = function () {
+            if (crypto) {
+                if (!randomNumbers) {
+                    randomNumbers = new ArrayType(NUM_RANDOM_NUMBERS);
+                }
+                crypto.getRandomValues(randomNumbers);
+                index = 0;
+            }
+        },
+
+        rand = function (min, max) {
+            var rand;
+
+            if (!min) {
+                min = 0;
+            }
+
+            if (!max) {
+                max = 1;
+            }
+
+            if (crypto) {
+                if (index === randomNumbers.length) {
+                    initialise();
+                }
+
+                rand = randomNumbers[index] / MAX_VALUE;
+                index += 1;
+            } else {
+                rand = Math.random();
+            }
+
+            return (rand * (max - min)) + min;
+        };
+
+    return {
+        random: rand,
+        setup:  initialise
+    };
+};
+
+MediaPlayer.utils.RNG.prototype = {
+    constructor: MediaPlayer.utils.RNG
+};

--- a/src/streaming/vo/metrics/DVBErrors.js
+++ b/src/streaming/vo/metrics/DVBErrors.js
@@ -1,0 +1,95 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+MediaPlayer.vo.metrics.DVBErrors = function () {
+    "use strict";
+
+    this.mpdurl = null;
+    // String - Absolute URL from which the MPD was originally
+    // retrieved (MPD updates will not change this value).
+
+    this.errorcode = null;
+    // String - The value of errorcode depends upon the type
+    // of error being reported. For an error listed in the
+    // ErrorType column below the value is as described in the
+    // Value column.
+    //
+    // ErrorType                                            Value
+    // ---------                                            -----
+    // HTTP error status code                               HTTP status code
+    // Unknown HTTP status code                             HTTP status code
+    // SSL connection failed                                "SSL" followed by SSL alert value
+    // DNS resolution failed                                "C00"
+    // Host unreachable                                     "C01"
+    // Connection refused                                   "C02"
+    // Connection error – Not otherwise specified           "C03"
+    // Corrupt media – ISO BMFF container cannot be parsed  "M00"
+    // Corrupt media – Not otherwise specified              "M01"
+    // Changing Base URL in use due to errors               "F00"
+    // Becoming an error reporting Player                   "S00"
+
+    this.terror = null;
+    // Real-Time - Date and time at which error occurred in UTC,
+    // formatted as a combined date and time according to ISO 8601.
+
+    this.url = null;
+    // String - Absolute URL from which data was being requested
+    // when this error occurred. If the error report is in relation
+    // to corrupt media or changing BaseURL, this may be a null
+    // string if the URL from which the media was obtained or
+    // which led to the change of BaseURL is no longer known.
+
+    this.ipaddress = null;
+    // String - IP Address which the host name in "url" resolved to.
+    // If the error report is in relation to corrupt media or
+    // changing BaseURL, this may be a null string if the URL
+    // from which the media was obtained or which led to the
+    // change of BaseURL is no longer known.
+
+    this.servicelocation = null;
+    // String - The value of the serviceLocation field in the
+    // BaseURL being used. In the event of this report indicating
+    // a change of BaseURL this is the value from the BaseURL
+    // being moved from.
+};
+
+MediaPlayer.vo.metrics.DVBErrors.prototype = {
+    constructor: MediaPlayer.vo.metrics.DVBErrors
+};
+
+MediaPlayer.vo.metrics.DVBErrors.SSL_CONNECTION_FAILED_PREFIX = 'SSL';
+MediaPlayer.vo.metrics.DVBErrors.DNS_RESOLUTION_FAILED =        'C00';
+MediaPlayer.vo.metrics.DVBErrors.HOST_UNREACHABLE =             'C01';
+MediaPlayer.vo.metrics.DVBErrors.CONNECTION_REFUSED =           'C02';
+MediaPlayer.vo.metrics.DVBErrors.CONNECTION_ERROR =             'C03';
+MediaPlayer.vo.metrics.DVBErrors.CORRUPT_MEDIA_ISOBMFF =        'M00';
+MediaPlayer.vo.metrics.DVBErrors.CORRUPT_MEDIA_OTHER =          'M01';
+MediaPlayer.vo.metrics.DVBErrors.BASE_URL_CHANGED =             'F00';
+MediaPlayer.vo.metrics.DVBErrors.BECAME_REPORTER =              'S00';

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -28,31 +28,34 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
 MediaPlayer.vo.metrics.HTTPRequest = function () {
     "use strict";
+    this.tcpid = null;              // Identifier of the TCP connection on which the HTTP request was sent.
+    this.type = null;               // This is an optional parameter and should not be included in HTTP request/response transactions for progressive download.
+                                        // The type of the request:
+                                        // - MPD
+                                        // - XLink expansion
+                                        // - Initialization Fragment
+                                        // - Index Fragment
+                                        // - Media Fragment
+                                        // - Bitstream Switching Fragment
+                                        // - other
+    this.url = null;                // The original URL (before any redirects or failures)
+    this.actualurl = null;          // The actual URL requested, if different from above
+    this.range = null;              // The contents of the byte-range-spec part of the HTTP Range header.
+    this.trequest = null;           // Real-Time | The real time at which the request was sent.
+    this.tresponse = null;          // Real-Time | The real time at which the first byte of the response was received.
+    this.responsecode = null;       // The HTTP response code.
+    this.interval = null;           // The duration of the throughput trace intervals (ms), for successful requests only.
+    this.trace = [];                // Throughput traces, for successful requests only.
 
-    this.stream = null;         // type of stream ("audio" | "video" etc..)
-    this.tcpid = null;          // Identifier of the TCP connection on which the HTTP request was sent.
-    this.type = null;           // This is an optional parameter and should not be included in HTTP request/response transactions for progressive download.
-                                    // The type of the request:
-                                    // - MPD
-                                    // - XLink expansion
-                                    // - Initialization Fragment
-                                    // - Index Fragment
-                                    // - Media Fragment
-                                    // - Bitstream Switching Fragment
-                                    // - other
-    this.url = null;            // The original URL (before any redirects or failures)
-    this.actualurl = null;      // The actual URL requested, if different from above
-    this.range = null;          // The contents of the byte-range-spec part of the HTTP Range header.
-    this.trequest = null;       // Real-Time | The real time at which the request was sent.
-    this.tresponse = null;      // Real-Time | The real time at which the first byte of the response was received.
-    this.tfinish = null;        // Real-Time | The real time at which the request finshed.
-    this.responsecode = null;   // The HTTP response code.
-    this.interval = null;       // The duration of the throughput trace intervals (ms), for successful requests only.
-    this.mediaduration = null;  // The duration of the media requests, if available, in milliseconds.
-    this.responseHeaders = null; // all the response headers from request.
-    this.trace = [];            // Throughput traces, for successful requests only.
+    // Additional metrics used internally which we do not want to report to the outside world
+    // Anything beginning with an _ will not be reported
+    this._stream = null;            // type of stream ("audio" | "video" etc..)
+    this._tfinish = null;           // Real-Time | The real time at which the request finshed.
+    this._mediaduration = null;     // The duration of the media requests, if available, in milliseconds.
+    this._responseHeaders = null;   // all the response headers from request.
 };
 
 MediaPlayer.vo.metrics.HTTPRequest.prototype = {
@@ -76,13 +79,10 @@ MediaPlayer.vo.metrics.HTTPRequest.Trace.prototype = {
     constructor : MediaPlayer.vo.metrics.HTTPRequest.Trace
 };
 
-// these should possibly be MPD, XLinkExpansion, InitializationSegment,
-// MediaSegment, IndexSegment, BitstreamSwitchingSegment, other. See
-// ISO 23009-1 D.4.3
 MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE = 'MPD';
-MediaPlayer.vo.metrics.HTTPRequest.XLINK_EXPANSION_TYPE = 'XLink Expansion';
-MediaPlayer.vo.metrics.HTTPRequest.INIT_SEGMENT_TYPE = 'Initialization Segment';
-MediaPlayer.vo.metrics.HTTPRequest.INDEX_SEGMENT_TYPE = 'Index Segment';
-MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE = 'Media Segment';
-MediaPlayer.vo.metrics.HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'Bitstream Switching Segment';
+MediaPlayer.vo.metrics.HTTPRequest.XLINK_EXPANSION_TYPE = 'XLinkExpansion';
+MediaPlayer.vo.metrics.HTTPRequest.INIT_SEGMENT_TYPE = 'InitializationSegment';
+MediaPlayer.vo.metrics.HTTPRequest.INDEX_SEGMENT_TYPE = 'IndexSegment';
+MediaPlayer.vo.metrics.HTTPRequest.MEDIA_SEGMENT_TYPE = 'MediaSegment';
+MediaPlayer.vo.metrics.HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'BitstreamSwitchingSegment';
 MediaPlayer.vo.metrics.HTTPRequest.OTHER_TYPE = 'other';

--- a/src/streaming/vo/metrics/PlayList.js
+++ b/src/streaming/vo/metrics/PlayList.js
@@ -31,35 +31,35 @@
 MediaPlayer.vo.metrics.PlayList = function () {
     "use strict";
 
-    this.stream = null;     // type of stream ("audio" | "video" etc..)
-    this.start = null;      // Real-Time | Timestamp of the user action that starts the playback stream...
-    this.mstart = null;     // Media-Time | Presentation time at which playout was requested by the user...
-    this.starttype = null;  // Type of user action which triggered playout
-                            //      - New playout request (e.g. initial playout or seeking)
-                            //      - Resume from pause
-                            //        - Other user request (e.g. user-requested quality change)
-                            //        - Start of a metrics collection stream (hence earlier entries in the play list not collected)
-    this.trace = [];        // List of streams of continuous rendering of decoded samples.
+    this.start = null;              // Real-Time | Timestamp of the user action that starts the playback stream...
+    this.mstart = null;             // Media-Time | Presentation time at which playout was requested by the user...
+    this.starttype = null;          // Enum | Type of user action which triggered playout
+                                    //          - New playout request (e.g. initial playout or seeking)
+                                    //          - Resume from pause
+                                    //          - Other user request (e.g. user-requested quality change)
+                                    //          - Start of a metrics collection stream (hence earlier entries in the play list not collected)
+    this.trace = [];                // List | Listof streams of continuous rendering of decoded samples.
 };
 
 MediaPlayer.vo.metrics.PlayList.Trace = function () {
     "use strict";
 
     /*
-     * representationid - The value of the Representation@id of the Representation from which the samples were taken.
-     * subreplevel      - If not present, this metrics concerns the Representation as a whole. If present, subreplevel indicates the greatest value of any Subrepresentation@level being rendered.
+     * representationid - String | The value of the Representation@id of the Representation from which the samples were taken.
+     * subreplevel      - Integer | If not present, this metrics concerns the Representation as a whole. If present, subreplevel indicates the greatest value of any Subrepresentation@level being rendered.
      * start            - Real-Time | The time at which the first sample was rendered.
      * mstart           - Media-Time | The presentation time of the first sample rendered.
-     * duration         - The duration of the continuously presented samples (which is the same in real time and media time). ―Continuously presented‖ means that the media clock continued to advance at the playout speed throughout the interval.
-     * playbackspeed    - The playback speed relative to normal playback speed (i.e.normal forward playback speed is 1.0).
-     * stopreason       - The reason why continuous presentation of this Representation was stopped.
+     * duration         - Integer | The duration of the continuously presented samples (which is the same in real time and media time). "Continuously presented" means that the media clock continued to advance at the playout speed throughout the interval. NOTE: the spec does not call out the units, but all other durations etc are in ms, and we use ms too.
+     * playbackspeed    - Real | The playback speed relative to normal playback speed (i.e.normal forward playback speed is 1.0).
+     * stopreason       - Enum | The reason why continuous presentation of this Representation was stopped.
      *                    Either:
      *                    representation switch
      *                    rebuffering
      *                    user request
+     *                    end of Period
      *                    end of Stream
      *                    end of content
-     *                    end of a metrics collection stream
+     *                    end of a metrics collection period
      */
     this.representationid = null;
     this.subreplevel = null;
@@ -75,15 +75,20 @@ MediaPlayer.vo.metrics.PlayList.prototype = {
 };
 
 /* Public Static Constants */
-MediaPlayer.vo.metrics.PlayList.INITIAL_PLAY_START_REASON = "initial_start";
+MediaPlayer.vo.metrics.PlayList.INITIAL_PLAYOUT_START_REASON = "initial_playout";
 MediaPlayer.vo.metrics.PlayList.SEEK_START_REASON = "seek";
+MediaPlayer.vo.metrics.PlayList.RESUME_FROM_PAUSE_START_REASON = "resume";
+MediaPlayer.vo.metrics.PlayList.METRICS_COLLECTION_START_REASON = "metrics_collection_start";
 
 MediaPlayer.vo.metrics.PlayList.Trace.prototype = {
     constructor: MediaPlayer.vo.metrics.PlayList.Trace()
 };
 
 /* Public Static Constants */
-MediaPlayer.vo.metrics.PlayList.Trace.USER_REQUEST_STOP_REASON = "user_request";
 MediaPlayer.vo.metrics.PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON = "representation_switch";
-MediaPlayer.vo.metrics.PlayList.Trace.END_OF_CONTENT_STOP_REASON = "end_of_content";
 MediaPlayer.vo.metrics.PlayList.Trace.REBUFFERING_REASON = "rebuffering";
+MediaPlayer.vo.metrics.PlayList.Trace.USER_REQUEST_STOP_REASON = "user_request";
+MediaPlayer.vo.metrics.PlayList.Trace.END_OF_PERIOD_STOP_REASON = "end_of_period";
+MediaPlayer.vo.metrics.PlayList.Trace.END_OF_CONTENT_STOP_REASON = "end_of_content";
+MediaPlayer.vo.metrics.PlayList.Trace.METRICS_COLLECTION_STOP_REASON = "metrics_collection_end";
+MediaPlayer.vo.metrics.PlayList.Trace.FAILURE_STOP_REASON = "failure";


### PR DESCRIPTION
This sizeable changeset implements DVB Error Reporting, including DASH metrics.

There are a couple of caveats:
* RepSwitchList.mt reports the media time at the switch request, not when the new Representation starts playout (see #754)
* Metrics collection period start and end does not affect Playlist as 23009-1 say it should
* BufferLevel.t does not update when the content is paused.

The DVB Reporting mechanism is implemented since this is the only mechanism reported currently. You can see a sample MPD at http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd. Note that you would need to add DASH metrics to the metrics attribute to report these, and the probability will need tweaking to ensure you see some output.

I'm out of the office for the next week or so, so won't be responding quickly, but welcome comments on this PR.