### PR TITLE
Fix obscure possible uncaught exception

### DIFF
--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -47,8 +47,9 @@ function FragmentLoader(config) {
 
     let mediaPlayerModel = MediaPlayerModel(context).getInstance();
 
-    let instance,
-        xhrs;
+    let instance;
+
+    let xhrs = [];
 
     function doLoad(request, remainingAttempts) {
         var req = new XMLHttpRequest();


### PR DESCRIPTION
If FragmentLoader was reset before attempting to load any fragments, `.abort` would attempt to check the length of `xhrs`, assuming it was an Array. Prior to refactor, `xhrs` was declared as an Array so this worked. Post-refactor, the type was only declared upon the first load.

PR declares type on module initialisation.