### PR TITLE
Refactor common loader code into XHRLoader

### DIFF
--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -1,0 +1,254 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import HTTPRequest from './vo/metrics/HTTPRequest.js';
+import FactoryMaker from '../core/FactoryMaker.js';
+import MediaPlayerModel from './models/MediaPlayerModel.js';
+
+/**
+ * @Module XHRLoader
+ * @description Manages download of resources via HTTP.
+ */
+function XHRLoader(cfg) {
+    const context = this.context;
+
+    //const log = Debug(context).getInstance().log;
+    const mediaPlayerModel = MediaPlayerModel(context).getInstance();
+
+    const errHandler = cfg.errHandler;
+    const metricsModel = cfg.metricsModel;
+    const requestModifier = cfg.requestModifier;
+
+    let instance;
+    let xhrs;
+    let downloadErrorToRequestTypeMap;
+
+    function setup() {
+        xhrs = [];
+
+        downloadErrorToRequestTypeMap = {
+            [HTTPRequest.MPD_TYPE]:                         errHandler.DOWNLOAD_ERROR_ID_MANIFEST,
+            [HTTPRequest.XLINK_EXPANSION_TYPE]:             errHandler.DOWNLOAD_ERROR_ID_XLINK,
+            [HTTPRequest.INIT_SEGMENT_TYPE]:                errHandler.DOWNLOAD_ERROR_ID_CONTENT,
+            [HTTPRequest.MEDIA_SEGMENT_TYPE]:               errHandler.DOWNLOAD_ERROR_ID_CONTENT,
+            [HTTPRequest.INDEX_SEGMENT_TYPE]:               errHandler.DOWNLOAD_ERROR_ID_CONTENT,
+            [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: errHandler.DOWNLOAD_ERROR_ID_CONTENT,
+            [HTTPRequest.OTHER_TYPE]:                       errHandler.DOWNLOAD_ERROR_ID_CONTENT
+        };
+    }
+
+    function internalLoad(config, remainingAttempts) {
+
+        var request = config.request;
+        var xhr = new XMLHttpRequest();
+        var traces = [];
+        var firstProgress = true;
+        var needFailureReport = true;
+        const requestStartTime = new Date();
+        var lastTraceTime = requestStartTime;
+        var lastTraceReceivedCount = 0;
+
+        const handleLoaded = function (success) {
+            needFailureReport = false;
+
+            request.requestStartDate = requestStartTime;
+            request.requestEndDate = new Date();
+            request.firstByteDate = request.firstByteDate || requestStartTime;
+
+            if (!request.checkExistenceOnly) {
+                metricsModel.addHttpRequest(
+                    request.mediaType,
+                    null,
+                    request.type,
+                    request.url,
+                    xhr.responseURL || null,
+                    request.range || null,
+                    request.requestStartDate,
+                    request.firstByteDate,
+                    request.requestEndDate,
+                    xhr.status,
+                    request.duration,
+                    xhr.getAllResponseHeaders(),
+                    success ? traces : null
+                );
+            }
+        };
+
+        const onloadend = function () {
+            if (xhrs.indexOf(xhr) === -1) {
+                return;
+            } else {
+                xhrs.splice(xhrs.indexOf(xhr), 1);
+            }
+
+            if (needFailureReport) {
+                handleLoaded(false);
+
+                if (remainingAttempts > 0) {
+                    remainingAttempts--;
+                    setTimeout(function () {
+                        internalLoad(config, remainingAttempts);
+                    }, mediaPlayerModel.getRetryIntervalForType(request.type));
+                } else {
+                    errHandler.downloadError(
+                        downloadErrorToRequestTypeMap[request.type],
+                        request.url,
+                        request
+                    );
+
+                    if (config.error) {
+                        config.error(request, 'error', xhr.statusText);
+                    }
+
+                    if (config.complete) {
+                        config.complete(request, xhr.statusText);
+                    }
+                }
+            }
+        };
+
+        const progress = function (event) {
+            var currentTime = new Date();
+
+            if (firstProgress) {
+                firstProgress = false;
+                if (!event.lengthComputable ||
+                    (event.lengthComputable && event.total !== event.loaded)) {
+                    request.firstByteDate = currentTime;
+                }
+            }
+
+            if (event.lengthComputable) {
+                request.bytesLoaded = event.loaded;
+                request.bytesTotal = event.total;
+            }
+
+            traces.push({
+                s: lastTraceTime,
+                d: currentTime.getTime() - lastTraceTime.getTime(),
+                b: [event.loaded ? event.loaded - lastTraceReceivedCount : 0]
+            });
+
+            lastTraceTime = currentTime;
+            lastTraceReceivedCount = event.loaded;
+
+            if (config.progress) {
+                config.progress();
+            }
+        };
+
+        const onload = function () {
+            if (xhr.status >= 200 && xhr.status <= 299) {
+                handleLoaded(true);
+
+                if (config.success) {
+                    config.success(xhr.response, xhr.statusText, request);
+                }
+
+                if (config.complete) {
+                    config.complete(request, xhr.statusText);
+                }
+            }
+        };
+
+        try {
+            const modifiedUrl = requestModifier.modifyRequestURL(request.url);
+            const verb = request.checkExistenceOnly ? 'HEAD' : 'GET';
+
+            xhr.open(verb, modifiedUrl, true);
+
+            if (request.responseType) {
+                xhr.responseType = request.responseType;
+            }
+
+            if (request.range) {
+                xhr.setRequestHeader('Range', 'bytes=' + request.range);
+            }
+
+            if (!request.requestStartDate) {
+                request.requestStartDate = requestStartTime;
+            }
+
+            xhr = requestModifier.modifyRequestHeader(xhr);
+
+            xhr.onload = onload;
+            xhr.onloadend = onloadend;
+            xhr.onerror = onloadend;
+            xhr.onprogress = progress;
+
+            xhrs.push(xhr);
+
+            xhr.send();
+        } catch (e) {
+            xhr.onerror();
+        }
+    }
+
+    /**
+     * Initiates a download of the resource described by config.request
+     * @param {Object} config - contains request (FragmentRequest or derived type), and callbacks
+     * @memberof module:XHRLoader
+     * @instance
+     */
+    function load(config) {
+        if (config.request) {
+            internalLoad(
+                config,
+                mediaPlayerModel.getRetryAttemptsForType(
+                    config.request.type
+                )
+            );
+        }
+    }
+
+    /**
+     * Aborts any inflight downloads
+     * @memberof module:XHRLoader
+     * @instance
+     */
+    function abort() {
+        xhrs.forEach(x => x.abort());
+        xhrs = [];
+    }
+
+    instance = {
+        load: load,
+        abort: abort
+    };
+
+    setup();
+
+    return instance;
+}
+
+XHRLoader.__dashjs_factory_name = 'XHRLoader';
+
+const factory = FactoryMaker.getClassFactory(XHRLoader);
+export default factory;

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -28,6 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+import XlinkLoader from '../XlinkLoader.js';
 import EventBus from '../../core/EventBus.js';
 import Events from '../../core/events/Events.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
@@ -45,16 +46,21 @@ function XlinkController(config) {
     let context = this.context;
     let eventBus = EventBus(context).getInstance();
 
-    let xlinkLoader = config.xlinkLoader;
-
     let instance,
         matchers,
         iron,
         manifest,
-        converter;
+        converter,
+        xlinkLoader;
 
     function setup() {
         eventBus.on(Events.XLINK_ELEMENT_LOADED, onXlinkElementLoaded, instance);
+
+        xlinkLoader = XlinkLoader(context).create({
+            errHandler: config.errHandler,
+            metricsModel: config.metricsModel,
+            requestModifier: config.requestModifier
+        });
     }
 
     function setMatchers(value) {
@@ -80,6 +86,11 @@ function XlinkController(config) {
 
     function reset() {
         eventBus.off(Events.XLINK_ELEMENT_LOADED, onXlinkElementLoaded, instance);
+
+        if (xlinkLoader) {
+            xlinkLoader.reset();
+            xlinkLoader = null;
+        }
     }
 
     function resolve(elements, type, resolveType) {

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -1,4 +1,35 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
 import FactoryMaker from '../../core/FactoryMaker.js';
+import HTTPRequest from '../vo/metrics/HTTPRequest.js';
 
 const DEFAULT_UTC_TIMING_SOURCE = { scheme: 'urn:mpeg:dash:utc:http-xsdate:2014', value: 'http://time.akamai.com/?iso' };
 const LIVE_DELAY_FRAGMENT_COUNT = 4;
@@ -19,6 +50,12 @@ const RICH_BUFFER_THRESHOLD = 20;
 
 const FRAGMENT_RETRY_ATTEMPTS = 3;
 const FRAGMENT_RETRY_INTERVAL = 1000;
+
+const MANIFEST_RETRY_ATTEMPTS = 3;
+const MANIFEST_RETRY_INTERVAL = 500;
+
+const XLINK_RETRY_ATTEMPTS = 1;
+const XLINK_RETRY_INTERVAL = 500;
 
 //This value influences the startup time for live (in ms).
 const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
@@ -42,8 +79,8 @@ function MediaPlayerModel() {
         richBufferThreshold,
         bandwidthSafetyFactor,
         abandonLoadTimeout,
-        fragmentRetryAttempts,
-        fragmentRetryInterval,
+        retryAttempts,
+        retryIntervals,
         wallclockTimeUpdateInterval,
         bufferOccupancyABREnabled;
 
@@ -65,9 +102,27 @@ function MediaPlayerModel() {
         richBufferThreshold = RICH_BUFFER_THRESHOLD;
         bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
-        fragmentRetryAttempts = FRAGMENT_RETRY_ATTEMPTS;
-        fragmentRetryInterval = FRAGMENT_RETRY_INTERVAL;
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
+
+        retryAttempts = {
+            [HTTPRequest.MPD_TYPE]:                         MANIFEST_RETRY_ATTEMPTS,
+            [HTTPRequest.XLINK_EXPANSION_TYPE]:             XLINK_RETRY_ATTEMPTS,
+            [HTTPRequest.MEDIA_SEGMENT_TYPE]:               FRAGMENT_RETRY_ATTEMPTS,
+            [HTTPRequest.INIT_SEGMENT_TYPE]:                FRAGMENT_RETRY_ATTEMPTS,
+            [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: FRAGMENT_RETRY_ATTEMPTS,
+            [HTTPRequest.INDEX_SEGMENT_TYPE]:               FRAGMENT_RETRY_ATTEMPTS,
+            [HTTPRequest.OTHER_TYPE]:                       FRAGMENT_RETRY_ATTEMPTS
+        };
+
+        retryIntervals = {
+            [HTTPRequest.MPD_TYPE]:                         MANIFEST_RETRY_INTERVAL,
+            [HTTPRequest.XLINK_EXPANSION_TYPE]:             XLINK_RETRY_INTERVAL,
+            [HTTPRequest.MEDIA_SEGMENT_TYPE]:               FRAGMENT_RETRY_INTERVAL,
+            [HTTPRequest.INIT_SEGMENT_TYPE]:                FRAGMENT_RETRY_INTERVAL,
+            [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: FRAGMENT_RETRY_INTERVAL,
+            [HTTPRequest.INDEX_SEGMENT_TYPE]:               FRAGMENT_RETRY_INTERVAL,
+            [HTTPRequest.OTHER_TYPE]:                       FRAGMENT_RETRY_INTERVAL
+        };
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -175,19 +230,35 @@ function MediaPlayerModel() {
     }
 
     function setFragmentRetryAttempts(value) {
-        fragmentRetryAttempts = value;
+        retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE] = value;
+    }
+
+    function setRetryAttemptsForType(type, value) {
+        retryAttempts[type] = value;
     }
 
     function getFragmentRetryAttempts() {
-        return fragmentRetryAttempts;
+        return retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE];
+    }
+
+    function getRetryAttemptsForType(type) {
+        return retryAttempts[type];
     }
 
     function setFragmentRetryInterval(value) {
-        fragmentRetryInterval = value;
+        retryIntervals[HTTPRequest.MEDIA_SEGMENT_TYPE] = value;
+    }
+
+    function setRetryIntervalForType(type, value) {
+        retryIntervals[type] = value;
     }
 
     function getFragmentRetryInterval() {
-        return fragmentRetryInterval;
+        return retryIntervals[HTTPRequest.MEDIA_SEGMENT_TYPE];
+    }
+
+    function getRetryIntervalForType(type) {
+        return retryIntervals[type];
     }
 
     function setWallclockTimeUpdateInterval(value) {
@@ -270,8 +341,12 @@ function MediaPlayerModel() {
         getBufferPruningInterval: getBufferPruningInterval,
         setFragmentRetryAttempts: setFragmentRetryAttempts,
         getFragmentRetryAttempts: getFragmentRetryAttempts,
+        setRetryAttemptsForType: setRetryAttemptsForType,
+        getRetryAttemptsForType: getRetryAttemptsForType,
         setFragmentRetryInterval: setFragmentRetryInterval,
         getFragmentRetryInterval: getFragmentRetryInterval,
+        setRetryIntervalForType: setRetryIntervalForType,
+        getRetryIntervalForType: getRetryIntervalForType,
         setWallclockTimeUpdateInterval: setWallclockTimeUpdateInterval,
         getWallclockTimeUpdateInterval: getWallclockTimeUpdateInterval,
         setScheduleWhilePaused: setScheduleWhilePaused,

--- a/src/streaming/utils/ErrorHandler.js
+++ b/src/streaming/utils/ErrorHandler.js
@@ -32,6 +32,21 @@ import EventBus from '../../core/EventBus.js';
 import Events from '../../core/events/Events.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
 
+const CAPABILITY_ERROR_MEDIASOURCE      = 'mediasource';
+const CAPABILITY_ERROR_MEDIAKEYS        = 'mediakeys';
+
+const DOWNLOAD_ERROR_ID_MANIFEST        = 'manifest';
+const DOWNLOAD_ERROR_ID_SIDX            = 'SIDX';
+const DOWNLOAD_ERROR_ID_CONTENT         = 'content';
+const DOWNLOAD_ERROR_ID_INITIALIZATION  = 'initialization';
+const DOWNLOAD_ERROR_ID_XLINK           = 'xlink';
+
+const MANIFEST_ERROR_ID_CODEC           = 'codec';
+const MANIFEST_ERROR_ID_PARSE           = 'parse';
+const MANIFEST_ERROR_ID_NOSTREAMS       = 'nostreams';
+
+const TIMED_TEXT_ERROR_ID_PARSE         = 'parse';
+
 function ErrorHandler() {
 
     let instance;
@@ -43,7 +58,7 @@ function ErrorHandler() {
         eventBus.trigger(Events.ERROR, {error: 'capability', event: err});
     }
 
-    // {id: "manifest"|"SIDX"|"content"|"initialization", url: "", request: {XMLHttpRequest instance}}
+    // {id: "manifest"|"SIDX"|"content"|"initialization"|"xlink", url: "", request: {XMLHttpRequest instance}}
     function downloadError(id, url, request) {
         eventBus.trigger(Events.ERROR, {error: 'download', event: {id: id, url: url, request: request}});
     }
@@ -53,6 +68,7 @@ function ErrorHandler() {
         eventBus.trigger(Events.ERROR, {error: 'manifestError', event: {message: message, id: id, manifest: manifest}});
     }
 
+    // {message: '', id: 'parse', cc: ''}
     function timedTextError(message, id, ccContent) {
         eventBus.trigger(Events.ERROR, {error: 'cc', event: {message: message, id: id, cc: ccContent}});
     }
@@ -81,5 +97,21 @@ function ErrorHandler() {
 
     return instance;
 }
+
 ErrorHandler.__dashjs_factory_name = 'ErrorHandler';
-export default FactoryMaker.getSingletonFactory(ErrorHandler);
+
+const factory = FactoryMaker.getSingletonFactory(ErrorHandler);
+
+factory.CAPABILITY_ERROR_MEDIASOURCE        = CAPABILITY_ERROR_MEDIASOURCE;
+factory.CAPABILITY_ERROR_MEDIAKEYS          = CAPABILITY_ERROR_MEDIAKEYS;
+factory.DOWNLOAD_ERROR_ID_MANIFEST          = DOWNLOAD_ERROR_ID_MANIFEST;
+factory.DOWNLOAD_ERROR_ID_SIDX              = DOWNLOAD_ERROR_ID_SIDX;
+factory.DOWNLOAD_ERROR_ID_CONTENT           = DOWNLOAD_ERROR_ID_CONTENT;
+factory.DOWNLOAD_ERROR_ID_INITIALIZATION    = DOWNLOAD_ERROR_ID_INITIALIZATION;
+factory.DOWNLOAD_ERROR_ID_XLINK             = DOWNLOAD_ERROR_ID_XLINK;
+factory.MANIFEST_ERROR_ID_CODEC             = MANIFEST_ERROR_ID_CODEC;
+factory.MANIFEST_ERROR_ID_PARSE             = MANIFEST_ERROR_ID_PARSE;
+factory.MANIFEST_ERROR_ID_NOSTREAMS         = MANIFEST_ERROR_ID_NOSTREAMS;
+factory.TIMED_TEXT_ERROR_ID_PARSE           = TIMED_TEXT_ERROR_ID_PARSE;
+
+export default factory;

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -28,37 +28,45 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
+import FactoryMaker from '../../core/FactoryMaker.js';
+
 /**
- * @class
- * @ignore
+ * @Module URLUtils
+ * @description Provides utility functions for operating on URLs.
+ * Initially this is simply a method to determine the Base URL of a URL, but
+ * should probably include other things provided all over the place such as
+ * determining whether a URL is relative/absolute, resolving two paths etc.
  */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+function URLUtils() {
+
+    let instance;
+
+    /**
+     * Returns a string that contains the Base URL of a URL, if determinable.
+     * @return {string}
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function parseBaseUrl(url) {
+        var base = '';
+
+        if (url.indexOf('/') !== -1) {
+            if (url.indexOf('?') !== -1) {
+                url = url.substring(0, url.indexOf('?'));
+            }
+            base = url.substring(0, url.lastIndexOf('/') + 1);
+        }
+
+        return base;
     }
+
+    instance = {
+        parseBaseUrl:   parseBaseUrl
+    };
+
+    return instance;
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
-
-export default FragmentRequest;
+URLUtils.__dashjs_factory_name = 'URLUtils';
+export default FactoryMaker.getSingletonFactory(URLUtils);

--- a/src/streaming/vo/HeadRequest.js
+++ b/src/streaming/vo/HeadRequest.js
@@ -32,33 +32,14 @@
  * @class
  * @ignore
  */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+import FragmentRequest from './FragmentRequest.js';
+
+class HeadRequest extends FragmentRequest {
+    constructor(url) {
+        super();
+        this.url = url || null;
+        this.checkForExistenceOnly = true;
     }
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
-
-export default FragmentRequest;
+export default HeadRequest;

--- a/src/streaming/vo/TextRequest.js
+++ b/src/streaming/vo/TextRequest.js
@@ -32,33 +32,16 @@
  * @class
  * @ignore
  */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+import FragmentRequest from './FragmentRequest.js';
+
+class TextRequest extends FragmentRequest {
+    constructor(url, type) {
+        super();
+        this.url = url || null;
+        this.type = type || null;
+        this.mediaType = 'stream';
+        this.responseType = 'text';
     }
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
-
-export default FragmentRequest;
+export default TextRequest;


### PR DESCRIPTION
Fixes #1048, at least the refactor part of it. All of the common code is contained in XHRLoader, with the previous loaders calling this, leaving just the unique code in these.

Extended MediaPlayerModel to allow different number of retries and intervals per resource type, although these are not actually used anywhere right now.

I haven't attempted to abstract anything too much in order to enable alternative transports, although this shouldn't be too tricky.

Note that diff'ing (Fragment|Xlink|Manifest)Loader isn't that helpful since they have changed radically.