### PR TITLE
Fix replaying of content in Firefox

### DIFF
--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -85,14 +85,13 @@ function NextFragmentRequestRule(config) {
         while (request && streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
             if (request.action === FragmentRequest.ACTION_COMPLETE) {
                 request = null;
-                streamProcessor.setIndexHandlerTime(NaN);
                 break;
             }
 
             request = adapter.getNextFragmentRequest(streamProcessor, representationInfo);
         }
 
-        if (request ) {
+        if (request) {
             streamProcessor.setIndexHandlerTime(request.startTime + request.duration);
             request.delayLoadingTime = new Date().getTime() + scheduleController.getTimeToLoadDelay();
         }


### PR DESCRIPTION
Steps to reproduce issue:

1. Start playing an MPD longer than a couple of minutes, such that early buffer is purged
2. Seek to a few seconds before the end (or play naturally through)
3. Wait for content to end
4. Click play again

Expected behaviour:
Playback restarts from the beginning of the media

Actual behaviour:
Playback never starts