### PR TITLE
FragmentModel isFragmentLoaded update

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -848,6 +848,7 @@ function DashHandler(config) {
         request.quality = representation.index;
         request.index = segment.availabilityIdx;
         request.mediaInfo = streamProcessor.getMediaInfo();
+        request.adaptationIndex = representation.adaptation.index;
 
         return request;
     }

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -84,7 +84,7 @@ function FragmentModel(config) {
         };
 
         var isEqualMedia = function (req1, req2) {
-            return ((req1.url === req2.url) && (req1.startTime === req2.startTime));
+            return !isNaN(req1.index) && (req1.index === req2.index) && (req1.startTime === req2.startTime) && (req1.adaptationIndex === req2.adaptationIndex);
         };
 
         var isEqualInit = function (req1, req2) {


### PR DESCRIPTION
isFragmentLoaded() was returning false if the fragment was loaded at a different quality. This is because the url does not match. The updated version compares the fragment index rather than the fragment url, thus avoiding redownloading the same fragment at different quality.

The update also checks the adaptation index so that fragments from different AdaptationSets do not match. The adaptation index is being stored in the request Object inside DashHandler to enable this change.