### PR TITLE
Commenting out unused btoa and atob polyfills. 

### DIFF
--- a/src/lib/base64.js
+++ b/src/lib/base64.js
@@ -144,9 +144,14 @@ var BASE64 = {};
     };
 })("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
+/*
+The following polyfills are not used in dash.js but have caused multiplayer integration issues.
+Therefore commenting them out.
+
 if (undefined === btoa) {
     var btoa = BASE64.encode;
 }
 if (undefined === atob) {
     var atob = BASE64.decode;
 }
+*/


### PR DESCRIPTION
None of the dash.js code uses btoa and atob, but the other code in this file. However, the btoa and atob  polyfills have caused some issues when integrating with jwplayer.