### PR TITLE
Clear all previous track data for HTML-rendered tracks when disabling all tracks.

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -36,21 +36,14 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
             var el = this.videoModel.getElement(),
                 tracks = el.textTracks,
                 ln = tracks.length,
-                self = this;
+                self = this,
+                previousTextTrack = self.textTrackExtensions.getCurrentTextTrack();
 
             for (var i = 0; i < ln; i++ ) {
                 var track = tracks[i];
                 allTracksAreDisabled = track.mode !== "showing";
                 if (track.mode === "showing") {
                     if (self.textTrackExtensions.getCurrentTrackIdx() !== i) { // do not reset track if already the current track.  This happens when all captions get turned off via UI and then turned on again and with videojs.
-                        var previousTextTrack = self.textTrackExtensions.getCurrentTextTrack(); //will be null when all tracks are disabled and turning back on.
-                        if (previousTextTrack !== null) {
-                            self.textTrackExtensions.deleteTrackCues(previousTextTrack);
-                            if (previousTextTrack.renderingType === "html") {
-                                self.textTrackExtensions.removeNativeCueStyle();
-                                self.textTrackExtensions.clearCues();
-                            }
-                        }
                         self.textTrackExtensions.setCurrentTrackIdx(i);
                         if (!self.mediaController.isCurrentTrack(self.allTracks[i])){
                             self.textTrackExtensions.deleteTrackCues(self.textTrackExtensions.getCurrentTextTrack());
@@ -59,8 +52,18 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                             self.buffered.clear();
                             self.mediaController.setTrack(self.allTracks[i]);
                         }
+                    } else {
+                        previousTextTrack = null;
                     }
                     break;
+                }
+            }
+            
+            if (previousTextTrack) {
+                self.textTrackExtensions.deleteTrackCues(previousTextTrack);
+                if (previousTextTrack.renderingType === "html") {
+                    self.textTrackExtensions.removeNativeCueStyle();
+                    self.textTrackExtensions.clearCues();
                 }
             }
 


### PR DESCRIPTION
Fix for #804.

The player stops fetching data when no text track is visible, but the cues are not cleared in this case. The  easiest way to reproduce the problem is to play content with HTML-rendered subtitles (like the reference player), and pause when subtitles are shown. When turning off the subtitle tracks, the text remains onscreen.