### PR TITLE
Don't error if there is no DVR window

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -202,7 +202,11 @@ function MediaPlayer() {
      * @instance
      */
     function getDVRWindowSize() {
-        return getDVRInfoMetric().manifestInfo.DVRWindowSize;
+        var metric = getDVRInfoMetric();
+        if (!metric) {
+            return NaN;
+        }
+        return metric.manifestInfo.DVRWindowSize;
     }
 
     /**


### PR DESCRIPTION
It's possible for there to be no DVRInfoMetric, which will cause dash.js to break. Add a check so that this doesn't happen.