### PR TITLE
Fixing getBufferLength API and issue #1089

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -272,20 +272,20 @@ function MediaPlayer() {
      * @instance
      */
     function getBufferLength(type) {
+
         if (!type)
         {
-            let videoBuffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor('video'));
-            let audioBuffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor('audio'));
-            videoBuffer = videoBuffer === null ? Number.MAX_SAFE_INTEGER :  videoBuffer.level;
-            audioBuffer = audioBuffer === null ? Number.MAX_SAFE_INTEGER :  audioBuffer.level;
-            return Math.min(videoBuffer,audioBuffer).toPrecision(3);
+            let videoBuffer = getTracksFor('video').length > 0 ? getMetricsExt().getCurrentBufferLevel(getMetricsFor('video')) : Number.MAX_SAFE_INTEGER;
+            let audioBuffer = getTracksFor('audio').length > 0 ? getMetricsExt().getCurrentBufferLevel(getMetricsFor('audio')) : Number.MAX_SAFE_INTEGER;
+            let textBuffer = getTracksFor('fragmentedText').length > 0 ? getMetricsExt().getCurrentBufferLevel(getMetricsFor('fragmentedText')) : Number.MAX_SAFE_INTEGER;
+            return Math.min(videoBuffer,audioBuffer,textBuffer).toPrecision(3);
         }
         else
         {
             if (type === 'video' || type === 'audio' || type === 'fragmentedText')
             {
                 let buffer = getMetricsExt().getCurrentBufferLevel(getMetricsFor(type));
-                return buffer ? buffer.level.toPrecision(3) : NaN;
+                return buffer ? buffer.toPrecision(3) : NaN;
             }
             else
             {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -417,7 +417,7 @@ function MediaPlayer() {
 
     /**
      * Use this method to get the current playhead time as an absolute value, the time in seconds since midnight UTC, Jan 1 1970.
-     * Note - this property only has meaning for live streams
+     * Note - this property only has meaning for live streams. If called before play() has begun, it will return a value of NaN.
      *
      * @returns {number} The current playhead time as UTC timestamp.
      * @memberof module:MediaPlayer
@@ -426,6 +426,9 @@ function MediaPlayer() {
     function timeAsUTC() {
         if (!playbackInitiated) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+        if (time() < 0) {
+            return NaN;
         }
         return getAsUTC(time());
     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -176,7 +176,6 @@ function PlaybackController() {
         } else {
             delay = streamInfo.manifestInfo.minBufferTime * 2;
         }
-
         return delay;
     }
 
@@ -307,12 +306,11 @@ function PlaybackController() {
 
     function updateCurrentTime() {
         if (isPaused() || !isDynamic || element.readyState === 0) return;
-
         var currentTime = getTime();
         var actualTime = getActualPresentationTime(currentTime);
         var timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
-
-        if (timeChanged) {
+        // we trap for a startTime of 0 due to issue #1089
+        if (timeChanged &&  currentTime > 0) {
             seek(actualTime);
         }
     }


### PR DESCRIPTION
Fixing getBufferlength() to handle new API change on metrics.

Fixing issue#1089 for the constant live delay being seen under Firefox. 