### PR TITLE
Corrected throughput calculation

### DIFF
--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -331,7 +331,7 @@ Dash.dependencies.DashMetricsExtensions = function () {
                     // this implies all were thought of as in the cache,
                     // just return the last throughput, it's likely to be
                     // higher than any of our manifests
-                    return throughput;
+                    return throughput*1000;
                 }
                 return -1;
             }


### PR DESCRIPTION
Added a missing factor of 1000 when downloading segments is very fast.
Fixes #937.

Test-content http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd

