### PR TITLE
fix playback hanging for delayed fragment at end of stream

### DIFF
--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -205,12 +205,12 @@ function XHRLoader(cfg) {
             xhr.onerror = onloadend;
             xhr.onprogress = progress;
 
-            xhrs.push(xhr);
-
             // Adds the ability to delay single fragment loading time to control buffer.
             let now = new Date().getTime();
-            if (now >= request.delayLoadingTime) {
+            if (isNaN(request.delayLoadingTime) || now >= request.delayLoadingTime) {
                 // no delay - just send xhr
+
+                xhrs.push(xhr);
                 xhr.send();
             } else {
                 // delay
@@ -223,6 +223,7 @@ function XHRLoader(cfg) {
                         delayedXhrs.splice(delayedXhrs.indexOf(delayedXhr), 1);
                     }
                     try {
+                        xhrs.push(delayedXhr.xhr);
                         delayedXhr.xhr.send();
                     } catch (e) {
                         delayedXhr.xhr.onerror();
@@ -258,10 +259,7 @@ function XHRLoader(cfg) {
      * @instance
      */
     function abort() {
-        delayedXhrs.forEach(function (x) {
-            clearTimeout(x.delayTimeout);
-            x.xhr.onloadend();
-        });
+        delayedXhrs.forEach(x => clearTimeout(x.delayTimeout));
         delayedXhrs = [];
 
         xhrs.forEach(x => x.abort());

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -53,7 +53,6 @@ function FragmentModel(config) {
         scheduleController,
         executedRequests,
         loadingRequests,
-        delayLoadingTimeout,
         fragmentLoader;
 
     function setup() {
@@ -63,7 +62,6 @@ function FragmentModel(config) {
         loadingRequests = [];
 
         eventBus.on(Events.LOADING_COMPLETED, onLoadingCompleted, instance);
-        eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
     }
 
     function setLoader(value) {
@@ -202,7 +200,6 @@ function FragmentModel(config) {
 
     function reset() {
         eventBus.off(Events.LOADING_COMPLETED, onLoadingCompleted, this);
-        eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, this);
 
         if (fragmentLoader) {
             fragmentLoader.abort();
@@ -315,12 +312,6 @@ function FragmentModel(config) {
 
         addSchedulingInfoMetrics(request, error ? FRAGMENT_MODEL_FAILED : FRAGMENT_MODEL_EXECUTED);
         eventBus.trigger(Events.FRAGMENT_LOADING_COMPLETED, { request: request, response: response, error: error, sender: this });
-    }
-
-    function onPlaybackSeeking () {
-        if (delayLoadingTimeout !== undefined) {
-            clearTimeout(delayLoadingTimeout);
-        }
     }
 
     instance = {

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -181,17 +181,7 @@ function FragmentModel(config) {
     }
 
     function executeRequest(request) {
-        var now = new Date().getTime();
-
         if (!request) return;
-
-        //Adds the ability to delay single fragment loading time to control buffer.
-        if (now < request.delayLoadingTime ) {
-            delayLoadingTimeout = setTimeout(function () {
-                executeRequest(request);
-            }, (request.delayLoadingTime - now) );
-            return;
-        }
 
         switch (request.action) {
             case FragmentRequest.ACTION_COMPLETE:

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -91,6 +91,7 @@ function NextFragmentRequestRule(config) {
         if (request) {
             adapter.setIndexHandlerTime(streamProcessor, request.startTime + request.duration);
             request.delayLoadingTime = new Date().getTime() + scheduleController.getTimeToLoadDelay();
+            scheduleController.setTimeToLoadDelay(0); // only delay one fragment
         }
 
         callback(SwitchRequest(context).create(request, p));


### PR DESCRIPTION
When fragment download is delayed by ScheduleController.setTimeToLoadDelay(), there was a race condition when a stream ends during a delay for loading a fragment.