### PR TITLE
Fixes an issue with importing UTF8.decode by replacing the functions …

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "uglify-js": "^2.4.21"
   },
   "dependencies": {
-    "codem-isoboxer": "0.2.1"
+    "codem-isoboxer": "0.2.2"
   },
   "repository": {
     "type": "git",

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -36,6 +36,7 @@ import FactoryMaker from '../core/FactoryMaker.js';
 import Debug from '../core/Debug.js';
 import VideoModel from './models/VideoModel.js';
 import TextTrackExtensions from './extensions/TextTrackExtensions.js';
+import ISOBoxer from 'codem-isoboxer';
 
 function TextSourceBuffer() {
 
@@ -190,7 +191,8 @@ function TextSourceBuffer() {
                     }
                     sampleList[i].cts -= firstSubtitleStart;
                     this.buffered.add(sampleList[i].cts / timescale,(sampleList[i].cts + sampleList[i].duration) / timescale);
-                    ccContent = window.UTF8.decode(new Uint8Array(bytes.slice(sampleList[i].offset, sampleList[i].offset + sampleList[i].size)));
+                    let dataView = new DataView(bytes, sampleList[i].offset, sampleList[i].size);
+                    ccContent = ISOBoxer.Utils.dataViewToString(dataView, 'utf-8');
                     parser = parser !== null ? parser : getParser(mimeType);
                     try {
                         result = parser.parse(ccContent);
@@ -201,8 +203,8 @@ function TextSourceBuffer() {
                 }
             }
         } else if (mediaType === 'text') {
-            bytes = new Uint8Array(bytes);
-            ccContent = window.UTF8.decode(bytes);
+            let dataView = new DataView(bytes, 0, bytes.byteLength);
+            ccContent = ISOBoxer.Utils.dataViewToString(dataView, 'utf-8');
             try {
                 result = getParser(mimeType).parse(ccContent);
                 createTextTrackFromMediaInfo(result, mediaInfo);


### PR DESCRIPTION
…with the one included in the latest version of codem-isoboxer.

The update of codem-isoboxer also prepares for WebVTT media segment parsing.
The UTF8 part of base64.js can now be removed.

Tested with
http://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd
http://vm2.dashif.org/dash/vod/testpic_2s/xml_subs.mpd