### PR TITLE
[1.5.2] Fixup metrics display in reference player

### DIFF
--- a/contrib/webmjs/app/main.js
+++ b/contrib/webmjs/app/main.js
@@ -180,7 +180,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
                 requestWindow = Requests
                     .slice(-20)
-                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req.mediaduration && req.type === "Media Segment" && req.stream === type;})
+                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req._mediaduration && req.type === "MediaSegment" && req._stream === type;})
                     .slice(-4);
                 if (requestWindow.length > 0) {
 
@@ -193,7 +193,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                         count: latencyTimes.length
                     };
 
-                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
+                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req._tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
                         average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
@@ -202,7 +202,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                         count: downloadTimes.length
                     };
 
-                    durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
+                    durationTimes = requestWindow.map(function (req){ return req._mediaduration;});
 
                     movingRatio[type] = {
                         average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
@@ -232,7 +232,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = (bufferLevel.level / 1000).toPrecision(5);
+                bufferLengthValue = bufferLevel.toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -195,7 +195,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
                 requestWindow = Requests
                     .slice(-20)
-                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req.mediaduration && req.type === "Media Segment" && req.stream === type;})
+                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req._mediaduration && req.type === "MediaSegment" && req._stream === type;})
                     .slice(-4);
                 if (requestWindow.length > 0) {
 
@@ -208,7 +208,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                         count: latencyTimes.length
                     };
 
-                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
+                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req._tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
                         average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
@@ -217,7 +217,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
                         count: downloadTimes.length
                     };
 
-                    durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
+                    durationTimes = requestWindow.map(function (req){ return req._mediaduration;});
 
                     movingRatio[type] = {
                         average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
@@ -250,7 +250,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type, streamIdx);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = (bufferLevel.level / 1000).toPrecision(5);
+                bufferLengthValue = bufferLevel.toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -445,7 +445,7 @@ Dash.dependencies.DashMetricsExtensions = function () {
                 httpRequest = httpRequestList[i];
 
                 if (httpRequest.type === MediaPlayer.vo.metrics.HTTPRequest.MPD_TYPE) {
-                    headers = parseResponseHeaders(httpRequest.responseHeaders);
+                    headers = parseResponseHeaders(httpRequest._responseHeaders);
                     break;
                 }
             }


### PR DESCRIPTION
Metrics display in the reference player had become broken due to some attribute renaming. Fixed references to renamed attributes.