### PR TITLE
Fix for #917. Don't clear fragmentedTextBuffer on text track switch.

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -49,7 +49,7 @@ MediaPlayer.dependencies.TextSourceBuffer = function () {
                                 self.textTrackExtensions.deleteTrackCues(self.textTrackExtensions.getCurrentTextTrack());
                                 self.fragmentModel.cancelPendingRequests();
                                 self.fragmentModel.abortRequests();
-                                self.buffered.clear();
+                                //self.buffered.clear(); //Don't clear to avoid that player stalls. New subtitle track will after current buffer is consumed.
                                 self.mediaController.setTrack(self.allTracks[i]);
                             }
                         }


### PR DESCRIPTION
Fix for #917.
Don't clear buffer on switching fragmented text track to avoid that player stalls, and segment fetching does not recover.

It will take some time until new content appear, though.
Can be tested with http://vm2.dashif.org/livesim/testpic_2s/multi_subs.mpd