### PR TITLE
Fix console warning about window when running tests

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -93,6 +93,13 @@ function RepresentationController() {
         eventBus.on(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, instance);
     }
 
+    function setConfig(config) {
+        // allow the abrController created in setup to be overidden
+        if (config.abrController) {
+            abrController = config.abrController;
+        }
+    }
+
     function initialize(StreamProcessor) {
         streamProcessor = StreamProcessor;
         indexHandler = streamProcessor.getIndexHandler();
@@ -372,6 +379,7 @@ function RepresentationController() {
 
     instance = {
         initialize: initialize,
+        setConfig: setConfig,
         getData: getData,
         getDataIndex: getDataIndex,
         isUpdating: isUpdating,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -110,6 +110,10 @@ function AbrController() {
         if (config.streamController) {
             streamController = config.streamController;
         }
+        // allow the domStorage created in setup to be overidden
+        if (config.domStorage) {
+            domStorage = config.domStorage;
+        }
     }
 
     function getTopQualityIndexFor(type, id) {

--- a/test/dash.RepresentationControllerSpec.js
+++ b/test/dash.RepresentationControllerSpec.js
@@ -6,6 +6,8 @@ import RepresentationControler from '../src/dash/controllers/RepresentationContr
 import ManifestModel from '../src/streaming/models/ManifestModel.js';
 import Events from '../src/core/events/Events.js';
 import SpecHelper from './helpers/SpecHelper.js';
+import DOMStorageHelper from './helpers/DOMStorageHelper.js';
+import AbrController from '../src/streaming/controllers/AbrController.js';
 
 const chai = require('chai'),
       spies = require('chai-spies');
@@ -15,6 +17,7 @@ chai.use(spies);
 const expect = chai.expect;
 const voHelper = new VoHelper();
 const objectsHelper = new ObjectsHelper();
+const domStorageHelper = new DOMStorageHelper();
 
 describe("RepresentationController", function () {
     // Arrange
@@ -31,8 +34,13 @@ describe("RepresentationController", function () {
 
     manifestModel.setValue(mpd);
 
+    const abrController = AbrController(context).getInstance();
+    abrController.initialize(testType, streamProcessor);
+    abrController.setConfig({domStorage: domStorageHelper});
+
     const representationControler = RepresentationControler(context).create();
     representationControler.initialize(streamProcessor);
+    representationControler.setConfig({abrController: abrController});
 
     it("should not contain data before it is set", function () {
         // Act

--- a/test/helpers/DOMStorageHelper.js
+++ b/test/helpers/DOMStorageHelper.js
@@ -1,0 +1,11 @@
+class DOMStorageHelper {
+    constructor() {
+        this.savedBitrate = NaN;
+    }
+
+    getSavedBitrateSettings(/*type*/) {
+        return this.savedBitrate;
+    }
+}
+
+export default DOMStorageHelper;


### PR DESCRIPTION
RepresentationController tests ultimately call a method from DOMStorage which throws a (caught) exception which prints a warning to the console since `window` is not available in the test environment.

Replaced DOMStorage with a helper object which just returns a number since that functionality is not important when testing RepresentationController.