### PR TITLE
Ensure all representations are updated before live edge search begins

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -234,6 +234,12 @@ function RepresentationController() {
         }
     }
 
+    function resetAvailabilityWindow() {
+        availableRepresentations.forEach(rep => {
+            rep.segmentAvailabilityRange = null;
+        });
+    }
+
     function postponeUpdate(availabilityDelay) {
         var delay = (availabilityDelay + (currentRepresentation.segmentDuration * mediaPlayerModel.getLiveDelayFragmentCount())) * 1000;
         var update = function () {
@@ -241,6 +247,10 @@ function RepresentationController() {
 
             updating = true;
             eventBus.trigger(Events.DATA_UPDATE_STARTED, { sender: instance });
+
+            // clear the segmentAvailabilityRange for all reps.
+            // this ensures all are updated before the live edge search starts
+            resetAvailabilityWindow();
 
             for (var i = 0; i < availableRepresentations.length; i++) {
                 indexHandler.updateRepresentation(availableRepresentations[i], true);


### PR DESCRIPTION
While testing streams with availabilityStartTime in the future I noticed that after the `postponeUpdate` only the first available representation would be updated and the remainder would have invalid segment availability data but would be deemed to be valid. This was particularly a problem when autoplay was disabled since updateAvailabilityWindow was not called, but even when it was the availability data could still be slightly stale if wall clock had not ticked.

Ultimately, this could cause the onLiveEdgeSearchCompleted handler to use stale data if the current representation was not the first in the list and therefore fail.

The solution is to reset the segment availability data on all representations to ensure that all are updated correctly prior to the live edge calculation occurring.

This is needed in addition to #1100.

Hope all this makes sense!