### PR TITLE
Bug fix: The text tracks are now sorted in same order as in Manifest.

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -116,7 +116,8 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
 
                 textTrackInfo.captionData = captionData;
                 textTrackInfo.lang = mediaInfo.lang;
-                textTrackInfo.label = mediaInfo.id;
+                textTrackInfo.label = mediaInfo.id; // AdaptationSet id (an unsigned int)
+                textTrackInfo.index = mediaInfo.index; // AdaptationSet index in manifest
                 textTrackInfo.video = self.videoModel.getElement();
                 textTrackInfo.defaultTrack = self.getIsDefault(mediaInfo);
                 textTrackInfo.isFragmented = self.isFragmented;

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -103,6 +103,9 @@ MediaPlayer.utils.TextTrackExtensions = function () {
             captionContainer = this.videoModel.getTTMLRenderingDiv();
 
             if(textTrackQueue.length === totalTextTracks) {
+                textTrackQueue.sort(function(a, b) { //Sort in same order as in manifest
+                    return a.index - b.index;
+                });
                 var defaultIndex = 0;
                 for(var i = 0 ; i < textTrackQueue.length; i++) {
                     var track = createTrackForUserAgent(i);


### PR DESCRIPTION
Previously, the order that the text tracks turned up in the menu was arbitrary and depended on the order that the parallel download requests were finished.