### PR TITLE
Feature/api wallclock time update interval

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -485,12 +485,15 @@ function BufferController(config) {
     function pruneBuffer() {
         if (type === 'fragmentedText') return;
 
+        log('try to prune buffer');
+
         var start = buffer.buffered.length ? buffer.buffered.start(0) : 0;
         var currentTime = playbackController.getTime();
         // we want to get rid off buffer that is more than x seconds behind current time
         var bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
 
         if (bufferToPrune > 0) {
+            og('pruning buffer: ' + bufferToPrune + ' seconds');
             isPruningInProgress = true;
             sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);
         }
@@ -640,9 +643,12 @@ function BufferController(config) {
     }
 
     function onWallclockTimeUpdated() {
+        var secondsElapsed;
         //constantly prune buffer every x seconds
         wallclockTicked++;
-        if ((wallclockTicked % mediaPlayerModel.getBufferPruningInterval()) === 0 && !isAppendingInProgress) {
+        secondsElapsed = (wallclockTicked * (mediaPlayerModel.getWallclockTimeUpdateInterval() / 1000));
+        if ((secondsElapsed >= mediaPlayerModel.getBufferPruningInterval()) && !isAppendingInProgress) {
+            wallclockTicked = 0;
             pruneBuffer();
         }
     }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -493,7 +493,7 @@ function BufferController(config) {
         var bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
 
         if (bufferToPrune > 0) {
-            og('pruning buffer: ' + bufferToPrune + ' seconds');
+            log('pruning buffer: ' + bufferToPrune + ' seconds');
             isPruningInProgress = true;
             sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);
         }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -493,7 +493,7 @@ function BufferController(config) {
         var bufferToPrune = currentTime - start - mediaPlayerModel.getBufferToKeep();
 
         if (bufferToPrune > 0) {
-            log('pruning buffer: ' + bufferToPrune + ' seconds');
+            log('pruning buffer: ' + bufferToPrune + ' seconds.');
             isPruningInProgress = true;
             sourceBufferExt.remove(buffer, 0, Math.round(start + bufferToPrune), mediaSource);
         }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -38,9 +38,6 @@ import Debug from '../../core/Debug.js';
 
 function PlaybackController() {
 
-    //This value influences the startup time for live.
-    const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
-
     let context = this.context;
     let log = Debug(context).getInstance().log;
     let eventBus = EventBus(context).getInstance();
@@ -299,7 +296,7 @@ function PlaybackController() {
             onWallclockTime();
         };
 
-        wallclockTimeIntervalId = setInterval(tick, WALLCLOCK_TIME_UPDATE_INTERVAL);
+        wallclockTimeIntervalId = setInterval(tick, mediaPlayerModel.getWallclockTimeUpdateInterval());
     }
 
     function stopUpdatingWallclockTime() {

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -20,6 +20,9 @@ const RICH_BUFFER_THRESHOLD = 20;
 const FRAGMENT_RETRY_ATTEMPTS = 3;
 const FRAGMENT_RETRY_INTERVAL = 1000;
 
+//This value influences the startup time for live (in ms).
+const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
+
 function MediaPlayerModel() {
 
     let instance,
@@ -41,6 +44,7 @@ function MediaPlayerModel() {
         abandonLoadTimeout,
         fragmentRetryAttempts,
         fragmentRetryInterval,
+        wallclockTimeUpdateInterval,
         bufferOccupancyABREnabled;
 
     function setup() {
@@ -63,6 +67,7 @@ function MediaPlayerModel() {
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         fragmentRetryAttempts = FRAGMENT_RETRY_ATTEMPTS;
         fragmentRetryInterval = FRAGMENT_RETRY_INTERVAL;
+        wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -185,6 +190,14 @@ function MediaPlayerModel() {
         return fragmentRetryInterval;
     }
 
+    function setWallclockTimeUpdateInterval(value) {
+        wallclockTimeUpdateInterval = value;
+    }
+
+    function getWallclockTimeUpdateInterval() {
+        return wallclockTimeUpdateInterval;
+    }
+
     function setScheduleWhilePaused(value) {
         scheduleWhilePaused = value;
     }
@@ -259,6 +272,8 @@ function MediaPlayerModel() {
         getFragmentRetryAttempts: getFragmentRetryAttempts,
         setFragmentRetryInterval: setFragmentRetryInterval,
         getFragmentRetryInterval: getFragmentRetryInterval,
+        setWallclockTimeUpdateInterval: setWallclockTimeUpdateInterval,
+        getWallclockTimeUpdateInterval: getWallclockTimeUpdateInterval,
         setScheduleWhilePaused: setScheduleWhilePaused,
         getScheduleWhilePaused: getScheduleWhilePaused,
         getUseSuggestedPresentationDelay: getUseSuggestedPresentationDelay,


### PR DESCRIPTION
make wallclock update interval configurable through MediaPlayer API and use this value to influence pruning buffer interval correctly.

This was implemented in 1.5.2 so we should also use it in 2.0