### PR TITLE
Don't close a media source that is a single fragment long prematurely

### DIFF
--- a/src/streaming/extensions/MediaSourceExtensions.js
+++ b/src/streaming/extensions/MediaSourceExtensions.js
@@ -81,6 +81,7 @@ function MediaSourceExtensions() {
 
         for (i; i < ln; i++) {
             if (buffers[i].updating) return;
+            if (buffers[i].buffered.length===0) return;
         }
 
         source.endOfStream();


### PR DESCRIPTION
Currently, if you play a piece of audio/video content that is only one fragment long, you may sometimes have only the audio or only the video played out.

This check ensures a stream cannot be flagged as complete until at least one fragment has been put into each track.

Will this potentially have issues with tracks which have been explicitly switched off so are not being loaded?