### PR TITLE
Various TTML fixes

### DIFF
--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -217,12 +217,6 @@ function TextTracks() {
     function checkVideoSize() {
         var track = this.getCurrentTextTrack();
         if (track && track.renderingType === 'html') {
-            if (!track.activeCues || track.activeCues.length === 0) {
-                return;
-            }
-            var newVideoWidth = video.clientWidth;
-            var newVideoHeight = video.clientHeight;
-
             // Create aspect ratio from cellResolutions
             let aspectRatio = 1;
             if (track.cellResolution) {
@@ -235,10 +229,10 @@ function TextTracks() {
                 use80Percent = true;
             }
 
-            var realVideoSize = getVideoVisibleVideoSize.call(this, video.clientWidth, video.clientHeight, video.videoWidth, video.videoHeight, aspectRatio, use80Percent);
+            const realVideoSize = getVideoVisibleVideoSize.call(this, video.clientWidth, video.clientHeight, video.videoWidth, video.videoHeight, aspectRatio, use80Percent);
 
-            newVideoWidth = realVideoSize.w;
-            newVideoHeight = realVideoSize.h;
+            const newVideoWidth = realVideoSize.w;
+            const newVideoHeight = realVideoSize.h;
 
             if (newVideoWidth != actualVideoWidth || newVideoHeight != actualVideoHeight) {
                 actualVideoLeft = realVideoSize.x;
@@ -250,9 +244,9 @@ function TextTracks() {
                 captionContainer.style.width = actualVideoWidth + 'px';
                 captionContainer.style.height = actualVideoHeight + 'px';
 
-                // Video view has changed size, so resize all active cues
-                for (var i = 0; i < track.activeCues.length; ++i) {
-                    var cue = track.activeCues[i];
+                // Video view has changed size, so resize any active cues
+                for (let i = 0; track.activeCues && i < track.activeCues.length; ++i) {
+                    let cue = track.activeCues[i];
                     cue.scaleCue(cue);
                 }
 

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -363,7 +363,7 @@ function TTMLParser() {
             'height': '10%;',
             'align-items': 'flex-start;',
             'overflow': 'visible;',
-            '-ms-writing-mode': 'lr-tb, horizontal-tb;;',
+            '-ms-writing-mode': 'lr-tb, horizontal-tb;',
             '-webkit-writing-mode': 'horizontal-tb;',
             '-moz-writing-mode': 'horizontal-tb;',
             'writing-mode': 'horizontal-tb;'
@@ -874,7 +874,7 @@ function TTMLParser() {
         // Extract the linePadding property from cueStyleProperties.
         var linePaddingLeft = getPropertyFromArray('padding-left', cueStyle);
         var linePaddingRight = getPropertyFromArray('padding-right', cueStyle);
-        var linePadding = linePaddingLeft.concat(' ' + linePaddingRight);
+        var linePadding = linePaddingLeft.concat(' ' + linePaddingRight + ' ');
 
         // Declaration of the HTML elements to be used in the cue innerHTML construction.
         var outerHTMLBeforeBr = '';

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -97,15 +97,15 @@ function TTMLParser() {
             removeNamespacePrefix(ttml, ttNS);
         }
 
-        // Extract styling and layout from the document.
-        ttmlLayout = ttml.tt.head.layout.region_asArray;
-        ttmlStyling = ttml.tt.head.styling.style_asArray;
-
         // Check if the document is conform to the specification.
         if (!passStructuralConstraints()) {
             var errorMsg = 'TTML document has incorrect structure';
             throw errorMsg;
         }
+
+        // Extract styling and layout from the document.
+        ttmlLayout = ttml.tt.head.layout.region_asArray;
+        ttmlStyling = ttml.tt.head.styling.style_asArray;
 
         // Extract the cellResolution information
         var cellResolution = getCellResolution();


### PR DESCRIPTION
I found a few issues while looking at the TTML parser

* Fixes #1170 - `checkVideoSize` needs to calculate `actualVideoWidth` and `actualVideoHeight` whether there are active cues or not.
* Typos in the CSS which is generated
* related to #1168 - parser throws a (caught) exception when no layout or styling in TTML document, whereas that should have been caught by the structural contraints test.