### PR TITLE
Add support for path-absolute paths in BaseURL

### DIFF
--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -50,6 +50,7 @@ function DashParser(/*config*/) {
         datetimeRegex,
         numericRegex,
         httpOrHttpsRegex,
+        originRegex,
         matchers;
 
     function setup() {
@@ -58,6 +59,7 @@ function DashParser(/*config*/) {
         datetimeRegex = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(?::([0-9]*)(\.[0-9]*)?)?(?:([+-])([0-9]{2})([0-9]{2}))?/;
         numericRegex = /^[-+]?[0-9]+[.]?[0-9]*([eE][-+]?[0-9]+)?$/;
         httpOrHttpsRegex = /^https?:\/\//i;
+        originRegex = /^(https?:\/\/[^\/]+)\/?/i;
         //TODO-Refactor clean this up and move into its own util or somewhere else.
         matchers = [
             {
@@ -306,11 +308,15 @@ function DashParser(/*config*/) {
                 name: 'BaseURL',
                 merge: true,
                 mergeFunction: function (parentValue, childValue) {
-                    var mergedValue;
+                    var mergedValue,
+                        origin;
 
                     // child is absolute, don't merge
                     if (httpOrHttpsRegex.test(childValue)) {
                         mergedValue = childValue;
+                    } else if (childValue.charAt(0) === '/' && originRegex.test(parentValue)) {
+                        origin = parentValue.match(originRegex);
+                        mergedValue = origin[1] + childValue;
                     } else {
                         mergedValue = parentValue + childValue;
                     }

--- a/src/dash/extensions/BaseURLExtensions.js
+++ b/src/dash/extensions/BaseURLExtensions.js
@@ -109,14 +109,16 @@ function BaseURLExtensions() {
     }
 
     function loadSegments(representation, type, range, loadingInfo, callback) {
-        var parts = range ? range.toString().split('-') : null;
+        if (range && (range.start === undefined || range.end === undefined)) {
+            var parts = range ? range.toString().split('-') : null;
+            range = parts ? {start: parseFloat(parts[0]), end: parseFloat(parts[1])} : null;
+        }
 
-        range = parts ? {start: parseFloat(parts[0]), end: parseFloat(parts[1])} : null;
         callback = !callback ? onLoaded : callback;
         var needFailureReport = true;
         var isoFile = null;
         var sidx = null;
-        var hasRange = range !== null;
+        var hasRange = !!range;
         var request = new XMLHttpRequest();
         var media = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
             AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].BaseURL;


### PR DESCRIPTION
This should resolve #521 

Once I got this running with the path-absolute URLs I ran into an issue where we were sending the `Range` header with a value of `bytes=NaN-NaN` which clearly isn't workable. The second commit on here fixes that issue.