### PR TITLE
Ensure symmetry in event registration

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -91,6 +91,7 @@ function RepresentationController() {
         eventBus.on(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.on(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);
+        eventBus.on(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, instance);
     }
 
     function initialize(StreamProcessor) {
@@ -122,6 +123,7 @@ function RepresentationController() {
 
         eventBus.off(Events.QUALITY_CHANGED, onQualityChanged, instance);
         eventBus.off(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
+        eventBus.off(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.off(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);
         eventBus.off(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, instance);
 

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -213,6 +213,7 @@ function ManifestLoader(config) {
     function reset() {
         eventBus.off(Events.XLINK_READY, onXlinkReady, instance);
         requestModifierExt = null;
+        xlinkController.reset();
         xlinkController = null;
     }
 

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The copyright in this software is being made available under the BSD License,
  * included below. This software may be subject to other third party and contributor
  * rights, including patent rights, and no such rights are granted under this license.
@@ -52,7 +52,7 @@ function InsufficientBufferRule(config) {
         bufferStateDict = {};
         lastSwitchTime = 0;
         waitToSwitchTime = 1000;
-        eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, this);
+        eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
     }
 
     function execute (rulesContext, callback) {
@@ -98,7 +98,7 @@ function InsufficientBufferRule(config) {
     }
 
     function reset() {
-        eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, this);
+        eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
         bufferStateDict = {};
         lastSwitchTime = 0;
     }


### PR DESCRIPTION
A number of leaks were occurring around event handlers:

* Missed `.off` in RepresentationController (and also a missed `.on`)
* Differing scope passed by `.on` and `.off` in InsufficientBufferRule
* xlinkcontroller was never reset so event handler was left each time