### PR TITLE
Apply requestModifierExt to the headers on manifest load.

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -178,6 +178,7 @@ function ManifestLoader(config) {
             request.onerror = report;
             request.onprogress = progress;
             request.open('GET', requestModifierExt.modifyRequestURL(url), true);
+            request = requestModifierExt.modifyRequestHeader(request);
             request.send();
         } catch (e) {
             request.onerror();


### PR DESCRIPTION
When loading fragments, the requestModifierExt is applied to both the
URL and the headers. This allows doing things like setting
`withCredentials` on each fragment request. Apply the same handling to
the manifest load in case the manifest load and fragment loads need to
be routed to the same server in a load balanced situation.