### PR TITLE
Fix for second issue described in #980.

### DIFF
--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -39,7 +39,6 @@ let FactoryMaker = (function () {
 
     function extend(name, childInstance, override, context) {
         let extensionContext = getExtensionContext(context);
-
         if (!extensionContext[name] && childInstance) {
             extensionContext[name] = {instance: childInstance, override: override};
         }
@@ -47,34 +46,30 @@ let FactoryMaker = (function () {
 
     function getSingletonInstance(context, className) {
         for (let i in singletonContexts) {
-            const obj = singletonContexts[i];
+            let obj = singletonContexts[i];
             if (obj.context === context && obj.name === className) {
                 return obj.instance;
             }
         }
-
         return null;
     }
 
     function setSingletonInstance(context, className, instance) {
         for (let i in singletonContexts) {
-            const obj = singletonContexts[i];
+            let obj = singletonContexts[i];
             if (obj.context === context && obj.name === className) {
                 singletonContexts[i].instance = instance;
                 return;
             }
         }
-
         singletonContexts.push({ name: className, context: context, instance: instance });
     }
 
     function getClassFactory(classConstructor) {
         return function (context) {
-
             if (context === undefined) {
                 context = {};
             }
-
             return {
                 create: function () {
                     return merge(classConstructor.__dashjs_factory_name, classConstructor.apply({ context: context }, arguments), context);
@@ -85,23 +80,21 @@ let FactoryMaker = (function () {
 
     function getSingletonFactory(classConstructor) {
         return function (context) {
-
+            let instance;
             if (context === undefined) {
                 context = {};
             }
-
-            let instance = getSingletonInstance(context, classConstructor.__dashjs_factory_name);
-
             return {
                 getInstance: function () {
-
                     if (instance) {
                         return instance;
+                    } else {
+                        instance = getSingletonInstance(context, classConstructor.__dashjs_factory_name);
                     }
-
-                    instance = merge(classConstructor.__dashjs_factory_name, classConstructor.apply({ context: context }, arguments), context);
-                    singletonContexts.push({ name: classConstructor.__dashjs_factory_name, context: context, instance: instance });
-
+                    if (!instance) {
+                        instance = merge(classConstructor.__dashjs_factory_name, classConstructor.apply({ context: context }, arguments), context);
+                        singletonContexts.push({ name: classConstructor.__dashjs_factory_name, context: context, instance: instance });
+                    }
                     return instance;
                 }
             };
@@ -109,7 +102,6 @@ let FactoryMaker = (function () {
     }
 
     function merge(name, classConstructor, context) {
-
         let extensionContext = getExtensionContext(context);
         let extensionObject = extensionContext[name];
         if (extensionObject) {
@@ -130,17 +122,14 @@ let FactoryMaker = (function () {
 
     function getExtensionContext(context) {
         let extensionContext;
-
         extensions.forEach(function (obj) {
             if (obj === context) {
                 extensionContext = obj;
             }
         });
-
         if (!extensionContext) {
             extensionContext = extensions.push(context);
         }
-
         return extensionContext;
     }
 


### PR DESCRIPTION
In other news the getSingletonFactory method also has a bug that can result in two instances being created. The following code will create two instances in the same context: