### PR TITLE
Improvements to getBufferLength method of MediaPlayer

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -261,19 +261,39 @@ function MediaPlayer() {
     }
 
     /**
-     * The length of the buffer for a given media type, in seconds. Valid media types are "video" and "audio". If no type
-     * is passed in, then the video buffer length is returned. The value is returned to a precision of two decimal places.
+     * The length of the buffer for a given media type, in seconds. Valid media types are "video", "audio" and "fragmentedText". If no type
+     * is passed in, then the minimum of the video and the audio buffer length is returned. The value is returned to a precision of two decimal places.
+     * NaN is returned if an invalid type is requested, or if the presentation does not contain that type or if no arguments are passed and the
+     * presentation doers not include any audio or video adaption sets.
      *
      * @returns {number} The length of the buffer for the given media type, in seconds.
      * @memberof module:MediaPlayer
      * @instance
      */
     function getBufferLength(type) {
+
         if (!type)
         {
-            type = 'video';
+            let videoBuffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor('video'));
+            let audioBuffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor('audio'));
+            videoBuffer = videoBuffer === null ? Number.MAX_SAFE_INTEGER :  videoBuffer.level;
+            audioBuffer = audioBuffer === null ? Number.MAX_SAFE_INTEGER :  audioBuffer.level;
+            return Math.min(videoBuffer,audioBuffer).toPrecision(3);
         }
-        return getMetricsExt().getCurrentBufferLevel(getMetricsFor(type)).level.toPrecision(3);
+        else
+        {
+            if (type === 'video' || type === 'audio' || type === 'fragmentedText')
+            {
+                let buffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor(type));
+                return buffer ? buffer.level.toPrecision(3) : NaN;
+            }
+            else
+            {
+                log('Warning  - getBufferLength requested for invalid type');
+                return NaN;
+            }
+        }
+
     }
 
     /**

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -293,7 +293,10 @@ function TextSourceBuffer() {
                 }
             }
         }
-        log('Warning: Non-supported text type: ' + mediaType);
+        else {
+            log('Warning: Non-supported text type: ' + mediaType);
+        }
+
     }
     /**
      * Extract CEA-608 data from a buffer of data.


### PR DESCRIPTION
1. Now returns the minimum of video or audio bufferLength if no type arg is supplied, so will work with audio-only and video-only presentations.  
2. Supports "fragmentedText" as a media type.
3. Send a log warning if you request an invalid type. 
4. NaN is returned if an invalid type is requested, or if the presentation does not contain that type or if no arguments are passed and the presentation does not include any audio or video adaption sets.