### PR TITLE
Handle XML parsing error sensibly

### DIFF
--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -359,6 +359,11 @@ Dash.dependencies.DashParser = function () {
             try {
                 //this.log("Converting from XML.");
                 manifest = converter.xml_str2json(data);
+
+                if (!manifest) {
+                    throw "parser error";
+                }
+
                 json = new Date();
 
                 if (!manifest.hasOwnProperty("BaseURL")) {

--- a/src/lib/xml2json.js
+++ b/src/lib/xml2json.js
@@ -355,11 +355,25 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
 
 		if (window.DOMParser) {
 			parser = new window.DOMParser();
-			ns = parser.parseFromString('<', 'text/xml').getElementsByTagName("parsererror")[0].namespaceURI;
-			xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
 
-			if(xmlDoc.getElementsByTagNameNS(ns, 'parsererror').length) {
-				xmlDoc = undefined;
+			try {
+				ns = parser.parseFromString('<', 'text/xml').getElementsByTagName("parsererror")[0].namespaceURI;
+			} catch (e) {
+				// IE11 will definitely throw SyntaxError here
+				// ns will be undefined
+			}
+
+			try {
+				xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
+
+				if (ns) {
+					if(xmlDoc.getElementsByTagNameNS(ns, 'parsererror').length) {
+						xmlDoc = undefined;
+					}
+				}
+			} catch (e) {
+				// IE11 may throw SyntaxError here if xmlDocStr is
+				// not well formed. xmlDoc will be undefined
 			}
 		}
 		else {

--- a/src/lib/xml2json.js
+++ b/src/lib/xml2json.js
@@ -349,10 +349,18 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
 	}
 	
 	this.parseXmlString = function(xmlDocStr) {
-		var xmlDoc;
+		var xmlDoc,
+			parser,
+			ns;
+
 		if (window.DOMParser) {
-			var parser=new window.DOMParser();			
+			parser = new window.DOMParser();
+			ns = parser.parseFromString('<', 'text/xml').getElementsByTagName("parsererror")[0].namespaceURI;
 			xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
+
+			if(xmlDoc.getElementsByTagNameNS(ns, 'parsererror').length) {
+				xmlDoc = undefined;
+			}
 		}
 		else {
 			// IE :(
@@ -372,7 +380,7 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
 	
 	this.xml_str2json = function (xmlDocStr) {
 		var xmlDoc = this.parseXmlString(xmlDocStr);	
-		return this.xml2json(xmlDoc);
+		return xmlDoc ? this.xml2json(xmlDoc) : undefined;
 	}
 
 	this.json2xml_str = function (jsonObj) {

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -61,7 +61,8 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                 self = this;
 
             onload = function () {
-                var actualUrl = null;
+                var actualUrl = null,
+                    errorMsg;
 
                 if (request.status < 200 || request.status > 299) {
                     return;
@@ -97,7 +98,21 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                     self.metricsModel.addManifestUpdate("stream", manifest.type, requestTime, loadedTime, manifest.availabilityStartTime);
                     self.xlinkController.resolveManifestOnLoad(manifest);
                 } else {
-                    self.notify(MediaPlayer.dependencies.ManifestLoader.eventList.ENAME_MANIFEST_LOADED, {manifest: null}, new MediaPlayer.vo.Error(null, "Failed loading manifest: " + url, null));
+                    errorMsg = "Failed loading manifest: " + url + ", parsing failed";
+
+                    self.notify(
+                        MediaPlayer.dependencies.ManifestLoader.eventList.ENAME_MANIFEST_LOADED,
+                        {
+                            manifest: null
+                        },
+                        new MediaPlayer.vo.Error(
+                            MediaPlayer.dependencies.ManifestLoader.PARSERERROR_ERROR_CODE,
+                            errorMsg,
+                            null
+                        )
+                    );
+
+                    self.log(errorMsg);
                 }
             };
 
@@ -183,6 +198,8 @@ MediaPlayer.dependencies.ManifestLoader = function () {
 MediaPlayer.dependencies.ManifestLoader.prototype = {
     constructor: MediaPlayer.dependencies.ManifestLoader
 };
+
+MediaPlayer.dependencies.ManifestLoader.PARSERERROR_ERROR_CODE = 1;
 
 MediaPlayer.dependencies.ManifestLoader.eventList = {
     ENAME_MANIFEST_LOADED: "manifestLoaded"

--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -859,6 +859,10 @@ MediaPlayer.utils.TTMLParser = function() {
             // Parse the TTML in a JSON object.
             ttml = converter.xml_str2json(data);
 
+            if (!ttml) {
+                throw "TTML document has incorrect structure";
+            }
+
             if (self.videoModel.getTTMLRenderingDiv()) {
                 type = 'html';
             }

--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -860,7 +860,7 @@ MediaPlayer.utils.TTMLParser = function() {
             ttml = converter.xml_str2json(data);
 
             if (!ttml) {
-                throw "TTML document has incorrect structure";
+                throw "TTML document could not be parsed";
             }
 
             if (self.videoModel.getTTMLRenderingDiv()) {


### PR DESCRIPTION
While testing another feature I discovered that XML parsing errors are handled differently across platforms and not caught in a sensible way on any. This could lead to the player attempting to continue with an incomplete manifest (Chrome, Safari) or fail but not for the correct reason (Firefox, but only because its error response contains a Processing Instruction node which causes the json conversion to barf).

This PR reliably detects parsererrors and forces a sensible (undefined) response from parser which makes the player act as I believe was intended. IE stop attempting to play the malformed manifest.

Please note I have NOT tested this on IE11/Edge as I don't have access to those browsers right now. Could someone try this out and let me know?