### PR TITLE
Fixed crash when EBU-TT-D mandatory TTML head elements not present.

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -206,7 +206,7 @@ function TextSourceBuffer() {
                             result = parser.parse(ccContent);
                             textTracks.addCaptions(currFragmentedTrackIdx, firstSubtitleStart / timescale, result);
                         } catch (e) {
-                            //empty cue ?
+                            log('TTML parser error: ' + e.message);
                         }
                     }
                 } else {


### PR DESCRIPTION
TTML does not require styling and layout elements in head, but EBU-TT-D does, and the TTML parser threw an exception when not present. Now fixed so that the parsing continues. Also logs TTML parser exceptions.