### PR TITLE
Migrate globals into dashjs namespace

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
                 options: {
                     browserifyOptions: {
                         debug: true,
-                        standalone: 'MediaPlayer'
+                        standalone: 'dashjs.MediaPlayer'
                     },
                     plugin: [
                       ['browserify-derequire']
@@ -137,7 +137,7 @@ module.exports = function (grunt) {
                 options: {
                     browserifyOptions: {
                         debug: true,
-                        standalone: 'Protection'
+                        standalone: 'dashjs.Protection'
                     },
                     plugin: [
                         ['browserify-derequire']
@@ -152,7 +152,7 @@ module.exports = function (grunt) {
                 options: {
                     browserifyOptions: {
                         debug: true,
-                        standalone: 'MetricsReporting'
+                        standalone: 'dashjs.MetricsReporting'
                     },
                     plugin: [
                         ['browserify-derequire']
@@ -162,11 +162,11 @@ module.exports = function (grunt) {
             },
             all: {
                 files: {
-                    'build/temp/dash.all.debug.js': ['src/All.js']
+                    'build/temp/dash.all.debug.js': ['index.js']
                 },
                 options: {
                     browserifyOptions: {
-                        debug: true,
+                        debug: true
                     },
                     plugin: [
                         ['browserify-derequire']
@@ -177,7 +177,7 @@ module.exports = function (grunt) {
 
             watch: {
                 files: {
-                    'build/temp/dash.all.debug.js': ['src/All.js']
+                    'build/temp/dash.all.debug.js': ['index.js']
                 },
                 options: {
                     watch: true,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Now comes the good stuff. We need to create a MediaPlayer and initialize it.  We
 ``` js
 (function(){
     var url = "http://dash.edgesuite.net/envivio/Envivio-dash2/manifest.mpd";
-    var player = MediaPlayer().create(); 
+    var player = dashjs.MediaPlayer().create();
     player.initialize(document.querySelector("#videoPlayer"), url, true);
 })();
 ```
@@ -73,7 +73,7 @@ When it is all done, it should look similar to this:
         <script>
             (function(){
                 var url = "http://dash.edgesuite.net/envivio/Envivio-dash2/manifest.mpd";
-                var player = MediaPlayer().create(); 
+                var player = dashjs.MediaPlayer().create();
                 player.initialize(document.querySelector("#videoPlayer"), url, true);
             })();
         </script>

--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -380,11 +380,11 @@ var ControlBar = function(dashjsMediaPlayer) {
             videoContainer = player.getVideoContainer();
             captionBtn.classList.add("hide");
 
-            player.on(MediaPlayer.events.PLAYBACK_STARTED, onPlayStart);
-            player.on(MediaPlayer.events.PLAYBACK_PAUSED, onPlaybackPaused);
-            player.on(MediaPlayer.events.PLAYBACK_TIME_UPDATED, onPlayTimeUpdate);
-            player.on(MediaPlayer.events.PLAYBACK_SEEKED, onSeeked);
-            player.on(MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);
+            player.on(dashjs.MediaPlayer.events.PLAYBACK_STARTED, onPlayStart);
+            player.on(dashjs.MediaPlayer.events.PLAYBACK_PAUSED, onPlaybackPaused);
+            player.on(dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED, onPlayTimeUpdate);
+            player.on(dashjs.MediaPlayer.events.PLAYBACK_SEEKED, onSeeked);
+            player.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);
 
             playPauseBtn.addEventListener("click", onPlayPauseClick);
             muteBtn.addEventListener("click", onMuteClick);
@@ -435,11 +435,11 @@ var ControlBar = function(dashjsMediaPlayer) {
             seekbar.removeEventListener("change", onSeekBarChange);
             seekbar.removeEventListener("input", onSeeking);
             volumebar.removeEventListener("input", setVolume);
-            player.off(MediaPlayer.events.PLAYBACK_STARTED, onPlayStart);
-            player.off(MediaPlayer.events.PLAYBACK_PAUSED, onPlaybackPaused);
-            player.off(MediaPlayer.events.PLAYBACK_TIME_UPDATED, onPlayTimeUpdate);
-            player.off(MediaPlayer.events.PLAYBACK_SEEKED, onSeeked);
-            player.off(MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);off
+            player.off(dashjs.MediaPlayer.events.PLAYBACK_STARTED, onPlayStart);
+            player.off(dashjs.MediaPlayer.events.PLAYBACK_PAUSED, onPlaybackPaused);
+            player.off(dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED, onPlayTimeUpdate);
+            player.off(dashjs.MediaPlayer.events.PLAYBACK_SEEKED, onSeeked);
+            player.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded);off
             document.removeEventListener("fullscreenchange", onFullScreenChange);
             document.removeEventListener("MSFullscreenChange", onFullScreenChange);
             document.removeEventListener("mozfullscreenchange", onFullScreenChange);

--- a/index.js
+++ b/index.js
@@ -29,13 +29,21 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import MediaPlayer from './streaming/MediaPlayer.js';
-import Protection from './streaming/protection/Protection.js';
-import MetricsReporting from './streaming/metrics/MetricsReporting.js';
+import MediaPlayer from './src/streaming/MediaPlayer.js';
+import Protection from './src/streaming/protection/Protection.js';
+import MetricsReporting from './src/streaming/metrics/MetricsReporting.js';
+import MediaPlayerFactory from './src/streaming/MediaPlayerFactory.js';
 
 
 // Shove both of these into the global scope
 var context = window || global;
-context.MediaPlayer = MediaPlayer;
-context.Protection = Protection;
-context.MetricsReporting = MetricsReporting;
+
+context.dashjs = {
+    MediaPlayer: MediaPlayer,
+    Protection: Protection,
+    MetricsReporting: MetricsReporting,
+    MediaPlayerFactory: MediaPlayerFactory
+};
+
+export default context.dashjs;
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dashjs",
   "version": "2.0.0",
   "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
-  "main": "dist/dash.all.min.js",
+  "main": "index.js",
   "scripts": {
     "test": "mocha --require mochahook",
     "prepublish": "grunt prepublish",

--- a/samples/ad-insertion/inband.html
+++ b/samples/ad-insertion/inband.html
@@ -57,7 +57,7 @@
 <script> (function () {
     $.get("http://se-mashup.fokus.fraunhofer.de:8080/getSession", function (data) {
         var url = "http://se-mashup.fokus.fraunhofer.de:8080/dash/assets/adinsertion-samples/events/inband/dash.mpd?sid=" + data.sessionID;
-        var player = MediaPlayer().create();
+        var player = dashjs.MediaPlayer().create();
         player.initialize(document.querySelector("#vid"), url, true);
     })
 })();

--- a/samples/ad-insertion/inline.html
+++ b/samples/ad-insertion/inline.html
@@ -58,7 +58,7 @@
 <script> (function () {
     $.get("http://se-mashup.fokus.fraunhofer.de:8080/getSession", function (data) {
         var url = "http://se-mashup.fokus.fraunhofer.de:8080/dash/assets/adinsertion-samples/events/inline/dash.mpd?sid=" + data.sessionID;
-        var player = MediaPlayer().create();
+        var player = dashjs.MediaPlayer().create();
         player.initialize(document.querySelector("#vid"), url, true);
     })
 })();

--- a/samples/ad-insertion/js/scte.js
+++ b/samples/ad-insertion/js/scte.js
@@ -2,8 +2,8 @@
  * Created by dsi on 11.05.2015.
  */
 (function() {
-    var player = MediaPlayer().create();
-        playerAd = MediaPlayer().create();
+    var player = dashjs.MediaPlayer().create();
+        playerAd = dashjs.MediaPlayer().create();
         contentUrl = 'http://vm2.dashif.org/livesim/scte35_1/testpic_2s/Manifest.mpd ',
         adUrl = 'http://dash.edgesuite.net/fokus/adinsertion-samples/scte/dash.mpd',
         currentlyAd = false;

--- a/samples/ad-insertion/xlink.html
+++ b/samples/ad-insertion/xlink.html
@@ -127,7 +127,7 @@
 
 <script>
     (function () {
-        var player = MediaPlayer().create();
+        var player = dashjs.MediaPlayer().create();
         player.initialize(document.querySelector("#vid"));
 
         document.getElementById('xlink-two-per').addEventListener('click', function () {

--- a/samples/captioning/caption_vtt.html
+++ b/samples/captioning/caption_vtt.html
@@ -17,7 +17,7 @@
                 video = document.querySelector(".dash-video-player video"),
                 player;
 
-            player = MediaPlayer({}).create();
+            player = dashjs.MediaPlayer({}).create();
             player.initialize(video, url, true);
         }
     </script>

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -23,7 +23,7 @@
             var url = FRAGMENTED_CAPTION_URL;
 
             videoElement = document.querySelector(".videoContainer video");
-            player = MediaPlayer({}).create();
+            player = dashjs.MediaPlayer().create();
             player.initialize(videoElement, url, true);
             controlbar = new ControlBar(player); // Checkout ControlBar.js for more info on how to target/add text tracks to UI
             controlbar.initialize();

--- a/samples/captioning/ttml-ebutt-sample.html
+++ b/samples/captioning/ttml-ebutt-sample.html
@@ -31,7 +31,7 @@
             videoElement = document.querySelector(".videoContainer video");
             TTMLRenderingDiv = document.querySelector("#ttml-rendering-div");
 
-            player = MediaPlayer({}).create();
+            player = dashjs.MediaPlayer().create();
             player.initialize(videoElement, url, true);
             player.attachTTMLRenderingDiv(TTMLRenderingDiv);
             controlbar = new ControlBar(player); // Checkout ControlBar.js for more info on how to target/add text tracks to UI

--- a/samples/chromecast/receiver/js/main.js
+++ b/samples/chromecast/receiver/js/main.js
@@ -150,7 +150,7 @@ function ReceiverController($scope) {
 
                     var video = document.querySelector(".dash-video-player video");
 
-                    player = MediaPlayer({}).create();
+                    player = dashjs.MediaPlayer().create();
                     player.initialize(video, url, true)
                     //player.setIsLive(isLive);
                     $scope.showSpinner = false;

--- a/samples/dash-if-reference-player/app/eme-main.js
+++ b/samples/dash-if-reference-player/app/eme-main.js
@@ -76,7 +76,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     ////////////////////////////////////////
 
     video = document.querySelector(".dash-video-player video");
-    player = MediaPlayer({}).create();
+    player = dashjs.MediaPlayer().create();
     player.initialize(video, null, true);
     player.on(MediaPlayer.events.ERROR, onError.bind(this));
     player.attachVideoContainer(document.getElementById("videoContainer"));

--- a/samples/dash-if-reference-player/app/eme-main.js
+++ b/samples/dash-if-reference-player/app/eme-main.js
@@ -78,7 +78,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     video = document.querySelector(".dash-video-player video");
     player = dashjs.MediaPlayer().create();
     player.initialize(video, null, true);
-    player.on(MediaPlayer.events.ERROR, onError.bind(this));
+    player.on(dashjs.MediaPlayer.events.ERROR, onError.bind(this));
     player.attachVideoContainer(document.getElementById("videoContainer"));
     controlbar = new ControlBar(player, video);
     controlbar.initialize();
@@ -174,7 +174,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         $scope.drmData.push(data);
         $scope.safeApply();
 
-        player.on(MediaPlayer.events.KEY_SYSTEM_SELECTED, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_SYSTEM_SELECTED, function(e) {
             if (!e.error) {
                 data.ksconfig = e.data.ksConfiguration;
             } else {
@@ -184,7 +184,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         }, $scope);
 
 
-        player.on(MediaPlayer.events.KEY_SESSION_CREATED, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_SESSION_CREATED, function(e) {
             if (!e.error) {
                 var persistedSession = findSession(e.data.getSessionID());
                 if (persistedSession) {
@@ -205,7 +205,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         }, $scope);
 
 
-        player.on(MediaPlayer.events.KEY_SESSION_REMOVED, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_SESSION_REMOVED, function(e) {
             if (!e.error) {
                 var session = findSession(e.data);
                 if (session) {
@@ -219,7 +219,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         }, $scope);
 
 
-        player.on(MediaPlayer.events.KEY_SESSION_CLOSED, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_SESSION_CLOSED, function(e) {
             if (!e.error) {
                 for (var i = 0; i < data.sessions.length; i++) {
                     if (data.sessions[i].sessionID === e.data) {
@@ -233,7 +233,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             $scope.safeApply();
         }, $scope);
 
-        player.on(MediaPlayer.events.KEY_STATUSES_CHANGED, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_STATUSES_CHANGED, function(e) {
             var session = findSession(e.data.getSessionID());
             if (session) {
                 var toGUID = function(uakey) {
@@ -267,7 +267,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             }
         }, $scope);
 
-        player.on(MediaPlayer.events.KEY_MESSAGE, function(e) {
+        player.on(dashjs.MediaPlayer.events.KEY_MESSAGE, function(e) {
             var session = findSession(e.data.sessionToken.getSessionID());
             if (session) {
                 session.lastMessage = "Last Message: " + e.data.message.byteLength + " bytes";
@@ -281,7 +281,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
             }
         }, $scope);
 
-        player.on(MediaPlayer.events.LICENSE_REQUEST_COMPLETE, function(e) {
+        player.on(dashjs.MediaPlayer.events.LICENSE_REQUEST_COMPLETE, function(e) {
             if (!e.error) {
                 var session = findSession(e.data.sessionToken.getSessionID());
                 if (session) {
@@ -300,7 +300,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     // Listen for protection system creation/destruction by the player itself.  This will
     // only happen in the case where we do not not provide a ProtectionController
     // to the player via MediaPlayer.attachSource()
-    player.on(MediaPlayer.events.PROTECTION_CREATED, function (e) {
+    player.on(dashjs.MediaPlayer.events.PROTECTION_CREATED, function (e) {
         var data = addDRMData(e.manifest, e.controller);
         data.isPlaying = true;
         for (var i = 0; i < $scope.drmData.length; i++) {
@@ -310,7 +310,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
         }
         $scope.safeApply();
     }, $scope);
-    player.on(MediaPlayer.events.PROTECTION_DESTROYED, function (e) {
+    player.on(dashjs.MediaPlayer.events.PROTECTION_DESTROYED, function (e) {
         for (var i = 0; i < $scope.drmData.length; i++) {
             if ($scope.drmData[i].manifest.url === e.data) {
                 $scope.drmData.splice(i, 1);

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -561,7 +561,7 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     ////////////////////////////////////////
 
     video = document.querySelector(".dash-video-player video");
-    player = MediaPlayer().create();
+    player = dashjs.MediaPlayer().create();
 
     $scope.version = player.getVersion();
 

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -566,11 +566,11 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     $scope.version = player.getVersion();
 
     player.initialize();
-    player.on(MediaPlayer.events.ERROR, onError.bind(this));
-    player.on(MediaPlayer.events.METRIC_CHANGED, metricChanged.bind(this));
-    player.on(MediaPlayer.events.METRIC_UPDATED, metricUpdated.bind(this));
-    player.on(MediaPlayer.events.PERIOD_SWITCH_COMPLETED, streamSwitch.bind(this));
-    player.on(MediaPlayer.events.STREAM_INITIALIZED, streamInitialized.bind(this));
+    player.on(dashjs.MediaPlayer.events.ERROR, onError.bind(this));
+    player.on(dashjs.MediaPlayer.events.METRIC_CHANGED, metricChanged.bind(this));
+    player.on(dashjs.MediaPlayer.events.METRIC_UPDATED, metricUpdated.bind(this));
+    player.on(dashjs.MediaPlayer.events.PERIOD_SWITCH_COMPLETED, streamSwitch.bind(this));
+    player.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, streamInitialized.bind(this));
     player.attachView(video);
     player.attachVideoContainer(document.getElementById("videoContainer"));
 

--- a/samples/getting-started-basic-embed/auto-load-multi-video.html
+++ b/samples/getting-started-basic-embed/auto-load-multi-video.html
@@ -16,7 +16,7 @@
         }
     </style>
 
-    <body onload="MediaPlayer.MediaPlayerFactory.createAll()">
+    <body onload="dashjs.MediaPlayerFactory.createAll()">
         <div>
             <video class="dashjs-player" autoplay controls>
                 <source src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" type="application/dash+xml"/>

--- a/samples/getting-started-basic-embed/auto-load-single-video-src.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-src.html
@@ -16,7 +16,7 @@
         }
     </style>
 
-    <body onload="MediaPlayer.MediaPlayerFactory.createAll()">
+    <body onload="dashjs.MediaPlayerFactory.createAll()">
         <div>
             <video class="dashjs-player" autoplay src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" controls="true"/>
         </div>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
@@ -19,18 +19,18 @@
 
             // Example specifying only the video element, where the video element has a child source element
             video = document.querySelector("#video1");
-            player = MediaPlayer.MediaPlayerFactory.create(video);
+            player = dashjs.MediaPlayerFactory.create(video);
 
             // Example specifying only the video element, where the video element has a src attribute
             video = document.querySelector("#video2");
-            player = MediaPlayer.MediaPlayerFactory.create(video);
+            player = dashjs.MediaPlayerFactory.create(video);
 
             //Example adding video and source
             video = document.querySelector("#video3");
             source = document.createElement("source");
             source.src = "http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd";
             source.type = "application/dash+xml";
-            player = MediaPlayer.MediaPlayerFactory.create(video, source);
+            player = dashjs.MediaPlayerFactory.create(video, source);
 
             //Example adding video, source and context
             video = document.querySelector("#video4");
@@ -38,7 +38,7 @@
             source.src = "http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd";
             source.type = "application/dash+xml";
             context = {}
-            player = MediaPlayer.MediaPlayerFactory.create(video, source, context);
+            player = dashjs.MediaPlayerFactory.create(video, source, context);
         }
     </script>
     <style>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -14,7 +14,7 @@
 
         function init()
         {
-            player = MediaPlayer.MediaPlayerFactory.create(document.querySelector(".dashjs-player"));
+            player = dashjs.MediaPlayerFactory.create(document.querySelector(".dashjs-player"));
             setInterval(updateStats,500)
         }
 

--- a/samples/getting-started-basic-embed/auto-load-single-video.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video.html
@@ -16,7 +16,7 @@
         }
     </style>
 
-    <body onload="MediaPlayer.MediaPlayerFactory.createAll()">
+    <body onload="dashjs.MediaPlayerFactory.createAll()">
         <div>
             <video class="dashjs-player" autoplay preload="none" controls="true">
                 <source src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" type="application/dash+xml"/>

--- a/samples/getting-started-basic-embed/manual-load-single-video.html
+++ b/samples/getting-started-basic-embed/manual-load-single-video.html
@@ -16,7 +16,7 @@
                 url = "http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd";
 
             video = document.querySelector("video");
-            player = MediaPlayer({}).create();
+            player = dashjs.MediaPlayer().create();
             player.initialize(video, url, true);
         }
     </script>

--- a/samples/live-streaming/live-delay-comparison.html
+++ b/samples/live-streaming/live-delay-comparison.html
@@ -18,32 +18,32 @@
 
 
             video = document.querySelector("#video1");
-            player1 = MediaPlayer().create();
+            player1 = dashjs.MediaPlayer().create();
             player1.initialize(video,MPD_2S_SEGMENTS ,true);
             player1.setLiveDelayFragmentCount(0);
 
             video = document.querySelector("#video2");
-            player2 = MediaPlayer().create();
+            player2 = dashjs.MediaPlayer().create();
             player2.initialize(video,MPD_2S_SEGMENTS ,true);
             player2.setLiveDelayFragmentCount(2);
 
             video = document.querySelector("#video3");
-            player3 = MediaPlayer().create();
+            player3 = dashjs.MediaPlayer().create();
             player3.initialize(video,MPD_2S_SEGMENTS ,true);
             player3.setLiveDelayFragmentCount(4);
 
             video = document.querySelector("#video4");
-            player4 = MediaPlayer().create();
+            player4 = dashjs.MediaPlayer().create();
             player4.initialize(video,MPD_6S_SEGMENTS ,true);
             player4.setLiveDelayFragmentCount(0);
 
             video = document.querySelector("#video5");
-            player5 = MediaPlayer().create();
+            player5 = dashjs.MediaPlayer().create();
             player5.initialize(video,MPD_6S_SEGMENTS ,true);
             player5.setLiveDelayFragmentCount(2);
 
             video = document.querySelector("#video6");
-            player6 = MediaPlayer().create();
+            player6 = dashjs.MediaPlayer().create();
             player6.initialize(video,MPD_6S_SEGMENTS ,true);
             player6.setLiveDelayFragmentCount(4);
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -65,7 +65,6 @@ import DashParser from '../dash/DashParser.js';
 import DashManifestExtensions from '../dash/extensions/DashManifestExtensions.js';
 import DashMetricsExtensions from '../dash/extensions/DashMetricsExtensions.js';
 import TimelineConverter from '../dash/TimelineConverter.js';
-import MediaPlayerFactory from '../streaming/MediaPlayerFactory.js';
 
 
 /**
@@ -1750,6 +1749,5 @@ function MediaPlayer() {
 
 MediaPlayer.__dashjs_factory_name = 'MediaPlayer';
 let factory = FactoryMaker.getClassFactory(MediaPlayer);
-factory.MediaPlayerFactory = MediaPlayerFactory().getInstance();
 factory.events = MediaPlayerEvents;
 export default factory;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -795,8 +795,8 @@ function MediaPlayer() {
      * Use this method to change the current text track for both external time text files and fragmented text tracks. There is no need to
      * set the track mode on the video object to switch a track when using this method.
      *
-     * @param idx - Index of track based on the order of the order the tracks are added Use -1 to disable all tracks. (turn captions off).  Use module:MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED.
-     * @see {@link module:MediaPlayer#MediaPlayer.events.TEXT_TRACK_ADDED}
+     * @param idx - Index of track based on the order of the order the tracks are added Use -1 to disable all tracks. (turn captions off).  Use module:MediaPlayer#dashjs.MediaPlayer.events.TEXT_TRACK_ADDED.
+     * @see {@link module:MediaPlayer#dashjs.MediaPlayer.events.TEXT_TRACK_ADDED}
      * @memberof module:MediaPlayer
      * @instance
      */

--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -75,4 +75,5 @@ function MediaPlayerFactory() {
     return instance;
 }
 MediaPlayerFactory.__dashjs_factory_name = 'MediaPlayerFactory';
-export default FactoryMaker.getSingletonFactory(MediaPlayerFactory);
+var factoryFactory = FactoryMaker.getSingletonFactory(MediaPlayerFactory);
+export default factoryFactory().getInstance();


### PR DESCRIPTION
This should resolve #1023 

Global properties have been migrated into the `dashjs` namespace.
Also adjusted the `main` script in the `package.json` which should make this library more friendly for importing into es6 style projects that are using WebPack or Browserify.