### PR TITLE
Fix for issue #1172

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -177,7 +177,7 @@ function StreamController() {
     }
 
     function startAutoPlay() {
-        if (!activeStream.isActivated()) return;
+        if (!activeStream.isActivated() || !initialPlayback) return;
         // only first stream must be played automatically during playback initialization
         if (activeStream.getStreamInfo().index === 0) {
             activeStream.startEventController();


### PR DESCRIPTION
Rep switch caused data to update and eventually triggered startAutoPlay check.  This would not happen with audio /video if paused unless schedulewhilepause was true and ABR switch occurred while paused, unlikely but possible.   Fragment Text on the other hand, controlled by UI,  can cause a rep update while paused so we prevent this if not the initialPlayback.  Will fix A/V edgecase as well. 
