### PR TITLE
Clean up externals global variables so it works with module loaders.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,11 +15,7 @@
     "predef" : [
         "it",
         "describe",
-        "ISOBoxer",
-        "ObjectIron",
-        "X2JS",
         "kendo",
-        "BASE64",
         "utils",
         "MediaPlayer",
         "Dash",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,25 +34,12 @@ module.exports = function (grunt) {
                 }
             },
 
-            build_all: {
-                options: {
-                    sourceMap: false,
-                },
-                files: {
-                    'build/temp/dash.all.min.js': ['build/temp/dash.no-externals.debug.js', 'externals/*.js']
-                }
-            },
             build_core: {
                 options: {
                     sourceMapIn: 'build/temp/dash.mediaplayer.debug.js.map'
                 },
                 files: {
                     'build/temp/dash.mediaplayer.min.js': 'build/temp/dash.mediaplayer.debug.js'
-                }
-            },
-            build_external: {
-                files: {
-                    'build/temp/dash.externals.min.js': 'externals/*.js',
                 }
             },
             build_protection: {
@@ -64,18 +51,6 @@ module.exports = function (grunt) {
                 }
             },
 
-            debug_external: {
-                options: {
-                    sourceMap: true,
-                    sourceMapRoot: './externals',
-                    beautify: false,
-                    compress: false,
-                    mangle: false
-                },
-                files: {
-                    'build/temp/dash.externals.debug.js': 'externals/*.js'
-                }
-            }
         },
         copy: {
             dist: {
@@ -83,11 +58,8 @@ module.exports = function (grunt) {
                 cwd: 'build/temp/',
                 src: [
                     'dash.all.min.js', 'dash.all.min.js.map',
-                    'dash.externals.min.js', 'dash.externals.min.js.map',
                     'dash.mediaplayer.min.js', 'dash.mediaplayer.min.js.map',
                     'dash.protection.min.js', 'dash.protection.min.js.map',
-                    'dash.no-externals.debug.js', 'dash.no-externals.debug.js.map',
-                    'dash.externals.debug.js', 'dash.externals.debug.js.map',
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
                     'dash.protection.debug.js', 'dash.protection.debug.js.map'
                 ],
@@ -96,12 +68,6 @@ module.exports = function (grunt) {
             }
         },
         exorcise: {
-            no_externals: {
-                options: {},
-                files: {
-                    'build/temp/dash.no-externals.debug.js.map': ['build/temp/dash.no-externals.debug.js']
-                }
-            },
             mediaplayer: {
                 options: {},
                 files: {
@@ -148,7 +114,7 @@ module.exports = function (grunt) {
             },
             all: {
                 files: {
-                    'build/temp/dash.no-externals.debug.js': ['src/All.js']
+                    'build/temp/dash.all.min.js': ['src/All.js']
                 },
                 options: {
                     browserifyOptions: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,14 @@ module.exports = function (grunt) {
                     'build/temp/dash.protection.min.js': 'build/temp/dash.protection.debug.js'
                 }
             },
+            build_all: {
+                options: {
+                    sourceMapIn: 'build/temp/dash.all.debug.js.map'
+                },
+                files: {
+                    'build/temp/dash.all.min.js': 'build/temp/dash.all.debug.js'
+                }
+            },
 
         },
         copy: {
@@ -78,6 +86,12 @@ module.exports = function (grunt) {
                 options: {},
                 files: {
                     'build/temp/dash.protection.debug.js.map': ['build/temp/dash.protection.debug.js']
+                }
+            },
+            all: {
+                options: {},
+                files: {
+                    'build/temp/dash.all.debug.js.map': ['build/temp/dash.all.debug.js']
                 }
             }
         },
@@ -114,7 +128,7 @@ module.exports = function (grunt) {
             },
             all: {
                 files: {
-                    'build/temp/dash.all.min.js': ['src/All.js']
+                    'build/temp/dash.all.debug.js': ['src/All.js']
                 },
                 options: {
                     browserifyOptions: {

--- a/externals/objectiron.js
+++ b/externals/objectiron.js
@@ -212,3 +212,5 @@ function ObjectIron(map) {
         run: performMapping
     };
 }
+
+export default ObjectIron;

--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -414,3 +414,4 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
 		escapeMode = enabled;
 	}
 }
+export default X2JS;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "time-grunt": "^1.2.0",
     "uglify-js": "^2.4.21"
   },
+  "dependencies": {
+    "codem-isoboxer": "0.2.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Dash-Industry-Forum/dash.js.git"

--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -31,6 +31,8 @@
 import ErrorHandler from '../streaming/ErrorHandler.js';
 import FactoryMaker from '../core/FactoryMaker.js';
 import Debug from '../core/Debug.js';
+import ObjectIron from '../../externals/objectiron.js';
+import X2JS from '../../externals/xml2json.js';
 
 function DashParser(/*config*/) {
 

--- a/src/streaming/TTMLParser.js
+++ b/src/streaming/TTMLParser.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../core/FactoryMaker.js';
+import X2JS from '../../externals/xml2json.js';
 
 const SECONDS_IN_HOUR = 60 * 60; // Expression of an hour in seconds
 const SECONDS_IN_MIN = 60; // Expression of a minute in seconds

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -31,6 +31,7 @@
 import EventBus from '../../core/EventBus.js';
 import Events from '../../core/events/Events.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
+import X2JS from '../../../externals/xml2json.js';
 
 const RESOLVE_TYPE_ONLOAD = 'onLoad';
 const RESOLVE_TYPE_ONACTUATE = 'onActuate';

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -29,6 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+import BASE64 from '../../../externals/base64.js';
+
 class CommonEncryption {
     /**
      * Find and return the ContentProtection element in the given array

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -39,6 +39,7 @@ import CommonEncryption from '../CommonEncryption.js';
 import Error from '../../vo/Error.js';
 
 import FactoryMaker from '../../../core/FactoryMaker.js';
+import BASE64 from '../../../../externals/base64.js';
 
 const uuid = '9a04f079-9840-4286-ab92-e65be0885f95';
 const systemString = 'com.microsoft.playready';

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -36,6 +36,7 @@
  * @class
  */
 import FactoryMaker from '../../../core/FactoryMaker.js';
+import BASE64 from '../../../../externals/base64.js';
 
 function DRMToday() {
 

--- a/src/streaming/utils/BoxParser.js
+++ b/src/streaming/utils/BoxParser.js
@@ -31,6 +31,7 @@
 
 import IsoFile from './IsoFile.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
+import ISOBoxer from 'codem-isoboxer';
 
 function BoxParser(/*config*/) {
 


### PR DESCRIPTION
Attempting to use dash.js with module loader javascript frameworks such
as web pack or browserify was not working well. This was because of
global libraries that were not being included using require or import
syntax.  Removing this global variable leak fixes the issues when
incorporating it into many modern stacks.

External libraries have been updated and all source files requiring
them are explicitly using the ‘import from …’ syntax.  Gruntfile and
.jshintrc have been updated.

It now builds into a single all.min.js file