### PR TITLE
Fix for issue #1154

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -79,6 +79,8 @@ function VideoModel() {
 
     function setElement(value) {
         element = value;
+        // Workaround to force Firefox to fire the canplay event.
+        element.preload = 'auto';
     }
 
     function setSource(source) {


### PR DESCRIPTION
Added @deprecated tag to getVideoModel. 
Added API that some may use  from videoModel to MediaPlayer.  (Only some should be public)
Added API docs to new API in MediaPlayer
store video element in Video Model only and always reference from there. 
Removed unneeded checks in initializePlayback as it is internally called and not part of Play() anymore. 
Moved hack for preload firefox into video model.