### PR TITLE
Add back astinfuture event

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -37,6 +37,7 @@ import EventsBase from './EventsBase.js';
 class CoreEvents extends EventsBase {
     constructor () {
         super();
+        this.AST_IN_FUTURE = 'astinfuture';
         this.BUFFERING_COMPLETED = 'bufferingCompleted';
         this.BUFFER_CLEARED = 'bufferCleared';
         this.BUFFER_LEVEL_STATE_CHANGED = 'bufferStateChanged';

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -248,6 +248,7 @@ function RepresentationController() {
         };
 
         updating = false;
+        eventBus.trigger(Events.AST_IN_FUTURE, { delay: delay });
         setTimeout(update, delay);
     }
 


### PR DESCRIPTION
This is one of the features added in 1.6.0 that was not in 1.5.1. I'm not entirely confident on how this is how to externally trigger events now - let me know if it's wrong!