### PR TITLE
Fixes #1018

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -195,6 +195,7 @@ function MediaPlayer() {
             } else {
                 streamController.loadWithManifest(source);
             }
+            element.autoplay = true;
         }
 
         if (!autoPlay || (isPaused() && playbackInitiated)) {
@@ -207,6 +208,7 @@ function MediaPlayer() {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
         playbackController.pause();
+        element.autoplay = false;
     }
 
     function isPaused() {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -396,6 +396,7 @@ function PlaybackController() {
 
     function onPlaybackEnded() {
         log('Native video element event: ended');
+        element.autoplay = false;
         stopUpdatingWallclockTime();
         eventBus.trigger(Events.PLAYBACK_ENDED);
     }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -147,7 +147,6 @@ function StreamController() {
 
     function onCanPlay(/*e*/) {
         canPlay = true;
-        startAutoPlay();
     }
 
     function onPlaybackError(e) {


### PR DESCRIPTION
Currently, playback resumes if you pause then seek if both autoplay and scheduleWhilePaused are true.

This is because after a see, a canplay will fire from the media element once content is in the buffer. Dash.js considers this the same as it does the first at startup and starts playback.

However, removing the startAutoPlay line from the onCanPlay event results in further problems. We use the autoplay property of the media element itself to track whether or not we are actively "trying to play", with the bonus of actually starting playback on a canplay event if that is the case.

I'm sure you'll think the direct access of element.autoplay here isn't great, and I agree and am open to ways to handle this better. I'd like to do it all in the playbackController, but part of the problem is that you can't call play() on the playbackController until it has been initialized, and it isn't initialized until the MPD is loaded etc. I'd be happy to take on board any suggestions to refactor this in a nicer way if it isn't a large piece of work.