### PR TITLE
Add video width and height to api getBitrateInfoListFor

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -325,9 +325,9 @@ function DashManifestModel() {
 
         for (var i = 0; i < ln; i++) {
             bitrateList.push({
-                bandwidth:reps[i].bandwidth,
-                width:reps[i].width || 0,
-                height:reps[i].height || 0
+                bandwidth: reps[i].bandwidth,
+                width: reps[i].width || 0,
+                height: reps[i].height || 0
             });
         }
 

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -324,7 +324,11 @@ function DashManifestModel() {
         var bitrateList = [];
 
         for (var i = 0; i < ln; i++) {
-            bitrateList.push(reps[i].bandwidth);
+            bitrateList.push({
+                bandwidth:reps[i].bandwidth,
+                width:reps[i].width || 0,
+                height:reps[i].height || 0
+            });
         }
 
         return bitrateList;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -340,7 +340,9 @@ function AbrController() {
             bitrateInfo = new BitrateInfo();
             bitrateInfo.mediaType = type;
             bitrateInfo.qualityIndex = i;
-            bitrateInfo.bitrate = bitrateList[i];
+            bitrateInfo.bitrate = bitrateList[i].bandwidth;
+            bitrateInfo.width = bitrateList[i].width;
+            bitrateInfo.height = bitrateList[i].height;
             infoList.push(bitrateInfo);
         }
 

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -373,7 +373,7 @@ function MediaController() {
             var tmp;
 
             trackArr.forEach(function (track) {
-                tmp = Math.max.apply(Math, track.bitrateList.map(function(obj) { return obj.bandwidth; }));
+                tmp = Math.max.apply(Math, track.bitrateList.map(function (obj) { return obj.bandwidth; }));
 
                 if (tmp > max) {
                     max = tmp;

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -373,7 +373,7 @@ function MediaController() {
             var tmp;
 
             trackArr.forEach(function (track) {
-                tmp = Math.max.apply(Math, track.bitrateList);
+                tmp = Math.max.apply(Math, track.bitrateList.map(function(obj) { return obj.bandwidth; }));
 
                 if (tmp > max) {
                     max = tmp;

--- a/src/streaming/vo/BitrateInfo.js
+++ b/src/streaming/vo/BitrateInfo.js
@@ -36,6 +36,8 @@ class BitrateInfo {
     constructor() {
         this.mediaType = null;
         this.bitrate = null;
+        this.width = null;
+        this.height = null;
         this.qualityIndex = NaN;
     }
 }

--- a/test/helpers/VOHelper.js
+++ b/test/helpers/VOHelper.js
@@ -139,7 +139,23 @@ class VoHelper {
 
         mediaInfo.id = 'DUMMY_MEDIA-01';
         mediaInfo.type = type;
-        mediaInfo.bitrateList = [1000, 2000, 3000];
+        mediaInfo.bitrateList = [
+            {
+                bandwidth: 1000,
+                width: 360,
+                height: 480
+            },
+            {
+                bandwidth: 2000,
+                width: 640,
+                height: 480
+            },
+            {
+                bandwidth: 3000,
+                width: 1280,
+                height: 720
+            }
+        ];
         mediaInfo.representationCount = 3;
         mediaInfo.streamInfo = this.getDummyStreamInfo();
 

--- a/test/streaming.AbrControllerSpec.js
+++ b/test/streaming.AbrControllerSpec.js
@@ -84,8 +84,7 @@ describe("AbrController", function () {
 
         match = expectedBitrates.filter(function(val, idx) {
             item = actualBitrates[idx];
-
-            return (item && (item.qualityIndex === idx) && (item.bitrate === val) && (item.mediaType === dummyMediaInfo.type));
+            return (item && (item.qualityIndex === idx) && (item.bitrate === val.bandwidth) && (item.mediaType === dummyMediaInfo.type) && (item.width === val.width) && (item.mediaType === dummyMediaInfo.type) && (item.height === val.height));
         });
 
         expect(match.length).to.be.equal(expectedBitrates.length);


### PR DESCRIPTION
@davidgarry commited a pr to enhance getBitrateInfoListFor api but it
was not merged into dash.js v2.0.0 release.
This commit based on his commit to make these information available in
dashjs 2.0.0 again