### PR TITLE
Consider the possibility of cached media

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -762,7 +762,7 @@ function DashHandler(config) {
                 frag = segments[i];
                 ft = frag.presentationStartTime;
                 fd = frag.duration;
-                epsilon = (timeThreshold === undefined || timeThreshold === null) ? fd/2 : timeThreshold;
+                epsilon = (timeThreshold === undefined || timeThreshold === null) ? fd / 2 : timeThreshold;
                 if ((time + epsilon) >= ft &&
                     (time - epsilon) < (ft + fd)) {
                     idx = frag.availabilityIdx;

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -781,13 +781,6 @@ function DashHandler(config) {
         var seg,
             i;
 
-        if (index < ln) {
-            seg = representation.segments[index];
-            if (seg && seg.availabilityIdx === index) {
-                return seg;
-            }
-        }
-
         for (i = 0; i < ln; i++) {
             seg = representation.segments[i];
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -781,6 +781,13 @@ function DashHandler(config) {
         var seg,
             i;
 
+        if (index < ln) {
+            seg = representation.segments[index];
+            if (seg && seg.availabilityIdx === index) {
+                return seg;
+            }
+        }
+
         for (i = 0; i < ln; i++) {
             seg = representation.segments[i];
 

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -33,12 +33,14 @@ import AbrController from '../../streaming/controllers/AbrController.js';
 import ManifestModel from '../../streaming/models/ManifestModel.js';
 import DashManifestExtensions from '../../dash/extensions/DashManifestExtensions.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
+import Debug from '../../core/Debug.js';
 
 function DashMetricsExtensions() {
 
     let instance;
     let context = this.context;
     let manifestModel = ManifestModel(context).getInstance();//TODO Need to pass this in not bake in
+    let log = Debug(context).getInstance().log;
 
     function getBandwidthForRepresentation(representationId, periodId) {
         var representation;
@@ -199,6 +201,64 @@ function DashMetricsExtensions() {
             httpListLastIndex--;
         }
         return currentHttpList;
+    }
+
+    function getRecentThroughput(metrics, length) {
+
+        var httpList = metrics.HttpList;
+        var interested = [];
+        var throughput,
+            i;
+
+        if (httpList === null) {
+            log('throughput no http list yet');
+            return -1;
+        }
+        var segmentCount = 0;
+
+        for (i = httpList.length - 1; (i >= 0 && interested.length < length); i--)
+        {
+            var response = httpList[i];
+            // only care about MediaSegments
+            if (response.responsecode && response.type == HTTPRequest.MEDIA_SEGMENT_TYPE) {
+                segmentCount++;
+                var downloadTime = response.interval;
+                var latency = (response.tresponse - response.trequest);
+                // Without a rule specific to latency we should
+                // include both as that is what is actually
+                // important.
+                throughput = (response._bytes * 8) / (downloadTime + latency);
+                // probably from cache simplified to just low
+                // latency and low download for now, should be
+                // more generalised into radically different
+                // latency and download time from the average,
+                // could also use logic about the progress events,
+                // on chrome for example first progress event is
+                // after exactly 32768 bytes
+                var probalyFromCache = downloadTime < 100 && latency < 100;
+                if (!probalyFromCache) {
+                    interested.push(throughput);
+                }
+            }
+        }
+
+        if (interested.length === 0 ) {
+            if (segmentCount > 5) {
+                // this implies all were thought of as in the cache,
+                // just return the last throughput, it's likely to be
+                // higher than any of our manifests
+                log('throughput likely all cached is:' + throughput);
+                return throughput;
+            }
+            log('throughput not enough valid data');
+            return -1;
+        }
+        var total = 0;
+        for (i = 0; i < interested.length; i++) {
+            total += interested[i];
+        }
+        log('averageThroughput is:' + (total / interested.length));
+        return total / interested.length;
     }
 
     function getHttpRequests(metrics) {
@@ -420,6 +480,7 @@ function DashMetricsExtensions() {
         getCurrentBufferLevel: getCurrentBufferLevel,
         getCurrentPlaybackRate: getCurrentPlaybackRate,
         getCurrentHttpRequest: getCurrentHttpRequest,
+        getRecentThroughput: getRecentThroughput,
         getHttpRequests: getHttpRequests,
         getCurrentDroppedFrames: getCurrentDroppedFrames,
         getCurrentSchedulingInfo: getCurrentSchedulingInfo,

--- a/src/dash/extensions/DashMetricsExtensions.js
+++ b/src/dash/extensions/DashMetricsExtensions.js
@@ -223,7 +223,7 @@ function DashMetricsExtensions() {
             return -1;
         }
 
-        for (i=httpList.length-1; (i>=0 && interested.length<length); i--)
+        for (i = httpList.length - 1; (i >= 0 && interested.length < length); i--)
         {
             response = httpList[i];
             // only care about MediaSegments
@@ -240,14 +240,14 @@ function DashMetricsExtensions() {
             if (segmentCount > 5) {
                 // this implies all were thought of as in the cache,
                 // just return the considered from cache time
-                log("latency likely all cached:" + PROBABLY_IN_CACHE_MS);
+                log('latency likely all cached:' + PROBABLY_IN_CACHE_MS);
                 return PROBABLY_IN_CACHE_MS;
             }
             return -1;
         }
 
         total = 0;
-        for (i=0; i<interested.length; i++) {
+        for (i = 0; i < interested.length; i++) {
             total += interested[i];
         }
         return total / interested.length;

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -172,6 +172,9 @@ function MetricsModel() {
         vo.responsecode = responsecode;
         vo.mediaduration = mediaduration;
         vo.responseHeaders = responseHeaders;
+        vo.latency = tresponse - trequest;
+        vo.time = tfinish - tresponse;
+
         getMetricsFor(mediaType).HttpList.push(vo);
 
         metricAdded(mediaType, adapter.metricsList.HTTP_REQUEST, vo);
@@ -192,6 +195,7 @@ function MetricsModel() {
         }
 
         httpRequest.interval += d;
+        httpRequest.bytes += b;
 
         metricUpdated(httpRequest.stream, adapter.metricsList.HTTP_REQUEST_TRACE, httpRequest);
         return vo;

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -195,7 +195,7 @@ function MetricsModel() {
         }
 
         httpRequest.interval += d;
-        httpRequest.bytes += b;
+        httpRequest.bytes += parseInt(b, 10);
 
         metricUpdated(httpRequest.stream, adapter.metricsList.HTTP_REQUEST_TRACE, httpRequest);
         return vo;

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -74,22 +74,25 @@ function ThroughputRule(config) {
         }
 
         averageThroughput = metricsExt.getRecentThroughput(metrics, (isDynamic ? AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE : AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD));
-        averageThroughput = Math.round((averageThroughput * mediaPlayerModel.getBandwidthSafetyFactor()) / 1000);
 
-        abrController.setAverageThroughput(mediaType, averageThroughput);
+        if (averageThroughput !== -1) {
+            averageThroughput = Math.round(averageThroughput * mediaPlayerModel.getBandwidthSafetyFactor());
 
-        if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
+            abrController.setAverageThroughput(mediaType, averageThroughput);
 
-            if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
-                var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput);
-                streamProcessor.getScheduleController().setTimeToLoadDelay(0); // TODO Watch out for seek event - no delay when seeking.!!
-                switchRequest = SwitchRequest(context).create(newQuality, SwitchRequest.DEFAULT);
-            }
+            if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
 
-            if (switchRequest.value !== SwitchRequest.NO_CHANGE && switchRequest.value !== current) {
-                log('ThroughputRule requesting switch to index: ', switchRequest.value, 'type: ',mediaType, ' Priority: ',
-                    switchRequest.priority === SwitchRequest.DEFAULT ? 'Default' :
-                        switchRequest.priority === SwitchRequest.STRONG ? 'Strong' : 'Weak', 'Average throughput', Math.round(averageThroughput), 'kbps');
+                if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
+                    var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput);
+                    streamProcessor.getScheduleController().setTimeToLoadDelay(0); // TODO Watch out for seek event - no delay when seeking.!!
+                    switchRequest = SwitchRequest(context).create(newQuality, SwitchRequest.DEFAULT);
+                }
+
+                if (switchRequest.value !== SwitchRequest.NO_CHANGE && switchRequest.value !== current) {
+                    log('ThroughputRule requesting switch to index: ', switchRequest.value, 'type: ',mediaType, ' Priority: ',
+                        switchRequest.priority === SwitchRequest.DEFAULT ? 'Default' :
+                            switchRequest.priority === SwitchRequest.STRONG ? 'Strong' : 'Weak', 'Average throughput', Math.round(averageThroughput), 'kbps');
+                }
             }
         }
 

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -91,7 +91,7 @@ function BufferLevelRule(config) {
             bufferTarget = textSourceBuffer.getAllTracksAreDisabled() ? 0 : trackInfo.fragmentDuration;
         }
 
-        recentLatency = Math.max(metricsExt.getRecentLatency(metrics, 4), MINIMUM_LATENCY_BUFFER);
+        recentLatency = Math.floor( Math.max(metricsExt.getRecentLatency(metrics, 4), MINIMUM_LATENCY_BUFFER) / 1000);
 
         return bufferTarget + recentLatency;
     }

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -33,6 +33,8 @@ import MediaPlayerModel from '../../models/MediaPlayerModel.js';
 import PlaybackController from '../../controllers/PlaybackController.js';
 import FactoryMaker from '../../../core/FactoryMaker.js';
 
+const MINIMUM_LATENCY_BUFFER = 500;
+
 function BufferLevelRule(config) {
 
     let instance;
@@ -72,7 +74,9 @@ function BufferLevelRule(config) {
         var trackInfo = rulesContext.getTrackInfo();
         var isDynamic = streamProcessor.isDynamic(); //TODO make is dynamic false if live stream is playing more than X seconds from live edge in DVR window. So it will act like VOD.
         var isLongFormContent = (duration >= mediaPlayerModel.getLongFormContentDurationThreshold());
+        var metrics = metricsModel.getReadOnlyMetricsFor(type);
         var bufferTarget = NaN;
+        var recentLatency;
 
         if (!isDynamic && abrController.isPlayingAtTopQuality(streamInfo)) {//TODO || allow larger buffer targets if we stabilize on a non top quality for more than 30 seconds.
             bufferTarget = isLongFormContent ? mediaPlayerModel.getBufferTimeAtTopQualityLongForm() : mediaPlayerModel.getBufferTimeAtTopQuality();
@@ -87,7 +91,9 @@ function BufferLevelRule(config) {
             bufferTarget = textSourceBuffer.getAllTracksAreDisabled() ? 0 : trackInfo.fragmentDuration;
         }
 
-        return bufferTarget;
+        recentLatency = Math.max(metricsExt.getRecentLatency(metrics, 4), MINIMUM_LATENCY_BUFFER);
+
+        return bufferTarget + recentLatency;
     }
 
     instance = {

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -53,6 +53,9 @@ class HTTPRequest {
         this.mediaduration = null;  // The duration of the media requests, if available, in milliseconds.
         this.responseHeaders = null; // all the response headers from request.
         this.trace = [];            // Throughput traces, for successful requests only.
+        this.latency = null;        // Latency of the request (time between sent and receipt of first byte)
+        this.time = null;           // Download time of the request (time between receipt of first and last byte)
+        this.bytes = null;          // The number of bytes received
     }
 }
 


### PR DESCRIPTION
This is a rework of the ABR rule changes that @jibberjim added around cached media in 1.6.0. It doesn't include cached fragments if they loaded incredibly quickly unless they *all* loaded incredibly quickly.