### PR TITLE
Fix for #1110

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -133,7 +133,7 @@ function AbrController() {
      */
     function getInitialBitrateFor(type) {
 
-        let saveBitrate = domStorage.getSavedBitrateSettings(type);
+        let savedBitrate = domStorage.getSavedBitrateSettings(type);
 
         if (!bitrateDict.hasOwnProperty(type)) {
             if (ratioDict.hasOwnProperty(type)) {
@@ -145,8 +145,8 @@ function AbrController() {
                 } else {
                     bitrateDict[type] = 0;
                 }
-            } else if (!isNaN(saveBitrate)) {
-                bitrateDict[type] = saveBitrate;
+            } else if (!isNaN(savedBitrate)) {
+                bitrateDict[type] = savedBitrate;
             } else {
                 bitrateDict[type] = (type === 'video') ? DEFAULT_VIDEO_BITRATE : DEFAULT_AUDIO_BITRATE;
             }

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -51,11 +51,11 @@ function BufferLevelRule(config) {
     }
 
     function execute(rulesContext, callback) {
-        var mediaInfo = rulesContext.getMediaInfo();
-        var mediaType = mediaInfo.type;
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        var bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
-        var fragmentCount;
+        let mediaInfo = rulesContext.getMediaInfo();
+        let mediaType = mediaInfo.type;
+        let metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        let bufferLevel = metricsExt.getCurrentBufferLevel(metrics);
+        let fragmentCount;
 
         fragmentCount = bufferLevel < getBufferTarget(rulesContext, mediaType) ? 1 : 0;
 
@@ -65,28 +65,23 @@ function BufferLevelRule(config) {
     function reset() {}
 
     function getBufferTarget(rulesContext, type) {
-        var streamProcessor = rulesContext.getStreamProcessor();
-        var streamInfo = rulesContext.getStreamInfo();
-        var abrController = streamProcessor.getABRController();
-        var duration = streamInfo.manifestInfo.duration;
-        var trackInfo = rulesContext.getTrackInfo();
-        var isDynamic = streamProcessor.isDynamic(); //TODO make is dynamic false if live stream is playing more than X seconds from live edge in DVR window. So it will act like VOD.
-        var isLongFormContent = (duration >= mediaPlayerModel.getLongFormContentDurationThreshold());
-        var bufferTarget = NaN;
-
-        if (!isDynamic && abrController.isPlayingAtTopQuality(streamInfo)) {//TODO || allow larger buffer targets if we stabilize on a non top quality for more than 30 seconds.
-            bufferTarget = isLongFormContent ? mediaPlayerModel.getBufferTimeAtTopQualityLongForm() : mediaPlayerModel.getBufferTimeAtTopQuality();
-        }else if (!isDynamic) {
-            //General VOD target non top quality and not stabilized on a given quality.
-            bufferTarget = mediaPlayerModel.getStableBufferTime();
-        } else {
-            bufferTarget = playbackController.getLiveDelay();
-        }
+        let streamProcessor = rulesContext.getStreamProcessor();
+        let streamInfo = rulesContext.getStreamInfo();
+        let trackInfo = rulesContext.getTrackInfo();
+        let abrController = streamProcessor.getABRController();
+        let duration = streamInfo.manifestInfo.duration;
+        let isLongFormContent = (duration >= mediaPlayerModel.getLongFormContentDurationThreshold());
+        let bufferTarget = NaN;
 
         if (type === 'fragmentedText') {
             bufferTarget = textSourceBuffer.getAllTracksAreDisabled() ? 0 : trackInfo.fragmentDuration;
+        } else {
+            if (abrController.isPlayingAtTopQuality(streamInfo)) {
+                bufferTarget = isLongFormContent ? mediaPlayerModel.getBufferTimeAtTopQualityLongForm() : mediaPlayerModel.getBufferTimeAtTopQuality();
+            }else {
+                bufferTarget = mediaPlayerModel.getStableBufferTime();
+            }
         }
-
         return bufferTarget;
     }
 

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -118,7 +118,7 @@ function DOMStorage() {
 
             if (!isNaN(bitrate) && !isExpired) {
                 savedBitrate = bitrate;
-                log('Last save bitrate for ' + type + ' was ' + bitrate);
+                log('Last saved bitrate for ' + type + ' was ' + bitrate);
             } else if (isExpired) {
                 localStorage.removeItem(key);
             }


### PR DESCRIPTION
At first we tried to make the bufferlevelrule too complex with different logic for live.  In reality for live we should have the same targets as vod and with live we just make best attempt to reach that target pending on the liveDelay.   This way we can use all the same stable buffer and top quality logic and expand from there in the future.    Bottom line this is simplified code that enhances buffer target logic for live!