### PR TITLE
Run JSCS as pre-commit hook

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -21,6 +21,5 @@
     "validateParameterSeparator": ", ",
     "disallowMultipleVarDecl": {
         "allExcept": ["undefined"]
-    },
-    "fix": true
+    }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,7 +150,7 @@ module.exports = function (grunt) {
                     watch: true,
                     keepAlive: true,
                     browserifyOptions: {
-                        debug:true
+                        debug: true
                     },
                     plugin: [
                       ['browserify-derequire']
@@ -184,6 +184,11 @@ module.exports = function (grunt) {
             options: {
                 config: '.jscsrc'
             }
+        },
+        githooks: {
+            all: {
+                'pre-commit': 'jscs'
+            }
         }
     });
 
@@ -195,5 +200,5 @@ module.exports = function (grunt) {
     grunt.registerTask('watch',     ['browserify:watch']);
     grunt.registerTask('release',   ['default', 'jsdoc']);
     grunt.registerTask('debug', ['clean', 'browserify:all', 'exorcise:all', 'copy:dist']);
-
+    grunt.registerTask('prepublish', ['githooks', 'dist']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,25 +180,26 @@ module.exports = function (grunt) {
             }
         },
         jscs: {
-            src: './src/**/*.js',
+            src: ['./src/**/*.js', 'Gruntfile.js'],
             options: {
                 config: '.jscsrc'
             }
         },
         githooks: {
             all: {
-                'pre-commit': 'jscs'
+                'pre-commit': 'lint'
             }
         }
     });
 
     require('load-grunt-tasks')(grunt);
-    grunt.registerTask('default',   ['dist', 'test']);
-    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:all', 'minimize', 'copy:dist']);
+    grunt.registerTask('default',   ['lint', 'dist', 'test']);
+    grunt.registerTask('dist',      ['clean', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:all', 'minimize', 'copy:dist']);
     grunt.registerTask('minimize',  ['exorcise', 'uglify']);
     grunt.registerTask('test',      ['mocha_istanbul:test']);
     grunt.registerTask('watch',     ['browserify:watch']);
     grunt.registerTask('release',   ['default', 'jsdoc']);
-    grunt.registerTask('debug', ['clean', 'browserify:all', 'exorcise:all', 'copy:dist']);
+    grunt.registerTask('debug',     ['clean', 'browserify:all', 'exorcise:all', 'copy:dist']);
+    grunt.registerTask('lint',      ['jshint', 'jscs']);
     grunt.registerTask('prepublish', ['githooks', 'dist']);
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/dash.all.min.js",
   "scripts": {
     "test": "mocha --require mochahook",
-    "prepublish": "grunt dist",
+    "prepublish": "grunt prepublish",
     "debug": "iron-mocha --require mochahook",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha --require mochahook -- test/"
   },
@@ -25,6 +25,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exorcise": "^2.1.0",
+    "grunt-githooks": "^0.5.0",
     "grunt-jscs": "^2.5.0",
     "grunt-jsdoc": "^0.5.8",
     "grunt-mocha-istanbul": "^3.0.1",


### PR DESCRIPTION
This PR adds a git pre-commit hook to run the linting tools and reject a commit if any of those tools fail.

Note: Existing users will need to run npm install (or grunt githooks) to enable the pre-commit hook. grunt githooks is called automatically during npm install for new users.

The grunt tasks have been rearranged slightly such that #1043 is no longer an issue if someone has managed to sneak in a violation.

I also added Gruntfile.js to the JSCS config for fun, and fixed an issue that found.