### PR TITLE
Re-enabled html-renderered subtitles for other browsers than Firefox.

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -574,9 +574,11 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
     player.attachView(video);
     player.attachVideoContainer(document.getElementById("videoContainer"));
 
-    // Add HTML-rendered TTML subtitles
-    //ttmlDiv = document.querySelector("#video-caption");
-    //player.attachTTMLRenderingDiv(ttmlDiv);
+    // Add HTML-rendered TTML subtitles except for Firefox (issue #1164)
+    if (typeof navigator !== 'undefined' && !navigator.userAgent.match(/Firefox/)) {
+        ttmlDiv = document.querySelector("#video-caption");
+        player.attachTTMLRenderingDiv(ttmlDiv);
+    }
 
     player.setAutoPlay(true);
     controlbar = new ControlBar(player);


### PR DESCRIPTION
Turn on the rich subtitle rendering in other browsers than Firefox for the reference player.
Still need to fix #1164, but Firefox keeps the non-styled rendering for now.