### PR TITLE
Fix for [2.0] Some API methods don't work before play #973

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -782,7 +782,7 @@ function DashHandler(config) {
         var seg,
             i;
 
-        if (index<ln) {
+        if (index < ln) {
             seg = representation.segments[index];
             if (seg && seg.availabilityIdx === index) {
                 return seg;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -75,6 +75,9 @@ import MediaPlayerFactory from '../streaming/MediaPlayerFactory.js';
 function MediaPlayer() {
 
     const VERSION = '2.0.0';
+    const PLAYBACK_NOT_INITIALIZED_ERROR = 'You must first call play() to init playback before calling this method';
+    const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
+    const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
 
     let context = this.context;
     let eventBus = EventBus(context).getInstance();
@@ -128,12 +131,16 @@ function MediaPlayer() {
         if (initialized) return;
         initialized = true;
 
+        abrController = AbrController(context).getInstance();
+        mediaPlayerModel = MediaPlayerModel(context).getInstance();
+        playbackController = PlaybackController(context).getInstance();
+        mediaController = MediaController(context).getInstance();
+        mediaController.initialize();
         manifestExt = DashManifestExtensions(context).getInstance();
         metricsExt = DashMetricsExtensions(context).getInstance();
         domStorage = DOMStorage(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
         metricsModel.setConfig({adapter: createAdaptor()});
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
         errHandler = ErrorHandler(context).getInstance();
 
         restoreDefaultUTCTimingSources();
@@ -174,7 +181,7 @@ function MediaPlayer() {
 
         if (!playbackInitiated) {
             if (!initialized) {
-                throw 'MediaPlayer not initialized!';
+                throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
             }
             if (!element || !source) {
                 throw 'Missing view or source.';
@@ -198,30 +205,51 @@ function MediaPlayer() {
     }
 
     function pause() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         playbackController.pause();
     }
 
     function isPaused() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return playbackController.isPaused();
     }
 
     function isSeeking() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return playbackController.isSeeking();
     }
 
     function setMute(value) {
+        if (!element) {
+            throw ELEMENT_NOT_ATTACHED_ERROR;
+        }
         element.muted = value;
     }
 
     function isMuted() {
+        if (!element) {
+            throw ELEMENT_NOT_ATTACHED_ERROR;
+        }
         return element.muted;
     }
 
     function setVolume(value) {
+        if (!element) {
+            throw ELEMENT_NOT_ATTACHED_ERROR;
+        }
         element.volume = value;
     }
 
     function getVolume() {
+        if (!element) {
+            throw ELEMENT_NOT_ATTACHED_ERROR;
+        }
         return element.volume;
     }
 
@@ -240,7 +268,7 @@ function MediaPlayer() {
     function getDVRWindowSize() {
         var metric = getDVRInfoMetric();
         if (!metric) {
-            return NaN;
+            return 0;
         }
         return metric.manifestInfo.DVRWindowSize;
     }
@@ -258,6 +286,11 @@ function MediaPlayer() {
      */
     function getDVRSeekOffset(value) {
         var metric = getDVRInfoMetric();
+
+        if (!metric) {
+            return 0;
+        }
+
         var val = metric.range.start + value;
 
         if (val > metric.range.end) {
@@ -277,6 +310,9 @@ function MediaPlayer() {
      * @instance
      */
     function seek(value) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         var s = playbackController.getIsDynamic() ? getDVRSeekOffset(value) : value;
         playbackController.seek(s);
     }
@@ -290,6 +326,9 @@ function MediaPlayer() {
      * @instance
      */
     function time() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         var t = element.currentTime;
         if (playbackController.getIsDynamic()) {
             var metric = getDVRInfoMetric();
@@ -306,6 +345,9 @@ function MediaPlayer() {
      * @instance
      */
     function duration() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         var d = element.duration;
 
         if (playbackController.getIsDynamic()) {
@@ -313,7 +355,7 @@ function MediaPlayer() {
             var metric = getDVRInfoMetric();
             var range;
 
-            if (metric === null) {
+            if (!metric) {
                 return 0;
             }
 
@@ -328,7 +370,7 @@ function MediaPlayer() {
         var availableFrom,
             utcValue;
 
-        if (metric === null) {
+        if (!metric) {
             return 0;
         }
         availableFrom = metric.manifestInfo.availableFrom.getTime() / 1000;
@@ -345,6 +387,9 @@ function MediaPlayer() {
      * @instance
      */
     function timeAsUTC() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return getAsUTC(time());
     }
 
@@ -357,6 +402,9 @@ function MediaPlayer() {
      * @instance
      */
     function durationAsUTC() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return getAsUTC(duration());
     }
 
@@ -395,6 +443,9 @@ function MediaPlayer() {
     }
 
     function getActiveStream() {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         var streamInfo = streamController.getActiveStreamInfo();
         return streamInfo ? streamController.getStreamById(streamInfo.id) : null;
     }
@@ -454,6 +505,9 @@ function MediaPlayer() {
      * @instance
      */
     function getVideoModel() {
+        if (!element) {
+            throw ELEMENT_NOT_ATTACHED_ERROR;
+        }
         return videoModel;
     }
 
@@ -508,7 +562,7 @@ function MediaPlayer() {
      *
      */
     function enableLastBitrateCaching(enable, ttl) {
-        domStorage.enableLastBitrateCaching(enable, ttl);
+        mediaPlayerModel.setLastBitrateCachingInfo(enable, ttl);
     }
 
     /**
@@ -526,7 +580,7 @@ function MediaPlayer() {
      *
      */
     function enableLastMediaSettingsCaching(enable, ttl) {
-        domStorage.enableLastMediaSettingsCaching(enable, ttl);
+        mediaPlayerModel.setLastMediaSettingsCachingInfo(enable, ttl);
     }
 
     /**
@@ -659,6 +713,9 @@ function MediaPlayer() {
      * @instance
      */
     function getQualityFor(type) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return abrController.getQualityFor(type, streamController.getActiveStreamInfo());
     }
 
@@ -671,6 +728,9 @@ function MediaPlayer() {
      * @instance
      */
     function setQualityFor(type, value) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         abrController.setPlaybackQuality(type, streamController.getActiveStreamInfo(), value);
     }
 
@@ -704,6 +764,9 @@ function MediaPlayer() {
      * @instance
      */
     function setTextTrack(idx) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         //For external time text file,  the only action needed to change a track is marking the track mode to showing.
         // Fragmented text tracks need the additional step of calling textSourceBuffer.setTextTrack();
         if (textSourceBuffer === undefined) {
@@ -732,6 +795,9 @@ function MediaPlayer() {
      * @instance
      */
     function getBitrateInfoListFor(type) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         var stream = getActiveStream();
         return stream ? stream.getBitrateListFor(type) : [];
     }
@@ -753,6 +819,9 @@ function MediaPlayer() {
      * @instance
      */
     function getInitialBitrateFor(type) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR; //abrController.getInitialBitrateFor is overloaded with ratioDict logic that needs manifest force it to not be callable pre play.
+        }
         return abrController.getInitialBitrateFor(type);
     }
 
@@ -784,6 +853,9 @@ function MediaPlayer() {
      * @instance
      */
     function getStreamsFromManifest(manifest) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         return adapter.getStreamsInfo(manifest);
     }
 
@@ -795,10 +867,11 @@ function MediaPlayer() {
      * @instance
      */
     function getTracksFor(type) {
-        var streamInfo = streamController ? streamController.getActiveStreamInfo() : null;
-
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+        let streamInfo = streamController.getActiveStreamInfo();
         if (!streamInfo) return [];
-
         return mediaController.getTracksFor(type, streamInfo);
     }
 
@@ -812,6 +885,10 @@ function MediaPlayer() {
      * @instance
      */
     function getTracksForTypeFromManifest(type, manifest, streamInfo) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+
         streamInfo = streamInfo || adapter.getStreamsInfo(manifest)[0];
 
         return streamInfo ? adapter.getAllMediaInfoForType(manifest, streamInfo, type) : [];
@@ -824,7 +901,10 @@ function MediaPlayer() {
      * @instance
      */
     function getCurrentTrackFor(type) {
-        var streamInfo = streamController ? streamController.getActiveStreamInfo() : null;
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+        var streamInfo = streamController.getActiveStreamInfo();
 
         if (!streamInfo) return null;
 
@@ -873,6 +953,9 @@ function MediaPlayer() {
      * @instance
      */
     function setCurrentTrack(track) {
+        if (!playbackInitiated) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
         mediaController.setTrack(track);
     }
 
@@ -980,23 +1063,12 @@ function MediaPlayer() {
         abrController.setAutoSwitchBitrateFor(type, value);
     }
 
-
-
-    /**
-     * A Callback function provided when retrieving manifests
-     *
-     * @callback MediaPlayer~retrieveManifestCallback
-     * @param {Object} manifest JSON version of the manifest XML data or null if an
-     * error was encountered
-     * @param {String} error An error string or null if the operation was successful
-     */
-
     /**
      * Allows application to retrieve a manifest.  Manifest loading is asynchronous and
      * requires the app-provided callback function
      *
-     * @param {string} url the manifest url
-     * @param {MediaPlayer~retrieveManifestCallback} callback manifest retrieval callback
+     * @param url {string} url the manifest url
+     * @param callback {function} A Callback function provided when retrieving manifests
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1175,7 +1247,7 @@ function MediaPlayer() {
      * @instance
      */
     function displayCaptionsOnTop(value) {
-        var textTrackExt = TextTrackExtensions(context).getInstance();
+        let textTrackExt = TextTrackExtensions(context).getInstance();
         textTrackExt.setConfig({videoModel: videoModel});
         textTrackExt.initialize();
         textTrackExt.displayCConTop(value);
@@ -1190,9 +1262,8 @@ function MediaPlayer() {
      */
     function attachVideoContainer(container) {
         if (!videoModel) {
-            throw 'Must call attachView with video element before you attach container element';
+            throw ELEMENT_NOT_ATTACHED_ERROR;
         }
-
         videoModel.setVideoContainer(container);
     }
 
@@ -1205,7 +1276,7 @@ function MediaPlayer() {
      */
     function attachView(view) {
         if (!initialized) {
-            throw 'MediaPlayer not initialized!';
+            throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
         }
         videoModel = null;
         element = view;
@@ -1229,7 +1300,7 @@ function MediaPlayer() {
      */
     function attachTTMLRenderingDiv(div) {
         if (!videoModel) {
-            throw 'Must call attachView with video element before you attach TTML Rendering Div';
+            throw ELEMENT_NOT_ATTACHED_ERROR;
         }
         videoModel.setTTMLRenderingDiv(div);
     }
@@ -1253,7 +1324,7 @@ function MediaPlayer() {
      */
     function attachSource(urlOrManifest, protectionCtrl, data) {//TODO way too overloaded with protection.  Break out all protection and only accept source.
         if (!initialized) {
-            throw 'MediaPlayer not initialized!';
+            throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
         }
 
         if (typeof urlOrManifest === 'string') {
@@ -1298,8 +1369,7 @@ function MediaPlayer() {
         }
     }
 
-    function onStreamTeardownComplete(/* e */) {
-        // Finish rest of shutdown process
+    function onStreamTeardownComplete() { //TODO see if we really need to be async here in streamController.reset() and resetAndPlay above.
         abrController.reset();
         rulesController.reset();
         playbackController.reset();
@@ -1333,14 +1403,11 @@ function MediaPlayer() {
             sourceBufferExt: sourceBufferExt
         });
 
-        mediaController = MediaController(context).getInstance();
         mediaController.initialize();
         mediaController.setConfig({
             DOMStorage: domStorage,
             errHandler: errHandler
         });
-
-        playbackController = PlaybackController(context).getInstance();
 
         rulesController = RulesController(context).getInstance();
         rulesController.initialize();
@@ -1370,7 +1437,6 @@ function MediaPlayer() {
         });
         streamController.initialize(autoPlay, protectionData);
 
-        abrController = AbrController(context).getInstance();
         abrController.setConfig({
             abrRulesCollection: abrRulesCollection,
             rulesController: rulesController,

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -314,9 +314,7 @@ function MediaController() {
      * @memberof MediaController#
      */
     function reset() {
-        resetInitialSettings();
-        resetSwitchMode();
-        tracks = {};
+        initialize();
         textSourceBuffer.resetEmbedded();
     }
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -5,6 +5,9 @@ const BUFFER_TO_KEEP = 30;
 const BUFFER_PRUNING_INTERVAL = 30;
 const LIVE_DELAY_FRAGMENT_COUNT = 4;
 
+const DEFAULT_LOCAL_STORAGE_BITRATE_EXPIRATION = 360000;
+const DEFAULT_LOCAL_STORAGE_MEDIA_SETTINGS_EXPIRATION = 360000;
+
 function MediaPlayerModel() {
 
     let instance,
@@ -14,13 +17,17 @@ function MediaPlayerModel() {
         liveDelayFragmentCount,
         scheduleWhilePaused,
         bufferToKeep,
-        bufferPruningInterval;
+        bufferPruningInterval,
+        lastBitrateCachingInfo,
+        lastMediaSettingsCachingInfo;
 
     function setup() {
         UTCTimingSources = [];
         useSuggestedPresentationDelay = false;
         useManifestDateHeaderTimeSource = true;
         scheduleWhilePaused = false;
+        lastBitrateCachingInfo = {enabled: true , ttl: DEFAULT_LOCAL_STORAGE_BITRATE_EXPIRATION};
+        lastMediaSettingsCachingInfo = {enabled: true , ttl: DEFAULT_LOCAL_STORAGE_MEDIA_SETTINGS_EXPIRATION};
         liveDelayFragmentCount = LIVE_DELAY_FRAGMENT_COUNT;
         bufferToKeep = BUFFER_TO_KEEP;
         bufferPruningInterval = BUFFER_PRUNING_INTERVAL;
@@ -33,6 +40,28 @@ function MediaPlayerModel() {
 
     function getBufferToKeep() {
         return bufferToKeep;
+    }
+
+    function setLastBitrateCachingInfo(enable, ttl) {
+        lastBitrateCachingInfo.enabled = enable;
+        if (ttl !== undefined && !isNaN(ttl) && typeof (ttl) === 'number') {
+            lastBitrateCachingInfo.ttl = ttl;
+        }
+    }
+
+    function getLastBitrateCachingInfo() {
+        return lastBitrateCachingInfo;
+    }
+
+    function setLastMediaSettingsCachingInfo(enable, ttl) {
+        lastMediaSettingsCachingInfo.enabled = enable;
+        if (ttl !== undefined && !isNaN(ttl) && typeof (ttl) === 'number') {
+            lastMediaSettingsCachingInfo.ttl = ttl;
+        }
+    }
+
+    function getLastMediaSettingsCachingInfo() {
+        return lastMediaSettingsCachingInfo;
     }
 
     function setBufferPruningInterval(value) {
@@ -88,6 +117,10 @@ function MediaPlayerModel() {
     }
 
     instance = {
+        setLastBitrateCachingInfo: setLastBitrateCachingInfo,
+        getLastBitrateCachingInfo: getLastBitrateCachingInfo,
+        setLastMediaSettingsCachingInfo: setLastMediaSettingsCachingInfo,
+        getLastMediaSettingsCachingInfo: getLastMediaSettingsCachingInfo,
         setBufferToKeep: setBufferToKeep,
         getBufferToKeep: getBufferToKeep,
         setBufferPruningInterval: setBufferPruningInterval,

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -207,7 +207,7 @@ function ProtectionModel_3Feb2014(config) {
           capabilities = keySystemAccess.ksConfiguration.audioCapabilities[0];
 
         if (capabilities === null)
-          throw new Error("Can not create sessions for unknown content types.");
+          throw new Error('Can not create sessions for unknown content types.');
 
         var contentType = capabilities.contentType;
         var session = mediaKeys.createSession(contentType, new Uint8Array(initData));

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -30,18 +30,15 @@
  */
 import AbrController from '../controllers/AbrController.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
+import MediaPlayerModel from '../models/MediaPlayerModel.js';
 import Debug from '../../core/Debug.js';
 
 const LOCAL_STORAGE_VIDEO_BITRATE_KEY = 'dashjs_vbitrate';
 const LOCAL_STORAGE_AUDIO_BITRATE_KEY = 'dashjs_abitrate';
 const LOCAL_STORAGE_AUDIO_SETTINGS_KEY = 'dashjs_asettings';
 const LOCAL_STORAGE_VIDEO_SETTINGS_KEY = 'dashjs_vsettings';
-const DEFAULT_LOCAL_STORAGE_BITRATE_EXPIRATION = 360000;
-const DEFAULT_LOCAL_STORAGE_MEDIA_SETTINGS_EXPIRATION = 360000;
 const STORAGE_TYPE_LOCAL = 'localStorage';
 const STORAGE_TYPE_SESSION = 'sessionStorage';
-const BITRATE_EXPIRATION = 0;
-const MEDIA_SETTINGS_EXPIRATION = 1;
 
 function DOMStorage() {
 
@@ -51,29 +48,11 @@ function DOMStorage() {
     let instance,
         supported,
         abrController,
-        lastBitrateCachingEnabled,
-        lastMediaSettingsCachingEnabled,
-        experationDict;
+        mediaPlayerModel;
 
     function setup() {
-        experationDict = {
-            BITRATE_EXPIRATION: DEFAULT_LOCAL_STORAGE_BITRATE_EXPIRATION,
-            MEDIA_SETTINGS_EXPIRATION: DEFAULT_LOCAL_STORAGE_MEDIA_SETTINGS_EXPIRATION
-        };
-
-        lastBitrateCachingEnabled = true;
-        lastMediaSettingsCachingEnabled = true;
+        mediaPlayerModel = MediaPlayerModel(context).getInstance();
         abrController = AbrController(context).getInstance();
-    }
-
-    function enableLastBitrateCaching(enable, ttl) {
-        lastBitrateCachingEnabled = enable;
-        setExpiration(BITRATE_EXPIRATION, ttl);
-    }
-
-    function enableLastMediaSettingsCaching(enable, ttl) {
-        lastMediaSettingsCachingEnabled = enable;
-        setExpiration(MEDIA_SETTINGS_EXPIRATION, ttl);
     }
 
     //type can be local, session
@@ -115,11 +94,11 @@ function DOMStorage() {
 
     function getSavedMediaSettings(type) {
         //Checks local storage to see if there is valid, non-expired media settings
-        if (!isSupported(STORAGE_TYPE_LOCAL) || !lastMediaSettingsCachingEnabled) return null;
+        if (!isSupported(STORAGE_TYPE_LOCAL) || !mediaPlayerModel.getLastMediaSettingsCachingInfo().enabled) return null;
 
         var key = type === 'video' ? LOCAL_STORAGE_VIDEO_SETTINGS_KEY : LOCAL_STORAGE_AUDIO_SETTINGS_KEY;
         var obj = JSON.parse(localStorage.getItem(key)) || {};
-        var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= experationDict[MEDIA_SETTINGS_EXPIRATION] || false;
+        var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= mediaPlayerModel.getLastMediaSettingsCachingInfo().ttl || false;
         var settings = obj.settings;
 
         if (isExpired) {
@@ -137,10 +116,10 @@ function DOMStorage() {
                 //Checks local storage to see if there is valid, non-expired bit rate
                 //hinting from the last play session to use as a starting bit rate. if not,
                 // it uses the default video and audio value in AbrController
-                if (isSupported(STORAGE_TYPE_LOCAL) && lastBitrateCachingEnabled) {
+                if (isSupported(STORAGE_TYPE_LOCAL) && mediaPlayerModel.getLastBitrateCachingInfo().enabled ) {
                     var key = value === 'video' ? LOCAL_STORAGE_VIDEO_BITRATE_KEY : LOCAL_STORAGE_AUDIO_BITRATE_KEY;
                     var obj = JSON.parse(localStorage.getItem(key)) || {};
-                    var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= experationDict[BITRATE_EXPIRATION] || false;
+                    var isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= mediaPlayerModel.getLastBitrateCachingInfo().ttl || false;
                     var bitrate = parseInt(obj.bitrate, 10);
 
                     if (!isNaN(bitrate) && !isExpired) {
@@ -159,17 +138,9 @@ function DOMStorage() {
         }, this);
     }
 
-    function setExpiration(type, ttl) {
-        if (ttl !== undefined && !isNaN(ttl) && typeof (ttl) === 'number') {
-            experationDict[type] = ttl;
-        }
-    }
-
     instance = {
         checkInitialBitrate: checkInitialBitrate,
         getSavedMediaSettings: getSavedMediaSettings,
-        enableLastMediaSettingsCaching: enableLastMediaSettingsCaching,
-        enableLastBitrateCaching: enableLastBitrateCaching,
         isSupported: isSupported
     };
 


### PR DESCRIPTION
Move creation of some controllers to mediaplayer init.  Moved some DOM storage logic into mediaplayer model.  