### PR TITLE
Enable HTML-rendered captions in all browsers

### DIFF
--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -24,10 +24,10 @@
             player.attachView(videoElement);
             player.setAutoPlay(true);
             player.attachSource(url);
-            player.addEventListener(MediaPlayer.events.TEXT_TRACK_ADDED, onTrackAdded);
+            player.addEventListener(MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);
         }
 
-        function onTrackAdded(e){
+        function onTracksAdded(e){
             var selectMenu = document.getElementById("caption-menu"),
                 tracks = videoElement.textTracks,
                 ln = tracks.length;

--- a/samples/captioning/ttml-ebutt-sample.html
+++ b/samples/captioning/ttml-ebutt-sample.html
@@ -33,10 +33,10 @@
             player.attachTTMLRenderingDiv(TTMLRenderingDiv);
             player.setAutoPlay(true);
             player.attachSource(url);
-            player.addEventListener(MediaPlayer.events.TEXT_TRACK_ADDED, onTrackAdded);
+            player.addEventListener(MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);
         }
 
-        function onTrackAdded(e){
+        function onTracksAdded(e){
             var selectMenu = document.getElementById("caption-menu"),
                 tracks = videoElement.textTracks,
                 ln = tracks.length;

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -569,12 +569,10 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     player.attachView(video);
     player.attachVideoContainer(document.getElementById("videoContainer"));
 
-    /* Only do this for Chrome and Safari, but not for Edge (Edge signals both Chrome and Safari) */
-    if (navigator.userAgent.match(/(Chrome|Safari)/) && !navigator.userAgent.match(/Edge/)) 
-    {
-        ttmlDiv = document.querySelector("#video-caption");
-        player.attachTTMLRenderingDiv(ttmlDiv);
-    }
+    // Add HTML-rendered TTML subtitles
+    ttmlDiv = document.querySelector("#video-caption");
+    player.attachTTMLRenderingDiv(ttmlDiv);
+
     player.setAutoPlay(true);
     controlbar = new ControlBar(player);
     controlbar.initialize();

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -41,7 +41,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
         actualVideoHeight = 0,
         captionContainer = null,
         videoSizeCheckInterval = null,
-        isIE11 = false,// Temp solution for the addCue InvalidStateError..
+        isIE11orEdge = false,// Temp solution for the addCue InvalidStateError..
         isChrome = false,
         fullscreenAttribute = null,
         displayCCOnTop = false,
@@ -51,9 +51,9 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             var kind = textTrackQueue[i].kind;
             var label = textTrackQueue[i].label !== undefined ? textTrackQueue[i].label : textTrackQueue[i].lang;
             var lang = textTrackQueue[i].lang;
-            var track = isIE11 ? video.addTextTrack(kind, label, lang) : document.createElement('track');
+            var track = isIE11orEdge ? video.addTextTrack(kind, label, lang) : document.createElement('track');
 
-             if (!isIE11) {
+             if (!isIE11orEdge) {
                  track.kind = kind;
                  track.label = label;
                  track.srclang = lang;
@@ -73,7 +73,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             //TODO Check if IE has resolved issues: Then revert to not using the addTextTrack API for all browsers.
             // https://connect.microsoft.com/IE/feedbackdetail/view/1660701/text-tracks-do-not-fire-change-addtrack-or-removetrack-events
             // https://connect.microsoft.com/IE/feedback/details/1573380/htmltrackelement-track-addcue-throws-invalidstateerror-when-adding-new-cue
-            isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./);
+            isIE11orEdge = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./) || navigator.userAgent.match(/Edge/);
             isChrome = !!navigator.userAgent.match(/Chrome/) && !navigator.userAgent.match(/Edge/);
             if (document.fullscreenElement !== undefined) {
                 fullscreenAttribute = "fullscreenElement"; // Standard and Edge
@@ -116,7 +116,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
                         track.default = true;
                         defaultIndex = i;
                     }
-                    if (!isIE11){
+                    if (!isIE11orEdge){
                         video.appendChild(track);
                     }
                     this.addCaptions(0, textTrackQueue[i].captionData);
@@ -397,7 +397,7 @@ MediaPlayer.utils.TextTrackExtensions = function () {
         deleteAllTextTracks:  function() {
             var ln = trackElementArr.length;
             for(var i = 0; i < ln; i++){
-                if (isIE11) {
+                if (isIE11orEdge) {
                     this.deleteTrackCues(this.getTextTrack(i));
                 }else {
                     video.removeChild(trackElementArr[i]);


### PR DESCRIPTION
The full-screen HTML rendering of subtitles is working in IE11 from #797.
Thus we can now enable this rendering in IE11. It also works in Edge similarly to IE11, so the IE11 test was extended to Edge. Fixes #748.

Also made a fix to the sample captioning apps which repeated subtitle tracks because they listened to the wrong event.