### PR TITLE
Fix for getting back to the same subtitle after turning them off.

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -644,9 +644,7 @@ MediaPlayer = function (context) {
                 }
             }
 
-            if (textSourceBuffer.isFragmented) {
-                textSourceBuffer.setTextTrack();
-            }
+            textSourceBuffer.setTextTrack();
         },
 
         /**


### PR DESCRIPTION
Fixed issue #837 that it was impossible to turn off subtitles and getting back to the same language (for fragment-based subtitles).

Also unified with XML-file-based TTML subtitles and detecting TTML already from the codec/mime-type instead of from the cues.
In all cases, if the video is paused as subtitles are shown, they vanish as the subtitles are turned off.