### PR TITLE
Re-add STREAM_TEARDOWN_COMPLETE event needed for metrics reset

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -720,6 +720,8 @@ function StreamController() {
                 eventBus.trigger(Events.PROTECTION_DESTROYED, {data: manifestModel.getValue().url});
             }
         }
+
+        eventBus.trigger(Events.STREAM_TEARDOWN_COMPLETE);
     }
 
     instance = {

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -114,7 +114,7 @@ function ThroughputRule(config) {
 
         }
 
-        if (lastRequest.trace.length) {
+        if (lastRequest.trace && lastRequest.trace.length) {
             downloadTime = (lastRequest._tfinish.getTime() - lastRequest.tresponse.getTime()) / 1000;
 
             bytes = lastRequest.trace.reduce(function (a, b) {


### PR DESCRIPTION
Whilst rebasing I failed to notice that #1051 removed the STREAM_TEARDOWN_COMPLETE event trigger from StreamController.

Metrics Reporting plugin relies on this event to reset correctly.

Also noticed a check was required when testing HTTPRequest.Trace length in ThroughputRule since this may be deleted if the last request failed which could cause uncaught exception.