### PR TITLE
Will now remove previous mimeMap entry to avoid conflicts

### DIFF
--- a/web.config
+++ b/web.config
@@ -3,6 +3,7 @@
 <configuration>
     <system.webServer>
         <staticContent>
+            <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
         </staticContent>
     </system.webServer>


### PR DESCRIPTION
Previous web.config did not consider that inherited configuration may already define the .json MIME type mapping. Now any inherited configuration is removed before applying a new one.