### PR TITLE
Detach MediaSource correctly when no longer required

### DIFF
--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -58,9 +58,7 @@ function MediaSourceController() {
     }
 
     function detachMediaSource(videoModel) {
-        // it seems that any value passed to the setSource is cast to a sting when setting element.src,
-        // so we cannot use null or undefined to reset the element. Use empty string instead.
-        videoModel.setSource('');
+        videoModel.setSource(null);
     }
 
     function setDuration(source, value) {

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -86,6 +86,9 @@ function VideoModel() {
     function setSource(source) {
         if (source) {
             element.src = source;
+        } else {
+            element.removeAttribute('src');
+            element.load();
         }
     }
 


### PR DESCRIPTION
Given the discussion at https://github.com/w3c/media-source/issues/53 and the linked W3C spec text [Best practices for authors using media elements](https://www.w3.org/TR/html5/embedded-content-0.html#best-practices-for-authors-using-media-elements), we should probably be following that advice in order to release correctly any resources which are no longer needed.

I have tested this on Safari (9.0.3), IE11, Edge, FF (Nightly) and Chrome.