### PR TITLE
Move all DOMStorage things to DOMStorage, anonymise data

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -359,14 +359,8 @@ function RepresentationController() {
 
         if (e.oldQuality !== e.newQuality) {
             currentRepresentation = getRepresentationForQuality(e.newQuality);
-            setLocalStorage(e.mediaType, currentRepresentation.bandwidth);
+            domStorage.setSavedBitrateSettings(e.mediaType, currentRepresentation.bandwidth);
             addRepresentationSwitch();
-        }
-    }
-
-    function setLocalStorage(type, bitrate) {
-        if (domStorage.isSupported(DOMStorage.STORAGE_TYPE_LOCAL) && (type === 'video' || type === 'audio')) {
-            localStorage.setItem(DOMStorage['LOCAL_STORAGE_' + type.toUpperCase() + '_BITRATE_KEY'], JSON.stringify({bitrate: bitrate / 1000, timestamp: new Date().getTime()}));
         }
     }
 

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -202,7 +202,7 @@ function MediaController() {
             settings.audioChannelConfiguration = settings.audioChannelConfiguration[0];
         }
 
-        storeLastSettings(type, settings);
+        domStorage.setSavedMediaSettings(type, settings);
     }
 
     /**
@@ -314,12 +314,6 @@ function MediaController() {
     function reset() {
         initialize();
         textSourceBuffer.resetEmbedded();
-    }
-
-    function storeLastSettings(type, value) {
-        if (domStorage.isSupported(DOMStorage.STORAGE_TYPE_LOCAL) && (type === 'video' || type === 'audio')) {
-            localStorage.setItem(DOMStorage['LOCAL_STORAGE_' + type.toUpperCase() + '_SETTINGS_KEY'], JSON.stringify({settings: value, timestamp: new Date().getTime()}));
-        }
     }
 
     function extractSettings(mediaInfo) {

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -91,7 +91,7 @@ function DOMStorage() {
 
     // Return current epoch time, ms, rounded to the nearest 10s to avoid fingerprinting user
     function getTimestamp() {
-        var ten_minutes_ms = 60 * 1000 * 10;
+        let ten_minutes_ms = 60 * 1000 * 10;
         return Math.round(new Date().getTime() / ten_minutes_ms) * ten_minutes_ms;
     }
 

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -89,6 +89,16 @@ function DOMStorage() {
         return supported;
     }
 
+    // Return current epoch time, ms, rounded to the nearest 10s to avoid fingerprinting user
+    function getTimestamp() {
+        var ten_minutes_ms = 60 * 1000 * 10;
+        return Math.round(new Date().getTime() / ten_minutes_ms) * ten_minutes_ms;
+    }
+
+    function canStore(storageType, key, streamType) {
+        return isSupported(storageType) && mediaPlayerModel['get' + key + 'CachingInfo']().enabled && (streamType === 'video' || streamType === 'audio');
+    }
+
     function getSavedMediaSettings(type) {
         //Checks local storage to see if there is valid, non-expired media settings
         if (!isSupported(STORAGE_TYPE_LOCAL) || !mediaPlayerModel.getLastMediaSettingsCachingInfo().enabled) return null;
@@ -126,9 +136,25 @@ function DOMStorage() {
         return savedBitrate;
     }
 
+    function setSavedMediaSettings(type, value) {
+        if (canStore(STORAGE_TYPE_LOCAL, 'LastMediaSettings', type)) {
+            let key = type === 'video' ? LOCAL_STORAGE_VIDEO_SETTINGS_KEY : LOCAL_STORAGE_AUDIO_SETTINGS_KEY;
+            localStorage.setItem(key, JSON.stringify({settings: value, timestamp: getTimestamp()}));
+        }
+    }
+
+    function setSavedBitrateSettings(type, bitrate) {
+        if (canStore(STORAGE_TYPE_LOCAL, 'LastBitrate', type) && bitrate) {
+            let key = type === 'video' ? LOCAL_STORAGE_VIDEO_BITRATE_KEY : LOCAL_STORAGE_AUDIO_BITRATE_KEY;
+            localStorage.setItem(key, JSON.stringify({bitrate: bitrate / 1000, timestamp: getTimestamp()}));
+        }
+    }
+
     instance = {
         getSavedBitrateSettings: getSavedBitrateSettings,
+        setSavedBitrateSettings: setSavedBitrateSettings,
         getSavedMediaSettings: getSavedMediaSettings,
+        setSavedMediaSettings: setSavedMediaSettings,
         isSupported: isSupported
     };
 


### PR DESCRIPTION
This PR refactors the storing of cached bitrate and media settings information, so that anything dealing with localStorage is handled in one place.

It also adjusts the timestamp used in the localStorage, rounding it to the nearest ten minutes. This prevents the timestamp from potentially being considered as unique or personally identifying data.

This changes was in 1.6, but I don't think it needs to be in the 2.0 milestone and can wait for 2.1.