### PR TITLE
Enable buffer pruning to span multiple buffered ranges

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -485,20 +485,16 @@ function BufferController(config) {
     function pruneBuffer() {
         if (type === 'fragmentedText') return;
 
-        var bufferToPrune = 0;
+        var start = buffer.buffered.length ? buffer.buffered.start(0) : 0;
         var currentTime = playbackController.getTime();
-        var currentRange = sourceBufferExt.getBufferRange(buffer, currentTime);
+        var bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
 
-        // we want to get rid off buffer that is more than x seconds behind current time
-        if (currentRange !== null) {
-            bufferToPrune = currentTime - currentRange.start - mediaPlayerModel.getBufferToKeep();
-            if (bufferToPrune > 0) {
-                isPruningInProgress = true;
-                sourceBufferExt.remove(buffer, 0, Math.round(currentRange.start + bufferToPrune), mediaSource);
-            }
+        bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
+        if (bufferToPrune > 0) {
+            isPruningInProgress = true;
+            sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);
         }
     }
-
 
     function getClearRange() {
         var currentTime,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -487,9 +487,9 @@ function BufferController(config) {
 
         var start = buffer.buffered.length ? buffer.buffered.start(0) : 0;
         var currentTime = playbackController.getTime();
+        // we want to get rid off buffer that is more than x seconds behind current time
         var bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
 
-        bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
         if (bufferToPrune > 0) {
             isPruningInProgress = true;
             sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);


### PR DESCRIPTION
This is a PR that reintroduces the simpler part of the buffer pruning change added in 1.6.0. It simply allows the pruning of data behind the playhead even if there's gaps in it. 1.6.0 also attempted to remove data substantially ahead of currentTime but I've left that out for now.