### PR TITLE
Don't error when playing audio-only content

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -354,7 +354,7 @@ function AbrController() {
 
     function checkMaxBitrate(idx, type) {
         var maxBitrate = getMaxAllowedBitrateFor(type);
-        if (isNaN(maxBitrate)) {
+        if (isNaN(maxBitrate) || !streamProcessorDict[type]) {
             return idx;
         }
         var maxIdx = getQualityForBitrate(streamProcessorDict[type].getMediaInfo(), maxBitrate);


### PR DESCRIPTION
Currently, if you attempt to play content with no video track, AbrController will error attempting to check the MediaInfo for the video track. This PR adds a check to prevent this.