### PR TITLE
MPEG/DVB-compliant Metrics Reporting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,5 +27,6 @@
         "Caster",
         "TextTrackCue",
         "HTMLMediaElement",
+        "MediaError",
         "cea608parser"]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,16 @@ module.exports = function (grunt) {
                     'build/temp/dash.protection.min.js': 'build/temp/dash.protection.debug.js'
                 }
             },
+
+            build_reporting: {
+                options: {
+                    sourceMapIn: 'build/temp/dash.reporting.debug.js.map'
+                },
+                files: {
+                    'build/temp/dash.reporting.min.js': 'build/temp/dash.reporting.debug.js'
+                }
+            },
+
             build_all: {
                 options: {
                     sourceMapIn: 'build/temp/dash.all.debug.js.map'
@@ -69,8 +79,10 @@ module.exports = function (grunt) {
                     'dash.mediaplayer.min.js', 'dash.mediaplayer.min.js.map',
                     'dash.protection.min.js', 'dash.protection.min.js.map',
                     'dash.all.debug.js', 'dash.all.debug.js.map',
+                    'dash.reporting.min.js', 'dash.reporting.min.js.map',
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
-                    'dash.protection.debug.js', 'dash.protection.debug.js.map'
+                    'dash.protection.debug.js', 'dash.protection.debug.js.map',
+                    'dash.reporting.debug.js', 'dash.reporting.debug.js.map'
                 ],
                 dest: 'dist/',
                 filter: 'isFile'
@@ -93,6 +105,12 @@ module.exports = function (grunt) {
                 options: {},
                 files: {
                     'build/temp/dash.all.debug.js.map': ['build/temp/dash.all.debug.js']
+                }
+            },
+            reporting: {
+                options: {},
+                files: {
+                    'build/temp/dash.reporting.debug.js.map': ['build/temp/dash.reporting.debug.js']
                 }
             }
         },
@@ -127,6 +145,21 @@ module.exports = function (grunt) {
                     transform: ['babelify']
                 }
             },
+            reporting: {
+                files: {
+                    'build/temp/dash.reporting.debug.js': ['src/streaming/metrics/MetricsReporting.js']
+                },
+                options: {
+                    browserifyOptions: {
+                        debug: true,
+                        standalone: 'MetricsReporting'
+                    },
+                    plugin: [
+                        ['browserify-derequire']
+                    ],
+                    transform: ['babelify']
+                }
+            },
             all: {
                 files: {
                     'build/temp/dash.all.debug.js': ['src/All.js']
@@ -150,7 +183,7 @@ module.exports = function (grunt) {
                     watch: true,
                     keepAlive: true,
                     browserifyOptions: {
-                        debug:true
+                        debug: true
                     },
                     plugin: [
                       ['browserify-derequire']
@@ -189,7 +222,7 @@ module.exports = function (grunt) {
 
     require('load-grunt-tasks')(grunt);
     grunt.registerTask('default',   ['dist', 'test']);
-    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:all', 'minimize', 'copy:dist']);
+    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:reporting', 'browserify:all', 'minimize', 'copy:dist']);
     grunt.registerTask('minimize',  ['exorcise', 'uglify']);
     grunt.registerTask('test',      ['mocha_istanbul:test']);
     grunt.registerTask('watch',     ['browserify:watch']);

--- a/contrib/webmjs/app/main.js
+++ b/contrib/webmjs/app/main.js
@@ -180,34 +180,34 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
                 requestWindow = Requests
                     .slice(-20)
-                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req.mediaduration && req.type === "Media Segment" && req.stream === type;})
+                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req._mediaduration && req.type === "MediaSegment" && req._stream === type;})
                     .slice(-4);
                 if (requestWindow.length > 0) {
 
                     latencyTimes = requestWindow.map(function (req){ return Math.abs(req.tresponse.getTime() - req.trequest.getTime()) / 1000;});
 
                     movingLatency[type] = {
-                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length, 
-                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length,
+                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: latencyTimes.length
                     };
 
-                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
+                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req._tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
-                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length, 
-                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
+                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: downloadTimes.length
                     };
 
-                    durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
+                    durationTimes = requestWindow.map(function (req){ return req._mediaduration;});
 
                     movingRatio[type] = {
-                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average, 
-                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low, 
-                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high, 
+                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
+                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low,
+                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high,
                         count: durationTimes.length
                     };
                 }
@@ -232,7 +232,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = bufferLevel.level.toPrecision(5);
+                bufferLengthValue = bufferLevel.toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {
@@ -535,28 +535,28 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     }
 
     // Get initial stream if it was passed in.
-	var paramUrl = null;
+    var paramUrl = null;
 
     if (vars && vars.hasOwnProperty("url")) {
-    	paramUrl = vars.url;
+        paramUrl = vars.url;
     }
 
     if (vars && vars.hasOwnProperty("mpd")) {
-    	paramUrl = vars.mpd;
+        paramUrl = vars.mpd;
     }
 
     if (paramUrl !== null) {
-    	var startPlayback = true;
-    
-    	$scope.selectedItem = {};
+        var startPlayback = true;
+
+        $scope.selectedItem = {};
         $scope.selectedItem.url = paramUrl;
 
         if (vars.hasOwnProperty("autoplay")) {
-        	startPlayback = (vars.autoplay === 'true');
+            startPlayback = (vars.autoplay === 'true');
         }
 
-    	if (startPlayback) {
-	    	$scope.doLoad();
-		}
+        if (startPlayback) {
+            $scope.doLoad();
+        }
     }
 });

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -141,17 +141,23 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
     $scope.getVideoTreeMetrics = function () {
         var metrics = player.getMetricsFor("video");
-        $scope.videoMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.videoMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     $scope.getAudioTreeMetrics = function () {
         var metrics = player.getMetricsFor("audio");
-        $scope.audioMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.audioMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     $scope.getStreamTreeMetrics = function () {
         var metrics = player.getMetricsFor("stream");
-        $scope.streamMetrics = converter.toTreeViewDataSource(metrics);
+        if (metrics) {
+            $scope.streamMetrics = converter.toTreeViewDataSource(metrics);
+        }
     }
 
     // from: https://gist.github.com/siongui/4969449
@@ -189,34 +195,34 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
                 requestWindow = Requests
                     .slice(-20)
-                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req.mediaduration && req.type === "Media Segment" && req.stream === type;})
+                    .filter(function(req){return req.responsecode >= 200 && req.responsecode < 300 && !!req._mediaduration && req.type === "MediaSegment" && req._stream === type;})
                     .slice(-4);
                 if (requestWindow.length > 0) {
 
                     latencyTimes = requestWindow.map(function (req){ return Math.abs(req.tresponse.getTime() - req.trequest.getTime()) / 1000;});
 
                     movingLatency[type] = {
-                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length, 
-                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: latencyTimes.reduce(function(l, r) {return l + r;}) / latencyTimes.length,
+                        high: latencyTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: latencyTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: latencyTimes.length
                     };
 
-                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req.tfinish.getTime() - req.tresponse.getTime()) / 1000;});
+                    downloadTimes = requestWindow.map(function (req){ return Math.abs(req._tfinish.getTime() - req.tresponse.getTime()) / 1000;});
 
                     movingDownload[type] = {
-                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length, 
-                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}), 
-                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}), 
+                        average: downloadTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length,
+                        high: downloadTimes.reduce(function(l, r) {return l < r ? r : l;}),
+                        low: downloadTimes.reduce(function(l, r) {return l < r ? l : r;}),
                         count: downloadTimes.length
                     };
 
-                    durationTimes = requestWindow.map(function (req){ return req.mediaduration;});
+                    durationTimes = requestWindow.map(function (req){ return req._mediaduration;});
 
                     movingRatio[type] = {
-                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average, 
-                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low, 
-                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high, 
+                        average: (durationTimes.reduce(function(l, r) {return l + r;}) / downloadTimes.length) / movingDownload[type].average,
+                        high: durationTimes.reduce(function(l, r) {return l < r ? r : l;}) / movingDownload[type].low,
+                        low: durationTimes.reduce(function(l, r) {return l < r ? l : r;}) / movingDownload[type].high,
                         count: durationTimes.length
                     };
                 }
@@ -244,7 +250,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             numBitratesValue = metricsExt.getMaxIndexForBufferType(type, streamIdx);
 
             if (bufferLevel !== null) {
-                bufferLengthValue = bufferLevel.level.toPrecision(5);
+                bufferLengthValue = bufferLevel.toPrecision(5);
             }
 
             if (droppedFramesMetrics !== null) {
@@ -699,28 +705,28 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     }
 
     // Get initial stream if it was passed in.
-	var paramUrl = null;
+    var paramUrl = null;
 
     if (vars && vars.hasOwnProperty("url")) {
-    	paramUrl = vars.url;
+        paramUrl = vars.url;
     }
 
     if (vars && vars.hasOwnProperty("mpd")) {
-    	paramUrl = vars.mpd;
+        paramUrl = vars.mpd;
     }
 
     if (paramUrl !== null) {
-    	var startPlayback = true;
-    
-    	$scope.selectedItem = {};
+        var startPlayback = true;
+
+        $scope.selectedItem = {};
         $scope.selectedItem.url = paramUrl;
 
         if (vars.hasOwnProperty("autoplay")) {
-        	startPlayback = (vars.autoplay === 'true');
+            startPlayback = (vars.autoplay === 'true');
         }
 
-    	if (startPlayback) {
-	    	$scope.doLoad();
-		}
+        if (startPlayback) {
+            $scope.doLoad();
+        }
     }
 });

--- a/samples/dash-if-reference-player/app/metrics.js
+++ b/samples/dash-if-reference-player/app/metrics.js
@@ -39,6 +39,7 @@ MetricsTreeConverter = function () {
                 representationidMetric,
                 subreplevelMetric,
                 startMetric,
+                mstartMetric,
                 durationMetric,
                 playbackspeedMetric,
                 stopreasonMetric,
@@ -54,27 +55,33 @@ MetricsTreeConverter = function () {
 
                 representationidMetric = {};
                 representationidMetric.text = "representationid: " + bufferMetric.representationid;
+                treeMetric.items.push(representationidMetric);
 
-                subreplevelMetric = {};
-                subreplevelMetric.text = "subreplevel: " + bufferMetric.subreplevel;
+                if (bufferMetric.subreplevel) {
+                    subreplevelMetric = {};
+                    subreplevelMetric.text = "subreplevel: " + bufferMetric.subreplevel;
+                    treeMetric.items.push(subreplevelMetric);
+                }
 
                 startMetric = {};
                 startMetric.text = "start: " + bufferMetric.start;
+                treeMetric.items.push(startMetric);
+
+                mstartMetric = {};
+                mstartMetric.text = "mstart: " + (bufferMetric.mstart / 1000);
+                treeMetric.items.push(mstartMetric);
 
                 durationMetric = {};
                 durationMetric.text = "duration: " + bufferMetric.duration;
+                treeMetric.items.push(durationMetric);
 
                 playbackspeedMetric = {};
                 playbackspeedMetric.text = "playbackspeed: " + bufferMetric.playbackspeed;
+                treeMetric.items.push(playbackspeedMetric);
 
                 stopreasonMetric = {};
                 stopreasonMetric.text = "stopreason: " + bufferMetric.stopreason;
 
-                treeMetric.items.push(representationidMetric);
-                treeMetric.items.push(subreplevelMetric);
-                treeMetric.items.push(startMetric);
-                treeMetric.items.push(durationMetric);
-                treeMetric.items.push(playbackspeedMetric);
                 treeMetric.items.push(stopreasonMetric);
 
                 treeMetrics.push(treeMetric);
@@ -91,6 +98,7 @@ MetricsTreeConverter = function () {
                 mstartMetric,
                 startTypeMetric,
                 traceMetric,
+                traceMetrics,
                 i;
 
             for (i = 0; i < playListMetrics.length; i++) {
@@ -103,21 +111,26 @@ MetricsTreeConverter = function () {
 
                 startMetric = {};
                 startMetric.text = "start: " + bufferMetric.start;
+                treeMetric.items.push(startMetric);
 
                 mstartMetric = {};
                 mstartMetric.text = "mstart: " + bufferMetric.mstart;
+                treeMetric.items.push(mstartMetric);
 
                 startTypeMetric = {};
                 startTypeMetric.text = "starttype: " + bufferMetric.starttype;
-
-                traceMetric = {};
-                traceMetric.text = "trace";
-                traceMetric.items = playListTraceMetricsToTreeMetrics(bufferMetric.trace);
-
-                treeMetric.items.push(startMetric);
-                treeMetric.items.push(mstartMetric);
                 treeMetric.items.push(startTypeMetric);
-                treeMetric.items.push(traceMetric);
+
+                traceMetrics = playListTraceMetricsToTreeMetrics(bufferMetric.trace);
+                if (traceMetrics) {
+                    traceMetric = {};
+                    traceMetric.text = "trace";
+                    traceMetric.items = traceMetrics;
+                }
+
+                if (traceMetric.items.length) {
+                    treeMetric.items.push(traceMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }
@@ -128,15 +141,15 @@ MetricsTreeConverter = function () {
         representationSwitchToTreeMetrics = function (representationSwitch) {
             var treeMetrics = [],
                 treeMetric,
-                bufferMetric,
+                switchMetric,
                 tMetric,
                 mtMetric,
                 toMetric,
                 ltoMetric,
                 i;
 
-            for (i = 0; i < representationSwitch.length; i++) {
-                bufferMetric = representationSwitch[i];
+            for (i = 0; i < representationSwitch.length; i += 1) {
+                switchMetric = representationSwitch[i];
 
                 treeMetric = {};
                 treeMetric.text = "Representation Switch: " + (i + 1);
@@ -144,21 +157,22 @@ MetricsTreeConverter = function () {
                 treeMetric.collapsed = true;
 
                 tMetric = {};
-                tMetric.text = "t: " + bufferMetric.t;
+                tMetric.text = "t: " + switchMetric.t;
+                treeMetric.items.push(tMetric);
 
                 mtMetric = {};
-                mtMetric.text = "mt: " + bufferMetric.mt;
+                mtMetric.text = "mt: " + (switchMetric.mt / 1000);
+                treeMetric.items.push(mtMetric);
 
                 toMetric = {};
-                toMetric.text = "to: " + bufferMetric.to;
-
-                ltoMetric = {};
-                ltoMetric.text = "lto: " + bufferMetric.lto;
-
-                treeMetric.items.push(tMetric);
-                treeMetric.items.push(mtMetric);
+                toMetric.text = "to: " + switchMetric.to;
                 treeMetric.items.push(toMetric);
-                treeMetric.items.push(ltoMetric);
+
+                if (switchMetric.lto) {
+                    ltoMetric = {};
+                    ltoMetric.text = "lto: " + switchMetric.lto;
+                    treeMetric.items.push(ltoMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }
@@ -260,49 +274,52 @@ MetricsTreeConverter = function () {
 
                 tcpidMetric = {};
                 tcpidMetric.text = "tcpid: " + bufferMetric.tcpid;
+                treeMetric.items.push(tcpidMetric);
 
                 typeMetric = {};
                 typeMetric.text = "type: " + bufferMetric.type;
+                treeMetric.items.push(typeMetric);
 
                 urlMetric = {};
                 urlMetric.text = "url: " + bufferMetric.url;
+                treeMetric.items.push(urlMetric);
 
                 actualurlMetric = {};
                 actualurlMetric.text = "actualurl: " + bufferMetric.actualurl;
+                treeMetric.items.push(actualurlMetric);
 
                 rangeMetric = {};
                 rangeMetric.text = "range: " + bufferMetric.range;
+                treeMetric.items.push(rangeMetric);
 
                 trequestMetric = {};
                 trequestMetric.text = "trequest: " + bufferMetric.trequest;
+                treeMetric.items.push(trequestMetric);
 
                 tresponseMetric = {};
                 tresponseMetric.text = "tresponse: " + bufferMetric.tresponse;
+                treeMetric.items.push(tresponseMetric);
 
                 responsecodeMetric = {};
                 responsecodeMetric.text = "responsecode: " + bufferMetric.responsecode;
+                treeMetric.items.push(responsecodeMetric);
 
-                intervalMetric = {};
-                intervalMetric.text = "interval: " + bufferMetric.interval;
+                if (bufferMetric.interval) {
+                    intervalMetric = {};
+                    intervalMetric.text = "interval: " + bufferMetric.interval;
+                    treeMetric.items.push(intervalMetric);
+                }
 
                 mediadurationMetric = {};
-                mediadurationMetric.text = "mediaduration: " + bufferMetric.mediaduration;
-
-                traceMetric = {};
-                traceMetric.text = "trace";
-                traceMetric.items = httpRequestTraceToTreeMetric(bufferMetric.trace);
-
-                treeMetric.items.push(tcpidMetric);
-                treeMetric.items.push(typeMetric);
-                treeMetric.items.push(urlMetric);
-                treeMetric.items.push(actualurlMetric);
-                treeMetric.items.push(rangeMetric);
-                treeMetric.items.push(trequestMetric);
-                treeMetric.items.push(tresponseMetric);
-                treeMetric.items.push(responsecodeMetric);
-                treeMetric.items.push(intervalMetric);
+                mediadurationMetric.text = "mediaduration: " + bufferMetric._mediaduration;
                 treeMetric.items.push(mediadurationMetric);
-                treeMetric.items.push(traceMetric);
+
+                if (bufferMetric.trace) {
+                    traceMetric = {};
+                    traceMetric.text = "trace";
+                    traceMetric.items = httpRequestTraceToTreeMetric(bufferMetric.trace);
+                    treeMetric.items.push(traceMetric);
+                }
 
                 treeMetrics.push(treeMetric);
             }
@@ -356,6 +373,28 @@ MetricsTreeConverter = function () {
             return treeMetrics;
         },
 
+        dvbErrorsToTreeMetric = function (dvbErrors) {
+            var treeMetrics = [];
+
+            dvbErrors.forEach(function (error, i) {
+                var treeMetric = {};
+
+                treeMetric.text = 'DVBErrors: ' + (i + 1);
+                treeMetric.items = [];
+                treeMetric.collapsed = true;
+
+                Object.keys(error).forEach(function (key) {
+                    var text = key + ': ' + error[key];
+                    treeMetric.items.push({text: text});
+                });
+
+
+                treeMetrics.push(treeMetric);
+            });
+
+            return treeMetrics;
+        },
+
         toTreeViewDataSource = function (metrics) {
             var bufferTreeMetrics = bufferLevelMetricToTreeMetric(metrics.BufferLevel),
                 playListMetrics = playListMetricToTreeMetric(metrics.PlayList),
@@ -363,6 +402,7 @@ MetricsTreeConverter = function () {
                 droppedFramesMetrics = droppedFramesToTreeMetrics(metrics.DroppedFrames),
                 httpRequestMetrics = httpRequestToTreeMetric(metrics.HttpList),
                 tcpConnectionMetrics = tcpConnectionToTreeMetric(metrics.TcpList),
+                dvbErrorsMetrics = dvbErrorsToTreeMetric(metrics.DVBErrors),
                 dataSource;
 
             dataSource = [
@@ -394,6 +434,11 @@ MetricsTreeConverter = function () {
                 {
                     text: "TCP Connection",
                     items: tcpConnectionMetrics,
+                    collapsed: true
+                },
+                {
+                    text: 'DVBErrors',
+                    items: dvbErrorsMetrics,
                     collapsed: true
                 }
             ];

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -29,7 +29,7 @@
             height: 360px;
         }
     </style>
-
+    </head>
     <body onload="init()">
         <div>
             <video class="dashjs-player" autoplay controls>

--- a/src/All.js
+++ b/src/All.js
@@ -31,9 +31,11 @@
 
 import MediaPlayer from './streaming/MediaPlayer.js';
 import Protection from './streaming/protection/Protection.js';
+import MetricsReporting from './streaming/metrics/MetricsReporting.js';
 
 
 // Shove both of these into the global scope
 var context = window || global;
 context.MediaPlayer = MediaPlayer;
 context.Protection = Protection;
+context.MetricsReporting = MetricsReporting;

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -38,10 +38,9 @@ import FactoryMaker from '../core/FactoryMaker.js';
 
 const METRIC_LIST = {
     //TODO need to refactor all that reference to be able to export like all other const on factory object.
-    TCP_CONNECTION: 'TcpConnection',
-    HTTP_REQUEST: 'HttpRequest',
-    HTTP_REQUEST_TRACE: 'HttpRequestTrace',
-    TRACK_SWITCH: 'RepresentationSwitch',
+    TCP_CONNECTION: 'TcpList',
+    HTTP_REQUEST: 'HttpList',
+    TRACK_SWITCH: 'RepSwitchList',
     BUFFER_LEVEL: 'BufferLevel',
     BUFFER_STATE: 'BufferState',
     DVR_INFO: 'DVRInfo',
@@ -52,7 +51,7 @@ const METRIC_LIST = {
     MANIFEST_UPDATE_STREAM_INFO: 'ManifestUpdatePeriodInfo',
     MANIFEST_UPDATE_TRACK_INFO: 'ManifestUpdateRepresentationInfo',
     PLAY_LIST: 'PlayList',
-    PLAY_LIST_TRACE: 'PlayListTrace'
+    DVB_ERRORS: 'DVBErrors'
 };
 
 function DashAdapter() {

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -184,9 +184,9 @@ function RepresentationController() {
     function addRepresentationSwitch() {
         var now = new Date();
         var currentRepresentation = getCurrentRepresentation();
-        var currentVideoTime = playbackController.getTime();
+        var currentVideoTimeMs = playbackController.getTime() * 1000;
 
-        metricsModel.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTime, currentRepresentation.id);
+        metricsModel.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTimeMs, currentRepresentation.id);
     }
 
     function addDVRMetric() {

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -125,52 +125,34 @@ function DashMetricsExtensions() {
         return currentRepSwitch;
     }
 
-    function getCurrentBufferLevel(metrics) {
+    function getLatestBufferLevelVO(metrics) {
         if (metrics === null) {
             return null;
         }
 
         var bufferLevel = metrics.BufferLevel;
-        var bufferLevelLength,
-            bufferLevelLastIndex,
-            currentBufferLevel;
-
         if (bufferLevel === null || bufferLevel.length <= 0) {
             return null;
         }
 
-        bufferLevelLength = bufferLevel.length;
-        bufferLevelLastIndex = bufferLevelLength - 1;
+        return bufferLevel[bufferLevel.length - 1];
+    }
 
-        currentBufferLevel = bufferLevel[bufferLevelLastIndex];
-        return currentBufferLevel;
+    function getCurrentBufferLevel(metrics) {
+        if (metrics === null) {
+            return 0;
+        }
+
+        var bufferLevel = metrics.BufferLevel;
+        if (bufferLevel === null || bufferLevel.length <= 0) {
+            return 0;
+        }
+
+        return bufferLevel[bufferLevel.length - 1].level / 1000;
     }
 
     function getRequestsQueue(metrics) {
         return metrics.RequestsQueue;
-    }
-
-    function getCurrentPlaybackRate(metrics) {
-        if (metrics === null) {
-            return null;
-        }
-
-        var playList = metrics.PlayList;
-        var trace,
-            currentRate;
-
-        if (playList === null || playList.length <= 0) {
-            return null;
-        }
-
-        trace = playList[playList.length - 1].trace;
-
-        if (trace === null || trace.length <= 0) {
-            return null;
-        }
-
-        currentRate = trace[trace.length - 1].playbackspeed;
-        return currentRate;
     }
 
     function getCurrentHttpRequest(metrics) {
@@ -304,7 +286,7 @@ function DashMetricsExtensions() {
             httpRequest = httpRequestList[i];
 
             if (httpRequest.type === HTTPRequest.MPD_TYPE) {
-                headers = parseResponseHeaders(httpRequest.responseHeaders);
+                headers = parseResponseHeaders(httpRequest._responseHeaders);
                 break;
             }
         }
@@ -319,9 +301,9 @@ function DashMetricsExtensions() {
         var httpRequest = getCurrentHttpRequest(metrics);
         var headers;
 
-        if (httpRequest === null || httpRequest.responseHeaders === null) return null;
+        if (httpRequest === null || httpRequest._responseHeaders === null) return null;
 
-        headers = parseResponseHeaders(httpRequest.responseHeaders);
+        headers = parseResponseHeaders(httpRequest._responseHeaders);
         return headers[id] === undefined ? null :  headers[id];
     }
 
@@ -417,8 +399,8 @@ function DashMetricsExtensions() {
         getMaxIndexForBufferType: getMaxIndexForBufferType,
         getMaxAllowedIndexForBufferType: getMaxAllowedIndexForBufferType,
         getCurrentRepresentationSwitch: getCurrentRepresentationSwitch,
+        getLatestBufferLevelVO: getLatestBufferLevelVO,
         getCurrentBufferLevel: getCurrentBufferLevel,
-        getCurrentPlaybackRate: getCurrentPlaybackRate,
         getCurrentHttpRequest: getCurrentHttpRequest,
         getHttpRequests: getHttpRequests,
         getCurrentDroppedFrames: getCurrentDroppedFrames,

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -74,8 +74,10 @@ function ManifestLoader(config) {
 
         var request = new XMLHttpRequest();
         var requestTime = new Date();
-        var loadedTime = null;
         var needFailureReport = true;
+        var lastTraceTime = requestTime;
+        var lastTraceReceivedCount = 0;
+        var traces = [];
 
         var manifest,
             onload,
@@ -86,6 +88,7 @@ function ManifestLoader(config) {
         onload = function () {
             var actualUrl = null;
             var errorMsg;
+            var loadedTime = new Date();
 
             if (request.status < 200 || request.status > 299) {
                 return;
@@ -94,7 +97,6 @@ function ManifestLoader(config) {
 
             needFailureReport = false;
             remainingAttempts = RETRY_ATTEMPTS;
-            loadedTime = new Date();
 
             // Handle redirects for the MPD - as per RFC3986 Section 5.1.3
             if (request.responseURL && request.responseURL !== url) {
@@ -113,12 +115,19 @@ function ManifestLoader(config) {
                 loadedTime,
                 request.status,
                 null,
-                request.getAllResponseHeaders());
+                request.getAllResponseHeaders(),
+                traces);
 
             manifest = parser.parse(request.responseText, baseUrl, xlinkController);
 
             if (manifest) {
                 manifest.url = actualUrl || url;
+
+                // URL from which the MPD was originally retrieved (MPD updates will not change this value)
+                if (!manifest.originalUrl) {
+                    manifest.originalUrl = manifest.url;
+                }
+
                 manifest.loadedTime = loadedTime;
                 metricsModel.addManifestUpdate('stream', manifest.type, requestTime, loadedTime, manifest.availabilityStartTime);
                 xlinkController.resolveManifestOnLoad(manifest);
@@ -130,8 +139,7 @@ function ManifestLoader(config) {
         };
 
         report = function () {
-            if (!needFailureReport)
-            {
+            if (!needFailureReport) {
                 return;
             }
             needFailureReport = false;
@@ -147,7 +155,8 @@ function ManifestLoader(config) {
                 new Date(),
                 request.status,
                 null,
-                request.getAllResponseHeaders());
+                request.getAllResponseHeaders(),
+                null);
 
             if (remainingAttempts > 0) {
                 log('Failed loading manifest: ' + url + ', retry in ' + RETRY_INTERVAL + 'ms' + ' attempts: ' + remainingAttempts);
@@ -163,12 +172,28 @@ function ManifestLoader(config) {
         };
 
         progress = function (event) {
+            var currentTime = new Date();
+
             if (firstProgressCall) {
                 firstProgressCall = false;
-                if (!event.lengthComputable || (event.lengthComputable && event.total != event.loaded)) {
-                    request.firstByteDate = new Date();
+                if (!event.lengthComputable || (event.lengthComputable && event.total !== event.loaded)) {
+                    request.firstByteDate = currentTime;
                 }
             }
+
+            if (event.lengthComputable) {
+                request.bytesLoaded = event.loaded;
+                request.bytesTotal = event.total;
+            }
+
+            traces.push({
+                s: lastTraceTime,
+                d: currentTime.getTime() - lastTraceTime.getTime(),
+                b: [event.loaded ? event.loaded - lastTraceReceivedCount : 0]
+            });
+
+            lastTraceTime = currentTime;
+            lastTraceReceivedCount = event.loaded;
         };
 
         try {
@@ -217,5 +242,6 @@ function ManifestLoader(config) {
     setup();
     return instance;
 }
+
 ManifestLoader.__dashjs_factory_name = 'ManifestLoader';
 export default FactoryMaker.getClassFactory(ManifestLoader);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -95,6 +95,7 @@ function MediaPlayer() {
         abrController,
         mediaController,
         protectionController,
+        metricsReportingController,
         adapter,
         domStorage,
         metricsModel,
@@ -1400,6 +1401,7 @@ function MediaPlayer() {
             // Workaround to force Firefox to fire the canplay event.
             element.preload = 'auto';
             detectProtection();
+            detectMetricsReporting();
         }
         resetAndCheckAutoPlay();
     }
@@ -1474,6 +1476,7 @@ function MediaPlayer() {
             rulesController.reset();
             mediaController.reset();
             streamController = null;
+            metricsReportingController = null;
             protectionController = null;
             protectionData = null;
             if (autoPlay && isReady()) {
@@ -1583,6 +1586,29 @@ function MediaPlayer() {
                 adapter: adapter
             });
             return protectionController;
+        }
+        /* jshint ignore:end */
+        return null;
+    }
+
+    function detectMetricsReporting() {
+        if (metricsReportingController) {
+            return metricsReportingController;
+        }
+
+        /* jshint ignore:start */
+        if (typeof MetricsReporting === 'function') {//TODO need a better way to register/detect plugin components
+            let metricsReporting = MetricsReporting(context).create();
+
+            metricsReportingController = metricsReporting.createMetricsReporting({
+                log: log,
+                eventBus: eventBus,
+                mediaElement: videoModel.getElement(),
+                manifestExt: manifestExt,
+                metricsModel: metricsModel
+            });
+
+            return metricsReportingController;
         }
         /* jshint ignore:end */
         return null;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -270,11 +270,10 @@ function MediaPlayer() {
      * @instance
      */
     function getBufferLength(type) {
-        if (!type)
-        {
+        if (!type) {
             type = 'video';
         }
-        return getMetricsExt().getCurrentBufferLevel(getMetricsFor(type)).level.toPrecision(3);
+        return getMetricsExt().getCurrentBufferLevel(getMetricsFor(type)).toPrecision(3);
     }
 
     /**

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -564,11 +564,13 @@ function Stream(config) {
         isActivated: isActivated,
         isInitialized: isInitialized,
         updateData: updateData,
-        reset: reset
+        reset: reset,
+        getProcessors: getProcessors
     };
 
     setup();
     return instance;
 }
+
 Stream.__dashjs_factory_name = 'Stream';
 export default FactoryMaker.getClassFactory(Stream);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -381,7 +381,7 @@ function BufferController(config) {
         //    level += virtualLevel;
         //}
 
-        metricsModel.addBufferLevel(type, new Date(), bufferLevel);
+        metricsModel.addBufferLevel(type, new Date(), bufferLevel * 1000);
     }
 
     function checkIfBufferingCompleted() {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -143,6 +143,11 @@ function PlaybackController() {
         return element.played;
     }
 
+    function getEnded() {
+        if (!element) return;
+        return element.ended;
+    }
+
     function getIsDynamic() {
         return isDynamic;
     }
@@ -348,7 +353,7 @@ function PlaybackController() {
 
     function onPlaybackPaused() {
         log('Native video element event: pause');
-        eventBus.trigger(Events.PLAYBACK_PAUSED);
+        eventBus.trigger(Events.PLAYBACK_PAUSED, {ended: getEnded()});
     }
 
     function onPlaybackSeeking() {
@@ -368,7 +373,7 @@ function PlaybackController() {
         var time = getTime();
         if (time === currentTime) return;
         currentTime = time;
-        eventBus.trigger(Events.PLAYBACK_TIME_UPDATED, {timeToEnd: getTimeToStreamEnd()});
+        eventBus.trigger(Events.PLAYBACK_TIME_UPDATED, {timeToEnd: getTimeToStreamEnd(), time: time});
     }
 
     function onPlaybackProgress() {
@@ -387,8 +392,9 @@ function PlaybackController() {
     }
 
     function onPlaybackRateChanged() {
-        log('Native video element event: ratechange: ', getPlaybackRate());
-        eventBus.trigger(Events.PLAYBACK_RATE_CHANGED);
+        var rate = getPlaybackRate();
+        log('Native video element event: ratechange: ', rate);
+        eventBus.trigger(Events.PLAYBACK_RATE_CHANGED, { playbackRate: rate });
     }
 
     function onPlaybackMetaDataLoaded() {
@@ -504,6 +510,7 @@ function PlaybackController() {
         getTime: getTime,
         getPlaybackRate: getPlaybackRate,
         getPlayedRanges: getPlayedRanges,
+        getEnded: getEnded,
         getIsDynamic: getIsDynamic,
         setLiveStartTime: setLiveStartTime,
         getLiveStartTime: getLiveStartTime,

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -1,0 +1,87 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import DVBErrorsTranslator from './utils/DVBErrorsTranslator.js';
+import MetricsReportingEvents from './MetricsReportingEvents.js';
+import MetricsCollectionController from './controllers/MetricsCollectionController.js';
+import MetricsHandlerFactory from './metrics/MetricsHandlerFactory.js';
+import ReportingFactory from './reporting/ReportingFactory.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
+
+function MetricsReporting() {
+
+    let context = this.context;
+    let instance;
+
+    let dvbErrorsTranslator;
+
+    /**
+     * Create a MetricsCollectionController, and a DVBErrorsTranslator
+     * @return {MetricsCollectionController} Metrics Collection Controller
+     */
+    function createMetricsReporting(config) {
+        dvbErrorsTranslator = DVBErrorsTranslator(context).getInstance({
+            eventBus: config.eventBus,
+            metricsModel: config.metricsModel,
+        });
+
+        return MetricsCollectionController(context).create(config);
+    }
+
+    /**
+     * Get the ReportingFactory to allow new reporters to be registered
+     * @return {ReportingFactory} Reporting Factory
+     */
+    function getReportingFactory() {
+        return ReportingFactory(context).getInstance();
+    }
+
+    /**
+     * Get the MetricsHandlerFactory to allow new handlers to be registered
+     * @return {MetricsHandlerFactory} Metrics Handler Factory
+     */
+    function getMetricsHandlerFactory() {
+        return MetricsHandlerFactory(context).getInstance();
+    }
+
+    instance = {
+        createMetricsReporting:     createMetricsReporting,
+        getReportingFactory:        getReportingFactory,
+        getMetricsHandlerFactory:   getMetricsHandlerFactory
+    };
+
+    return instance;
+}
+
+MetricsReporting.__dashjs_factory_name = 'MetricsReporting';
+let factory = FactoryMaker.getClassFactory(MetricsReporting);
+factory.events = MetricsReportingEvents;
+export default factory;

--- a/src/streaming/metrics/MetricsReportingEvents.js
+++ b/src/streaming/metrics/MetricsReportingEvents.js
@@ -28,25 +28,16 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-/**
- * @class
- * @ignore
- */
-class MetricsList {
-    constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+import EventsBase from '../../core/events/EventsBase.js';
+
+class MetricsReportingEvents extends EventsBase {
+    constructor () {
+        super();
+
+        this.METRICS_INITIALISATION_COMPLETE = 'internal_metricsReportingInitialized';
+        this.BECAME_REPORTING_PLAYER = 'internal_becameReportingPlayer';
     }
 }
 
-export default MetricsList;
+let metricsReportingEvents = new MetricsReportingEvents();
+export default metricsReportingEvents;

--- a/src/streaming/metrics/controllers/MetricsCollectionController.js
+++ b/src/streaming/metrics/controllers/MetricsCollectionController.js
@@ -1,0 +1,107 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import MetricsController from './MetricsController.js';
+import ManifestParsing from '../utils/ManifestParsing.js';
+import FactoryMaker from '../../../core/FactoryMaker.js';
+import MetricsReportingEvents from '../MetricsReportingEvents.js';
+import Events from '../../../core/events/Events.js';
+
+function MetricsCollectionController(config) {
+
+    let metricsControllers = {};
+
+    let context = this.context;
+    let eventBus = config.eventBus;
+
+    function update(e) {
+        if (e.error) {
+            return;
+        }
+
+        // start by assuming all existing controllers need removing
+        let controllersToRemove = Object.keys(metricsControllers);
+
+        const metrics = ManifestParsing(context).getInstance({
+            manifestExt: config.manifestExt
+        }).getMetrics(e.manifest);
+
+        metrics.forEach(m => {
+            const key = JSON.stringify(m);
+
+            if (!metricsControllers.hasOwnProperty(key)) {
+                try {
+                    var controller = MetricsController(context).create(config);
+                    controller.initialize(m);
+                    metricsControllers[key] = controller;
+                } catch (e) {
+                    // fail quietly
+                }
+            } else {
+                // we still need this controller - delete from removal list
+                controllersToRemove.splice(key, 1);
+            }
+        });
+
+        // now remove the unwanted controllers
+        controllersToRemove.forEach(c => {
+            metricsControllers[c].reset();
+            delete metricsControllers[c];
+        });
+
+        eventBus.trigger(
+            MetricsReportingEvents.METRICS_INITIALISATION_COMPLETE
+        );
+    }
+
+    function reset() {
+        Object.keys(metricsControllers).forEach(key => {
+            metricsControllers[key].reset();
+        });
+
+        metricsControllers = {};
+    }
+
+    function setup() {
+
+
+        eventBus.on(Events.MANIFEST_UPDATED, update);
+        eventBus.on(Events.STREAM_TEARDOWN_COMPLETE, reset);
+    }
+
+    setup();
+
+    // don't export any actual methods
+    return {};
+}
+
+MetricsCollectionController.__dashjs_factory_name = 'MetricsCollectionController';
+export default FactoryMaker.getClassFactory(MetricsCollectionController);

--- a/src/streaming/metrics/controllers/MetricsHandlersController.js
+++ b/src/streaming/metrics/controllers/MetricsHandlersController.js
@@ -1,0 +1,126 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import MetricsHandlerFactory from '../metrics/MetricsHandlerFactory.js';
+import FactoryMaker from '../../../core/FactoryMaker.js';
+import MediaPlayerEvents from '../../MediaPlayerEvents.js';
+
+function MetricsHandlersController(config) {
+    let handlers = [];
+
+    let instance;
+    let context = this.context;
+    let eventBus = config.eventBus;
+
+    let metricsHandlerFactory = MetricsHandlerFactory(context).getInstance({
+        log: config.log,
+        eventBus: config.eventBus
+    });
+
+    function handle(e) {
+        handlers.forEach(handler => {
+            handler.handleNewMetric(e.metric, e.value, e.mediaType);
+        });
+    }
+
+    function initialize(metrics, reportingController) {
+        metrics.split(',').forEach(
+            (m, midx, ms) => {
+                var handler;
+
+                // there is a bug in ISO23009-1 where the metrics attribute
+                // is a comma-seperated list but HttpList key can contain a
+                // comma enclosed by ().
+                if ((m.indexOf('(') !== -1) && m.indexOf(')') === -1) {
+                    let nextm = ms[midx + 1];
+
+                    if (nextm &&
+                            (nextm.indexOf('(') === -1) &&
+                            (nextm.indexOf(')') !== -1)) {
+                        m += ',' + nextm;
+
+                        // delete the next metric so forEach does not visit.
+                        delete ms[midx + 1];
+                    }
+                }
+
+                handler = metricsHandlerFactory.create(
+                    m,
+                    reportingController
+                );
+
+                if (handler) {
+                    handlers.push(handler);
+                }
+            }
+        );
+
+        eventBus.on(
+            MediaPlayerEvents.METRIC_ADDED,
+            handle,
+            instance
+        );
+
+        eventBus.on(
+            MediaPlayerEvents.METRIC_UPDATED,
+            handle,
+            instance
+        );
+    }
+
+    function reset() {
+        eventBus.off(
+            MediaPlayerEvents.METRIC_ADDED,
+            handle,
+            instance
+        );
+
+        eventBus.off(
+            MediaPlayerEvents.METRIC_UPDATED,
+            handle,
+            instance
+        );
+
+        handlers.forEach(handler => handler.reset());
+
+        handlers = [];
+    }
+
+    instance = {
+        initialize: initialize,
+        reset:      reset
+    };
+
+    return instance;
+}
+
+MetricsHandlersController.__dashjs_factory_name = 'MetricsHandlersController';
+export default FactoryMaker.getClassFactory(MetricsHandlersController);

--- a/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
+++ b/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
@@ -1,0 +1,109 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../../../../core/FactoryMaker.js';
+import HandlerHelpers from '../../utils/HandlerHelpers.js';
+
+function BufferLevelHandler() {
+
+    let instance,
+        reportingController,
+        n,
+        name,
+        interval,
+        lastReportedTime;
+
+    let context = this.context;
+    let handlerHelpers = HandlerHelpers(context).getInstance();
+
+    let storedVOs = [];
+
+    function getLowestBufferLevelVO() {
+        try {
+            return Object.keys(storedVOs).map(
+                key => storedVOs[key]
+            ).reduce(
+                (a, b) => {
+                    return (a.level < b.level) ? a : b;
+                }
+            );
+        } catch (e) {
+            return;
+        }
+    }
+
+    function intervalCallback() {
+        var vo = getLowestBufferLevelVO();
+
+        if (vo) {
+            if (lastReportedTime !== vo.t) {
+                lastReportedTime = vo.t;
+                reportingController.report(name, vo);
+            }
+        }
+    }
+
+    function initialize(basename, rc, n_ms) {
+        if (rc) {
+            // this will throw if n is invalid, to be
+            // caught by the initialize caller.
+            n = handlerHelpers.validateN(n_ms);
+            reportingController = rc;
+            name = handlerHelpers.reconstructFullMetricName(basename, n_ms);
+            interval = setInterval(intervalCallback, n);
+        }
+    }
+
+    function reset() {
+        clearInterval(interval);
+        interval = null;
+        n = 0;
+        reportingController = null;
+        lastReportedTime = null;
+    }
+
+    function handleNewMetric(metric, vo, type) {
+        if (metric === 'BufferLevel') {
+            storedVOs[type] = vo;
+        }
+    }
+
+    instance = {
+        initialize:         initialize,
+        reset:              reset,
+        handleNewMetric:    handleNewMetric
+    };
+
+    return instance;
+}
+
+BufferLevelHandler.__dashjs_factory_name = 'BufferLevelHandler';
+export default FactoryMaker.getClassFactory(BufferLevelHandler);

--- a/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
+++ b/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
@@ -28,25 +28,42 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-/**
- * @class
- * @ignore
- */
-class MetricsList {
-    constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+
+import FactoryMaker from '../../../../core/FactoryMaker.js';
+
+function GenericMetricHandler() {
+
+    let instance,
+        metricName,
+        reportingController;
+
+    function initialize(name, rc) {
+        metricName = name;
+        reportingController = rc;
     }
+
+    function reset() {
+        reportingController = null;
+        metricName = undefined;
+    }
+
+    function handleNewMetric(metric, vo) {
+        // simply pass metric straight through
+        if (metric === metricName) {
+            if (reportingController) {
+                reportingController.report(metricName, vo);
+            }
+        }
+    }
+
+    instance = {
+        initialize:         initialize,
+        reset:              reset,
+        handleNewMetric:    handleNewMetric
+    };
+
+    return instance;
 }
 
-export default MetricsList;
+GenericMetricHandler.__dashjs_factory_name = 'GenericMetricHandler';
+export default FactoryMaker.getClassFactory(GenericMetricHandler);

--- a/src/streaming/metrics/metrics/handlers/HttpListHandler.js
+++ b/src/streaming/metrics/metrics/handlers/HttpListHandler.js
@@ -1,0 +1,110 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../../../../core/FactoryMaker.js';
+import HandlerHelpers from '../../utils/HandlerHelpers.js';
+
+function HttpListHandler() {
+
+    let instance,
+        reportingController,
+        n,
+        type,
+        name,
+        interval;
+
+    let storedVos = [];
+
+    let handlerHelpers = HandlerHelpers(this.context).getInstance();
+
+    function intervalCallback() {
+        var vos = storedVos;
+
+        if (vos.length) {
+            if (reportingController) {
+                reportingController.report(name, vos);
+            }
+        }
+
+        storedVos = [];
+    }
+
+    function initialize(basename, rc, n_ms, requestType) {
+        if (rc) {
+
+            // this will throw if n is invalid, to be
+            // caught by the initialize caller.
+            n = handlerHelpers.validateN(n_ms);
+
+            reportingController = rc;
+
+            if (requestType && requestType.length) {
+                type = requestType;
+            }
+
+            name = handlerHelpers.reconstructFullMetricName(
+                basename,
+                n_ms,
+                requestType
+            );
+
+            interval = setInterval(intervalCallback, n);
+        }
+    }
+
+    function reset() {
+        clearInterval(interval);
+        interval = null;
+        n = null;
+        type = null;
+        storedVos = [];
+        reportingController = null;
+    }
+
+    function handleNewMetric(metric, vo) {
+        if (metric === 'HttpList') {
+            if (!type || (type === vo.type)) {
+                storedVos.push(vo);
+            }
+        }
+    }
+
+    instance = {
+        initialize:         initialize,
+        reset:              reset,
+        handleNewMetric:    handleNewMetric
+    };
+
+    return instance;
+}
+
+HttpListHandler.__dashjs_factory_name = 'HttpListHandler';
+export default FactoryMaker.getClassFactory(HttpListHandler);

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -1,0 +1,181 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../../../core/FactoryMaker.js';
+import MetricSerialiser from '../../utils/MetricSerialiser.js';
+import RNG from '../../utils/RNG.js';
+
+function DVBReporting() {
+    let instance;
+
+    let context = this.context;
+    let metricSerialiser = MetricSerialiser(context).getInstance();
+    let randomNumberGenerator = RNG(context).getInstance();
+
+    let USE_DRAFT_DVB_SPEC = true;
+    let isReportingPlayer = false;
+    let reportingPlayerStatusDecided = false;
+    let reportingUrl = null;
+    let rangeController = null;
+    let allowPendingRequestsToCompleteOnReset = true;
+    let pendingRequests = [];
+
+    function doGetRequest(url, successCB, failureCB) {
+        var req = new XMLHttpRequest();
+        var oncomplete = function () {
+            var reqIndex = pendingRequests.indexOf(req);
+
+            if (reqIndex === -1) {
+                return;
+            } else {
+                pendingRequests.splice(reqIndex, 1);
+            }
+
+            if ((req.status >= 200) && (req.status < 300)) {
+                if (successCB) {
+                    successCB();
+                }
+            } else {
+                if (failureCB) {
+                    failureCB();
+                }
+            }
+        };
+
+        pendingRequests.push(req);
+
+        try {
+            req.open('GET', url);
+            req.onloadend = oncomplete;
+            req.onerror = oncomplete;
+            req.send();
+        } catch (e) {
+            req.onerror();
+        }
+    }
+
+    function report(type, vos) {
+        if (!Array.isArray(vos)) {
+            vos = [vos];
+        }
+
+        // If the Player is not a reporting Player, then the Player shall
+        // not report any errors.
+        // ... In addition to any time restrictions specified by a Range
+        // element within the Metrics element.
+        if (isReportingPlayer && rangeController.isEnabled()) {
+
+            // This reporting mechanism operates by creating one HTTP GET
+            // request for every entry in the top level list of the metric.
+            vos.forEach(function (vo) {
+                var url = metricSerialiser.serialise(vo);
+
+                // this has been proposed for errata
+                if (USE_DRAFT_DVB_SPEC && (type !== 'DVBErrors')) {
+                    url = `metricname=${type}&${url}`;
+                }
+
+                // Take the value of the @reportingUrl attribute, append a
+                // question mark ('?') character and then append the string
+                // created in the previous step.
+                url = `${reportingUrl}?${url}`;
+
+                // Make an HTTP GET request to the URL contained within the
+                // string created in the previous step.
+                doGetRequest(url, null, function () {
+                    // If the Player is unable to make the report, for
+                    // example because the @reportingUrl is invalid, the
+                    // host cannot be reached, or an HTTP status code other
+                    // than one in the 200 series is received, the Player
+                    // shall cease being a reporting Player for the
+                    // duration of the MPD.
+                    isReportingPlayer = false;
+                });
+            });
+        }
+    }
+
+    function initialize(entry, rc) {
+        var probability;
+
+        rangeController = rc;
+
+        reportingUrl = entry['dvb:reportingUrl'];
+
+        // If a required attribute is missing, the Reporting descriptor may
+        // be ignored by the Player
+        if (!reportingUrl) {
+            throw new Error(
+                'required parameter missing (dvb:reportingUrl)'
+            );
+        }
+
+        // A Player's status, as a reporting Player or not, shall remain
+        // static for the duration of the MPD, regardless of MPD updates.
+        // (i.e. only calling reset (or failure) changes this state)
+        if (!reportingPlayerStatusDecided) {
+            // NOTE: DVB spec has a typo where it incorrectly references the
+            // priority attribute, which should be probability
+            probability = entry['dvb:probability'] || entry['dvb:priority'] || 0;
+            // If the @priority attribute is set to 1000, it shall be a reporting Player.
+            // If the @priority attribute is missing, the Player shall not be a reporting Player.
+            // For any other value of the @probability attribute, it shall decide at random whether to be a
+            // reporting Player, such that the probability of being one is @probability/1000.
+            if (probability && (probability === 1000 || ((probability / 1000) >= randomNumberGenerator.random()))) {
+                isReportingPlayer = true;
+            }
+
+            reportingPlayerStatusDecided = true;
+        }
+    }
+
+    function reset() {
+        if (!allowPendingRequestsToCompleteOnReset) {
+            pendingRequests.forEach(req => req.abort());
+            pendingRequests = [];
+        }
+
+        reportingPlayerStatusDecided = false;
+        isReportingPlayer = false;
+        reportingUrl = null;
+        rangeController = null;
+    }
+
+    instance = {
+        report:     report,
+        initialize: initialize,
+        reset:      reset
+    };
+
+    return instance;
+}
+
+DVBReporting.__dashjs_factory_name = 'DVBReporting';
+export default FactoryMaker.getClassFactory(DVBReporting);

--- a/src/streaming/metrics/utils/DVBErrorsTranslator.js
+++ b/src/streaming/metrics/utils/DVBErrorsTranslator.js
@@ -1,0 +1,166 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import DVBErrors from '../vo/DVBErrors.js';
+import Events from '../../../core/events/Events.js';
+import MediaPlayerEvents from '../../MediaPlayerEvents.js';
+import MetricsReportingEvents from '../MetricsReportingEvents.js';
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function DVBErrorsTranslator(config) {
+
+    let instance;
+    let eventBus = config.eventBus;
+    let metricModel = config.metricsModel;
+    let mpd;
+
+    function onManifestUpdate(e) {
+        if (e.error) {
+            return;
+        }
+
+        mpd = e.manifest;
+    }
+
+    function onBecameReporter() {
+        report({
+            errorcode: DVBErrors.BECAME_REPORTER
+        });
+    }
+
+    function handleHttpMetric(vo) {
+        if ((vo.responsecode === 0) ||      // connection failure - unknown
+                (vo.responsecode >= 400) || // HTTP error status code
+                (vo.responsecode < 100) ||  // unknown status codes
+                (vo.responsecode >= 600)) { // unknown status codes
+            report({
+                errorcode:  vo.responsecode || DVBErrors.CONNECTION_ERROR,
+                url:        vo.url,
+                terror:     vo.tresponse
+            });
+        }
+    }
+
+    function onMetricEvent(e) {
+        switch (e.metric) {
+        case 'HttpList':
+            handleHttpMetric(e.value);
+            break;
+        default:
+            break;
+        }
+    }
+
+    function onPlaybackError(e) {
+        var reason = e.error ? e.error.code : 0;
+        var errorcode;
+
+        switch (reason) {
+            case MediaError.MEDIA_ERR_NETWORK:
+                errorcode = DVBErrors.CONNECTION_ERROR;
+                break;
+            case MediaError.MEDIA_ERR_DECODE:
+                errorcode = DVBErrors.CORRUPT_MEDIA_OTHER;
+                break;
+            default:
+                return;
+        }
+
+        report({
+            errorcode: errorcode
+        });
+    }
+
+    function report(vo) {
+        var o = new DVBErrors();
+
+        if (!mpd) {
+            return;
+        }
+
+        for (const key in vo) {
+            if (vo.hasOwnProperty(key)) {
+                o[key] = vo[key];
+            }
+        }
+
+        if (!o.mpdurl) {
+            o.mpdurl = mpd.originalUrl || mpd.url;
+        }
+
+        if (!o.servicelocation) {
+            // note, this will need changing when we get BaseURL switching
+            o.servicelocation = mpd.BaseURL.serviceLocation;
+        }
+
+        if (!o.terror) {
+            o.terror = new Date();
+        }
+
+        metricModel.addDVBErrors(o);
+    }
+
+    function initialise() {
+        eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdate, instance);
+        eventBus.on(MediaPlayerEvents.METRIC_ADDED, onMetricEvent, instance);
+        eventBus.on(MediaPlayerEvents.METRIC_UPDATED, onMetricEvent, instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_ERROR, onPlaybackError, instance);
+        eventBus.on(
+            MetricsReportingEvents.BECAME_REPORTING_PLAYER,
+            onBecameReporter,
+            instance
+        );
+    }
+
+    function reset() {
+        eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdate, instance);
+        eventBus.off(MediaPlayerEvents.METRIC_ADDED, onMetricEvent, instance);
+        eventBus.off(MediaPlayerEvents.METRIC_UPDATED, onMetricEvent, instance);
+        eventBus.off(MediaPlayerEvents.PLAYBACK_ERROR, onPlaybackError, instance);
+        eventBus.off(
+            MetricsReportingEvents.BECAME_REPORTING_PLAYER,
+            onBecameReporter,
+            instance
+        );
+    }
+
+    instance = {
+        initialise: initialise,
+        reset:      reset
+    };
+
+    initialise();
+
+    return instance;
+}
+
+DVBErrorsTranslator.__dashjs_factory_name = 'DVBErrorsTranslator';
+export default FactoryMaker.getSingletonFactory(DVBErrorsTranslator);

--- a/src/streaming/metrics/utils/HandlerHelpers.js
+++ b/src/streaming/metrics/utils/HandlerHelpers.js
@@ -28,25 +28,46 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-/**
- * @class
- * @ignore
- */
-class MetricsList {
-    constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
-    }
+
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function HandlerHelpers() {
+    return {
+        reconstructFullMetricName: function (key, n, type) {
+            var mn = key;
+
+            if (n) {
+                mn += '(' + n;
+
+                if (type && type.length) {
+                    mn += ',' + type;
+                }
+
+                mn += ')';
+            }
+
+            return mn;
+        },
+
+        validateN: function (n_ms) {
+            if (!n_ms) {
+                throw 'missing n';
+            }
+
+            if (isNaN(n_ms)) {
+                throw 'n is NaN';
+            }
+
+            // n is a positive integer is defined to refer to the metric
+            // in which the buffer level is recorded every n ms.
+            if (n_ms < 0) {
+                throw 'n must be positive';
+            }
+
+            return n_ms;
+        }
+    };
 }
 
-export default MetricsList;
+HandlerHelpers.__dashjs_factory_name = 'HandlerHelpers';
+export default FactoryMaker.getSingletonFactory(HandlerHelpers);

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -1,0 +1,120 @@
+import Metrics from '../vo/Metrics.js';
+import Range from '../vo/Range.js';
+import Reporting from '../vo/Reporting.js';
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function ManifestParsing (config) {
+    let instance;
+    let manifestExt = config.manifestExt;
+
+    function getMetricsRangeStartTime(manifest, dynamic, range) {
+        var mpd = manifestExt.getMpd(manifest);
+        var periods;
+        var presentationStartTime = 0;
+        var reportingStartTime;
+
+        if (dynamic) {
+            // For services with MPD@type='dynamic', the start time is
+            // indicated in wall clock time by adding the value of this
+            // attribute to the value of the MPD@availabilityStartTime
+            // attribute.
+            presentationStartTime = mpd.availabilityStartTime.getTime() / 1000;
+        } else {
+            // For services with MPD@type='static', the start time is indicated
+            // in Media Presentation time and is relative to the PeriodStart
+            // time of the first Period in this MPD.
+            periods = this.getRegularPeriods(manifest, mpd);
+
+            if (periods.length) {
+                presentationStartTime = periods[0].start;
+            }
+        }
+
+        // When not present, DASH Metrics collection is
+        // requested from the beginning of content
+        // consumption.
+        reportingStartTime = presentationStartTime;
+
+        if (range && range.hasOwnProperty('starttime')) {
+            reportingStartTime += range.starttime;
+        }
+
+        return reportingStartTime;
+    }
+
+    function getMetrics(manifest) {
+        var metrics = [];
+
+        if (manifest.Metrics_asArray) {
+            manifest.Metrics_asArray.forEach(metric => {
+                var metricEntry = new Metrics();
+                var isDynamic = manifestExt.getIsDynamic(manifest);
+
+                if (metric.hasOwnProperty('metrics')) {
+                    metricEntry.metrics = metric.metrics;
+                } else {
+                    //console.log("Invalid Metrics. metrics must be set. Ignoring.");
+                    return;
+                }
+
+                if (metric.Range_asArray) {
+                    metric.Range_asArray.forEach(range => {
+                        var rangeEntry = new Range();
+
+                        rangeEntry.starttime =
+                            getMetricsRangeStartTime(manifest, isDynamic, range);
+
+                        if (range.hasOwnProperty('duration')) {
+                            rangeEntry.duration = range.duration;
+                        } else {
+                            // if not present, the value is identical to the
+                            // Media Presentation duration.
+                            rangeEntry.duration = manifestExt.getDuration(manifest);
+                        }
+
+                        rangeEntry._useWallClockTime = isDynamic;
+
+                        metricEntry.Range.push(rangeEntry);
+                    });
+                }
+
+                if (metric.Reporting_asArray) {
+                    metric.Reporting_asArray.forEach(reporting => {
+                        var reportingEntry = new Reporting();
+
+                        if (reporting.hasOwnProperty('schemeIdUri')) {
+                            reportingEntry.schemeIdUri = reporting.schemeIdUri;
+                        } else {
+                            // Invalid Reporting. schemeIdUri must be set. Ignore.
+                            return;
+                        }
+
+                        for (const prop in reporting) {
+                            if (reporting.hasOwnProperty(prop)) {
+                                reportingEntry[prop] = reporting[prop];
+                            }
+                        }
+
+                        metricEntry.Reporting.push(reportingEntry);
+                    });
+                } else {
+                    // Invalid Metrics. At least one reporting must be present. Ignore
+                    return;
+                }
+
+                metrics.push(metricEntry);
+            });
+        }
+
+        return metrics;
+    }
+
+    instance = {
+        getMetrics: getMetrics
+    };
+
+    return instance;
+}
+
+ManifestParsing.__dashjs_factory_name = 'ManifestParsing';
+export default FactoryMaker.getSingletonFactory(ManifestParsing);

--- a/src/streaming/metrics/utils/MetricSerialiser.js
+++ b/src/streaming/metrics/utils/MetricSerialiser.js
@@ -1,0 +1,99 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function MetricSerialiser() {
+
+    // For each entry in the top level list within the metric (in the case
+    // of the DVBErrors metric each entry corresponds to an "error event"
+    // described in clause 10.8.4) the Player shall:
+    function serialise(metric) {
+        var pairs = [];
+        var obj = [];
+        var key,
+            value;
+
+        // Take each (key, value) pair from the metric entry and create a
+        // string consisting of the name of the key, followed by an equals
+        // ('=') character, followed by the string representation of the
+        // value. The string representation of the value is created based
+        // on the type of the value following the instructions in Table 22.
+        for (key in metric) {
+            if (metric.hasOwnProperty(key) && (key.indexOf('_') !== 0)) {
+                value = metric[key];
+
+                // we want to ensure that keys still end up in the report
+                // even if there is no value
+                if ((value === undefined) || (value === null)) {
+                    value = '';
+                }
+
+                // DVB A168 10.12.4 Table 22
+                if (Array.isArray(value)) {
+                    // if trace or similar is null, do not include in output
+                    if (!value.length) {
+                        continue;
+                    }
+
+                    obj = [];
+
+                    value.forEach(function (v) {
+                        var isBuiltIn = Object.prototype.toString.call(v).slice(8, -1) !== 'Object';
+
+                        obj.push(isBuiltIn ? v : serialise(v));
+                    });
+
+                    value = encodeURIComponent(obj.join(','));
+                } else if (typeof value === 'string') {
+                    value = encodeURIComponent(value);
+                } else if (value instanceof Date) {
+                    value = value.toISOString();
+                } else if (typeof value === 'number') {
+                    value = Math.round(value);
+                }
+
+                pairs.push(key + '=' + value);
+            }
+        }
+
+        // Concatenate the strings created in the previous step with an
+        // ampersand ('&') character between each one.
+        return pairs.join('&');
+    }
+
+    return {
+        serialise: serialise
+    };
+}
+
+MetricSerialiser.__dashjs_factory_name = 'MetricSerialiser';
+export default FactoryMaker.getSingletonFactory(MetricSerialiser);

--- a/src/streaming/metrics/utils/RNG.js
+++ b/src/streaming/metrics/utils/RNG.js
@@ -28,25 +28,71 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-/**
- * @class
- * @ignore
- */
-class MetricsList {
-    constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function RNG() {
+
+    // check whether secure random numbers are available. if not, revert to
+    // using Math.random
+    let crypto = window.crypto || window.msCrypto;
+
+    // could just as easily use any other array type by changing line below
+    let ArrayType = Uint32Array;
+    let MAX_VALUE = Math.pow(2, ArrayType.BYTES_PER_ELEMENT * 8) - 1;
+
+    // currently there is only one client for this code, and that only uses
+    // a single random number per initialisation. may want to increase this
+    // number if more consumers in the future
+    let NUM_RANDOM_NUMBERS = 10;
+
+    let randomNumbers,
+        index,
+        instance;
+
+    function initialise() {
+        if (crypto) {
+            if (!randomNumbers) {
+                randomNumbers = new ArrayType(NUM_RANDOM_NUMBERS);
+            }
+            crypto.getRandomValues(randomNumbers);
+            index = 0;
+        }
     }
+
+    function rand(min, max) {
+        var r;
+
+        if (!min) {
+            min = 0;
+        }
+
+        if (!max) {
+            max = 1;
+        }
+
+        if (crypto) {
+            if (index === randomNumbers.length) {
+                initialise();
+            }
+
+            r = randomNumbers[index] / MAX_VALUE;
+            index += 1;
+        } else {
+            r = Math.random();
+        }
+
+        return (r * (max - min)) + min;
+    }
+
+    instance = {
+        random: rand,
+    };
+
+    initialise();
+
+    return instance;
 }
 
-export default MetricsList;
+RNG.__dashjs_factory_name = 'RNG';
+export default FactoryMaker.getSingletonFactory(RNG);

--- a/src/streaming/metrics/vo/DVBErrors.js
+++ b/src/streaming/metrics/vo/DVBErrors.js
@@ -1,0 +1,97 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @class
+ * @ignore
+ */
+class DVBErrors {
+    constructor() {
+        this.mpdurl = null;
+        // String - Absolute URL from which the MPD was originally
+        // retrieved (MPD updates will not change this value).
+
+        this.errorcode = null;
+        // String - The value of errorcode depends upon the type
+        // of error being reported. For an error listed in the
+        // ErrorType column below the value is as described in the
+        // Value column.
+        //
+        // ErrorType                                            Value
+        // ---------                                            -----
+        // HTTP error status code                               HTTP status code
+        // Unknown HTTP status code                             HTTP status code
+        // SSL connection failed                                "SSL" followed by SSL alert value
+        // DNS resolution failed                                "C00"
+        // Host unreachable                                     "C01"
+        // Connection refused                                   "C02"
+        // Connection error – Not otherwise specified           "C03"
+        // Corrupt media – ISO BMFF container cannot be parsed  "M00"
+        // Corrupt media – Not otherwise specified              "M01"
+        // Changing Base URL in use due to errors               "F00"
+        // Becoming an error reporting Player                   "S00"
+
+        this.terror = null;
+        // Real-Time - Date and time at which error occurred in UTC,
+        // formatted as a combined date and time according to ISO 8601.
+
+        this.url = null;
+        // String - Absolute URL from which data was being requested
+        // when this error occurred. If the error report is in relation
+        // to corrupt media or changing BaseURL, this may be a null
+        // string if the URL from which the media was obtained or
+        // which led to the change of BaseURL is no longer known.
+
+        this.ipaddress = null;
+        // String - IP Address which the host name in "url" resolved to.
+        // If the error report is in relation to corrupt media or
+        // changing BaseURL, this may be a null string if the URL
+        // from which the media was obtained or which led to the
+        // change of BaseURL is no longer known.
+
+        this.servicelocation = null;
+        // String - The value of the serviceLocation field in the
+        // BaseURL being used. In the event of this report indicating
+        // a change of BaseURL this is the value from the BaseURL
+        // being moved from.
+    }
+}
+
+DVBErrors.SSL_CONNECTION_FAILED_PREFIX = 'SSL';
+DVBErrors.DNS_RESOLUTION_FAILED =        'C00';
+DVBErrors.HOST_UNREACHABLE =             'C01';
+DVBErrors.CONNECTION_REFUSED =           'C02';
+DVBErrors.CONNECTION_ERROR =             'C03';
+DVBErrors.CORRUPT_MEDIA_ISOBMFF =        'M00';
+DVBErrors.CORRUPT_MEDIA_OTHER =          'M01';
+DVBErrors.BASE_URL_CHANGED =             'F00';
+DVBErrors.BECAME_REPORTER =              'S00';
+
+export default DVBErrors;

--- a/src/streaming/metrics/vo/Metrics.js
+++ b/src/streaming/metrics/vo/Metrics.js
@@ -32,21 +32,13 @@
  * @class
  * @ignore
  */
-class MetricsList {
+class Metrics {
     constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+
+        this.metrics = '';
+        this.Range = [];
+        this.Reporting = [];
     }
 }
 
-export default MetricsList;
+export default Metrics;

--- a/src/streaming/metrics/vo/Range.js
+++ b/src/streaming/metrics/vo/Range.js
@@ -32,21 +32,16 @@
  * @class
  * @ignore
  */
-class MetricsList {
+class Range {
     constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+
+        // as defined in ISO23009-1
+        this.starttime = 0;
+        this.duration = Infinity;
+
+        // for internal use
+        this._useWallClockTime = false;
     }
 }
 
-export default MetricsList;
+export default Range;

--- a/src/streaming/metrics/vo/Reporting.js
+++ b/src/streaming/metrics/vo/Reporting.js
@@ -32,21 +32,12 @@
  * @class
  * @ignore
  */
-class MetricsList {
+class Reporting {
     constructor() {
-        this.TcpList = [];
-        this.HttpList = [];
-        this.RepSwitchList = [];
-        this.BufferLevel = [];
-        this.BufferState = [];
-        this.PlayList = [];
-        this.DroppedFrames = [];
-        this.SchedulingInfo = [];
-        this.DVRInfo = [];
-        this.ManifestUpdate = [];
-        this.RequestsQueue = null;
-        this.DVBErrors = [];
+        // Reporting is a DescriptorType and doesn't have any additional fields
+        this.schemeIdUri = '';
+        this.value = '';
     }
 }
 
-export default MetricsList;
+export default Reporting;

--- a/src/streaming/rules/abr/BufferOccupancyRule.js
+++ b/src/streaming/rules/abr/BufferOccupancyRule.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -41,6 +41,7 @@ function BufferOccupancyRule(config) {
     let log = Debug(context).getInstance().log;
 
     let metricsModel = config.metricsModel;
+    let metricsExt = config.metricsExt;
 
     let lastSwitchTime,
         mediaPlayerModel;
@@ -60,7 +61,7 @@ function BufferOccupancyRule(config) {
         var streamProcessor = rulesContext.getStreamProcessor();
         var abrController = streamProcessor.getABRController();
         var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        var lastBufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null;
+        var lastBufferLevel = metricsExt.getCurrentBufferLevel(metrics);
         var lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         var isBufferRich = false;
         var maxIndex = mediaInfo.representationCount - 1;
@@ -72,11 +73,12 @@ function BufferOccupancyRule(config) {
             return;
         }
 
-        if (lastBufferLevelVO !== null && lastBufferStateVO !== null) {
+        if (lastBufferStateVO !== null) {
             // This will happen when another rule tries to switch from top to any other.
             // If there is enough buffer why not try to stay at high level.
-            if (lastBufferLevelVO.level > lastBufferStateVO.target) {
-                isBufferRich = (lastBufferLevelVO.level - lastBufferStateVO.target) > mediaPlayerModel.getRichBufferThreshold();
+            if (lastBufferLevel > lastBufferStateVO.target) {
+                isBufferRich = (lastBufferLevel - lastBufferStateVO.target) > mediaPlayerModel.getRichBufferThreshold();
+
                 if (isBufferRich && mediaInfo.representationCount > 1) {
                     switchRequest = SwitchRequest(context).create(maxIndex, SwitchRequest.STRONG);
                 }

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -90,6 +90,7 @@ function ThroughputRule(config) {
 
     function execute (rulesContext, callback) {
         var downloadTime;
+        var bytes;
         var averageThroughput;
         var lastRequestThroughput;
 
@@ -113,10 +114,14 @@ function ThroughputRule(config) {
 
         }
 
-        downloadTime = (lastRequest.tfinish.getTime() - lastRequest.tresponse.getTime()) / 1000;
-
         if (lastRequest.trace.length) {
-            lastRequestThroughput = Math.round((lastRequest.trace[lastRequest.trace.length - 1].b * 8 ) / downloadTime);
+            downloadTime = (lastRequest._tfinish.getTime() - lastRequest.tresponse.getTime()) / 1000;
+
+            bytes = lastRequest.trace.reduce(function (a, b) {
+                return a + b.b[0];
+            }, 0);
+
+            lastRequestThroughput = Math.round(bytes * 8) / downloadTime;
             storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
         }
 

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -54,7 +54,7 @@ function BufferLevelRule(config) {
         var mediaInfo = rulesContext.getMediaInfo();
         var mediaType = mediaInfo.type;
         var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        var bufferLevel = metricsExt.getCurrentBufferLevel(metrics) ? metricsExt.getCurrentBufferLevel(metrics).level : 0;
+        var bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
         var fragmentCount;
 
         fragmentCount = bufferLevel < getBufferTarget(rulesContext, mediaType) ? 1 : 0;

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -31,53 +31,53 @@
 
 class HTTPRequest {
     constructor() {
-        this.stream = null;         // type of stream ("audio" | "video" etc..)
         this.tcpid = null;          // Identifier of the TCP connection on which the HTTP request was sent.
-        this.type = null;           // This is an optional parameter and should not be included in HTTP request/response transactions for progressive download.
-        // The type of the request:
-        // - MPD
-        // - XLink expansion
-        // - Initialization Fragment
-        // - Index Fragment
-        // - Media Fragment
-        // - Bitstream Switching Fragment
-        // - other
+        this.type = null;           /* This is an optional parameter and should not be included in HTTP request/response transactions for progressive download.
+                                     * The type of the request:
+                                     * - MPD
+                                     * - XLink expansion
+                                     * - Initialization Fragment
+                                     * - Index Fragment
+                                     * - Media Fragment
+                                     * - Bitstream Switching Fragment
+                                     * - other */
         this.url = null;            // The original URL (before any redirects or failures)
         this.actualurl = null;      // The actual URL requested, if different from above
         this.range = null;          // The contents of the byte-range-spec part of the HTTP Range header.
         this.trequest = null;       // Real-Time | The real time at which the request was sent.
         this.tresponse = null;      // Real-Time | The real time at which the first byte of the response was received.
-        this.tfinish = null;        // Real-Time | The real time at which the request finshed.
         this.responsecode = null;   // The HTTP response code.
         this.interval = null;       // The duration of the throughput trace intervals (ms), for successful requests only.
-        this.mediaduration = null;  // The duration of the media requests, if available, in milliseconds.
-        this.responseHeaders = null; // all the response headers from request.
         this.trace = [];            // Throughput traces, for successful requests only.
+
+        // Additional metrics used internally which we do not want to report to the outside world
+        // Anything beginning with an _ will not be reported
+        this._stream = null;            // type of stream ("audio" | "video" etc..)
+        this._tfinish = null;           // Real-Time | The real time at which the request finshed.
+        this._mediaduration = null;     // The duration of the media requests, if available, in milliseconds.
+        this._responseHeaders = null;   // all the response headers from request.
     }
 }
 
 HTTPRequest.Trace = class {
     constructor() {
         /*
-     * s - Real-Time | Measurement stream start.
-     * d - Measurement stream duration (ms).
-     * b - List of integers counting the bytes received in each trace interval within the measurement stream.
-     */
+         * s - Real-Time | Measurement stream start.
+         * d - Measurement stream duration (ms).
+         * b - List of integers counting the bytes received in each trace interval within the measurement stream.
+         */
         this.s = null;
         this.d = null;
         this.b = [];
     }
 };
 
-// these should possibly be MPD, XLinkExpansion, InitializationSegment,
-// MediaSegment, IndexSegment, BitstreamSwitchingSegment, other. See
-// ISO 23009-1 D.4.3
 HTTPRequest.MPD_TYPE = 'MPD';
-HTTPRequest.XLINK_EXPANSION_TYPE = 'XLink Expansion';
-HTTPRequest.INIT_SEGMENT_TYPE = 'Initialization Segment';
-HTTPRequest.INDEX_SEGMENT_TYPE = 'Index Segment';
-HTTPRequest.MEDIA_SEGMENT_TYPE = 'Media Segment';
-HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'Bitstream Switching Segment';
+HTTPRequest.XLINK_EXPANSION_TYPE = 'XLinkExpansion';
+HTTPRequest.INIT_SEGMENT_TYPE = 'InitializationSegment';
+HTTPRequest.INDEX_SEGMENT_TYPE = 'IndexSegment';
+HTTPRequest.MEDIA_SEGMENT_TYPE = 'MediaSegment';
+HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'BitstreamSwitchingSegment';
 HTTPRequest.OTHER_TYPE = 'other';
 
 export default HTTPRequest;

--- a/src/streaming/vo/metrics/PlayList.js
+++ b/src/streaming/vo/metrics/PlayList.js
@@ -31,35 +31,35 @@
 
 class PlayList {
     constructor() {
-        this.stream = null;     // type of stream ("audio" | "video" etc..)
         this.start = null;      // Real-Time | Timestamp of the user action that starts the playback stream...
         this.mstart = null;     // Media-Time | Presentation time at which playout was requested by the user...
-        this.starttype = null;  // Type of user action which triggered playout
-        //      - New playout request (e.g. initial playout or seeking)
-        //      - Resume from pause
-        //        - Other user request (e.g. user-requested quality change)
-        //        - Start of a metrics collection stream (hence earlier entries in the play list not collected)
-        this.trace = [];        // List of streams of continuous rendering of decoded samples.
+        this.starttype = null;  /* Enum | Type of user action which triggered playout
+                                 *  - New playout request (e.g. initial playout or seeking)
+                                 *  - Resume from pause
+                                 *  - Other user request (e.g. user-requested quality change)
+                                 *  - Start of a metrics collection stream (hence earlier entries in the play list not collected) */
+        this.trace = [];        // List | List of streams of continuous rendering of decoded samples.
     }
 }
 
 PlayList.Trace = class {
     constructor() {
         /*
-         * representationid - The value of the Representation@id of the Representation from which the samples were taken.
-         * subreplevel      - If not present, this metrics concerns the Representation as a whole. If present, subreplevel indicates the greatest value of any Subrepresentation@level being rendered.
+         * representationid - String | The value of the Representation@id of the Representation from which the samples were taken.
+         * subreplevel      - Integer | If not present, this metrics concerns the Representation as a whole. If present, subreplevel indicates the greatest value of any Subrepresentation@level being rendered.
          * start            - Real-Time | The time at which the first sample was rendered.
          * mstart           - Media-Time | The presentation time of the first sample rendered.
-         * duration         - The duration of the continuously presented samples (which is the same in real time and media time). ―Continuously presented‖ means that the media clock continued to advance at the playout speed throughout the interval.
-         * playbackspeed    - The playback speed relative to normal playback speed (i.e.normal forward playback speed is 1.0).
-         * stopreason       - The reason why continuous presentation of this Representation was stopped.
+         * duration         - Integer | The duration of the continuously presented samples (which is the same in real time and media time). "Continuously presented" means that the media clock continued to advance at the playout speed throughout the interval. NOTE: the spec does not call out the units, but all other durations etc are in ms, and we use ms too.
+         * playbackspeed    - Real | The playback speed relative to normal playback speed (i.e.normal forward playback speed is 1.0).
+         * stopreason       - Enum | The reason why continuous presentation of this Representation was stopped.
          *                    Either:
          *                    representation switch
          *                    rebuffering
          *                    user request
+         *                    end of Period
          *                    end of Stream
          *                    end of content
-         *                    end of a metrics collection stream
+         *                    end of a metrics collection period
          */
         this.representationid = null;
         this.subreplevel = null;
@@ -71,14 +71,19 @@ PlayList.Trace = class {
     }
 };
 
-/* Public Static Constants */
-PlayList.INITIAL_PLAY_START_REASON = 'initial_start';
-PlayList.SEEK_START_REASON = 'seek';
 
 /* Public Static Constants */
-PlayList.Trace.USER_REQUEST_STOP_REASON = 'user_request';
+PlayList.INITIAL_PLAYOUT_START_REASON = 'initial_playout';
+PlayList.SEEK_START_REASON = 'seek';
+PlayList.RESUME_FROM_PAUSE_START_REASON = 'resume';
+PlayList.METRICS_COLLECTION_START_REASON = 'metrics_collection_start';
+
 PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON = 'representation_switch';
-PlayList.Trace.END_OF_CONTENT_STOP_REASON = 'end_of_content';
 PlayList.Trace.REBUFFERING_REASON = 'rebuffering';
+PlayList.Trace.USER_REQUEST_STOP_REASON = 'user_request';
+PlayList.Trace.END_OF_PERIOD_STOP_REASON = 'end_of_period';
+PlayList.Trace.END_OF_CONTENT_STOP_REASON = 'end_of_content';
+PlayList.Trace.METRICS_COLLECTION_STOP_REASON = 'metrics_collection_end';
+PlayList.Trace.FAILURE_STOP_REASON = 'failure';
 
 export default PlayList;

--- a/test/helpers/VOHelper.js
+++ b/test/helpers/VOHelper.js
@@ -4,16 +4,17 @@ import MpdHelper from './MPDHelper.js';
 import SpecHelper from './SpecHelper.js';
 import Representation from '../../src/dash/vo/Representation.js';
 import FragmentRequest from '../../src/streaming/vo/FragmentRequest.js';
+import HTTPRequest from '../../src/streaming/vo/metrics/HTTPRequest.js';
 
 class VoHelper {
     constructor() {
         this.mpdHelper = new MpdHelper();
         this.specHelper = new SpecHelper();
-        this.voRep;
-        this.voAdaptation;
+        this.voRep = undefined;
+        this.voAdaptation = undefined;
         this.unixTime = this.specHelper.getUnixTime();
-        this.adaptation;
-        this.defaultMpdType = "static";
+        this.adaptation = undefined;
+        this.defaultMpdType = 'static';
     }
 
     createMpd(type) {
@@ -36,7 +37,7 @@ class VoHelper {
         period.mpd = this.createMpd();
         period.start = 0;
 
-        period.id = "id1";
+        period.id = 'id1';
         period.index = 0;
         period.duration = 100;
         period.liveEdge = 50;
@@ -56,14 +57,13 @@ class VoHelper {
     }
 
     createRepresentation(type) {
-        var rep = new Representation(),
-            data = this.adaptation || this.mpdHelper.getAdaptationWithSegmentTemplate(type);
+        var rep = new Representation();
 
         rep.id = null;
         rep.index = 0;
         rep.adaptation = this.createAdaptation(type);
         rep.fragmentInfoType = null;
-        rep.initialization = "http://dash.edgesuite.net/envivio/dashpr/clear/video4/Header.m4s";
+        rep.initialization = 'http://dash.edgesuite.net/envivio/dashpr/clear/video4/Header.m4s';
         rep.segmentDuration = 1;
         rep.timescale = 1;
         rep.startNumber = 1;
@@ -82,14 +82,14 @@ class VoHelper {
         var req = {};
         req.action = FragmentRequest.ACTION_DOWNLOAD;
         req.quality = 0;
-        req.mediaType = "video";
+        req.mediaType = 'video';
         req.type = type;
-        req.url = "http://dash.edgesuite.net/envivio/dashpr/clear/video4/Header.m4s";
+        req.url = 'http://dash.edgesuite.net/envivio/dashpr/clear/video4/Header.m4s';
         req.startTime = NaN;
         req.duration = NaN;
 
-        if (type === "Media Segment") {
-            req.url = "http://dash.edgesuite.net/envivio/dashpr/clear/video4/0.m4s";
+        if (type === HTTPRequest.MEDIA_SEGMENT_TYPE) {
+            req.url = 'http://dash.edgesuite.net/envivio/dashpr/clear/video4/0.m4s';
             req.startTime = 0;
             req.duration = 4;
             req.index = 0;
@@ -115,11 +115,11 @@ class VoHelper {
     }
 
     getMediaRequest() {
-        return this.createRequest("Media Segment");
+        return this.createRequest(HTTPRequest.MEDIA_SEGMENT_TYPE);
     }
 
     getInitRequest() {
-        return this.createRequest("Initialization Segment");
+        return this.createRequest(HTTPRequest.INIT_SEGMENT_TYPE);
     }
 
     getCompleteRequest() {
@@ -130,7 +130,7 @@ class VoHelper {
         const streamInfo = new StreamInfo();
 
         streamInfo.id = 'DUMMY_STREAM-01';
-        
+
         return streamInfo;
     }
 
@@ -141,7 +141,7 @@ class VoHelper {
         mediaInfo.type = type;
         mediaInfo.bitrateList = [1000, 2000, 3000];
         mediaInfo.representationCount = 3;
-        mediaInfo.streamInfo = this.getDummyStreamInfo(); 
+        mediaInfo.streamInfo = this.getDummyStreamInfo();
 
         return mediaInfo;
     }


### PR DESCRIPTION
This sizable PR is a reworking of the Metrics Reporting functionality introduced in 1.6.0, which can be split roughly in two.

Changes in the core code are to ensure that client metric reporting and subsequent display is more aligned with Annex D of ISO 23009-1. Clients consuming metrics should note that units and attribute names have changed on some metric VOs. There is an internal API change, where getCurrentBufferLevel now returns a time rather than a BufferLevel VO. All existing code has been updated to 

The remainder has been refactored into an external "plugin", using the same detection and initialisation mechanism as the Protection functionality (ie a single new attribute and explicit detection method on the MediaPlayer object). Aside from this it is completely separated from the core code, and can be included optionally by those who require it. There are APIs for adding custom metrics handling and custom reporting schemes.

The DVB Reporting scheme (as defined in DVB A168) is implemented since this is the only mechanism defined currently. You can see a sample MPD at http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd. Note that you would need to add DASH metrics to the metrics attribute to report these, and the probability will need tweaking to ensure you see some output.

Note the following limitations:
* RepSwitchList.mt reports the media time at the switch request, not when the new Representation starts playout (see #754)
* Metrics collection period start and end does not affect Playlist as ISO 23009-1 say it should