### PR TITLE
Always have a radix for parseInt

### DIFF
--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -531,7 +531,7 @@ function TTMLParser() {
         // Separate the values in pairs.
         var hexMatrice = hex.match(/.{2}/g);
         // Convert the alpha value in decimal between 0 and 1.
-        var alpha = parseFloat(parseInt((parseInt(hexMatrice[3], 16) / 255) * 1000) / 1000);
+        var alpha = parseFloat(parseInt((parseInt(hexMatrice[3], 16) / 255) * 1000, 10) / 1000);
         // Get the standard RGB value.
         var rgb = hexMatrice.slice(0, 3).map(function (i) {
             return parseInt(i, 16);

--- a/src/streaming/VTTParser.js
+++ b/src/streaming/VTTParser.js
@@ -125,7 +125,7 @@ function VTTParser() {
             if (element.split(/:/).length > 1) {
                 var val = element.split(/:/)[1];
                 if (val && val.search(/%/) != -1) {
-                    val = parseInt(val.replace(/%/, ''));
+                    val = parseInt(val.replace(/%/, ''), 10);
                 }
                 if (element.match(/align/) || element.match(/A/)) {
                     styleObject.align = val;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -227,7 +227,7 @@ function PlaybackController() {
      */
     function getStreamStartTime(streamInfo) {
         var presentationStartTime;
-        var startTimeOffset = parseInt(URIQueryAndFragmentModel(context).getInstance().getURIFragmentData().s);
+        var startTimeOffset = parseInt(URIQueryAndFragmentModel(context).getInstance().getURIFragmentData().s, 10);
 
         if (isDynamic) {
 

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -119,7 +119,7 @@ function DOMStorage() {
 
         var key = type === 'video' ? LOCAL_STORAGE_VIDEO_SETTINGS_KEY : LOCAL_STORAGE_AUDIO_SETTINGS_KEY;
         var obj = JSON.parse(localStorage.getItem(key)) || {};
-        var isExpired = (new Date().getTime() - parseInt(obj.timestamp)) >= experationDict[MEDIA_SETTINGS_EXPIRATION] || false;
+        var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= experationDict[MEDIA_SETTINGS_EXPIRATION] || false;
         var settings = obj.settings;
 
         if (isExpired) {
@@ -140,8 +140,8 @@ function DOMStorage() {
                 if (isSupported(STORAGE_TYPE_LOCAL) && lastBitrateCachingEnabled) {
                     var key = value === 'video' ? LOCAL_STORAGE_VIDEO_BITRATE_KEY : LOCAL_STORAGE_AUDIO_BITRATE_KEY;
                     var obj = JSON.parse(localStorage.getItem(key)) || {};
-                    var isExpired = (new Date().getTime() - parseInt(obj.timestamp)) >= experationDict[BITRATE_EXPIRATION] || false;
-                    var bitrate = parseInt(obj.bitrate);
+                    var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= experationDict[BITRATE_EXPIRATION] || false;
+                    var bitrate = parseInt(obj.bitrate, 10);
 
                     if (!isNaN(bitrate) && !isExpired) {
                         abrController.setInitialBitrateFor(value, bitrate);


### PR DESCRIPTION
Ensure all calls to parseInt that currently do not have a radix have a radix to ensure predictable behaviour.

However, it's probably worth considering whether the second TTMLParser parseInt (L534) is necessary, or whether a Math.floor/round would be more preferable.