### PR TITLE
Removal of live startup stall by reducing time value.

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -31,7 +31,7 @@
 MediaPlayer.dependencies.PlaybackController = function () {
     "use strict";
 
-    var WALLCLOCK_TIME_UPDATE_INTERVAL = 1000,
+    var WALLCLOCK_TIME_UPDATE_INTERVAL = 50, //This value influences the startup time for live.
         currentTime = 0,
         liveStartTime = NaN,
         wallclockTimeIntervalId = null,


### PR DESCRIPTION
Reduction of timer period since it induces a corresponding stall in the live startup time. 
Lowered the value from 1000ms to 50ms. See issue #838.