### PR TITLE
Build dist on prepublish instead of on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/dash.all.js",
   "scripts": {
     "test": "npm install && grunt",
-    "postinstall": "grunt uglify"
+    "prepublish": "grunt uglify"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
After these recent commits
https://github.com/Dash-Industry-Forum/dash.js/commit/29a4f8ad922e4df63566a4db91ccc3ccba8d70a9
https://github.com/Dash-Industry-Forum/dash.js/commit/aade0f2504c99794df4d0e646e1c01ca04870b87

`dist` is no longer bundled with the git repository and needs to be built. A `postinstall` hook has been provided, but it fails when dashjs is included as a dependency, since `npm install` from the parent project won't install the grunt devDependency. 

Changing `postinstall`into `prepublish` solves the problem since it will now only be run on local npm install or publish.

Steps to reproduce:
1) Initialize a new project with `npm init`
2) Add dashjs as a dependency (by pointing to the latest commit of the development branch)
3) Run `npm install`
gives:
`Failed at the dashjs@1.5.1 postinstall script 'grunt uglify'.`
`sh: grunt: command not found`
or alternatively (if grunt is installed globally)
`Unable to find local grunt.`


