### PR TITLE
Update samples to reference dash.all.debug.js

### DIFF
--- a/samples/ad-insertion/adinsertion_inband.html
+++ b/samples/ad-insertion/adinsertion_inband.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
 
 </head>

--- a/samples/ad-insertion/adinsertion_inline.html
+++ b/samples/ad-insertion/adinsertion_inline.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
 
 </head>

--- a/samples/ad-insertion/xlink.html
+++ b/samples/ad-insertion/xlink.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no">
     <link href="style.css" rel="stylesheet" type="text/css" />
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
 
 </head>
 <body ng-controller="DashController">

--- a/samples/captioning/caption_vtt.html
+++ b/samples/captioning/caption_vtt.html
@@ -6,7 +6,7 @@
     <meta name="description" content="" />
     <link rel="icon" type="image/x-icon" href="http://dashif.org/wp-content/uploads/2014/12/dashif.ico" />
 
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
 
     <script>
         function startVideo() {

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="../../contrib/akamai/controlbar/controlbar.css">
     <script src="../../contrib/akamai/controlbar/ControlBar.js"></script>
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
 
     <script>
         var EXTERNAL_CAPTION_URL = "http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd", // need to manually seek to get stream to start... issue with MPD but only sample with multi adaptations for external sidecar caption text xml

--- a/samples/captioning/ttml-ebutt-sample.html
+++ b/samples/captioning/ttml-ebutt-sample.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="../../contrib/akamai/controlbar/controlbar.css">
     <script src="../../contrib/akamai/controlbar/ControlBar.js"></script>
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     
 
     <script>

--- a/samples/chromecast/index.html
+++ b/samples/chromecast/index.html
@@ -17,7 +17,7 @@
     <script src="https://www.gstatic.com/cast/js/receiver/1.0/cast_receiver.js"></script>
 
     <!-- Minified Dash -->
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
 
     <script src="receiver/js/main.js"></script>
 

--- a/samples/dash-if-reference-player/eme.html
+++ b/samples/dash-if-reference-player/eme.html
@@ -24,7 +24,7 @@
     <script src="app/lib/bootstrap/js/bootstrap.min.js"></script>
 
 
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     <script src="../../dist/dash.protection.min.js"></script>
 
     <!-- App -->

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -39,7 +39,7 @@
     <!-- https://github.com/eu81273/angular.treeview -->
     <script src="app/lib/angular.treeview/angular.treeview.min.js"></script>
 
-    <script src="../../dist/dash.debug.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     <script src="../../dist/dash.protection.debug.js"></script>
 
     <!-- App -->

--- a/samples/getting-started-basic-embed/auto-load-multi-video.html
+++ b/samples/getting-started-basic-embed/auto-load-multi-video.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Auto-player instantiation example</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <style>

--- a/samples/getting-started-basic-embed/auto-load-single-video-src.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-src.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="utf-8"/>
     <title>Auto-player instantiation example, single videoElement, using src attribute</title>
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <style>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Auto-player instantiation example, single videoElement, supplying context and source</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <script>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Auto-player instantiation example, showing how to obtain a reference to the MediaPlayer</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <script>

--- a/samples/getting-started-basic-embed/auto-load-single-video.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Auto-player instantiation example, single videoElement</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <style>

--- a/samples/getting-started-basic-embed/manual-load-single-video.html
+++ b/samples/getting-started-basic-embed/manual-load-single-video.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Manual-player instantiation example</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <script>

--- a/samples/live-streaming/live-delay-comparison.html
+++ b/samples/live-streaming/live-delay-comparison.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8"/>
     <title>Live delay comparison</title>
 
-    <script src="../../dist/dash.debug.js"></script>
-    <!--dash.all.js should be used in production over dash.debug.js. dash.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.js should be used in production over dash.all.debug.js. dash.all.debug.js is not compressed or obfuscated and the file size is much larger compared with dash.all.js-->
     <!--<script src="../../dist/dash.all.js"></script>-->
 
     <script>

--- a/test/helpers/DashUtil.html
+++ b/test/helpers/DashUtil.html
@@ -24,7 +24,7 @@
     </style>
 
     <!-- Player -->
-    <script src="../../../dist/dash.debug.js"></script>    
+    <script src="../../../dist/dash.all.debug.js"></script>
 
     <script src="MPDList.js"></script>
     <script src="DashUtil.js"></script>


### PR DESCRIPTION
This replaces the dash.debug.js which no longer exists.
This fixes the fact that the samples were broken in #1004.