### PR TITLE
Fix style of cue-image

### DIFF
--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -38,7 +38,7 @@
     height: 100%; 
     top: 0px; 
     visibility: visible !important; 
-    position: absolute !important;
+    position: relative !important;
 }
 
 body {


### PR DESCRIPTION
This patch fixes the position of SMPTE-TT image subtitles (with embedded PNG) which was displayed out of video screen. Textual subtitles works well.