### PR TITLE
Fix FragmentLoader TypeError on fragment abandonment

### DIFF
--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -128,6 +128,12 @@ function FragmentLoader(config) {
     function abort() {
         if (xhrLoader) {
             xhrLoader.abort();
+        }
+    }
+
+    function reset() {
+        if (xhrLoader) {
+            xhrLoader.abort();
             xhrLoader = null;
         }
     }
@@ -135,7 +141,8 @@ function FragmentLoader(config) {
     instance = {
         checkForExistence: checkForExistence,
         load: load,
-        abort: abort
+        abort: abort,
+        reset: reset
     };
 
     setup();

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -215,7 +215,7 @@ function FragmentModel(config) {
         eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, this);
 
         if (fragmentLoader) {
-            fragmentLoader.abort();
+            fragmentLoader.reset();
             fragmentLoader = null;
         }
 


### PR DESCRIPTION
Gah, the perils of manual testing on a high-bandwidth connection!

I missed that `abort` and `reset` need to be different in the case of the FragmentLoader since abort is called when the FragmentModel wishes to abort in-flight requests on Representation switch.

Sorry!