### PR TITLE
Fix for #1033

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -450,6 +450,7 @@ function AbrController() {
         if (elementWidth > 0 && elementHeight > 0) {
             while (
                 newIdx > 0 &&
+                representation[newIdx] &&
                 elementWidth < representation[newIdx].width &&
                 elementWidth - representation[newIdx - 1].width < representation[newIdx].width - elementWidth
             ) {


### PR DESCRIPTION
This adds an additional guard to ensure we don't go out of the range of available indexes in the portal size rule.