### PR TITLE
Add npmignore file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+samples
+docs
+build
+test
+.travis.yml
+mochahook.js
+reports
+
+.idea


### PR DESCRIPTION
This ensures that we don't cause users to donwload files that aren't
necessary when they're installing via a package manager.

This is progress on #1173