### PR TITLE
Fixes that the prunings gets into a bad state.

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -319,7 +319,7 @@ MediaPlayer.dependencies.BufferController = function () {
             // we want to get rid off buffer that is more than x
             // seconds behind current time, but no pruning once it's
             // finished.
-            if (!isPruningInProgress && mediaSource.readyState !== "ended") {
+            if (bufferToPrune > 0 && !isPruningInProgress && mediaSource.readyState !== "ended") {
                 isPruningInProgress = true;
                 this.sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);
             }


### PR DESCRIPTION
Makes sure to only call sourceBufferExt.remove() if there is anything to remove.
Fixes #936.