### PR TITLE
Adding getBufferLength() method to MediaPlayer

### DIFF
--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -21,11 +21,7 @@
 
         function updateStats()
         {
-            var metrics = player.getMetricsFor('video'),
-                metricsExt = player.getMetricsExt(),
-                bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
-
-            document.querySelector("#stats").innerHTML = "Buffer level " + bufferLevel.level.toPrecision(3) + "s";
+            document.querySelector("#stats").innerHTML = "Buffer level " + player.getBufferLength() + "s";
         }
     </script>
     <style>

--- a/samples/live-streaming/live-delay-comparison.html
+++ b/samples/live-streaming/live-delay-comparison.html
@@ -59,7 +59,9 @@
                 {
                     var p = eval("player"+i);
                     document.querySelector("#video" + i + "delay").innerHTML = Math.round((d.getTime()/1000) - Number(p.timeAsUTC()));
+                    document.querySelector("#video" + i + "buffer").innerHTML = p.getBufferLength()+ "s";
                 }
+
 
             },1000);
 
@@ -87,17 +89,20 @@ Lowest latency is achieved with shorter segments and with a lower liveDelayFragm
     2s segment, 0 segments behind live<br/>
         <video id="video1" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video1delay"></span>
+        Seconds behind live: <span id="video1delay"></span><br/>
+        Buffer length: <span id="video1buffer"></span>
     </td><td>
         2s segment, 2 segments behind live<br/>
         <video id="video2" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video2delay"></span>
+        Seconds behind live: <span id="video2delay"></span><br/>
+        Buffer length: <span id="video2buffer"></span>
     </td><td>
         2s segment, 4 segments behind live (default)<br/>
         <video id="video3" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video3delay"></span>
+        Seconds behind live: <span id="video3delay"></span><br/>
+        Buffer length: <span id="video3buffer"></span>
     </td>
     <td>Wall clock time
         <div class="clock">
@@ -108,17 +113,20 @@ Lowest latency is achieved with shorter segments and with a lower liveDelayFragm
         6s segment, 0 segments behind live<br/>
         <video id="video4" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video4delay"></span>
+        Seconds behind live: <span id="video4delay"></span><br/>
+        Buffer length: <span id="video4buffer"></span>
     </td><td>
         6s segment, 2 segments behind live<br/>
         <video id="video5" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video5delay"></span>
+        Seconds behind live: <span id="video5delay"></span><br/>
+        Buffer length: <span id="video5buffer"></span>
     </td><td>
         6s segment, 4 segments behind live (default)<br/>
         <video id="video6" controls="true">
         </video><br/>
-        Seconds behind live: <span id="video6delay"></span>
+        Seconds behind live: <span id="video6delay"></span><br/>
+        Buffer length: <span id="video6buffer"></span>
     </td></tr>
     </div>
 </div>

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -261,6 +261,22 @@ function MediaPlayer() {
     }
 
     /**
+     * The length of the buffer for a given media type, in seconds. Valid media types are "video" and "audio". If no type
+     * is passed in, then the video buffer length is returned. The value is returned to a precision of two decimal places.
+     *
+     * @returns {number} The length of the buffer for the given media type, in seconds.
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getBufferLength(type) {
+        if (!type)
+        {
+            type = 'video';
+        }
+        return getMetricsExt().getCurrentBufferLevel(getMetricsFor(type)).level.toPrecision(3);
+    }
+
+    /**
      * The timeShiftBufferLength (DVR Window), in seconds.
      *
      * @returns {number} The window of allowable play time behind the live point of a live stream.
@@ -1599,6 +1615,7 @@ function MediaPlayer() {
         formatUTC: formatUTC,
         getVersion: getVersion,
         getDebug: getDebug,
+        getBufferLength: getBufferLength,
         getVideoModel: getVideoModel,
         getVideoContainer: getVideoContainer,
         setLiveDelayFragmentCount: setLiveDelayFragmentCount,


### PR DESCRIPTION
Bufferlength is a core metric to track in player QoS. The prior solution to extract the buffer length from mediaPlayer requires:

 var metrics = player.getMetricsFor('video'),
-                metricsExt = player.getMetricsExt(),
-                bufferLevel = metricsExt.getCurrentBufferLevel(metrics);

This is non-intuitive for new users. To facilitate easier extraction of the buffer length, I have added a new getter for MediaPlayer:

player.getBufferLength()

This takes optional arguments of "video" or "audio". If no argument is passed, the video buffer length of video is returned.

Updated two sample files to show this API in action. 