### PR TITLE
Fix #1153, #1130 - Guard against dereferencing null objects

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -213,8 +213,11 @@ function ManifestLoader(config) {
     function reset() {
         eventBus.off(Events.XLINK_READY, onXlinkReady, instance);
         requestModifier = null;
-        xlinkController.reset();
-        xlinkController = null;
+
+        if (xlinkController) {
+            xlinkController.reset();
+            xlinkController = null;
+        }
     }
 
     function parseBaseUrl(url) {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -147,13 +147,19 @@ function Stream(config) {
     }
 
     function reset() {
-        playbackController.pause();
-        fragmentController.reset();
+        if (playbackController) {
+            playbackController.pause();
+            playbackController = null;
+        }
+
+        if (fragmentController) {
+            fragmentController.reset();
+            fragmentController = null;
+        }
+
         liveEdgeFinder.abortSearch();
         deactivate();
 
-        playbackController = null;
-        fragmentController = null;
         mediaController = null;
         abrController = null;
         manifestUpdater = null;

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -127,17 +127,31 @@ function StreamProcessor(config) {
     }
 
     function reset(errored) {
-        fragmentModel.reset();
+        if (fragmentModel) {
+            fragmentModel.reset();
+            fragmentModel = null;
+        }
+
         indexHandler.reset();
-        bufferController.reset(errored);
-        scheduleController.reset();
-        representationController.reset();
-        bufferController = null;
-        scheduleController = null;
-        representationController = null;
+
+        if (bufferController) {
+            bufferController.reset(errored);
+            bufferController = null;
+        }
+
+        if (scheduleController) {
+            scheduleController.reset();
+            scheduleController = null;
+        }
+
+        if (representationController) {
+            representationController.reset();
+            representationController = null;
+        }
+
         fragmentController = null;
         fragmentLoader = null;
-        fragmentModel = null;
+
         eventController = null;
         stream = null;
         dynamic = null;

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -214,8 +214,11 @@ function FragmentModel(config) {
         eventBus.off(Events.LOADING_COMPLETED, onLoadingCompleted, this);
         eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, this);
 
-        fragmentLoader.abort();
-        fragmentLoader = null;
+        if (fragmentLoader) {
+            fragmentLoader.abort();
+            fragmentLoader = null;
+        }
+
         context = null;
         executedRequests = [];
         loadingRequests = [];

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -276,8 +276,10 @@ function ProtectionController(config) {
 
         keySystem = undefined;//TODO-Refactor look at why undefined is needed for this. refactor
 
-        protectionModel.reset();
-        protectionModel = null;
+        if (protectionModel) {
+            protectionModel.reset();
+            protectionModel = null;
+        }
     }
 
     ///////////////


### PR DESCRIPTION
I looked at all the reset methods for instances where modules are reset then the reference to them set to null and put guards around these so that multiple calls to reset do not attempt to call methods on undefined.

The longer term answer is to fix this properly by understanding object ownership and ensuring reset code can only be called by the correct modules.

If there is going to be a RC5, it'd probably be worth sticking this in.