### PR TITLE
Updating log messages

### DIFF
--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -48,8 +48,8 @@ function Debug() {
 
     function setup() {
         logToBrowserConsole = true;
-        showLogTimestamp = false;
-        //showCalleeName = false,
+        showLogTimestamp = true;
+        //showCalleeName = true;
         startTime = new Date().getTime();
     }
 
@@ -108,11 +108,11 @@ function Debug() {
             message += '[' + (logTime - startTime) + ']';
         }
 
-        //if (showCalleeName && this.getName) {
-        //    message += "[" + this.getName() + "]";
+        //if (showCalleeName && this) {
+            //message += "[" + this + "]";
         //}
 
-        //if (this.getMediaType && this.getMediaType()) {
+    //if (this.getMediaType && this.getMediaType()) {
         //    message += "[" + this.getMediaType() + "]";
         //}
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -863,7 +863,7 @@ function DashHandler(config) {
 
         requestedTime = time;
 
-        log('Getting the request for time: ' + time);
+        log('Getting the request for ' + type + ' time : ' + time);
         index = getIndexForSegments(time, representation, timeThreshold);
         //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
         getSegments(representation);
@@ -871,7 +871,7 @@ function DashHandler(config) {
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 
-        log('Index for time ' + time + ' is ' + index);
+        log('Index for ' + type + ' time ' + time + ' is ' + index);
 
         finished = !ignoreIsFinished ? isMediaFinished(representation) : false;
         if (finished) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -149,7 +149,7 @@ function ScheduleController(config) {
         if (initialPlayback) {
             initialPlayback = false;
         }
-        log('start');
+        log('Schedule controller starting for ' + type);
         //if starting from a pause we want to call validate to kick off the cycle that was stopped by pausing stream.
         if (playbackController.getPlayedRanges().length > 0) {
             validate();
@@ -168,7 +168,7 @@ function ScheduleController(config) {
     function doStop() {
         if (isStopped) return;
         isStopped = true;
-        log('stop');
+        log('Schedule controller stopping for ' + type);
         clearInterval(validateTimeout);
         clearPlayListTraceMetrics(new Date(), PlayList.Trace.USER_REQUEST_STOP_REASON);
     }


### PR DESCRIPTION
Adding back timestamps to console log messages by default. I think this highlights some timing problems and there is an API to remove it from the log lines if you don't like it.

Also, making certain log statements clearer. For example:

Was: "stop"
Now: "Schedule controller stopping for video"