### PR TITLE
Use device pixel ratio to calculate size of portal for max representation size

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -443,6 +443,10 @@ function AbrController() {
         let element = videoModel.getElement();
         let elementWidth = element.clientWidth;
         let elementHeight = element.clientHeight;
+        if (window.devicePixelRatio) {
+            elementWidth = elementWidth * window.devicePixelRatio;
+            elementHeight = elementHeight * window.devicePixelRatio;
+        }
         let manifest = manifestModel.getValue();
         let representation = manifestExt.getAdaptationForType(manifest, 0, type).Representation;
         let newIdx = idx;


### PR DESCRIPTION
This uses `window.devicePixelRatio` (if set) to calculate the element width and height.

This makes sure that devices that have a device-pixel-ratio of more than 1 (e.g. Retina iOS / Mac devices) will get the correct quality video. See also #1028 where I suggested doing this.