### PR TITLE
New feature: embedded CEA-608 captioning support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,5 +30,6 @@
         "MediaKeys",
         "Caster",
         "TextTrackCue",
-        "HTMLMediaElement"]
+        "HTMLMediaElement",
+        "cea608parser"]
 }

--- a/externals/cea608-parser.js
+++ b/externals/cea608-parser.js
@@ -1,0 +1,1115 @@
+(function(exports) {
+
+    "use strict";
+
+    /**
+     *  Exceptions from regular ASCII. CodePoints are mapped to UTF-16 codes
+     */
+
+    var specialCea608CharsCodes = {
+        0x2a : 0xe1, // lowercase a, acute accent
+        0x5c : 0xe9, // lowercase e, acute accent
+        0x5e : 0xed, // lowercase i, acute accent
+        0x5f : 0xf3, // lowercase o, acute accent
+        0x60 : 0xfa, // lowercase u, acute accent
+        0x7b : 0xe7, // lowercase c with cedilla
+        0x7c : 0xf7, // division symbol
+        0x7d : 0xd1, // uppercase N tilde
+        0x7e : 0xf1, // lowercase n tilde
+        0x7f : 0x2588, // Full block
+        // THIS BLOCK INCLUDES THE 16 EXTENDED (TWO-BYTE) LINE 21 CHARACTERS
+        // THAT COME FROM HI BYTE=0x11 AND LOW BETWEEN 0x30 AND 0x3F
+        // THIS MEANS THAT \x50 MUST BE ADDED TO THE VALUES
+        0x80 : 0xae, // Registered symbol (R)
+        0x81 : 0xb0, // degree sign
+        0x82 : 0xbd, // 1/2 symbol
+        0x83 : 0xbf, // Inverted (open) question mark
+        0x84 : 0x2122, // Trademark symbol (TM)
+        0x85 : 0xa2, // Cents symbol
+        0x86 : 0xa3, // Pounds sterling
+        0x87 : 0x266a, // Music 8'th note
+        0x88 : 0xe0, // lowercase a, grave accent
+        0x89 : 0x20, // transparent space (regular)
+        0x8a : 0xe8, // lowercase e, grave accent
+        0x8b : 0xe2, // lowercase a, circumflex accent
+        0x8c : 0xea, // lowercase e, circumflex accent
+        0x8d : 0xee, // lowercase i, circumflex accent
+        0x8e : 0xf4, // lowercase o, circumflex accent
+        0x8f : 0xfb, // lowercase u, circumflex accent
+        // THIS BLOCK INCLUDES THE 32 EXTENDED (TWO-BYTE) LINE 21 CHARACTERS
+        // THAT COME FROM HI BYTE=0x12 AND LOW BETWEEN 0x20 AND 0x3F
+        0x90 : 0xc1, // capital letter A with acute
+        0x91 : 0xc9, // capital letter E with acute
+        0x92 : 0xd3, // capital letter O with acute
+        0x93 : 0xda, // capital letter U with acute
+        0x94 : 0xdc, // capital letter U with diaresis
+        0x95 : 0xfc, // lowercase letter U with diaeresis
+        0x96 : 0x2018, // opening single quote
+        0x97 : 0xa1, // inverted exclamation mark
+        0x98 : 0x2a, // asterisk
+        0x99 : 0x2019, // closing single quote
+        0x9a : 0x2501, // box drawings heavy horizontal
+        0x9b : 0xa9, // copyright sign
+        0x9c : 0x2120, // Service mark
+        0x9d : 0x2022, // (round) bullet
+        0x9e : 0x201c, // Left double quotation mark
+        0x9f : 0x201d, // Right double quotation mark
+        0xa0 : 0xc0, // uppercase A, grave accent
+        0xa1 : 0xc2, // uppercase A, circumflex
+        0xa2 : 0xc7, // uppercase C with cedilla
+        0xa3 : 0xc8, // uppercase E, grave accent
+        0xa4 : 0xca, // uppercase E, circumflex
+        0xa5 : 0xcb, // capital letter E with diaresis
+        0xa6 : 0xeb, // lowercase letter e with diaresis
+        0xa7 : 0xce, // uppercase I, circumflex
+        0xa8 : 0xcf, // uppercase I, with diaresis
+        0xa9 : 0xef, // lowercase i, with diaresis
+        0xaa : 0xd4, // uppercase O, circumflex
+        0xab : 0xd9, // uppercase U, grave accent
+        0xac : 0xf9, // lowercase u, grave accent
+        0xad : 0xdb, // uppercase U, circumflex
+        0xae : 0xab, // left-pointing double angle quotation mark
+        0xaf : 0xbb, // right-pointing double angle quotation mark
+        // THIS BLOCK INCLUDES THE 32 EXTENDED (TWO-BYTE) LINE 21 CHARACTERS
+        // THAT COME FROM HI BYTE=0x13 AND LOW BETWEEN 0x20 AND 0x3F
+        0xb0 : 0xc3, // Uppercase A, tilde
+        0xb1 : 0xe3, // Lowercase a, tilde
+        0xb2 : 0xcd, // Uppercase I, acute accent
+        0xb3 : 0xcc, // Uppercase I, grave accent
+        0xb4 : 0xec, // Lowercase i, grave accent
+        0xb5 : 0xd2, // Uppercase O, grave accent
+        0xb6 : 0xf2, // Lowercase o, grave accent
+        0xb7 : 0xd5, // Uppercase O, tilde
+        0xb8 : 0xf5, // Lowercase o, tilde
+        0xb9 : 0x7b, // Open curly brace
+        0xba : 0x7d, // Closing curly brace
+        0xbb : 0x5c, // Backslash
+        0xbc : 0x5e, // Caret
+        0xbd : 0x5f, // Underscore
+        0xbe : 0x7c, // Pipe (vertical line)
+        0xbf : 0x223c, // Tilde operator
+        0xc0 : 0xc4, // Uppercase A, umlaut
+        0xc1 : 0xe4, // Lowercase A, umlaut
+        0xc2 : 0xd6, // Uppercase O, umlaut
+        0xc3 : 0xf6, // Lowercase o, umlaut
+        0xc4 : 0xdf, // Esszett (sharp S)
+        0xc5 : 0xa5, // Yen symbol
+        0xc6 : 0xa4, // Generic currency sign
+        0xc7 : 0x2503, // Box drawings heavy vertical
+        0xc8 : 0xc5, // Uppercase A, ring
+        0xc9 : 0xe5, // Lowercase A, ring
+        0xca : 0xd8, // Uppercase O, stroke
+        0xcb : 0xf8, // Lowercase o, strok
+        0xcc : 0x250f, // Box drawings heavy down and right
+        0xcd : 0x2513, // Box drawings heavy down and left
+        0xce : 0x2517, // Box drawings heavy up and right
+        0xcf : 0x251b // Box drawings heavy up and left
+    };
+
+    /**
+     * Get Unicode Character from CEA-608 byte code
+     */
+    var getCharForByte = function(byte) {
+        var charCode = byte;
+        if (specialCea608CharsCodes.hasOwnProperty(byte)) {
+            charCode = specialCea608CharsCodes[byte];
+        }
+        return String.fromCharCode(charCode);
+    };
+
+    var NR_ROWS = 15,
+        NR_COLS = 32;
+    // Tables to look up row from PAC data
+    var rowsLowCh1 = {0x11 : 1, 0x12 : 3, 0x15 : 5, 0x16 : 7, 0x17 : 9, 0x10 : 11, 0x13 : 12, 0x14 : 14};
+    var rowsHighCh1 = {0x11 : 2, 0x12 : 4, 0x15 : 6, 0x16 : 8, 0x17 : 10, 0x13 : 13, 0x14 : 15};
+    var rowsLowCh2 = {0x19 : 1, 0x1A : 3, 0x1D : 5, 0x1E : 7, 0x1F : 9, 0x18 : 11, 0x1B : 12, 0x1C : 14};
+    var rowsHighCh2 = {0x19 : 2, 0x1A : 4, 0x1D : 6, 0x1E : 8, 0x1F : 10, 0x1B : 13, 0x1C : 15};
+
+    var backgroundColors = ['white', 'green', 'blue', 'cyan', 'red', 'yellow', 'magenta', 'black', 'transparent'];
+
+    /**
+     * Simple logger class to be able to write with time-stamps and filter on level.
+     */
+    var logger = {
+        verboseFilter : {'DATA' : 3, 'DEBUG' : 3, 'INFO' : 2, 'WARNING' : 2, 'TEXT' : 1, 'ERROR' : 0},
+        time : null,
+        verboseLevel : 0, // Only write errors
+        setTime : function(newTime) {
+            this.time = newTime;
+        },
+        log : function(severity, msg) {
+            var minLevel = this.verboseFilter[severity];
+            if (this.verboseLevel >= minLevel) {
+                console.log(this.time + " [" + severity + "] " + msg);
+            }
+        }
+    };
+
+    var numArrayToHexArray = function(numArray) {
+        var hexArray = [];
+        for (var j = 0; j < numArray.length; j++) {
+            hexArray.push(numArray[j].toString(16));
+        }
+        return hexArray;
+    };
+
+    /**
+     * State of CEA-608 pen or character
+     * @constructor
+     */
+    var PenState = function(foreground, underline, italics, background, flash) {
+        this.foreground = foreground || "white";
+        this.underline = underline || false;
+        this.italics = italics || false;
+        this.background = background || "black";
+        this.flash = flash || false;
+    };
+
+    PenState.prototype = {
+        
+        reset : function() {
+            this.foreground = "white";
+            this.underline = false;
+            this.italics = false;
+            this.background = "black";
+            this.flash = false;
+        },
+        
+        setStyles : function(styles) {
+            var attribs = ["foreground", "underline", "italics", "background", "flash"];
+            for (var i = 0 ; i < attribs.length; i++) {
+                var style = attribs[i];
+                if (styles.hasOwnProperty(style)) {
+                    this[style] = styles[style];
+                }
+            }
+        },
+        
+        isDefault : function() {
+            return (this.foreground === "white" && !this.underline && !this.italics && 
+                    this.background === "black" && !this.flash);
+        },
+
+        equals : function(other) {
+            return ( (this.foreground === other.foreground) && 
+                     (this.underline === other.underline) &&
+                     (this.italics === other.italics) &&
+                     (this.background === other.background) &&
+                     (this.flash === other.flash) );
+        },
+
+        copy : function(newPenState) {
+            this.foreground = newPenState.foreground;
+            this.underline = newPenState.underline;
+            this.italics = newPenState.italics;
+            this.background = newPenState.background;
+            this.flash = newPenState.flash;
+        },
+        
+        toString: function() {
+            return ("color=" + this.foreground + ", underline=" + this.underline + ", italics=" + this.italics +
+                ", background=" + this.background + ", flash=" + this.flash);
+        }
+    };
+
+    /**
+     * Unicode character with styling and background.
+     * @constructor
+     */
+    var StyledUnicodeChar = function(uchar, foreground, underline, italics, background, flash) {
+        this.uchar = uchar || ' '; // unicode character
+        this.penState = new PenState(foreground, underline,italics, background, flash);
+    };
+
+    StyledUnicodeChar.prototype = {
+        
+        reset: function() {
+            this.uchar = ' ';
+            this.penState.reset();
+        },
+        
+        setChar: function(uchar, newPenState) {
+            this.uchar = uchar;
+            this.penState.copy(newPenState);
+        },
+        
+        setPenState: function(newPenState) {
+            this.penState.copy(newPenState);
+        },
+        
+        equals: function(other) {
+            return this.uchar === other.uchar && this.penState.equals(other.penState);
+        },
+        
+        copy: function(newChar) {
+            this.uchar = newChar.uchar;
+            this.penState.copy(newChar.penState);
+        },
+        
+        isEmpty : function() {
+            return this.uchar === ' ' && this.penState.isDefault();
+        }
+    };
+
+    /**
+     * CEA-608 row consisting of NR_COLS instances of StyledUnicodeChar.
+     * @constructor
+     */
+    var Row = function() {
+        this.chars = [];
+        for (var i = 0 ; i < NR_COLS ; i++) {
+            this.chars.push(new StyledUnicodeChar());
+        }
+        this.pos = 0;
+        this.currPenState = new PenState();
+    };
+
+    Row.prototype = {
+        
+        equals: function(other) {
+            var equal = true;
+            for (var i = 0 ; i < NR_COLS; i ++) {
+                if (!this.chars[i].equals(other.chars[i])) {
+                    equal = false;
+                    break;
+                }
+            }
+            return equal;
+        },
+        
+        copy: function(other) {
+            for (var i = 0 ; i < NR_COLS; i ++) {
+                this.chars[i].copy(other.chars[i]);
+            }
+        },
+        
+        isEmpty : function() {
+            var empty = true;
+            for (var i = 0 ; i < NR_COLS; i ++) {
+                if (!this.chars[i].isEmpty()) {
+                    empty = false;
+                    break;
+                }
+            }
+            return empty;
+        },
+
+        /**
+         *  Set the cursor to a valid column.
+         */
+        setCursor : function(absPos) {
+            if (this.pos !== absPos) {
+                this.pos = absPos;
+            }
+            if (this.pos < 0) {
+                logger.log("ERROR", "Negative cursor position " + this.pos);
+                this.pos = 0;
+            } else if (this.pos > NR_COLS) {
+                logger.log("ERROR", "Too large cursor position " + this.pos);
+                this.pos = NR_COLS;
+            }
+        },
+
+        /** 
+         * Move the cursor relative to current position.
+         */
+        moveCursor : function(relPos) {
+            var newPos = this.pos + relPos;
+            if (relPos > 1) {
+                for (var i = this.pos+1; i < newPos+1 ; i++) {
+                    this.chars[i].setPenState(this.currPenState);
+                }
+            }
+            this.setCursor(newPos);
+        },
+
+        /**
+         * Backspace, move one step back and clear character.
+         */
+        backSpace : function () {
+            this.moveCursor(-1);
+            this.chars[this.pos].setChar(' ', this.currPenState);
+        },
+
+        insertChar: function(byte) {
+            if (byte >= 0x90) { //Extended char
+                this.backSpace();
+            }
+            var char = getCharForByte(byte);
+            if (this.pos >= NR_COLS) {
+                logger.log("ERROR", "Cannot insert " + byte.toString(16) +  
+                            " (" + char + ") at position " + this.pos + ". Skipping it!");
+                return;
+            }
+            this.chars[this.pos].setChar(char, this.currPenState);
+            this.moveCursor(1);
+        },
+
+        clearFromPos : function(startPos) {
+            var i;
+            for (i = startPos ; i < NR_COLS ; i++) {
+                this.chars[i].reset();
+            }
+        },
+
+        clear : function() {
+            this.clearFromPos(0);
+            this.pos = 0;
+            this.currPenState.reset();
+        },
+
+        clearToEndOfRow : function() {
+            this.clearFromPos(this.pos);
+        },
+
+        getTextString: function() {
+            var chars = [];
+            var empty = true;
+            for (var i = 0 ; i < NR_COLS ; i++) {
+                var char = this.chars[i].uchar;
+                if (char !== " ") {
+                    empty = false;
+                }
+                chars.push(char);
+            }
+            if (empty) {
+                return "";
+            } else {
+                return chars.join("");
+            }
+        },
+
+        setPenStyles: function(styles) {
+            this.currPenState.setStyles(styles);
+            var currChar = this.chars[this.pos];
+            currChar.setPenState(this.currPenState);
+        }
+    };
+
+    /**
+     * Keep a CEA-608 screen of 32x15 styled characters
+     * @constructor
+    */
+    var CaptionScreen = function() {
+
+        this.rows = [];
+        for (var i = 0 ; i <  NR_ROWS; i++) {
+            this.rows.push(new Row()); // Note that we use zero-based numbering (0-14)
+        }
+        this.currRow = NR_ROWS - 1;
+        this.nrRollUpRows = null;
+        this.reset();
+    };
+
+    CaptionScreen.prototype = {
+
+        reset : function() {
+            for (var i = 0 ; i < NR_ROWS ; i++) {
+                this.rows[i].clear();
+            }
+            this.currRow = NR_ROWS - 1;
+        },
+
+        equals : function(other) {
+            var equal = true;
+            for (var i = 0 ; i < NR_ROWS ; i++) {
+                if (!this.rows[i].equals(other.rows[i])) {
+                    equal = false;
+                    break;
+                }
+            }
+            return equal;
+        },
+
+        copy : function(other) {
+            for (var i = 0 ; i < NR_ROWS ; i++) {
+                this.rows[i].copy(other.rows[i]);
+            }
+        },
+
+        isEmpty : function() {
+            var empty = true;
+            for (var i = 0 ; i < NR_ROWS ; i++) {
+                if (!this.rows[i].isEmpty()) {
+                    empty = false;
+                    break;
+                }
+            }
+            return empty;
+        },
+
+        backSpace : function() {
+            var row = this.rows[this.currRow]; 
+            row.backSpace();
+        },
+
+        clearToEndOfRow : function() {
+            var row = this.rows[this.currRow];
+            row.clearToEndOfRow();
+        },
+
+        /**
+         * Insert a character (without styling) in the current row.
+         */
+        insertChar : function(char) {
+            var row = this.rows[this.currRow];
+            row.insertChar(char);
+        },
+
+        setPen : function(styles) {
+            var row = this.rows[this.currRow];
+            row.setPenStyles(styles);
+        },
+
+        moveCursor : function(relPos) {
+            var row = this.rows[this.currRow];
+            row.moveCursor(relPos); 
+        },
+
+        setCursor : function(absPos) {
+            logger.log("INFO", "setCursor: " + absPos);
+            var row = this.rows[this.currRow];
+            row.setCursor(absPos);
+        },
+
+        setPAC : function(pacData) {
+            logger.log("INFO", "pacData = " + JSON.stringify(pacData));
+            var newRow = pacData.row - 1;
+            if (this.nrRollUpRows  && newRow < this.nrRollUpRows - 1) {
+                    newRow = this.nrRollUpRows-1;
+            }
+            this.currRow = newRow;
+            var row = this.rows[this.currRow];
+            if (pacData.indent !== null) {
+                var indent = pacData.indent;
+                var prevPos = Math.max(indent-1, 0);
+                row.setCursor(pacData.indent);
+                pacData.color = row.chars[prevPos].penState.foreground;
+            }
+            var styles = {foreground : pacData.color, underline : pacData.underline, italics : pacData.italics, background : 'black', flash : false};
+            this.setPen(styles);
+        },
+
+        /**
+         * Set background/extra foreground, but first do back_space, and then insert space (backwards compatibility).
+         */
+        setBkgData : function(bkgData) {
+
+            logger.log("INFO", "bkgData = " + JSON.stringify(bkgData));
+            this.backSpace();
+            this.setPen(bkgData);
+            this.insertChar(0x20); //Space
+        },
+
+        setRollUpRows : function(nrRows) {
+            this.nrRollUpRows = nrRows;
+        },
+
+        rollUp : function() {
+            if (this.nrRollUpRows === null) {
+                logger.log("DEBUG", "roll_up but nrRollUpRows not set yet");
+                return; //Not properly setup
+            }
+            logger.log("TEXT", this.getDisplayText());
+            var topRowIndex = this.currRow + 1 - this.nrRollUpRows;
+            var topRow = this.rows.splice(topRowIndex, 1)[0];
+            topRow.clear();
+            this.rows.splice(this.currRow, 0, topRow);
+            logger.log("INFO", "Rolling up");
+            //logger.log("TEXT", this.get_display_text())
+        },
+
+       /**
+        * Get all non-empty rows with as unicode text. 
+        */        
+        getDisplayText : function(asOneRow) {
+            asOneRow = asOneRow || false;
+            var displayText = [];
+            var text = "";
+            var rowNr = -1;
+            for (var i = 0 ; i < NR_ROWS ; i++) {
+                var rowText = this.rows[i].getTextString();
+                if (rowText) {
+                    rowNr = i+1;
+                    if (asOneRow) {
+                        displayText.push("Row " + rowNr + ': "' + rowText + '"');
+                    } else {
+                        displayText.push(rowText.trim());
+                    }
+                }
+            }
+            if (displayText.length > 0) {
+                if (asOneRow) {
+                    text = "[" + displayText.join(" | ") + "]";
+                } else {
+                    text = displayText.join("\n");
+                }
+            }
+            return text;
+        },
+
+        getTextAndFormat : function() {
+            return this.rows;
+        }
+    };
+
+    /**
+     * Handle a CEA-608 channel and send decoded data to outputFilter
+     * @constructor
+     * @param {Number} channelNumber (1 or 2)
+     * @param {CueHandler} outputFilter Output from channel1 newCue(startTime, endTime, captionScreen)
+    */
+    var Cea608Channel = function(channelNumber, outputFilter) {
+
+        this.chNr = channelNumber;
+        this.outputFilter = outputFilter;
+        this.mode = null;
+        this.verbose = 0;
+        this.displayedMemory = new CaptionScreen();
+        this.nonDisplayedMemory = new CaptionScreen();
+        this.lastOutputScreen = new CaptionScreen();
+        this.currRollUpRow = this.displayedMemory.rows[NR_ROWS-1];
+        this.writeScreen = this.displayedMemory;
+        this.mode = null;
+        this.cueStartTime = null; // Keeps track of where a cue started.
+    };
+
+    Cea608Channel.prototype = {
+        
+        modes : ["MODE_ROLL-UP", "MODE_POP-ON", "MODE_PAINT-ON", "MODE_TEXT"],
+        
+        reset : function() {
+            this.mode = null;
+            this.displayedMemory.reset();
+            this.nonDisplayedMemory.reset();
+            this.lastOutputScreen.reset();
+            this.currRollUpRow = this.displayedMemory.rows[NR_ROWS-1];
+            this.writeScreen = this.displayedMemory;
+            this.mode = null;
+            this.cueStartTime = null;
+            this.lastCueEndTime = null;
+        },
+
+        getHandler : function() {
+            return this.outputFilter;
+        },
+
+        setHandler : function(newHandler) {
+            this.outputFilter = newHandler;
+        },
+
+        setPAC : function(pacData) {
+            this.writeScreen.setPAC(pacData);
+        },
+
+        setBkgData : function(bkgData) {
+            this.writeScreen.setBkgData(bkgData);
+        },
+
+        setMode : function(newMode) {
+            if (newMode === this.mode) {
+                return;
+            }
+            this.mode = newMode;
+            logger.log("INFO", "MODE=" + newMode);
+            if (this.mode == "MODE_POP-ON") {
+                this.writeScreen = this.nonDisplayedMemory;
+            } else {
+                this.writeScreen = this.displayedMemory;
+                this.writeScreen.reset();
+            }
+            if (this.mode !== "MODE_ROLL-UP") {
+                this.displayedMemory.nrRollUpRows = null;
+                this.nonDisplayedMemory.nrRollUpRows = null;
+            }
+            this.mode = newMode;
+        },
+
+        insertChars : function(chars) {
+            for (var i = 0 ; i < chars.length ; i++) {
+                this.writeScreen.insertChar(chars[i]);
+            }
+            var screen = this.writeScreen === this.displayedMemory ? "DISP" : "NON_DISP";
+            logger.log("INFO", screen + ": " + this.writeScreen.getDisplayText(true));
+            if (this.mode === "MODE_PAINT-ON" || this.mode === "MODE_ROLL-UP") {
+                logger.log("TEXT", "DISPLAYED: " + this.displayedMemory.getDisplayText(true));
+                this.outputDataUpdate();
+            }
+        },
+
+        cc_RCL: function() { // Resume Caption Loading (switch mode to Pop On)
+            logger.log("INFO", "RCL - Resume Caption Loading");
+            this.setMode("MODE_POP-ON");
+        },
+        cc_BS: function() { // BackSpace
+            logger.log("INFO", "BS - BackSpace");
+            if (this.mode === "MODE_TEXT") {
+                return;
+            }
+            this.writeScreen.backSpace();
+            if (this.writeScreen === this.displayedMemory) {
+                this.outputDataUpdate();
+            }
+        },
+        cc_AOF : function() { // Reserved (formerly Alarm Off)
+            return;
+        },
+        cc_AON: function() { // Reserved (formerly Alarm On)
+            return;
+        },
+        cc_DER: function() { // Delete to End of Row
+            logger.log("INFO", "DER- Delete to End of Row");
+            this.writeScreen.clearToEndOfRow();
+            this.outputDataUpdate();
+        },
+        cc_RU: function(nrRows) { //Roll-Up Captions-2,3,or 4 Rows
+            logger.log("INFO", "RU(" + nrRows +") - Roll Up");
+            this.writeScreen = this.displayedMemory;
+            this.setMode("MODE_ROLL-UP");
+            this.writeScreen.setRollUpRows(nrRows);
+        },
+        cc_FON: function() { //Flash On
+            logger.log("INFO", "FON - Flash On");
+            this.writeScreen.setPen({flash : true});
+        },
+        cc_RDC: function() { // Resume Direct Captioning (switch mode to PaintOn)
+            logger.log("INFO", "RDC - Resume Direct Captioning");
+            this.setMode("MODE_PAINT-ON");
+        },
+        cc_TR: function() { // Text Restart in text mode (not supported, however)
+            logger.log("INFO", "TR");
+            this.setMode("MODE_TEXT");
+        },
+        cc_RTD: function() { // Resume Text Display in Text mode (not supported, however)
+            logger.log("INFO", "RTD");
+            this.setMode("MODE_TEXT");
+        },
+        cc_EDM: function() { // Erase Displayed Memory
+            logger.log("INFO", "EDM - Erase Displayed Memory");
+            this.displayedMemory.reset();
+            this.outputDataUpdate();
+        },
+        cc_CR: function() { // Carriage Return
+            logger.log("CR - Carriage Return");
+            this.writeScreen.rollUp();
+            this.outputDataUpdate();
+        },
+        cc_ENM: function() { //Erase Non-Displayed Memory
+            logger.log("INFO", "ENM - Erase Non-displayed Memory");
+            this.nonDisplayedMemory.reset();
+        },
+        cc_EOC: function() { //End of Caption (Flip Memories)
+            logger.log("INFO", "EOC - End Of Caption");
+            if (this.mode === "MODE_POP-ON") {
+                var tmp = this.displayedMemory;
+                this.displayedMemory = this.nonDisplayedMemory;
+                this.nonDisplayedMemory = tmp;
+                this.writeScreen = this.nonDisplayedMemory;
+                logger.log("TEXT", "DISP: " + this.displayedMemory.getDisplayText());
+            }
+            this.outputDataUpdate();
+        },
+        cc_TO: function(nrCols) { // Tab Offset 1,2, or 3 columns
+            logger.log("INFO", "TO(" + nrCols + ") - Tab Offset");
+            this.writeScreen.moveCursor(nrCols);
+        },
+        cc_MIDROW: function(secondByte) { // Parse MIDROW command
+            var styles = {flash : false};
+            styles.underline = secondByte % 2 === 1;
+            styles.italics = secondByte >= 0x2e;
+            if (!styles.italics) {
+                var colorIndex = Math.floor(secondByte/2) - 0x10;
+                var colors = ["white", "green", "blue", "cyan", "red", "yellow", "magenta"];
+                styles.foreground = colors[colorIndex];
+            } else {
+                styles.foreground = "white";
+            }
+            logger.log("INFO", "MIDROW: " + JSON.stringify(styles));
+            this.writeScreen.setPen(styles);
+        },
+
+        outputDataUpdate: function() {
+            var t = logger.time;
+            if (t === null) {
+                return;
+            }
+            if (this.outputFilter) {
+                if (this.outputFilter.updateData) {
+                    this.outputFilter.updateData(t, this.displayedMemory);
+                }
+                if (this.cueStartTime === null && !this.displayedMemory.isEmpty()) { // Start of a new cue
+                    this.cueStartTime = t;
+                } else {
+                    if (!this.displayedMemory.equals(this.lastOutputScreen)) { 
+                        if (this.outputFilter.newCue) {
+                            this.outputFilter.newCue(this.cueStartTime, t, this.lastOutputScreen);
+                        }
+                        this.cueStartTime = this.displayedMemory.isEmpty() ? null : t;
+                    }
+                }
+                this.lastOutputScreen.copy(this.displayedMemory);
+            }
+        },
+
+        cueSplitAtTime : function(t) {
+            if (this.outputFilter) {
+                if (!this.displayedMemory.isEmpty()) {
+                    if (this.outputFilter.newCue) {
+                        this.outputFilter.newCue(this.cueStartTime, t, this.displayedMemory);
+                    }
+                    this.cueStartTime = t;
+                }
+            }
+        }
+    };
+
+    /**
+     * Parse CEA-608 data and send decoded data to out1 and out2.
+     * @constructor
+     * @param {Number} field  CEA-608 field (1 or 2)
+     * @param {CueHandler} out1 Output from channel1 newCue(startTime, endTime, captionScreen)
+     * @param {CueHandler} out2 Output from channel2 newCue(startTime, endTime, captionScreen)
+     */
+    var Cea608Parser = function(field, out1, out2) {
+        this.field = field || 1;
+        this.outputs = [out1, out2];
+        this.channels = [new Cea608Channel(1, out1), new Cea608Channel(2, out2)];
+        this.currChNr = -1; // Will be 1 or 2
+        this.lastCmdA = null; // First byte of last command
+        this.lastCmdB = null; // Second byte of last command
+        this.bufferedData = [];
+        this.startTime = null;
+        this.lastTime = null;
+        this.dataCounters = {'padding' : 0, 'char' : 0, 'cmd' : 0, 'other' : 0};
+    };
+
+    Cea608Parser.prototype = {
+        
+        getHandler : function(index) {
+            return this.channels[index].getHandler();
+        },
+        
+        setHandler : function(index, newHandler) {
+            this.channels[index].setHandler(newHandler);
+        },
+
+        /**
+         * Add data for time t in forms of list of bytes (unsigned ints). The bytes are treated as pairs.
+         */
+        addData : function(t, byteList) {
+            var cmdFound, a, b, 
+            charsFound = false;
+            
+            this.lastTime = t;
+            logger.setTime(t);
+
+            for (var i = 0 ; i < byteList.length ; i+=2) {
+                a = byteList[i] & 0x7f;
+                b = byteList[i+1] & 0x7f;
+                if (a === 0 && b === 0) {
+                    this.dataCounters.padding += 2;
+                    continue;
+                } else {
+                    logger.log("DATA", "[" + numArrayToHexArray([byteList[i], byteList[i+1]]) +"] -> (" + numArrayToHexArray([a, b]) + ")");
+                }
+                cmdFound = this.parseCmd(a, b);
+                if (!cmdFound) {
+                    cmdFound = this.parseMidrow(a, b);
+                }
+                if (!cmdFound) {
+                    cmdFound = this.parsePAC(a, b);
+                }
+                if (!cmdFound) {
+                    cmdFound = this.parseBackgroundAttributes(a, b);
+                }
+                if (!cmdFound) {
+                    charsFound = this.parseChars(a, b);
+                    if (charsFound) {
+                        if (this.currChNr && this.currChNr >=0) {
+                            var channel = this.channels[this.currChNr-1];
+                            channel.insertChars(charsFound);
+                        } else {
+                            logger.log("WARNING", "No channel found yet. TEXT-MODE?");
+                        }
+                    }
+                }
+                if (cmdFound) {
+                    this.dataCounters.cmd += 2;
+                } else if (charsFound) {
+                    this.dataCounters.char += 2;
+                } else {
+                    this.dataCounters.other += 2;
+                    logger.log("WARNING", "Couldn't parse cleaned data " + numArrayToHexArray([a, b]) +
+                                " orig: " + numArrayToHexArray([byteList[i], byteList[i+1]]));
+                }
+            }
+        },
+
+        /**
+         * Parse Command.
+         * @returns {Boolean} Tells if a command was found
+         */
+        parseCmd: function(a, b) {
+            var chNr = null;
+
+            var cond1 = (a === 0x14 || a === 0x1C) && (0x20 <= b && b <= 0x2F);
+            var cond2 = (a === 0x17 || a === 0x1F) && (0x21 <= b && b <= 0x23);
+            if (!(cond1 || cond2)) {
+                return false;
+            }
+                 
+            if (a === this.lastCmdA && b === this.lastCmdB) {
+                this.lastCmdA = null;
+                this.lastCmdB = null; // Repeated commands are dropped (once)
+                logger.log("DEBUG", "Repeated command (" + numArrayToHexArray([a, b]) + ") is dropped");
+                return true;
+            }
+
+            if (a === 0x14 || a === 0x17) {
+                chNr = 1;
+            } else {
+                chNr = 2; // (a === 0x1C || a=== 0x1f)
+            }
+
+            var channel = this.channels[chNr - 1];
+
+            if (a === 0x14 || a === 0x1C) {
+                if (b === 0x20) {
+                    channel.cc_RCL();
+                } else if (b === 0x21) {
+                    channel.cc_BS();
+                } else if (b === 0x22) {
+                    channel.cc_AOF();
+                } else if (b === 0x23) {
+                    channel.cc_AON();
+                } else if (b === 0x24) {
+                    channel.cc_DER();
+                } else if (b === 0x25) {
+                    channel.cc_RU(2);
+                } else if (b === 0x26) {
+                    channel.cc_RU(3);
+                } else if (b === 0x27) {
+                    channel.cc_RU(4);
+                } else if (b === 0x28) {
+                    channel.cc_FON();
+                } else if (b === 0x29) {
+                    channel.cc_RDC();
+                } else if (b === 0x2A) {
+                    channel.cc_TR();
+                } else if (b === 0x2B) {
+                    channel.cc_RTD();
+                } else if (b === 0x2C) {
+                    channel.cc_EDM();
+                } else if (b === 0x2D) {
+                    channel.cc_CR();
+                } else if (b === 0x2E) {
+                    channel.cc_ENM();
+                } else if (b === 0x2F) {
+                    channel.cc_EOC();
+                }
+            } else { //a == 0x17 || a == 0x1F
+                channel.cc_TO(b - 0x20);
+            }
+            this.lastCmdA = a;
+            this.lastCmdB = b;
+            this.currChNr = chNr;
+            return true;
+        },
+
+        /**
+         * Parse midrow styling command
+         * @returns {Boolean}
+         */
+        parseMidrow : function(a, b) {
+            var chNr = null;
+                
+            if ( ((a === 0x11) || (a === 0x19)) && 0x20 <= b && b <= 0x2f) {
+                if (a === 0x11) {
+                    chNr = 1;
+                } else  {
+                    chNr = 2;
+                }
+                if (chNr !== this.currChNr) {
+                    logger.log("ERROR", "Mismatch channel in midrow parsing");
+                    return false;
+                }
+                var channel = this.channels[chNr-1];
+                channel.cc_MIDROW(b);
+                logger.log("DEBUG", "MIDROW (" + numArrayToHexArray([a, b]) + ")");
+                return true;
+            }
+            return false;
+        },
+        /**
+         * Parse Preable Access Codes (Table 53).
+         * @returns {Boolean} Tells if PAC found
+         */
+        parsePAC : function(a, b) {
+
+           var chNr = null;
+           var row = null;
+            
+            var case1 = ((0x11 <= a  && a <= 0x17) || (0x19 <= a && a <= 0x1F)) && (0x40 <= b && b <= 0x7F);
+            var case2 = (a === 0x10 || a === 0x18) && (0x40 <= b && b <= 0x5F);
+            if (! (case1 || case2)) {
+                return false;
+            }
+
+            if (a === this.lastCmdA && b === this.lastCmdB) {
+                this.lastCmdA = null;
+                this.lastCmdB = null;
+                return true; // Repeated commands are dropped (once)
+            }
+
+            chNr = (a <= 0x17) ? 1 : 2;
+
+            if (0x40 <= b && b <= 0x5F) {
+                row = (chNr === 1) ? rowsLowCh1[a] : rowsLowCh2[a];
+            } else { // 0x60 <= b <= 0x7F
+                row = (chNr === 1) ? rowsHighCh1[a] : rowsHighCh2[a];
+            }
+            var pacData = this.interpretPAC(row, b);
+            var channel = this.channels[chNr-1];
+            channel.setPAC(pacData);
+            this.lastCmdA = a;
+            this.lastCmdB = b;
+            this.currChNr = chNr;
+            return true;
+        },
+
+        /**
+         * Interpret the second byte of the pac, and return the information.
+         * @returns {Object} pacData with style parameters.
+         */
+        interpretPAC : function (row, byte) {
+            var pacIndex = byte;
+            var pacData = {color : null, italics : false, indent : null, underline : false, row : row};
+            
+            if (byte > 0x5F) {
+                pacIndex = byte - 0x60;
+            } else {
+                pacIndex = byte - 0x40;
+            }
+            pacData.underline = (pacIndex & 1) === 1;
+            if (pacIndex <= 0xd) {
+                pacData.color = ['white', 'green', 'blue', 'cyan', 'red', 'yellow', 'magenta', 'white'][Math.floor(pacIndex/2)];
+            } else if (pacIndex <= 0xf) {
+                pacData.italics = true;
+                pacData.color = 'white';
+            } else {
+                pacData.indent = (Math.floor((pacIndex-0x10)/2))*4;
+            }
+            return pacData; // Note that row has zero offset. The spec uses 1.
+        },
+
+        /**
+         * Parse characters.
+         * @returns An array with 1 to 2 codes corresponding to chars, if found. null otherwise.
+         */
+        parseChars : function(a, b) {
+
+           var  channelNr = null,
+                charCodes = null,
+                charCode1 = null,
+                charCode2 = null;
+
+            if (a >= 0x19) {
+                channelNr = 2;
+                charCode1 = a - 8;
+            } else {
+                channelNr = 1;
+                charCode1 = a;
+            }
+            if (0x11 <= charCode1 && charCode1 <= 0x13) {
+                // Special character
+                var oneCode = b;
+                if (charCode1 === 0x11) {
+                    oneCode = b + 0x50;
+                } else if (charCode1 === 0x12) {
+                    oneCode = b + 0x70;
+                } else {
+                    oneCode = b + 0x90;
+                }
+                logger.log("INFO", "Special char '" + getCharForByte(oneCode) + "' in channel " + channelNr);
+                charCodes = [oneCode];
+            } else if (0x20 <= a && a <= 0x7f) {
+                charCodes = (b === 0) ? [a] : [a, b];
+            }
+            if (charCodes) {
+                var hexCodes = numArrayToHexArray(charCodes);
+                logger.log("DEBUG", "Char codes =  " + hexCodes.join(","));
+                this.lastCmdA = null;
+                this.lastCmdB = null;
+            }
+            return charCodes;
+        },
+        
+        /**
+        * Parse extended background attributes as well as new foreground color black.
+        * @returns{Boolean} Tells if background attributes are found
+        */
+        parseBackgroundAttributes : function(a, b) {
+           var  bkgData,
+                index,
+                chNr,
+                channel;
+
+            var case1 = (a === 0x10 || a === 0x18) && (0x20 <= b && b <= 0x2f);
+            var case2 = (a === 0x17 || a === 0x1f) && (0x2d <=b && b <= 0x2f);
+            if (!(case1 || case2)) {
+                return false;
+            }
+            bkgData = {};
+            if (a  === 0x10 || a === 0x18) {
+                index = Math.floor((b-0x20)/2);
+                bkgData.background = backgroundColors[index];
+                if (b % 2 === 1) {
+                    bkgData.background = bkgData.background + "_semi";
+                }
+            } else if (b === 0x2d) {
+                bkgData.background = "transparent";
+            } else {
+                bkgData.foreground = "black";
+                if (b === 0x2f) {
+                    bkgData.underline = true;
+                }
+            }
+            chNr = (a < 0x18) ? 1 : 2;
+            channel = this.channels[chNr-1];
+            channel.setBkgData(bkgData);
+            this.lastCmdA = null;
+            this.lastCmdB = null;
+            return true;
+        },
+
+        /**
+         * Reset state of parser and its channels.
+         */
+        reset : function() {
+            for (var i=0 ; i < this.channels.length ; i++) {
+                if (this.channels[i]) {
+                    this.channels[i].reset();
+                }
+            }
+            this.lastCmdA = null;
+            this.lastCmdB = null;
+        },
+
+        /**
+         * Trigger the generation of a cue, and the start of a new one if displayScreens are not empty.
+         */
+        cueSplitAtTime : function(t) {
+            for (var i=0 ; i < this.channels.length ; i++) {
+                if (this.channels[i]) {
+                    this.channels[i].cueSplitAtTime(t);
+                }
+            }
+        },
+    };
+
+    exports.logger = logger;
+    exports.PenState = PenState;
+    exports.CaptionScreen = CaptionScreen;  
+    exports.Cea608Parser = Cea608Parser;
+
+}(typeof exports === 'undefined' ? this.cea608parser = {} : exports));

--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -245,3 +245,7 @@ chart {
     font-size: 22px;
     color: #555;
 }
+
+#videoContainer {
+    position:relative;
+}

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -310,6 +310,11 @@
             "name": "BBC R&D EBU-TT-D Subtitling Test",
             "url": "http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd",
             "browsers": ""
+        },
+         {
+            "name": "Emedded CEA-608 captions and segmented subs (VoD)",
+            "url": "http://vm2.dashif.org/dash/vod/testpic_2s/cea608_and_segs.mpd",
+            "browsers": ""
         }
     ]
 }

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -129,7 +129,17 @@ function DashAdapter() {
         viewpoint = manifestExt.getViewpointForAdaptation(a);
         mediaInfo.viewpoint = viewpoint ? viewpoint.value : undefined;
         mediaInfo.accessibility = manifestExt.getAccessibilityForAdaptation(a).map(function (accessibility) {
-            return accessibility.value;
+            let accessibilityValue = accessibility.value;
+            let accessiblityData = accessibilityValue;
+            if (accessibility.schemeIdUri && (accessibility.schemeIdUri.search("cea-608") >= 0)) {
+                if (accessibilityValue) {
+                    accessiblityData = "cea-608:" + accessibilityValue;
+               } else {
+                    accessiblityData = "cea-608";
+               }
+               mediaInfo.embeddedCaptions = true;
+            }
+            return accessiblityData;
         });
         mediaInfo.audioChannelConfiguration =  manifestExt.getAudioChannelConfigurationForAdaptation(a).map(function (audioChannelConfiguration) {
             return audioChannelConfiguration.value;
@@ -151,6 +161,17 @@ function DashAdapter() {
         mediaInfo.isText = manifestExt.getIsTextTrack(mediaInfo.mimeType);
 
         return mediaInfo;
+    }
+    
+    function convertVideoInfoToEmbeddedTextInfo(mediaInfo, channel, lang) {
+        mediaInfo.id = channel; // CC1, CC2, CC3, or CC4
+        mediaInfo.index = 100 + parseInt(channel.substring(2, 3));
+        mediaInfo.type = "embeddedText";
+        mediaInfo.codec = "cea-608-in-SEI";
+        mediaInfo.isText = true;
+        mediaInfo.isEmbedded = true;
+        mediaInfo.lang = channel + " " + lang;
+        mediaInfo.roles = ['caption'];
     }
 
     function convertPeriodToStreamInfo(manifest, period) {
@@ -199,24 +220,63 @@ function DashAdapter() {
     function getAllMediaInfoForType(manifest, streamInfo, type) {
         var periodInfo = getPeriodForStreamInfo(streamInfo);
         var periodId = periodInfo.id;
-        var adaptationsForType = manifestExt.getAdaptationsForType(manifest, streamInfo.index, type);
+        var adaptationsForType = manifestExt.getAdaptationsForType(manifest, streamInfo.index, type !== "embeddedText" ? type : "video");
 
         var mediaArr = [];
 
         var data,
             media,
-            idx;
+            idx,
+            i,
+            j,
+            ln;
 
         if (!adaptationsForType) return mediaArr;
 
         adaptations[periodId] = adaptations[periodId] || manifestExt.getAdaptationsForPeriod(manifest, periodInfo);
 
-        for (var i = 0, ln = adaptationsForType.length; i < ln; i++) {
+        for (i = 0, ln = adaptationsForType.length; i < ln; i++) {
             data = adaptationsForType[i];
             idx = manifestExt.getIndexForAdaptation(data, manifest, streamInfo.index);
             media = convertAdaptationToMediaInfo(manifest, adaptations[periodId][idx]);
 
-            if (media) {
+            if (type === "embeddedText") {
+                var accessibilityLength = media.accessibility.length;
+                for (j = 0; j < accessibilityLength; j++) {
+                    if (!media) {
+                        continue;
+                    }
+                    var accessibility = media.accessibility[j];
+                    if (accessibility.indexOf("cea-608:") === 0) {
+                        var value = accessibility.substring(8);
+                        var parts = value.split(";");
+                        if (parts[0].substring(0, 2) === "CC") {
+                            for (j = 0; j < parts.length; j++) {
+                                if (!media) {
+                                    media = convertAdaptationToMediaInfo.call(this, manifest, adaptations[periodId][idx]);
+                                }
+                                convertVideoInfoToEmbeddedTextInfo(media, parts[j].substring(0, 3), parts[j].substring(4));
+                                mediaArr.push(media);
+                                media = null;
+                            }
+                        } else {
+                            for (j = 0; j < parts.length; j++) { // Only languages for CC1, CC2, ...
+                                if (!media) {
+                                    media = convertAdaptationToMediaInfo.call(this, manifest, adaptations[periodId][idx]);
+                                }
+                                convertVideoInfoToEmbeddedTextInfo(media, "CC" + (j + 1), parts[j]);
+                                mediaArr.push(media);
+                                media = null;
+                            }
+                        }
+                    } else if (accessibility.indexOf("cea-608") === 0) { // Nothing known. We interpret it as CC1=eng                        
+                        convertVideoInfoToEmbeddedTextInfo(media, "CC1", "eng");
+                        mediaArr.push(media);
+                        media = null;
+                    }
+                }
+            }
+            if (media && type !== "embeddedText") {
                 mediaArr.push(media);
             }
         }

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -131,13 +131,13 @@ function DashAdapter() {
         mediaInfo.accessibility = manifestExt.getAccessibilityForAdaptation(a).map(function (accessibility) {
             let accessibilityValue = accessibility.value;
             let accessiblityData = accessibilityValue;
-            if (accessibility.schemeIdUri && (accessibility.schemeIdUri.search("cea-608") >= 0)) {
+            if (accessibility.schemeIdUri && (accessibility.schemeIdUri.search('cea-608') >= 0) && typeof (cea608parser) !== 'undefined') {
                 if (accessibilityValue) {
-                    accessiblityData = "cea-608:" + accessibilityValue;
-               } else {
-                    accessiblityData = "cea-608";
-               }
-               mediaInfo.embeddedCaptions = true;
+                    accessiblityData = 'cea-608:' + accessibilityValue;
+                } else {
+                    accessiblityData = 'cea-608';
+                }
+                mediaInfo.embeddedCaptions = true;
             }
             return accessiblityData;
         });
@@ -162,15 +162,15 @@ function DashAdapter() {
 
         return mediaInfo;
     }
-    
+
     function convertVideoInfoToEmbeddedTextInfo(mediaInfo, channel, lang) {
         mediaInfo.id = channel; // CC1, CC2, CC3, or CC4
         mediaInfo.index = 100 + parseInt(channel.substring(2, 3));
-        mediaInfo.type = "embeddedText";
-        mediaInfo.codec = "cea-608-in-SEI";
+        mediaInfo.type = 'embeddedText';
+        mediaInfo.codec = 'cea-608-in-SEI';
         mediaInfo.isText = true;
         mediaInfo.isEmbedded = true;
-        mediaInfo.lang = channel + " " + lang;
+        mediaInfo.lang = channel + ' ' + lang;
         mediaInfo.roles = ['caption'];
     }
 
@@ -220,7 +220,7 @@ function DashAdapter() {
     function getAllMediaInfoForType(manifest, streamInfo, type) {
         var periodInfo = getPeriodForStreamInfo(streamInfo);
         var periodId = periodInfo.id;
-        var adaptationsForType = manifestExt.getAdaptationsForType(manifest, streamInfo.index, type !== "embeddedText" ? type : "video");
+        var adaptationsForType = manifestExt.getAdaptationsForType(manifest, streamInfo.index, type !== 'embeddedText' ? type : 'video');
 
         var mediaArr = [];
 
@@ -240,17 +240,17 @@ function DashAdapter() {
             idx = manifestExt.getIndexForAdaptation(data, manifest, streamInfo.index);
             media = convertAdaptationToMediaInfo(manifest, adaptations[periodId][idx]);
 
-            if (type === "embeddedText") {
+            if (type === 'embeddedText') {
                 var accessibilityLength = media.accessibility.length;
                 for (j = 0; j < accessibilityLength; j++) {
                     if (!media) {
                         continue;
                     }
                     var accessibility = media.accessibility[j];
-                    if (accessibility.indexOf("cea-608:") === 0) {
+                    if (accessibility.indexOf('cea-608:') === 0) {
                         var value = accessibility.substring(8);
-                        var parts = value.split(";");
-                        if (parts[0].substring(0, 2) === "CC") {
+                        var parts = value.split(';');
+                        if (parts[0].substring(0, 2) === 'CC') {
                             for (j = 0; j < parts.length; j++) {
                                 if (!media) {
                                     media = convertAdaptationToMediaInfo.call(this, manifest, adaptations[periodId][idx]);
@@ -264,19 +264,19 @@ function DashAdapter() {
                                 if (!media) {
                                     media = convertAdaptationToMediaInfo.call(this, manifest, adaptations[periodId][idx]);
                                 }
-                                convertVideoInfoToEmbeddedTextInfo(media, "CC" + (j + 1), parts[j]);
+                                convertVideoInfoToEmbeddedTextInfo(media, 'CC' + (j + 1), parts[j]);
                                 mediaArr.push(media);
                                 media = null;
                             }
                         }
-                    } else if (accessibility.indexOf("cea-608") === 0) { // Nothing known. We interpret it as CC1=eng                        
-                        convertVideoInfoToEmbeddedTextInfo(media, "CC1", "eng");
+                    } else if (accessibility.indexOf('cea-608') === 0) { // Nothing known. We interpret it as CC1=eng
+                        convertVideoInfoToEmbeddedTextInfo(media, 'CC1', 'eng');
                         mediaArr.push(media);
                         media = null;
                     }
                 }
             }
-            if (media && type !== "embeddedText") {
+            if (media && type !== 'embeddedText') {
                 mediaArr.push(media);
             }
         }

--- a/src/dash/extensions/FragmentExtensions.js
+++ b/src/dash/extensions/FragmentExtensions.js
@@ -50,6 +50,7 @@ function FragmentExtensions(/*config*/) {
         var tfdtBox = isoFile.getBox('tfdt');
         var trunBox = isoFile.getBox('trun');
         var moofBox = isoFile.getBox('moof');
+        var mfhdBox = isoFile.getBox('mfhd');
 
         var sampleDuration,
             sampleCompostionTimeOffset,
@@ -59,8 +60,11 @@ function FragmentExtensions(/*config*/) {
             sampleList,
             sample,
             i,
-            dataOffset;
+            dataOffset,
+            sequenceNumber,
+            totalDuration;
 
+        sequenceNumber = mfhdBox.sequence_number;
         sampleCount = trunBox.sample_count;
         sampleDts = tfdtBox.baseMediaDecodeTime;
         dataOffset = (tfhdBox.base_data_offset || 0) + (trunBox.data_offset || 0);
@@ -80,7 +84,8 @@ function FragmentExtensions(/*config*/) {
             dataOffset += sampleSize;
             sampleDts += sampleDuration;
         }
-        return sampleList;
+        totalDuration = sampleDts - tfdtBox.baseMediaDecodeTime;
+        return {sampleList : sampleList, sequenceNumber : sequenceNumber, totalDuration : totalDuration};
     }
 
     function getMediaTimescaleFromMoov(ab) {

--- a/src/dash/extensions/FragmentExtensions.js
+++ b/src/dash/extensions/FragmentExtensions.js
@@ -85,7 +85,7 @@ function FragmentExtensions(/*config*/) {
             sampleDts += sampleDuration;
         }
         totalDuration = sampleDts - tfdtBox.baseMediaDecodeTime;
-        return {sampleList : sampleList, sequenceNumber : sequenceNumber, totalDuration : totalDuration};
+        return {sampleList: sampleList, sequenceNumber: sequenceNumber, totalDuration: totalDuration};
     }
 
     function getMediaTimescaleFromMoov(ab) {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -44,6 +44,7 @@ import EventBus from '../core/EventBus.js';
 import Events from '../core/events/Events.js';
 import Debug from '../core/Debug.js';
 import FactoryMaker from '../core/FactoryMaker.js';
+import TextSourceBuffer from './TextSourceBuffer.js';
 
 function Stream(config) {
 
@@ -74,7 +75,8 @@ function Stream(config) {
         mediaController,
         fragmentController,
         eventController,
-        abrController;
+        abrController,
+        textSourceBuffer;
 
 
     function setup() {
@@ -91,6 +93,7 @@ function Stream(config) {
         abrController = AbrController(context).getInstance();
         mediaController = MediaController(context).getInstance();
         fragmentController = FragmentController(context).create();
+        textSourceBuffer = TextSourceBuffer(context).getInstance();
 
         eventBus.on(Events.BUFFERING_COMPLETED, onBufferingCompleted, instance);
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, instance);
@@ -250,7 +253,7 @@ function Stream(config) {
             return false;
         }
 
-        if ((type === 'text') || (type === 'fragmentedText')) return true;
+        if ((type === 'text') || (type === 'fragmentedText') || (type === 'embeddedText')) return true;
 
         codec = mediaInfo.codec;
         log(type + ' codec: ' + codec);
@@ -357,14 +360,20 @@ function Stream(config) {
         for (var i = 0, ln = allMediaForType.length; i < ln; i++) {
             mediaInfo = allMediaForType[i];
 
-            if (!isMediaSupported(mediaInfo, mediaSource, manifest)) continue;
+            if (type === 'embeddedText') {
+                textSourceBuffer.addEmbeddedTrack(mediaInfo);
+            } else {
+                if (!isMediaSupported(mediaInfo, mediaSource, manifest)) continue;
 
-            if (mediaController.isMultiTrackSupportedByType(mediaInfo.type)) {
-                mediaController.addTrack(mediaInfo, streamInfo);
+                if (mediaController.isMultiTrackSupportedByType(mediaInfo.type)) {
+                    mediaController.addTrack(mediaInfo, streamInfo);
+                }
             }
         }
-
-        if (mediaController.getTracksFor(type, streamInfo).length === 0) return;
+        
+        if (type === 'embeddedText' || mediaController.getTracksFor(type, streamInfo).length === 0) {
+         return;
+        }
 
         mediaController.checkInitialMediaSettings(streamInfo);
         initialMediaInfo = mediaController.getCurrentTrackFor(type, streamInfo);
@@ -393,6 +402,7 @@ function Stream(config) {
         initializeMediaForType('audio', mediaSource);
         initializeMediaForType('text', mediaSource);
         initializeMediaForType('fragmentedText', mediaSource);
+        initializeMediaForType('embeddedText', mediaSource);
         initializeMediaForType('muxed', mediaSource);
 
         createBuffers();

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -370,9 +370,9 @@ function Stream(config) {
                 }
             }
         }
-        
+
         if (type === 'embeddedText' || mediaController.getTracksFor(type, streamInfo).length === 0) {
-         return;
+            return;
         }
 
         mediaController.checkInitialMediaSettings(streamInfo);
@@ -406,7 +406,7 @@ function Stream(config) {
         initializeMediaForType('muxed', mediaSource);
 
         createBuffers();
-        
+
         //TODO. Consider initialization of TextSourceBuffer here if embeddedText, but no sideloadedText.
 
         isMediaInitialized = true;

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -406,6 +406,8 @@ function Stream(config) {
         initializeMediaForType('muxed', mediaSource);
 
         createBuffers();
+        
+        //TODO. Consider initialization of TextSourceBuffer here if embeddedText, but no sideloadedText.
 
         isMediaInitialized = true;
         isUpdating = false;

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -39,7 +39,7 @@ import TextTrackExtensions from './extensions/TextTrackExtensions.js';
 
 function TextSourceBuffer() {
 
-    let context = this.context;    
+    let context = this.context;
     let log = Debug(context).getInstance().log;
     let embeddedInitialized = false;
     let captionId = 0;
@@ -82,7 +82,7 @@ function TextSourceBuffer() {
         timescale = NaN;
         fragmentedTracks = [];
         firstSubtitleStart = null;
-        
+
         if (!embeddedInitialized) {
             initEmbedded();
         }
@@ -99,17 +99,17 @@ function TextSourceBuffer() {
         if (isFragmented) {
             fragmentModel = streamProcessor.getFragmentModel();
             this.buffered =  CustomTimeRanges(context).create();
-            fragmentedTracks = mediaController.getTracksFor("fragmentedText", streamController.getActiveStreamInfo());
-            var currFragTrack = mediaController.getCurrentTrackFor("fragmentedText", streamController.getActiveStreamInfo());
+            fragmentedTracks = mediaController.getTracksFor('fragmentedText', streamController.getActiveStreamInfo());
+            var currFragTrack = mediaController.getCurrentTrackFor('fragmentedText', streamController.getActiveStreamInfo());
             for (var i = 0 ; i < fragmentedTracks.length; i++) {
-               if (fragmentedTracks[i] === currFragTrack) {
-                   currFragmentedTrackIdx = i;
-                   break;
-               }
+                if (fragmentedTracks[i] === currFragTrack) {
+                    currFragmentedTrackIdx = i;
+                    break;
+                }
             }
         }
     }
-    
+
     function initEmbedded() {
         embeddedTracks = [];
         mediaInfos = [];
@@ -159,7 +159,7 @@ function TextSourceBuffer() {
                 }
                 return ttml;
             };
-            
+
             textTrackInfo.captionData = captionData;
             textTrackInfo.lang = mediaInfo.lang;
             textTrackInfo.label = mediaInfo.id; // AdaptationSet id (an unsigned int)
@@ -210,7 +210,7 @@ function TextSourceBuffer() {
                 errHandler.timedTextError(e, 'parse', ccContent);
             }
         } else if (mediaType === 'video') { //embedded text
-            if (chunk.segmentType === "Initialization Segment") {
+            if (chunk.segmentType === 'Initialization Segment') {
                 if (embeddedTimescale === 0) {
                     embeddedTimescale = fragmentExt.getMediaTimescaleFromMoov(bytes);
                     for (i = 0; i < embeddedTracks.length; i++) {
@@ -219,7 +219,7 @@ function TextSourceBuffer() {
                 }
             } else { // MediaSegment
                 if (embeddedTimescale === 0) {
-                    log("CEA-608: No timescale for embeddedTextTrack yet");
+                    log('CEA-608: No timescale for embeddedTextTrack yet');
                     return;
                 }
                 var makeCueAdderForIndex = function (self, trackIndex) {
@@ -227,19 +227,19 @@ function TextSourceBuffer() {
                         var captionsArray = null;
                         if (videoModel.getTTMLRenderingDiv()) {
                             captionsArray = createHTMLCaptionsFromScreen(videoModel.getElement(), startTime, endTime, captionScreen);
-                        } else { 
+                        } else {
                             var text = captionScreen.getDisplayText();
                             //console.log("CEA text: " + startTime + "-" + endTime + "  '" + text + "'");
                             captionsArray = [{ start: startTime, end: endTime, data: text, styles: {} }];
-                        } 
+                        }
                         if (captionsArray) {
                             textTrackExtensions.addCaptions(trackIndex, 0, captionsArray);
                         }
                     }
                     return newCue;
                 };
-                
-            
+
+
                 samplesInfo = fragmentExt.getSamplesInfo(bytes);
                 var sequenceNumber = samplesInfo.sequenceNumber;
 
@@ -247,15 +247,15 @@ function TextSourceBuffer() {
                     // Time to setup the CEA-608 parsing
                     let field, handler, trackIdx;
                     for (i = 0; i < embeddedTracks.length; i++) {
-                        if (embeddedTracks[i].id === "CC1") {
+                        if (embeddedTracks[i].id === 'CC1') {
                             field = 0;
-                            trackIdx = textTrackExtensions.getTrackIdxForId("CC1");
-                        } else if (embeddedTracks[i].id === "CC3") {
+                            trackIdx = textTrackExtensions.getTrackIdxForId('CC1');
+                        } else if (embeddedTracks[i].id === 'CC3') {
                             field = 1;
-                            trackIdx = textTrackExtensions.getTrackIdxForId("CC3");
+                            trackIdx = textTrackExtensions.getTrackIdxForId('CC3');
                         }
                         if (trackIdx === -1) {
-                            console.log("CEA-608: data before track is ready.");
+                            console.log('CEA-608: data before track is ready.');
                             return;
                         }
                         handler = makeCueAdderForIndex(this, trackIdx);
@@ -293,7 +293,7 @@ function TextSourceBuffer() {
                 }
             }
         }
-        log("Warning: Non-supported text type: " + mediaType);
+        log('Warning: Non-supported text type: ' + mediaType);
     }
     /**
      * Extract CEA-608 data from a buffer of data.
@@ -301,7 +301,7 @@ function TextSourceBuffer() {
      * @returns ccData corresponding to one segment.
     */
     function extractCea608Data(data) {
-        
+
         /** Insert [time, data] pairs in order into array. */
         var insertInOrder = function (arr, time, data) {
             var len = arr.length;
@@ -336,7 +336,7 @@ function TextSourceBuffer() {
         }
         trun = truns[0];
         if (truns.length > 1) {
-            console.log("Warning: Too many truns");
+            console.log('Warning: Too many truns');
         }
         var baseOffset = moof.offset + trun.data_offset;
         //Doublecheck that trun.offset == moof.size + 8
@@ -372,37 +372,37 @@ function TextSourceBuffer() {
     function checkIndent(chars) {
         var line = '';
 
-        for (var c=0; c < chars.length; ++c) {
+        for (var c = 0; c < chars.length; ++c) {
             var uc = chars[c];
             line += uc.uchar;
         }
 
         var l = line.length;
-        var ll = line.replace(/^\s+/,"").length;
-        return l-ll;
+        var ll = line.replace(/^\s+/,'').length;
+        return l - ll;
     }
 
     function getRegionProperties(region) {
-        return "left: " + (region.x * 3.125) + "%; top: " + (region.y1 * 6.66) + "%; width: " + (100 - (region.x * 3.125)) + "%; height: " + (Math.max((region.y2 - 1) - region.y1, 1) * 6.66) + "%; align-items: flex-start; overflow: visible; -webkit-writing-mode: horizontal-tb;";
+        return 'left: ' + (region.x * 3.125) + '%; top: ' + (region.y1 * 6.66) + '%; width: ' + (100 - (region.x * 3.125)) + '%; height: ' + (Math.max((region.y2 - 1) - region.y1, 1) * 6.66) + '%; align-items: flex-start; overflow: visible; -webkit-writing-mode: horizontal-tb;';
     }
 
     function createRGB(color) {
-        if (color == "red") {
-            return "rgb(255, 0, 0)";
-        } else if (color == "green") {
-            return "rgb(0, 255, 0)";
-        } else if (color == "blue") {
-            return "rgb(0, 0, 255)";
-        } else if (color == "cyan") {
-            return "rgb(0, 255, 255)";
-        } else if (color == "magenta") {
-            return "rgb(255, 0, 255)";
-        } else if (color == "yellow") {
-            return "rgb(255, 255, 0)";
-        } else if (color == "white") {
-            return "rgb(255, 255, 255)";
-        } else if (color == "black") {
-            return "rgb(0, 0, 0)";
+        if (color == 'red') {
+            return 'rgb(255, 0, 0)';
+        } else if (color == 'green') {
+            return 'rgb(0, 255, 0)';
+        } else if (color == 'blue') {
+            return 'rgb(0, 0, 255)';
+        } else if (color == 'cyan') {
+            return 'rgb(0, 255, 255)';
+        } else if (color == 'magenta') {
+            return 'rgb(255, 0, 255)';
+        } else if (color == 'yellow') {
+            return 'rgb(255, 255, 0)';
+        } else if (color == 'white') {
+            return 'rgb(255, 255, 255)';
+        } else if (color == 'black') {
+            return 'rgb(0, 0, 0)';
         }
         return color;
     }
@@ -410,12 +410,12 @@ function TextSourceBuffer() {
     function getStyle(videoElement, style) {
         var fontSize = videoElement.videoHeight / 15.0;
         if (style) {
-            return "font-size: " + fontSize + "px; font-family: Menlo, Consolas, 'Cutive Mono', monospace; color: " + ((style.foreground) ? createRGB(style.foreground) : "rgb(255, 255, 255)") + "; font-style: " + (style.italics ? "italic" : "normal") + "; text-decoration: " + (style.underline ? "underline" : "none") + "; white-space: pre; background-color: " + ((style.background) ? createRGB(style.background) : "trasparent") + ";";
+            return 'font-size: ' + fontSize + 'px; font-family: Menlo, Consolas, \'Cutive Mono\', monospace; color: ' + ((style.foreground) ? createRGB(style.foreground) : 'rgb(255, 255, 255)') + '; font-style: ' + (style.italics ? 'italic' : 'normal') + '; text-decoration: ' + (style.underline ? 'underline' : 'none') + '; white-space: pre; background-color: ' + ((style.background) ? createRGB(style.background) : 'trasparent') + ';';
         } else {
-            return "font-size: " + fontSize + "px; font-family: Menlo, Consolas, 'Cutive Mono', monospace; justify-content: flex-start; text-align: left; color: rgb(255, 255, 255); font-style: normal; white-space: pre; line-height: normal; font-weight: normal; text-decoration: none; width: 100%; display: flex;";
+            return 'font-size: ' + fontSize + 'px; font-family: Menlo, Consolas, \'Cutive Mono\', monospace; justify-content: flex-start; text-align: left; color: rgb(255, 255, 255); font-style: normal; white-space: pre; line-height: normal; font-weight: normal; text-decoration: none; width: 100%; display: flex;';
         }
     }
-    
+
     function ltrim(s) {
         var trimmed = s.replace(/^\s+/g, '');
         return trimmed;
@@ -432,8 +432,8 @@ function TextSourceBuffer() {
         let existingRegion = null;
         let lastRowHasText = false;
         let lastRowIndentL = -1;
-        let currP = { start:startTime, end:endTime, spans:[] };
-        let currentStyle = "style_cea608_white_black";
+        let currP = { start: startTime, end: endTime, spans: [] };
+        let currentStyle = 'style_cea608_white_black';
         let seenRegions = { };
         let styleStates = { };
         let regions = [];
@@ -452,15 +452,15 @@ function TextSourceBuffer() {
 
                 /* Create a new region is there is none */
                 if (currRegion === null) {
-                    currRegion = { x:rowIndent, y1:r, y2:(r+1), p:[] };
+                    currRegion = { x: rowIndent, y1: r, y2: (r + 1), p: [] };
                 }
 
                 /* Check if indentation has changed and we had text of last row */
                 if ((rowIndent !== lastRowIndentL) && lastRowHasText) {
                     currRegion.p.push(currP);
-                    currP = { start:startTime, end:endTime, spans:[] };
+                    currP = { start: startTime, end: endTime, spans: [] };
                     currRegion.y2 = r;
-                    currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+                    currRegion.name = 'region_' + currRegion.x + '_' + currRegion.y1 + '_' + currRegion.y2;
                     if (false === seenRegions.hasOwnProperty(currRegion.name)) {
                         regions.push(currRegion);
                         seenRegions[currRegion.name] = currRegion;
@@ -469,7 +469,7 @@ function TextSourceBuffer() {
                         existingRegion.p.contat(currRegion.p);
                     }
 
-                    currRegion = { x:rowIndent, y1:r, y2:(r+1), p:[] };
+                    currRegion = { x: rowIndent, y1: r, y2: (r + 1), p: [] };
                 }
 
                 for (let c = 0; c < row.chars.length; ++c) {
@@ -477,16 +477,16 @@ function TextSourceBuffer() {
                     let currPenState = uc.penState;
                     if ((prevPenState === null) || (!currPenState.equals(prevPenState))) {
                         if (line.trim().length > 0) {
-                            currP.spans.push({ name:currentStyle, line:line, row:r });
+                            currP.spans.push({ name: currentStyle, line: line, row: r });
                             line = '';
                         }
 
-                        let currPenStateString = "style_cea608_" + currPenState.foreground + "_" + currPenState.background;
+                        let currPenStateString = 'style_cea608_' + currPenState.foreground + '_' + currPenState.background;
                         if (currPenState.underline) {
-                            currPenStateString += "_underline";
+                            currPenStateString += '_underline';
                         }
                         if (currPenState.italics) {
-                            currPenStateString += "_italics";
+                            currPenStateString += '_italics';
                         }
 
                         if (!styleStates.hasOwnProperty(currPenStateString)) {
@@ -502,7 +502,7 @@ function TextSourceBuffer() {
                 }
 
                 if (line.trim().length > 0) {
-                    currP.spans.push({ name:currentStyle, line:line, row:r });
+                    currP.spans.push({ name: currentStyle, line: line, row: r });
                 }
 
                 lastRowHasText = true;
@@ -514,9 +514,9 @@ function TextSourceBuffer() {
 
                 if (currRegion) {
                     currRegion.p.push(currP);
-                    currP = { start:startTime, end:endTime, spans:[] };
+                    currP = { start: startTime, end: endTime, spans: [] };
                     currRegion.y2 = r;
-                    currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+                    currRegion.name = 'region_' + currRegion.x + '_' + currRegion.y1 + '_' + currRegion.y2;
                     if (false === seenRegions.hasOwnProperty(currRegion.name)) {
                         regions.push(currRegion);
                         seenRegions[currRegion.name] = currRegion;
@@ -534,7 +534,7 @@ function TextSourceBuffer() {
         if (currRegion) {
             currRegion.p.push(currP);
             currRegion.y2 = r + 1;
-            currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+            currRegion.name = 'region_' + currRegion.x + '_' + currRegion.y1 + '_' + currRegion.y2;
             if (false === seenRegions.hasOwnProperty(currRegion.name)) {
                 regions.push(currRegion);
                 seenRegions[currRegion.name] = currRegion;
@@ -550,24 +550,24 @@ function TextSourceBuffer() {
         //console.log(regions);
 
         let captionsArray = [];
-    
+
         /* Loop thru regions */
         for (r = 0; r < regions.length; ++r) {
             let region = regions[r];
 
-            let cueID = "sub_" + (captionId++);
+            let cueID = 'sub_' + (captionId++);
             let finalDiv = document.createElement('div');
-            finalDiv.id = "subtitle_" + cueID;
+            finalDiv.id = 'subtitle_' + cueID;
             let cueRegionProperties = getRegionProperties(region);
-            finalDiv.style.cssText = "position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;" + cueRegionProperties;
+            finalDiv.style.cssText = 'position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;' + cueRegionProperties;
 
             let bodyDiv = document.createElement('div');
-            bodyDiv.className = "paragraph bodyStyle";
+            bodyDiv.className = 'paragraph bodyStyle';
             bodyDiv.style.cssText = getStyle(videoElement);
 
             let cueUniWrapper = document.createElement('div');
-            cueUniWrapper.className = "cueUniWrapper";
-            cueUniWrapper.style.cssText = "unicode-bidi: normal; direction: ltr;";
+            cueUniWrapper.className = 'cueUniWrapper';
+            cueUniWrapper.style.cssText = 'unicode-bidi: normal; direction: ltr;';
 
             for (let p = 0; p < region.p.length; ++p) {
                 let ptag = region.p[p];
@@ -577,7 +577,7 @@ function TextSourceBuffer() {
                     if (span.line.length > 0) {
                         if ((s !== 0) && lastSpanRow != span.row) {
                             let brElement = document.createElement('br');
-                            brElement.className = "lineBreak";
+                            brElement.className = 'lineBreak';
                             cueUniWrapper.appendChild(brElement);
                         }
                         let sameRow = false;
@@ -587,7 +587,7 @@ function TextSourceBuffer() {
                         lastSpanRow = span.row;
                         let spanStyle = styleStates[span.name];
                         let spanElement = document.createElement('span');
-                        spanElement.className = "spanPadding " + span.name + " customSpanColor";
+                        spanElement.className = 'spanPadding ' + span.name + ' customSpanColor';
                         spanElement.style.cssText = getStyle(videoElement, spanStyle);
                         if ((s !== 0) && sameRow) {
                             if (s === ptag.spans.length - 1) {
@@ -622,34 +622,34 @@ function TextSourceBuffer() {
 
             finalDiv.appendChild(bodyDiv);
 
-            let fontSize = { 'bodyStyle':90 };
+            let fontSize = { 'bodyStyle': 90 };
             for (s in styleStates) {
                 if (styleStates.hasOwnProperty(s)) {
                     fontSize[s] = 90;
                 }
             }
 
-            captionsArray.push({ type:'html',
-                                 start:startTime,
-                                 end:endTime,
-                                 cueHTMLElement:finalDiv,
-                                 cueID:cueID,
-                                 cellResolution:[32, 15],
+            captionsArray.push({ type: 'html',
+                                 start: startTime,
+                                 end: endTime,
+                                 cueHTMLElement: finalDiv,
+                                 cueID: cueID,
+                                 cellResolution: [32, 15],
                                  isFromCEA608: true,
                                  regions: regions,
                                  regionID: region.name,
-                                 videoHeight   : videoElement.videoHeight,
-                                 videoWidth    : videoElement.videoWidth,
-                                 fontSize      : fontSize || {
+                                 videoHeight: videoElement.videoHeight,
+                                 videoWidth: videoElement.videoWidth,
+                                 fontSize: fontSize || {
                                      defaultFontSize: '100'
                                  },
-                                 lineHeight    : {},
-                                 linePadding   : {},
+                                 lineHeight: {},
+                                 linePadding: {},
                                });
         }
         return captionsArray;
     }
- 
+
     function abort() {
         textTrackExtensions.deleteAllTextTracks();
         allTracksAreDisabled = false;
@@ -667,18 +667,18 @@ function TextSourceBuffer() {
         embeddedInitialized = false;
         embeddedTracks = null;
     }
-    
+
     function addEmbeddedTrack(mediaInfo) {
         if (!embeddedInitialized) {
             initEmbedded();
         }
-        if (mediaInfo.id === "CC1" || mediaInfo.id === "CC3") {
+        if (mediaInfo.id === 'CC1' || mediaInfo.id === 'CC3') {
             embeddedTracks.push(mediaInfo);
         } else {
-            log("Warning: Embedded track " + mediaInfo.id + " not supported!");
+            log('Warning: Embedded track ' + mediaInfo.id + ' not supported!');
         }
     }
-    
+
     function resetEmbedded() {
         embeddedInitialized = false;
         embeddedTracks = [];
@@ -739,7 +739,7 @@ function TextSourceBuffer() {
                     textTrackExtensions.setCurrentTrackIdx(i);
                     textTrackExtensions.addCaptions(i, 0, null); // Make sure that previously queued captions are added as cues
                     if (isFragmented && i < nrNonEmbeddedTracks) {
-                        var currentFragTrack = mediaController.getCurrentTrackFor("fragmentedText", streamController.getActiveStreamInfo());
+                        var currentFragTrack = mediaController.getCurrentTrackFor('fragmentedText', streamController.getActiveStreamInfo());
                         var newFragTrack = fragmentedTracks[i];
                         if (newFragTrack !== currentFragTrack) {
                             fragmentModel.abortRequests();
@@ -764,9 +764,9 @@ function TextSourceBuffer() {
         // Eg subtitles etc. You can have multiple role tags per adaptation Not defined in the spec yet.
         var isDefault = false;
         if (embeddedTracks.length > 1) {
-            isDefault = (mediaInfo.id && mediaInfo.id === "CC1"); // CC1 if both CC1 and CC3 exist
+            isDefault = (mediaInfo.id && mediaInfo.id === 'CC1'); // CC1 if both CC1 and CC3 exist
         } else if (embeddedTracks.length === 1) {
-            if (mediaInfo.id && mediaInfo.id.substring(0, 2) === "CC") {// Either CC1 or CC3
+            if (mediaInfo.id && mediaInfo.id.substring(0, 2) === 'CC') {// Either CC1 or CC3
                 isDefault = true;
             }
         } else {

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -42,6 +42,7 @@ function TextSourceBuffer() {
     let context = this.context;    
     let log = Debug(context).getInstance().log;
     let embeddedInitialized = false;
+    let captionId = 0;
 
     let instance,
         boxParser,
@@ -224,13 +225,13 @@ function TextSourceBuffer() {
                 var makeCueAdderForIndex = function (self, trackIndex) {
                     function newCue(startTime, endTime, captionScreen) {
                         var captionsArray = null;
-                        /*if (self.videoModel.getTTMLRenderingDiv()) {
-                            captionsArray = createHTMLCaptionsFromScreen(self.videoModel.getElement(), startTime, endTime, captionScreen);
-                        } else { */
-                        var text = captionScreen.getDisplayText();
-                        //console.log("CEA text: " + startTime + "-" + endTime + "  '" + text + "'");
-                        captionsArray = [{ start: startTime, end: endTime, data: text, styles: {} }];
-                        /* } */
+                        if (videoModel.getTTMLRenderingDiv()) {
+                            captionsArray = createHTMLCaptionsFromScreen(videoModel.getElement(), startTime, endTime, captionScreen);
+                        } else { 
+                            var text = captionScreen.getDisplayText();
+                            //console.log("CEA text: " + startTime + "-" + endTime + "  '" + text + "'");
+                            captionsArray = [{ start: startTime, end: endTime, data: text, styles: {} }];
+                        } 
                         if (captionsArray) {
                             textTrackExtensions.addCaptions(trackIndex, 0, captionsArray);
                         }
@@ -365,6 +366,288 @@ function TextSourceBuffer() {
         allCcData.startTime = baseSampleTime;
         allCcData.endTime = endSampleTime;
         return allCcData;
+    }
+
+    /* HTML Rendering functions */
+    function checkIndent(chars) {
+        var line = '';
+
+        for (var c=0; c < chars.length; ++c) {
+            var uc = chars[c];
+            line += uc.uchar;
+        }
+
+        var l = line.length;
+        var ll = line.replace(/^\s+/,"").length;
+        return l-ll;
+    }
+
+    function getRegionProperties(region) {
+        return "left: " + (region.x * 3.125) + "%; top: " + (region.y1 * 6.66) + "%; width: " + (100 - (region.x * 3.125)) + "%; height: " + (Math.max((region.y2 - 1) - region.y1, 1) * 6.66) + "%; align-items: flex-start; overflow: visible; -webkit-writing-mode: horizontal-tb;";
+    }
+
+    function createRGB(color) {
+        if (color == "red") {
+            return "rgb(255, 0, 0)";
+        } else if (color == "green") {
+            return "rgb(0, 255, 0)";
+        } else if (color == "blue") {
+            return "rgb(0, 0, 255)";
+        } else if (color == "cyan") {
+            return "rgb(0, 255, 255)";
+        } else if (color == "magenta") {
+            return "rgb(255, 0, 255)";
+        } else if (color == "yellow") {
+            return "rgb(255, 255, 0)";
+        } else if (color == "white") {
+            return "rgb(255, 255, 255)";
+        } else if (color == "black") {
+            return "rgb(0, 0, 0)";
+        }
+        return color;
+    }
+
+    function getStyle(videoElement, style) {
+        var fontSize = videoElement.videoHeight / 15.0;
+        if (style) {
+            return "font-size: " + fontSize + "px; font-family: Menlo, Consolas, 'Cutive Mono', monospace; color: " + ((style.foreground) ? createRGB(style.foreground) : "rgb(255, 255, 255)") + "; font-style: " + (style.italics ? "italic" : "normal") + "; text-decoration: " + (style.underline ? "underline" : "none") + "; white-space: pre; background-color: " + ((style.background) ? createRGB(style.background) : "trasparent") + ";";
+        } else {
+            return "font-size: " + fontSize + "px; font-family: Menlo, Consolas, 'Cutive Mono', monospace; justify-content: flex-start; text-align: left; color: rgb(255, 255, 255); font-style: normal; white-space: pre; line-height: normal; font-weight: normal; text-decoration: none; width: 100%; display: flex;";
+        }
+    }
+    
+    function ltrim(s) {
+        var trimmed = s.replace(/^\s+/g, '');
+        return trimmed;
+    }
+    function rtrim(s) {
+        var trimmed = s.replace(/\s+$/g, '');
+        return trimmed;
+    }
+
+
+    function createHTMLCaptionsFromScreen(videoElement, startTime, endTime, captionScreen) {
+
+        let currRegion = null;
+        let existingRegion = null;
+        let lastRowHasText = false;
+        let lastRowIndentL = -1;
+        let currP = { start:startTime, end:endTime, spans:[] };
+        let currentStyle = "style_cea608_white_black";
+        let seenRegions = { };
+        let styleStates = { };
+        let regions = [];
+        let r, s;
+
+        for (r = 0; r < 15; ++r) {
+            let row = captionScreen.rows[r];
+            let line = '';
+            let prevPenState = null;
+
+            if (false === row.isEmpty()) {
+                /* Row is not empty */
+
+                /* Get indentation of this row */
+                let rowIndent = checkIndent(row.chars);
+
+                /* Create a new region is there is none */
+                if (currRegion === null) {
+                    currRegion = { x:rowIndent, y1:r, y2:(r+1), p:[] };
+                }
+
+                /* Check if indentation has changed and we had text of last row */
+                if ((rowIndent !== lastRowIndentL) && lastRowHasText) {
+                    currRegion.p.push(currP);
+                    currP = { start:startTime, end:endTime, spans:[] };
+                    currRegion.y2 = r;
+                    currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+                    if (false === seenRegions.hasOwnProperty(currRegion.name)) {
+                        regions.push(currRegion);
+                        seenRegions[currRegion.name] = currRegion;
+                    } else {
+                        existingRegion = seenRegions[currRegion.name];
+                        existingRegion.p.contat(currRegion.p);
+                    }
+
+                    currRegion = { x:rowIndent, y1:r, y2:(r+1), p:[] };
+                }
+
+                for (let c = 0; c < row.chars.length; ++c) {
+                    let uc = row.chars[c];
+                    let currPenState = uc.penState;
+                    if ((prevPenState === null) || (!currPenState.equals(prevPenState))) {
+                        if (line.trim().length > 0) {
+                            currP.spans.push({ name:currentStyle, line:line, row:r });
+                            line = '';
+                        }
+
+                        let currPenStateString = "style_cea608_" + currPenState.foreground + "_" + currPenState.background;
+                        if (currPenState.underline) {
+                            currPenStateString += "_underline";
+                        }
+                        if (currPenState.italics) {
+                            currPenStateString += "_italics";
+                        }
+
+                        if (!styleStates.hasOwnProperty(currPenStateString)) {
+                            styleStates[currPenStateString] = JSON.parse(JSON.stringify(currPenState));
+                        }
+
+                        prevPenState = currPenState;
+
+                        currentStyle = currPenStateString;
+                    }
+
+                    line += uc.uchar;
+                }
+
+                if (line.trim().length > 0) {
+                    currP.spans.push({ name:currentStyle, line:line, row:r });
+                }
+
+                lastRowHasText = true;
+                lastRowIndentL = rowIndent;
+            } else {
+                /* Row is empty */
+                lastRowHasText = false;
+                lastRowIndentL = -1;
+
+                if (currRegion) {
+                    currRegion.p.push(currP);
+                    currP = { start:startTime, end:endTime, spans:[] };
+                    currRegion.y2 = r;
+                    currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+                    if (false === seenRegions.hasOwnProperty(currRegion.name)) {
+                        regions.push(currRegion);
+                        seenRegions[currRegion.name] = currRegion;
+                    } else {
+                        existingRegion = seenRegions[currRegion.name];
+                        existingRegion.p.contat(currRegion.p);
+                    }
+
+                    currRegion = null;
+                }
+
+            }
+        }
+
+        if (currRegion) {
+            currRegion.p.push(currP);
+            currRegion.y2 = r + 1;
+            currRegion.name = 'region_' + currRegion.x + "_" + currRegion.y1 + "_" + currRegion.y2;
+            if (false === seenRegions.hasOwnProperty(currRegion.name)) {
+                regions.push(currRegion);
+                seenRegions[currRegion.name] = currRegion;
+            } else {
+                existingRegion = seenRegions[currRegion.name];
+                existingRegion.p.contat(currRegion.p);
+            }
+
+            currRegion = null;
+        }
+
+        //console.log(styleStates);
+        //console.log(regions);
+
+        let captionsArray = [];
+    
+        /* Loop thru regions */
+        for (r = 0; r < regions.length; ++r) {
+            let region = regions[r];
+
+            let cueID = "sub_" + (captionId++);
+            let finalDiv = document.createElement('div');
+            finalDiv.id = "subtitle_" + cueID;
+            let cueRegionProperties = getRegionProperties(region);
+            finalDiv.style.cssText = "position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;" + cueRegionProperties;
+
+            let bodyDiv = document.createElement('div');
+            bodyDiv.className = "paragraph bodyStyle";
+            bodyDiv.style.cssText = getStyle(videoElement);
+
+            let cueUniWrapper = document.createElement('div');
+            cueUniWrapper.className = "cueUniWrapper";
+            cueUniWrapper.style.cssText = "unicode-bidi: normal; direction: ltr;";
+
+            for (let p = 0; p < region.p.length; ++p) {
+                let ptag = region.p[p];
+                let lastSpanRow = 0;
+                for (s = 0; s < ptag.spans.length; ++s) {
+                    let span = ptag.spans[s];
+                    if (span.line.length > 0) {
+                        if ((s !== 0) && lastSpanRow != span.row) {
+                            let brElement = document.createElement('br');
+                            brElement.className = "lineBreak";
+                            cueUniWrapper.appendChild(brElement);
+                        }
+                        let sameRow = false;
+                        if (lastSpanRow === span.row) {
+                            sameRow = true;
+                        }
+                        lastSpanRow = span.row;
+                        let spanStyle = styleStates[span.name];
+                        let spanElement = document.createElement('span');
+                        spanElement.className = "spanPadding " + span.name + " customSpanColor";
+                        spanElement.style.cssText = getStyle(videoElement, spanStyle);
+                        if ((s !== 0) && sameRow) {
+                            if (s === ptag.spans.length - 1) {
+                                spanElement.textContent = rtrim(span.line);
+                            } else {
+                                spanElement.textContent = span.line;
+                            }
+                        } else {
+                            if (s === 0) {
+                                if (ptag.spans.length > 1) {
+                                    /* Check if next text is on same row */
+                                    if (span.row === ptag.spans[1].row) {
+                                        /* Next element on same row, trim start */
+                                        spanElement.textContent = ltrim(span.line);
+                                    } else {
+                                        /* Different rows, trim */
+                                        spanElement.textContent = span.line.trim();
+                                    }
+                                } else {
+                                    spanElement.textContent = span.line.trim();
+                                }
+                            } else {
+                                spanElement.textContent = span.line.trim();
+                            }
+                        }
+                        cueUniWrapper.appendChild(spanElement);
+                    }
+                }
+            }
+
+            bodyDiv.appendChild(cueUniWrapper);
+
+            finalDiv.appendChild(bodyDiv);
+
+            let fontSize = { 'bodyStyle':90 };
+            for (s in styleStates) {
+                if (styleStates.hasOwnProperty(s)) {
+                    fontSize[s] = 90;
+                }
+            }
+
+            captionsArray.push({ type:'html',
+                                 start:startTime,
+                                 end:endTime,
+                                 cueHTMLElement:finalDiv,
+                                 cueID:cueID,
+                                 cellResolution:[32, 15],
+                                 isFromCEA608: true,
+                                 regions: regions,
+                                 regionID: region.name,
+                                 videoHeight   : videoElement.videoHeight,
+                                 videoWidth    : videoElement.videoWidth,
+                                 fontSize      : fontSize || {
+                                     defaultFontSize: '100'
+                                 },
+                                 lineHeight    : {},
+                                 linePadding   : {},
+                               });
+        }
+        return captionsArray;
     }
  
     function abort() {
@@ -516,5 +799,6 @@ function TextSourceBuffer() {
 
     return instance;
 }
+
 TextSourceBuffer.__dashjs_factory_name = 'TextSourceBuffer';
 export default FactoryMaker.getSingletonFactory(TextSourceBuffer);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -112,7 +112,6 @@ function BufferController(config) {
         isAppendingInProgress = false;
         isPruningInProgress = false;
         inbandEventFound = false;
-
     }
 
     function initialize(Type, Source, StreamProcessor) {
@@ -271,6 +270,12 @@ function BufferController(config) {
         isAppendingInProgress = true;
         appendedBytesInfo = chunk;
         sourceBufferExt.append(buffer, chunk);
+        
+        if (chunk.mediaInfo.type === 'video') {
+            if (chunk.mediaInfo.embeddedCaptions) {
+                textSourceBuffer.append(chunk.bytes, chunk);
+            }
+        }
     }
 
     function onAppended(e) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -270,7 +270,7 @@ function BufferController(config) {
         isAppendingInProgress = true;
         appendedBytesInfo = chunk;
         sourceBufferExt.append(buffer, chunk);
-        
+
         if (chunk.mediaInfo.type === 'video') {
             if (chunk.mediaInfo.embeddedCaptions) {
                 textSourceBuffer.append(chunk.bytes, chunk);

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -32,6 +32,7 @@ import Events from '../../core/events/Events.js';
 import EventBus from '../../core/EventBus.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
 import Debug from '../../core/Debug.js';
+import TextSourceBuffer from '../TextSourceBuffer.js';
 
 const TRACK_SWITCH_MODE_NEVER_REPLACE = 'neverReplace';
 const TRACK_SWITCH_MODE_ALWAYS_REPLACE = 'alwaysReplace';
@@ -44,6 +45,7 @@ function MediaController() {
     let context = this.context;
     let log = Debug(context).getInstance().log;
     let eventBus = EventBus(context).getInstance();
+    let textSourceBuffer = TextSourceBuffer(context).getInstance();
 
     let instance,
         tracks,
@@ -57,7 +59,6 @@ function MediaController() {
         tracks = {};
         resetInitialSettings();
         resetSwitchMode();
-
     }
 
     /**
@@ -311,6 +312,7 @@ function MediaController() {
         resetInitialSettings();
         resetSwitchMode();
         tracks = {};
+        textSourceBuffer.resetEmbedded();
     }
 
     function storeLastSettings(type, value) {

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -59,7 +59,6 @@ function TextTrackExtensions() {
         topZIndex;
 
     function initialize () {
-        log("TOBBE: TextTrackExtensions: initialize");
         Cue = window.VTTCue || window.TextTrackCue;
         textTrackQueue = [];
         trackElementArr = [];
@@ -113,7 +112,7 @@ function TextTrackExtensions() {
     function addTextTrack(textTrackInfoVO, totalTextTracks) {
         
         if (textTrackQueue.length === totalTextTracks) {
-            log("TOBBE cannot add another text track since there are already " + totalTextTracks);
+            log("Trying to add too many tracks.");
             return;
         }
 
@@ -121,8 +120,6 @@ function TextTrackExtensions() {
         if (video === undefined) {
             video = textTrackInfoVO.video;
         }
-        
-        log("TOBBE: addTextTrack " + textTrackQueue.length + " " + totalTextTracks);
 
         if (textTrackQueue.length === totalTextTracks) {
             textTrackQueue.sort(function (a, b) { //Sort in same order as in manifest

--- a/src/streaming/extensions/TextTrackExtensions.js
+++ b/src/streaming/extensions/TextTrackExtensions.js
@@ -110,9 +110,9 @@ function TextTrackExtensions() {
     }
 
     function addTextTrack(textTrackInfoVO, totalTextTracks) {
-        
+
         if (textTrackQueue.length === totalTextTracks) {
-            log("Trying to add too many tracks.");
+            log('Trying to add too many tracks.');
             return;
         }
 
@@ -153,7 +153,7 @@ function TextTrackExtensions() {
             }
             setCurrentTrackIdx.call(this, defaultIndex);
             if (defaultIndex >= 0) {
-                video.textTracks[defaultIndex].mode = "showing";
+                video.textTracks[defaultIndex].mode = 'showing';
                 this.addCaptions(defaultIndex, 0, null);
             }
             eventBus.trigger(Events.TEXT_TRACKS_ADDED, {index: currentTrackIdx, tracks: textTrackQueue});//send default idx.
@@ -200,15 +200,15 @@ function TextTrackExtensions() {
         }
 
         if (use80Percent) {
-            return { x:videoPictureXAspect + (videoPictureWidthAspect * 0.1),
-                     y:videoPictureYAspect + (videoPictureHeightAspect * 0.1),
-                     w:videoPictureWidthAspect * 0.8,
-                     h:videoPictureHeightAspect* 0.8 }; /* Maximal picture size in videos aspect ratio */
+            return { x: videoPictureXAspect + (videoPictureWidthAspect * 0.1),
+                     y: videoPictureYAspect + (videoPictureHeightAspect * 0.1),
+                     w: videoPictureWidthAspect * 0.8,
+                     h: videoPictureHeightAspect * 0.8 }; /* Maximal picture size in videos aspect ratio */
         } else {
-            return { x:videoPictureXAspect,
-                     y:videoPictureYAspect,
-                     w:videoPictureWidthAspect,
-                     h:videoPictureHeightAspect }; /* Maximal picture size in videos aspect ratio */
+            return { x: videoPictureXAspect,
+                     y: videoPictureYAspect,
+                     w: videoPictureWidthAspect,
+                     h: videoPictureHeightAspect }; /* Maximal picture size in videos aspect ratio */
         }
     }
 
@@ -329,13 +329,13 @@ function TextTrackExtensions() {
         var self = this;
 
         if (!track) return;
-        if (track.mode !== "showing") {
+        if (track.mode !== 'showing') {
             if (captionData && captionData.length > 0) {
                 track.nonAddedCues = track.nonAddedCues.concat(captionData);
             }
             return;
         }
-        
+
         if (!captionData) {
             captionData = track.nonAddedCues;
             track.nonAddedCues = [];
@@ -455,7 +455,7 @@ function TextTrackExtensions() {
     function getCurrentTrackIdx() {
         return currentTrackIdx;
     }
-    
+
     function getTrackIdxForId(trackId) {
         var idx = -1;
         for (var i = 0; i < video.textTracks.length; i++) {

--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -141,7 +141,7 @@ function IsoFile() {
         mdhdProps = {
             timescale: 'timescale'
         };
-        
+
         mfhdProps = {
             sequence_number: 'sequence_number'
         };

--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -41,6 +41,7 @@ function IsoFile() {
         sidxRefProps,
         emsgProps,
         mdhdProps,
+        mfhdProps,
         tfhdProps,
         tfdtProps,
         trunProps,
@@ -140,6 +141,10 @@ function IsoFile() {
         mdhdProps = {
             timescale: 'timescale'
         };
+        
+        mfhdProps = {
+            sequence_number: 'sequence_number'
+        };
 
         tfhdProps = {
             base_data_offset: 'base_data_offset',
@@ -204,6 +209,9 @@ function IsoFile() {
                 break;
             case 'mdhd':
                 copyProps(boxData, box, mdhdProps);
+                break;
+            case 'mfhd':
+                copyProps(boxData, box, mfhdProps);
                 break;
             case 'tfhd':
                 copyProps(boxData, box, tfhdProps);

--- a/src/streaming/vo/TextTrackInfo.js
+++ b/src/streaming/vo/TextTrackInfo.js
@@ -41,6 +41,7 @@ class TextTrackInfo {
         this.defaultTrack = false;
         this.kind = null;
         this.isFragmented = false;
+        this.isEmbedded = false;
     }
 }
 


### PR DESCRIPTION
We have added support for CEA-608 video captioning embedded in the video tracks.
This is signalled in the MPD as Accessibility of the video adaptation set as described in the DASH-IF IOP 3.1. CC1 and CC3 tracks are supported and can coexist with other type of text tracks.
If the MPD does not signal the availability of CEA-608, the video segments will not be scanned for captions.

Test content with multiple colors was added at the bottom of the content list of the reference player.
The link is http://vm2.dashif.org/dash/vod/testpic_2s/cea608_and_segs.mpd
There are two CEA-608 tracks and one subtitle track using segmented TTML.

The corresponding simulated live stream is also available as: http://vm2.dashif.org/livesim/testpic_2s/cea608_and_segs.mpd

