### PR TITLE
BaseURL support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,7 @@
     "esnext": true,
     "noarg": true,
     "noempty": true,
-    "latedef": true,
+    "latedef": "nofunc",
     "undef": true,
     "unused": true,
     "strict": false,

--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -63,6 +63,7 @@ class CoreEvents extends EventsBase {
         this.QUOTA_EXCEEDED = 'quotaExceeded';
         this.REPRESENTATION_UPDATED = 'representationUpdated';
         this.SEGMENTS_LOADED = 'segmentsLoaded';
+        this.SERVICE_LOCATION_BLACKLIST_CHANGED = 'serviceLocationBlacklistChanged';
         this.SOURCEBUFFER_APPEND_COMPLETED = 'sourceBufferAppendCompleted';
         this.SOURCEBUFFER_REMOVE_COMPLETED = 'sourceBufferRemoveCompleted';
         this.STREAMS_COMPOSED = 'streamsComposed';
@@ -72,6 +73,7 @@ class CoreEvents extends EventsBase {
         this.STREAM_TEARDOWN_COMPLETE = 'streamTeardownComplete';
         this.TIMED_TEXT_REQUESTED = 'timedTextRequested';
         this.TIME_SYNCHRONIZATION_COMPLETED = 'timeSynchronizationComplete';
+        this.URL_RESOLUTION_FAILED = 'urlResolutionFailed';
         this.WALLCLOCK_TIME_UPDATED = 'wallclockTimeUpdated';
         this.XLINK_ALL_ELEMENTS_LOADED = 'xlinkAllElementsLoaded';
         this.XLINK_ELEMENT_LOADED = 'xlinkElementLoaded';

--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -298,85 +298,16 @@ function DashParser(/*config*/) {
         return period;
     }
 
-    function getBaseUrlValuesMap() {
-        var mpd,
-            period,
-            adaptationSet,
-            representation,
-            common;
-
-        common = [
-            {
-                name: 'BaseURL',
-                merge: true,
-                mergeFunction: function (parentValue, childValue) {
-                    var mergedValue,
-                        origin;
-
-                    // child is absolute, don't merge
-                    if (httpOrHttpsRegex.test(childValue)) {
-                        mergedValue = childValue;
-                    } else if (childValue.charAt(0) === '/' && originRegex.test(parentValue)) {
-                        origin = parentValue.match(originRegex);
-                        mergedValue = origin[1] + childValue;
-                    } else {
-                        mergedValue = parentValue + childValue;
-                    }
-
-                    return mergedValue;
-                }
-            }
-        ];
-
-        mpd = {};
-        mpd.name = 'mpd';
-        mpd.isRoot = true;
-        mpd.isArray = true;
-        mpd.parent = null;
-        mpd.children = [];
-        mpd.properties = common;
-
-        period = {};
-        period.name = 'Period';
-        period.isRoot = false;
-        period.isArray = true;
-        period.parent = null;
-        period.children = [];
-        period.properties = common;
-        mpd.children.push(period);
-
-        adaptationSet = {};
-        adaptationSet.name = 'AdaptationSet';
-        adaptationSet.isRoot = false;
-        adaptationSet.isArray = true;
-        adaptationSet.parent = period;
-        adaptationSet.children = [];
-        adaptationSet.properties = common;
-        period.children.push(adaptationSet);
-
-        representation = {};
-        representation.name = 'Representation';
-        representation.isRoot = false;
-        representation.isArray = true;
-        representation.parent = adaptationSet;
-        representation.children = [];
-        representation.properties = common;
-        adaptationSet.children.push(representation);
-
-        return mpd;
-    }
-
     function getDashMap() {
         var result = [];
 
         result.push(getCommonValuesMap());
         result.push(getSegmentValuesMap());
-        result.push(getBaseUrlValuesMap());
 
         return result;
     }
 
-    function parse(data, baseUrl, xlinkController) {
+    function parse(data, xlinkController) {
 
         var converter = new X2JS(matchers, '', true);
         var iron = new ObjectIron(getDashMap());
@@ -395,18 +326,6 @@ function DashParser(/*config*/) {
             }
 
             json = new Date();
-
-            if (!manifest.hasOwnProperty('BaseURL')) {
-                //log("Setting baseURL: " + baseUrl);
-                manifest.BaseURL = baseUrl;
-            } else {
-                // Setting manifest's BaseURL to the first BaseURL
-                manifest.BaseURL = manifest.BaseURL_asArray[0];
-
-                if (manifest.BaseURL.toString().indexOf('http') !== 0) {
-                    manifest.BaseURL = baseUrl + manifest.BaseURL;
-                }
-            }
 
             if (manifest.hasOwnProperty('Location')) {
                 // for now, do not support multiple Locations -

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -36,7 +36,9 @@ import Mpd from '../vo/Mpd.js';
 import UTCTiming from '../vo/UTCTiming.js';
 import TimelineConverter from '../utils/TimelineConverter.js';
 import Event from '../vo/Event.js';
+import BaseURL from '../vo/BaseURL.js';
 import EventStream from '../vo/EventStream.js';
+import URLUtils from '../../streaming/utils/URLUtils.js';
 import FactoryMaker from '../../core/FactoryMaker.js';
 
 function DashManifestModel() {
@@ -44,6 +46,7 @@ function DashManifestModel() {
     let instance;
     let context = this.context;
     let timelineConverter = TimelineConverter(context).getInstance();//TODO Need to pass this in not bake in
+    const urlUtils = URLUtils(context).getInstance();
 
     function getIsTypeOf(adaptation, type) {
 
@@ -154,11 +157,13 @@ function DashManifestModel() {
         })[0];
     }
 
+    function getRepresentationSortFunction() {
+        return (a, b) => a.bandwidth - b.bandwidth;
+    }
+
     function processAdaptation(adaptation) {
         if (adaptation.Representation_asArray !== undefined && adaptation.Representation_asArray !== null) {
-            adaptation.Representation_asArray.sort(function (a, b) {
-                return a.bandwidth - b.bandwidth;
-            });
+            adaptation.Representation_asArray.sort(getRepresentationSortFunction());
         }
 
         return adaptation;
@@ -273,14 +278,22 @@ function DashManifestModel() {
         return isDVR;
     }
 
-    function getIsOnDemand(manifest) {
-        var isOnDemand = false;
+    function hasProfile(manifest, profile) {
+        var has = false;
 
         if (manifest.profiles && manifest.profiles.length > 0) {
-            isOnDemand = (manifest.profiles.indexOf('urn:mpeg:dash:profile:isoff-on-demand:2011') !== -1);
+            has = (manifest.profiles.indexOf(profile) !== -1);
         }
 
-        return isOnDemand;
+        return has;
+    }
+
+    function getIsOnDemand(manifest) {
+        return hasProfile(manifest, 'urn:mpeg:dash:profile:isoff-on-demand:2011');
+    }
+
+    function getIsDVB(manifest) {
+        return hasProfile(manifest, 'urn:dvb:dash:profile:dvb-dash:2014');
     }
 
     function getDuration(manifest) {
@@ -399,11 +412,9 @@ function DashManifestModel() {
                 if (initialization.hasOwnProperty('sourceURL')) {
                     representation.initialization = initialization.sourceURL;
                 } else if (initialization.hasOwnProperty('range')) {
-                    representation.initialization = r.BaseURL;
                     representation.range = initialization.range;
                 }
             } else if (r.hasOwnProperty('mimeType') && getIsTextTrack(r.mimeType)) {
-                representation.initialization = r.BaseURL;
                 representation.range = 0;
             }
 
@@ -429,6 +440,9 @@ function DashManifestModel() {
             }
 
             representation.MSETimeOffset = timelineConverter.calcMSETimeOffset(representation);
+
+            representation.path = [adaptation.period.index, adaptation.index, i];
+
             representations.push(representation);
         }
 
@@ -773,6 +787,56 @@ function DashManifestModel() {
         return utcTimingEntries;
     }
 
+    function getBaseURLsFromElement(node) {
+        let baseUrls = [];
+        let entries = node.BaseURL_asArray || [node.baseUri] || [];
+
+        entries.some(entry => {
+            if (entry) {
+                const baseUrl = new BaseURL();
+                const text = entry.__text || entry;
+
+                baseUrl.url = text;
+
+                // serviceLocation is optional, but we need it in order
+                // to blacklist correctly. if it's not available, use
+                // anything unique since there's no relationship to any
+                // other BaseURL and, in theory, the url should be
+                // unique so use this instead.
+                if (entry.hasOwnProperty('serviceLocation') &&
+                        entry.serviceLocation.length) {
+                    baseUrl.serviceLocation = entry.serviceLocation;
+                } else {
+                    baseUrl.serviceLocation = text;
+                }
+
+                if (entry.hasOwnProperty('dvb:priority')) {
+                    baseUrl.dvb_priority = entry['dvb:priority'];
+                }
+
+                if (entry.hasOwnProperty('dvb:weight')) {
+                    baseUrl.dvb_weight = entry['dvb:weight'];
+                }
+
+                /* NOTE: byteRange, availabilityTimeOffset,
+                 * availabilityTimeComplete currently unused
+                 */
+
+                baseUrls.push(baseUrl);
+
+                if (urlUtils.isRelative(text)) {
+                    // it doesn't really make sense to have relative and
+                    // absolute URLs at the same level, or multiple
+                    // relative URLs at the same level, so assume we are
+                    // done from this level of the MPD
+                    return true;
+                }
+            }
+        });
+
+        return baseUrls;
+    }
+
     instance = {
         getIsTypeOf: getIsTypeOf,
         getIsAudio: getIsAudio,
@@ -800,6 +864,7 @@ function DashManifestModel() {
         getIsDynamic: getIsDynamic,
         getIsDVR: getIsDVR,
         getIsOnDemand: getIsOnDemand,
+        getIsDVB: getIsDVB,
         getDuration: getDuration,
         getBandwidth: getBandwidth,
         getRefreshDelay: getRefreshDelay,
@@ -818,7 +883,9 @@ function DashManifestModel() {
         getEventStreams: getEventStreams,
         getEventStreamForAdaptationSet: getEventStreamForAdaptationSet,
         getEventStreamForRepresentation: getEventStreamForRepresentation,
-        getUTCTimingSources: getUTCTimingSources
+        getUTCTimingSources: getUTCTimingSources,
+        getBaseURLsFromElement: getBaseURLsFromElement,
+        getRepresentationSortFunction: getRepresentationSortFunction
     };
 
     return instance;

--- a/src/dash/vo/BaseURL.js
+++ b/src/dash/vo/BaseURL.js
@@ -32,34 +32,28 @@
  * @class
  * @ignore
  */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.serviceLocation = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+
+const DEFAULT_DVB_PRIORITY = 1;
+const DEFAULT_DVB_WEIGHT = 1;
+
+class BaseURL {
+    constructor(url, serviceLocation, priority, weight) {
+        this.url = url || '';
+        this.serviceLocation = serviceLocation || url || '';
+
+        // DVB extensions
+        this.dvb_priority = priority || DEFAULT_DVB_PRIORITY;
+        this.dvb_weight = weight || DEFAULT_DVB_WEIGHT;
+
+        /* currently unused:
+         * byteRange,
+         * availabilityTimeOffset,
+         * availabilityTimeComplete
+         */
     }
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
+BaseURL.DEFAULT_DVB_PRIORITY = DEFAULT_DVB_PRIORITY;
+BaseURL.DEFAULT_DVB_WEIGHT = DEFAULT_DVB_WEIGHT;
 
-export default FragmentRequest;
+export default BaseURL;

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -84,17 +84,17 @@ function ManifestLoader(config) {
             request: request,
             success: function (data, textStatus, xhr) {
                 var actualUrl;
-                var baseUrl;
+                var baseUri;
 
                 // Handle redirects for the MPD - as per RFC3986 Section 5.1.3
                 if (xhr.responseURL && xhr.responseURL !== url) {
-                    baseUrl = urlUtils.parseBaseUrl(xhr.responseURL);
+                    baseUri = urlUtils.parseBaseUrl(xhr.responseURL);
                     actualUrl = xhr.responseURL;
                 } else {
-                    baseUrl = urlUtils.parseBaseUrl(url);
+                    baseUri = urlUtils.parseBaseUrl(url);
                 }
 
-                const manifest = parser.parse(data, baseUrl, xlinkController);
+                const manifest = parser.parse(data, xlinkController);
 
                 if (manifest) {
                     manifest.url = actualUrl || url;
@@ -104,6 +104,7 @@ function ManifestLoader(config) {
                         manifest.originalUrl = manifest.url;
                     }
 
+                    manifest.baseUri = baseUri;
                     manifest.loadedTime = new Date();
                     xlinkController.resolveManifestOnLoad(manifest);
                 } else {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -52,6 +52,7 @@ import VideoModel from './models/VideoModel.js';
 import RulesController from './rules/RulesController.js';
 import SynchronizationRulesCollection from './rules/synchronization/SynchronizationRulesCollection.js';
 import MediaSourceController from './controllers/MediaSourceController.js';
+import BaseURLController from './controllers/BaseURLController.js';
 import Debug from './../core/Debug.js';
 import EventBus from './../core/EventBus.js';
 import Events from './../core/events/Events.js';
@@ -1738,6 +1739,7 @@ function MediaPlayer() {
             liveEdgeFinder: LiveEdgeFinder(context).getInstance(),
             mediaSourceController: MediaSourceController(context).getInstance(),
             timeSyncController: TimeSyncController(context).getInstance(),
+            baseURLController: BaseURLController(context).getInstance(),
             virtualBuffer: virtualBuffer,
             errHandler: errHandler,
             timelineConverter: TimelineConverter(context).getInstance()

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -60,6 +60,7 @@ function Stream(config) {
     let capabilities = config.capabilities;
     let errHandler = config.errHandler;
     let timelineConverter = config.timelineConverter;
+    let baseURLController = config.baseURLController;
 
     let instance,
         streamProcessors,
@@ -297,13 +298,17 @@ function Stream(config) {
     function createIndexHandler() {
 
         let segmentBaseLoader = SegmentBaseLoader(context).getInstance();
+        segmentBaseLoader.setConfig({
+            baseURLController: baseURLController
+        });
         segmentBaseLoader.initialize();
 
         let handler = DashHandler(context).create({
             segmentBaseLoader: segmentBaseLoader,
             timelineConverter: timelineConverter,
             dashMetrics: DashMetrics(context).getInstance(),
-            metricsModel: MetricsModel(context).getInstance()
+            metricsModel: MetricsModel(context).getInstance(),
+            baseURLController: baseURLController
         });
 
         return handler;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -60,6 +60,7 @@ function StreamController() {
         liveEdgeFinder,
         mediaSourceController,
         timeSyncController,
+        baseURLController,
         virtualBuffer,
         errHandler,
         timelineConverter,
@@ -483,7 +484,8 @@ function StreamController() {
                         adapter: adapter,
                         timelineConverter: timelineConverter,
                         capabilities: capabilities,
-                        errHandler: errHandler
+                        errHandler: errHandler,
+                        baseURLController: baseURLController
                     });
                     stream.initialize(streamInfo, protectionController);
 
@@ -582,6 +584,8 @@ function StreamController() {
                 }
             });
 
+            baseURLController.initialize(manifest);
+
             timeSyncController.setConfig({
                 metricsModel: metricsModel,
                 dashMetrics: dashMetrics
@@ -655,6 +659,9 @@ function StreamController() {
         if (config.timeSyncController) {
             timeSyncController = config.timeSyncController;
         }
+        if (config.baseURLController) {
+            baseURLController = config.baseURLController;
+        }
         if (config.virtualBuffer) {
             virtualBuffer = config.virtualBuffer;
         }
@@ -692,6 +699,7 @@ function StreamController() {
         eventBus.off(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
         eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdated, this);
 
+        baseURLController.reset();
         manifestUpdater.reset();
         metricsModel.clearAllCurrentMetrics();
         manifestModel.setValue(null);

--- a/src/streaming/models/BaseURLTreeModel.js
+++ b/src/streaming/models/BaseURLTreeModel.js
@@ -1,0 +1,163 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import DashManifestModel from '../../dash/models/DashManifestModel.js';
+import ObjectUtils from '../utils/ObjectUtils.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
+
+const DEFAULT_INDEX = NaN;
+
+class Node {
+    constructor(_baseUrls, _selectedIdx) {
+        this.data = {
+            baseUrls: _baseUrls || null,
+            selectedIdx: _selectedIdx || DEFAULT_INDEX
+        };
+        this.children = [];
+    }
+}
+
+function BaseURLTreeModel() {
+
+    let instance;
+    let root;
+
+    const context = this.context;
+    const dashManifestModel = DashManifestModel(context).getInstance();
+    const objectUtils = ObjectUtils(context).getInstance();
+
+    function setup() {
+        root = new Node();
+    }
+
+    function updateChildData(node, index, element) {
+        let baseUrls = dashManifestModel.getBaseURLsFromElement(element);
+
+        if (!node[index]) {
+            node[index] = new Node(baseUrls);
+        } else {
+            if (!objectUtils.areSimpleEquivalent(baseUrls, node[index].data.baseUrls)) {
+                node[index].data.baseUrls = baseUrls;
+                node[index].data.selectedIdx = DEFAULT_INDEX;
+            }
+        }
+    }
+
+    function getBaseURLCollectionsFromManifest(manifest) {
+        let baseUrls = dashManifestModel.getBaseURLsFromElement(manifest);
+
+        if (!objectUtils.areSimpleEquivalent(baseUrls, root.data.baseUrls)) {
+            root.data.baseUrls = baseUrls;
+            root.data.selectedIdx = DEFAULT_INDEX;
+        }
+
+        if (manifest.Period_asArray) {
+            manifest.Period_asArray.forEach((p, pi) => {
+                updateChildData(root.children, pi, p);
+
+                if (p.AdaptationSet_asArray) {
+                    p.AdaptationSet_asArray.forEach((a, ai) => {
+                        updateChildData(root.children[pi].children, ai, a);
+
+                        if (a.Representation_asArray) {
+                            a.Representation_asArray.sort(
+                                dashManifestModel.getRepresentationSortFunction()
+                            ).forEach((r, ri) => {
+                                updateChildData(
+                                    root.children[pi].children[ai].children,
+                                    ri,
+                                    r
+                                );
+                            });
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    function walk(callback, node) {
+        var target = node || root;
+
+        callback(target.data);
+
+        if (target.children) {
+            target.children.forEach(child => walk(callback, child));
+        }
+    }
+
+    function invalidateSelectedIndexes(serviceLocation) {
+        walk((data) => {
+            if (!isNaN(data.selectedIdx)) {
+                if (serviceLocation === data.baseUrls[data.selectedIdx].serviceLocation) {
+                    data.selectedIdx = DEFAULT_INDEX;
+                }
+            }
+        });
+    }
+
+    function update(manifest) {
+        getBaseURLCollectionsFromManifest(manifest);
+    }
+
+    function reset() {
+        root = new Node();
+    }
+
+    function getForPath(path) {
+        var target = root;
+        var nodes = [target.data];
+
+        path.forEach(p => {
+            target = target.children[p];
+
+            if (target) {
+                nodes.push(target.data);
+            }
+        });
+
+        return nodes.filter(n => n.baseUrls.length);
+    }
+
+    instance = {
+        reset: reset,
+        update: update,
+        getForPath: getForPath,
+        invalidateSelectedIndexes: invalidateSelectedIndexes
+    };
+
+    setup();
+
+    return instance;
+}
+
+BaseURLTreeModel.__dashjs_factory_name = 'BaseURLTreeModel';
+export default FactoryMaker.getClassFactory(BaseURLTreeModel);

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -130,7 +130,25 @@ function MetricsModel() {
         return vo;
     }
 
-    function addHttpRequest(mediaType, tcpid, type, url, actualurl, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders, traces) {
+    function appendHttpTrace(httpRequest, s, d, b) {
+        var vo = new HTTPRequest.Trace();
+
+        vo.s = s;
+        vo.d = d;
+        vo.b = b;
+
+        httpRequest.trace.push(vo);
+
+        if (!httpRequest.interval) {
+            httpRequest.interval = 0;
+        }
+
+        httpRequest.interval += d;
+
+        return vo;
+    }
+
+    function addHttpRequest(mediaType, tcpid, type, url, actualurl, serviceLocation, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders, traces) {
         var vo = new HTTPRequest();
 
         // ISO 23009-1 D.4.3 NOTE 2:
@@ -148,6 +166,7 @@ function MetricsModel() {
                 null,
                 type,
                 url,
+                null,
                 null,
                 range,
                 trequest,
@@ -174,6 +193,7 @@ function MetricsModel() {
         vo._stream = mediaType;
         vo._mediaduration = mediaduration;
         vo._responseHeaders = responseHeaders;
+        vo._serviceLocation = serviceLocation;
 
         if (traces) {
             traces.forEach(trace => {
@@ -188,24 +208,6 @@ function MetricsModel() {
         getMetricsFor(mediaType).HttpList.push(vo);
 
         metricAdded(mediaType, adapter.metricsList.HTTP_REQUEST, vo);
-        return vo;
-    }
-
-    function appendHttpTrace(httpRequest, s, d, b) {
-        var vo = new HTTPRequest.Trace();
-
-        vo.s = s;
-        vo.d = d;
-        vo.b = b;
-
-        httpRequest.trace.push(vo);
-
-        if (!httpRequest.interval) {
-            httpRequest.interval = 0;
-        }
-
-        httpRequest.interval += d;
-
         return vo;
     }
 

--- a/src/streaming/rules/baseUrlResolution/BasicSelector.js
+++ b/src/streaming/rules/baseUrlResolution/BasicSelector.js
@@ -28,38 +28,36 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-/**
- * @class
- * @ignore
- */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.serviceLocation = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function BasicSelector(config) {
+
+    let instance;
+
+    const blacklistController = config.blacklistController;
+
+    function select(baseUrls) {
+        var index = 0;
+        var selectedBaseUrl;
+
+        if (baseUrls && baseUrls.some((baseUrl, idx) => {
+            index = idx;
+
+            return (!blacklistController.contains(baseUrl.serviceLocation));
+        })) {
+            selectedBaseUrl = baseUrls[index];
+        }
+
+        return selectedBaseUrl;
     }
+
+    instance = {
+        select: select
+    };
+
+    return instance;
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
-
-export default FragmentRequest;
+BasicSelector.__dashjs_factory_name = 'BasicSelector';
+export default FactoryMaker.getClassFactory(BasicSelector);

--- a/src/streaming/rules/baseUrlResolution/DVBSelector.js
+++ b/src/streaming/rules/baseUrlResolution/DVBSelector.js
@@ -1,0 +1,147 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../../core/FactoryMaker.js';
+
+function DVBSelector(config) {
+
+    let instance;
+
+    const blacklistController = config.blacklistController;
+
+    function getNonBlacklistedBaseUrls(urls) {
+        var removedPriorities = [];
+
+        const samePrioritiesFilter = function (el) {
+            if (removedPriorities.length) {
+                if ((el.dvb_priority) &&
+                        (removedPriorities.indexOf(el.dvb_priority) !== -1)) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        const serviceLocationFilter = function (baseUrl) {
+            if (blacklistController.contains(baseUrl.serviceLocation)) {
+                // whenever a BaseURL is removed from the available list of
+                // BaseURLs, any other BaseURL with the same @priority
+                // value as the BaseURL being removed shall also be removed
+                if (baseUrl.dvb_priority) {
+                    removedPriorities.push(baseUrl.dvb_priority);
+                }
+
+                // all URLs in the list which have a @serviceLocation
+                // attribute matching an entry in the blacklist shall be
+                // removed from the available list of BaseURLs
+                return false;
+            }
+
+            return true;
+        };
+
+        return urls.filter(serviceLocationFilter).filter(samePrioritiesFilter);
+    }
+
+    function selectByWeight(availableUrls) {
+        const prioritySorter = function (a, b) {
+            var diff = a.dvb_priority - b.dvb_priority;
+            return isNaN(diff) ? 0 : diff;
+        };
+
+        const topPriorityFilter = function (baseUrl, idx, arr) {
+            return !idx || (
+                (arr[0].dvb_priority && baseUrl.dvb_priority) &&
+                (arr[0].dvb_priority === baseUrl.dvb_priority)
+            );
+        };
+
+        var totalWeight = 0;
+        var cumulWeights = [];
+        var idx = 0;
+        var rn;
+        var urls;
+
+        // It shall begin by taking the set of resolved BaseURLs present or inherited at the current
+        // position in the MPD, resolved and filtered as described in 10.8.2.1, that have the lowest
+        // @priority attribute value.
+        urls = availableUrls.sort(prioritySorter).filter(topPriorityFilter);
+
+        if (urls.length) {
+            if (urls.length > 1) {
+                // If there is more than one BaseURL with this lowest @priority attribute value then the Player
+                // shall select one of them at random such that the probability of each BaseURL being chosen
+                // is proportional to the value of its @weight attribute. The method described in RFC 2782
+                // [26] or picking from a number of weighted entries is suitable for this, but there may be other
+                // algorithms which achieve the same effect.
+
+                // add all the weights together, storing the accumulated weight per entry
+                urls.forEach(baseUrl => {
+                    totalWeight += baseUrl.dvb_weight;
+                    cumulWeights.push(totalWeight);
+                });
+
+                // pick a random number between zero and totalWeight
+                rn = Math.floor(Math.random() * (totalWeight - 1));
+
+                // select the index for the range rn falls within
+                cumulWeights.every((limit, index) => {
+                    idx = index;
+
+                    if (rn < limit) {
+                        return false;
+                    }
+
+                    return true;
+                });
+            }
+
+            return urls[idx];
+        }
+    }
+
+    function select(baseUrls) {
+        return baseUrls && selectByWeight(
+            getNonBlacklistedBaseUrls(
+                baseUrls
+            )
+        );
+    }
+
+    instance = {
+        select: select
+    };
+
+    return instance;
+}
+
+DVBSelector.__dashjs_factory_name = 'DVBSelector';
+export default FactoryMaker.getClassFactory(DVBSelector);

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -1,0 +1,131 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import EventBus from '../../core/EventBus.js';
+import Events from '../../core/events/Events.js';
+import DashManifestModel from '../../dash/models/DashManifestModel.js';
+import BlacklistController from '../controllers/BlacklistController.js';
+import DVBSelector from '../rules/baseUrlResolution/DVBSelector.js';
+import BasicSelector from '../rules/baseUrlResolution/BasicSelector.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
+
+const URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = 1;
+const URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE = 'Failed to resolve a valid URL';
+
+function BaseURLSelector() {
+
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+    const dashManifestModel = DashManifestModel(context).getInstance();
+
+    let instance,
+        serviceLocationBlacklistController,
+        basicSelector,
+        dvbSelector,
+        selector;
+
+    function setup() {
+        serviceLocationBlacklistController = BlacklistController(context).create({
+            updateEventName:        Events.SERVICE_LOCATION_BLACKLIST_CHANGED,
+            loadFailedEventName:    Events.FRAGMENT_LOADING_COMPLETED
+        });
+
+        basicSelector = BasicSelector(context).create({
+            blacklistController: serviceLocationBlacklistController
+        });
+
+        dvbSelector = DVBSelector(context).create({
+            blacklistController: serviceLocationBlacklistController
+        });
+
+        selector = basicSelector;
+    }
+
+    function chooseSelectorFromManifest(manifest) {
+        if (dashManifestModel.getIsDVB(manifest)) {
+            selector = dvbSelector;
+        } else {
+            selector = basicSelector;
+        }
+    }
+
+    function select(data) {
+        const baseUrls = data.baseUrls;
+        const selectedIdx = data.selectedIdx;
+
+        // Once a random selection has been carried out amongst a group of BaseURLs with the same
+        // @priority attribute value, then that choice should be re-used if the selection needs to be made again
+        // unless the blacklist has been modified or the available BaseURLs have changed.
+        if (!isNaN(selectedIdx)) {
+            return baseUrls[selectedIdx];
+        }
+
+        let selectedBaseUrl = selector.select(baseUrls);
+
+        if (!selectedBaseUrl) {
+            eventBus.trigger(
+                Events.URL_RESOLUTION_FAILED,
+                {
+                    error: new Error(
+                        URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE,
+                        URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE
+                    )
+                }
+            );
+
+            return;
+        }
+
+        data.selectedIdx = baseUrls.indexOf(selectedBaseUrl);
+
+        return selectedBaseUrl;
+    }
+
+    function reset() {
+        serviceLocationBlacklistController.reset();
+    }
+
+    instance = {
+        chooseSelectorFromManifest: chooseSelectorFromManifest,
+        select: select,
+        reset: reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+BaseURLSelector.__dashjs_factory_name = 'BaseURLSelector';
+let factory = FactoryMaker.getClassFactory(BaseURLSelector);
+factory.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE;
+factory.URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE = URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE;
+export default factory;

--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -28,38 +28,34 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
+import FactoryMaker from '../../core/FactoryMaker.js';
+
 /**
- * @class
- * @ignore
+ * @Module ObjectUtils
+ * @description Provides utility functions for objects
  */
-class FragmentRequest {
-    constructor() {
-        this.action = FragmentRequest.ACTION_DOWNLOAD;
-        this.startTime = NaN;
-        this.mediaType = null;
-        this.mediaInfo = null;
-        this.type = null;
-        this.duration = NaN;
-        this.timescale = NaN;
-        this.range = null;
-        this.url = null;
-        this.serviceLocation = null;
-        this.requestStartDate = null;
-        this.firstByteDate = null;
-        this.requestEndDate = null;
-        this.quality = NaN;
-        this.index = NaN;
-        this.availabilityStartTime = null;
-        this.availabilityEndTime = null;
-        this.wallStartTime = null;
-        this.bytesLoaded = NaN;
-        this.bytesTotal = NaN;
-        this.delayLoadingTime = NaN;
-        this.responseType = 'arraybuffer';
+function ObjectUtils() {
+
+    let instance;
+
+    /**
+     * Returns true if objects resolve to the same string. Only really useful
+     * when the user controls the object generation
+     * @return {boolean}
+     * @memberof module:ObjectUtils
+     * @instance
+     */
+    function areSimpleEquivalent(obj1, obj2) {
+        return JSON.stringify(obj1) === JSON.stringify(obj2);
     }
+
+    instance = {
+        areSimpleEquivalent: areSimpleEquivalent
+    };
+
+    return instance;
 }
 
-FragmentRequest.ACTION_DOWNLOAD = 'download';
-FragmentRequest.ACTION_COMPLETE = 'complete';
-
-export default FragmentRequest;
+ObjectUtils.__dashjs_factory_name = 'ObjectUtils';
+export default FactoryMaker.getSingletonFactory(ObjectUtils);

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -34,6 +34,8 @@
 class HTTPRequest {
     /**
      * @description This Object holds reference to the HTTPRequest for manifest, fragment and xlink loading.
+     * Members which are not defined in ISO23009-1 Annex D should be prefixed by a _ so that they are ignored
+     * by Metrics Reporting code.
      */
     constructor() {
         /**
@@ -115,6 +117,11 @@ class HTTPRequest {
          * @public
          */
         this._responseHeaders = null;
+        /**
+         * The selected service location for the request. string.
+         * @public
+         */
+        this._serviceLocation = null;
     }
 }
 

--- a/test/dash.DashHandlerSpec.js
+++ b/test/dash.DashHandlerSpec.js
@@ -4,11 +4,11 @@ import DashHandler from '../src/dash/DashHandler.js';
 
 const expect = require('chai').expect;
 
-describe("DashHandler", function () {
+describe('DashHandler', function () {
     const objectsHelper = new ObjectsHelper();
     const voHelper = new VoHelper();
 
-    it("should generate an init segment for a representation",function() {
+    it('should generate an init segment for a representation', () => {
         // Arrange
         const context = {};
         const testType = 'video';
@@ -16,8 +16,12 @@ describe("DashHandler", function () {
         const representation = voHelper.getDummyRepresentation(testType);
         const timelineConverter = objectsHelper.getDummyTimelineConverter();
         const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);
+        const baseURLController = objectsHelper.getDummyBaseURLController();
 
-        const config = { timelineConverter : timelineConverter };
+        const config = {
+            timelineConverter: timelineConverter,
+            baseURLController: baseURLController
+        };
         const dashHandler = DashHandler(context).create(config);
         dashHandler.initialize(streamProcessor);
 
@@ -25,6 +29,6 @@ describe("DashHandler", function () {
         const initRequest = dashHandler.getInitRequest(representation);
 
         // Assert
-        expect(initRequest).to.exist;
+        expect(initRequest).to.exist; // jshint ignore:line
     });
 });

--- a/test/dash.DashManifestModel.js
+++ b/test/dash.DashManifestModel.js
@@ -1,0 +1,136 @@
+import DashManifestModel from '../src/dash/models/DashManifestModel.js';
+import BaseURL from '../src/dash/vo/BaseURL.js';
+
+const expect = require('chai').expect;
+
+const context = {};
+const dashManifestModel = DashManifestModel(context).getInstance();
+
+const TEST_URL = 'http://www.example.com/';
+const SERVICE_LOCATION = 'testServiceLocation';
+
+describe('DashManifestModel', function () {
+
+    it('should return true when getIsDVB is called and manifest contains a valid DVB profile', () => {
+        const manifest = {
+            profiles: 'urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014'
+        };
+
+        const isDVB = dashManifestModel.getIsDVB(manifest);
+
+        expect(isDVB).to.be.true; // jshint ignore:line
+    });
+
+    it('should return false when getIsDVB is called and manifest does not contain a valid DVB profile', () => {
+        const manifest = {
+            profiles: 'urn:mpeg:dash:profile:isoff-on-demand:2011, http://dashif.org/guildelines/dash264'
+        };
+
+        const isDVB = dashManifestModel.getIsDVB(manifest);
+
+        expect(isDVB).to.be.false; // jshint ignore:line
+    });
+
+    it('should return true when getIsOnDemand is called and manifest contains the on-demand profile', () => {
+        const manifest = {
+            profiles: 'urn:dvb:dash:profile:dvb-dash:2014,urn:mpeg:dash:profile:isoff-on-demand:2011'
+        };
+
+        const isOnDemand = dashManifestModel.getIsOnDemand(manifest);
+
+        expect(isOnDemand).to.be.true; // jshint ignore:line
+    });
+
+    it('returns an empty Array when no BaseURLs or baseUri are present on a node', () => {
+        const node = {};
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);    // jshint ignore:line
+        expect(obj).to.be.empty;                // jshint ignore:line
+
+    });
+
+    it('returns an Array of BaseURLs when no BaseURLs are present on a node, but there is a baseUri', () => {
+        const node = {
+            baseUri: TEST_URL
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);        // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);            // jshint ignore:line
+        expect(obj[0]).to.be.instanceOf(BaseURL);   // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL);      // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] serviceLocation set to URL when no serviceLocation was specified', () => {
+        const node = {
+            BaseURL_asArray: [{
+                __text: TEST_URL
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                    // jshint ignore:line
+        expect(obj[0]).to.be.instanceOf(BaseURL);           // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL);              // jshint ignore:line
+        expect(obj[0].serviceLocation).to.equal(TEST_URL);  // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs when multiple BaseUrls were specified', () => {
+        const node = {
+            BaseURL_asArray: [
+                {
+                    __text: TEST_URL + '0'
+                },
+                {
+                    __text: TEST_URL + '1'
+                }
+            ]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);        // jshint ignore:line
+        expect(obj).to.have.lengthOf(2);            // jshint ignore:line
+        obj.forEach((o, i) => {
+            expect(o).to.be.instanceOf(BaseURL);    // jshint ignore:line
+            expect(o.url).to.equal(TEST_URL + i);   // jshint ignore:line
+        });
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] serviceLocation set when serviceLocation was specified', () => {
+        const node = {
+            BaseURL_asArray: [{
+                __text: TEST_URL,
+                serviceLocation: SERVICE_LOCATION
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                        // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                            // jshint ignore:line
+        expect(obj[0]).to.be.instanceOf(BaseURL);                   // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL);                      // jshint ignore:line
+        expect(obj[0].serviceLocation).to.equal(SERVICE_LOCATION);  // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] having correct defaults for DVB extensions when not specified', () => {
+        const node = {
+            BaseURL_asArray: [{
+                __text: TEST_URL
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
+        expect(obj[0].dvb_priority).to.equal(BaseURL.DEFAULT_DVB_PRIORITY); // jshint ignore:line
+        expect(obj[0].dvb_weight).to.equal(BaseURL.DEFAULT_DVB_WEIGHT);     // jshint ignore:line
+    });
+});

--- a/test/helpers/ObjectsHelper.js
+++ b/test/helpers/ObjectsHelper.js
@@ -1,6 +1,6 @@
 class ObjectsHelper {
     constructor() {
-        this.defaultStreamType = "video";
+        this.defaultStreamType = 'video';
     }
 
     getDummyStreamProcessor(type) {
@@ -9,21 +9,21 @@ class ObjectsHelper {
         return {
             getType: () => type,
             getCurrentTrack: () => {},
-            getStreamInfo: () => { return {id: 'some_id'} },
-            getMediaInfo: () => { return { bitrateList: [] } },
+            getStreamInfo: () => { return { id: 'some_id' }; },
+            getMediaInfo: () => { return { bitrateList: [] }; },
             getIndexHandler: () => this.getDummyIndexHandler(),
             isDynamic: () => true
         };
     }
 
     getDummyLogger() {
-        return (message) => {console.log(message)}
+        return (message) => { console.log(message); };
     }
 
     getDummyIndexHandler() {
         return {
-            updateRepresentation : () => {}
-        }
+            updateRepresentation: () => {}
+        };
     }
 
     getDummyTimelineConverter() {
@@ -32,110 +32,18 @@ class ObjectsHelper {
             calcAvailabilityEndTimeFromPresentationTime: () => 0
         };
     }
+
+    getDummyBaseURLController() {
+        return {
+            resolve: () => {}
+        };
+    }
+
+    getDummyBlacklistController() {
+        return {
+            contains: () => {}
+        };
+    }
 }
 
 export default ObjectsHelper;
-/*
-(function(global){
-    var system = new dijon.System(),
-        notifier,
-        context,
-        defaultStreamType = "video",
-        objectsHelper,
-
-        createObject = function(objName) {
-            setup();
-            return system.getObject(objName);
-        },
-
-        createPlayerInstance = function() {
-            var context = new Dash.di.DashContext();
-
-            return new MediaPlayer(context);
-        },
-
-        getDummyStreamProcessor = function(type) {
-            type = type || defaultStreamType;
-
-            return {
-                getType: function() {
-                    return type;
-                },
-                getCurrentTrack: function() {
-                    return {};
-                },
-                getStreamInfo: function() {
-                    return {};
-                },
-				getMediaInfo: function() {
-					return {bitrateList:[]};
-				}
-            }
-        },
-
-        setup = function() {
-            if (context) return;
-
-            context = new Dash.di.DashContext();
-            system.mapValue("system", system);
-            system.mapOutlet("system");
-            system.mapValue("eventBus", new MediaPlayer.utils.EventBus());
-            system.mapOutlet("eventBus");
-            var debug = new MediaPlayer.utils.Debug();
-            system.mapValue("debug", debug);
-            system.mapOutlet("debug");
-            system.injectInto(debug);
-            system.injectInto(context);
-            notifier = system.getObject("notifier");
-
-        };
-
-    objectsHelper =  {
-        getAbrController: function() {
-            return createObject("abrController");
-        },
-
-        getRepresentationController: function(type) {
-            var ctrl = createObject("representationController");
-            ctrl.streamProcessor = getDummyStreamProcessor(type);
-
-            return ctrl;
-        },
-
-        getLiveEdgeFinder: function(type) {
-            var finder = createObject("liveEdgeFinder");
-            finder.streamProcessor = getDummyStreamProcessor(type);
-            return finder;
-        },
-
-        getTimelineConverter: function() {
-            return createObject("timelineConverter");
-        },
-
-        getIndexHandler: function(type) {
-            var handler = createObject("indexHandler");
-            handler.streamProcessor = getDummyStreamProcessor(type);
-
-            return handler;
-        },
-
-        getFragmentController: function() {
-            return createObject("fragmentController");
-        },
-
-        getFragmentModel: function() {
-            return createObject("fragmentModel");
-        },
-
-        getFragmentLoader: function() {
-            return createObject("fragmentLoader");
-        },
-
-        getNewMediaPlayerInstance: function() {
-            return createPlayerInstance();
-        }
-    };
-
-    global.Helpers.setObjectsHelper(objectsHelper);
-}(window));
-*/

--- a/test/streaming.BasicSelector.js
+++ b/test/streaming.BasicSelector.js
@@ -104,4 +104,3 @@ describe('BaseURLResolution/BasicSelector', function () {
         expect(selected).to.be.undefined; // jshint ignore:line
     });
 });
-

--- a/test/streaming.BasicSelector.js
+++ b/test/streaming.BasicSelector.js
@@ -1,0 +1,107 @@
+import ObjectsHelper from './helpers/ObjectsHelper.js';
+import BasicSelector from '../src/streaming/rules/baseUrlResolution/BasicSelector.js';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const objectsHelper = new ObjectsHelper();
+
+const defaultConfig = {
+    blacklistController: objectsHelper.getDummyBlacklistController()
+};
+
+const context = {};
+
+const SERVICE_LOCATION_A = 'A';
+const SERVICE_LOCATION_B = 'B';
+
+const entryA = { serviceLocation: SERVICE_LOCATION_A };
+const entryB = { serviceLocation: SERVICE_LOCATION_B };
+
+describe('BaseURLResolution/BasicSelector', function () {
+
+    it('should return undefined when the input is undefined', () => {
+        const basicSelector = BasicSelector(context).create(defaultConfig);
+        const selected = basicSelector.select(undefined);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return undefined when the input is empty', () => {
+        const basicSelector = BasicSelector(context).create(defaultConfig);
+        const selected = basicSelector.select([]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return undefined when the blacklist contains the requested serviceLocation', () => {
+        const containsServiceLocationABlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A
+        };
+        const config = {
+            blacklistController: containsServiceLocationABlacklistController
+        };
+
+        const basicSelector = BasicSelector(context).create(config);
+
+        const selected = basicSelector.select([entryA]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return the first entry in the list when the blacklist does not contain the requested serviceLocation', () => {
+
+        const containsServiceLocationBBlacklistController = {
+            contains: input => input === SERVICE_LOCATION_B
+        };
+        const config = {
+            blacklistController: containsServiceLocationBBlacklistController
+        };
+
+        const basicSelector = BasicSelector(context).create(config);
+
+        const selected = basicSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.equal(entryA); // jshint ignore:line
+    });
+
+    it('should return the next entry in the list when the blacklist contains the serviceLocation of the first', () => {
+        const containsServiceLocationABlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A
+        };
+        const config = {
+            blacklistController: containsServiceLocationABlacklistController
+        };
+
+        const basicSelector = BasicSelector(context).create(config);
+
+        const selected = basicSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.equal(entryB); // jshint ignore:line
+    });
+
+    it('should return undefined when the blacklist contains all the serviceLocations', () => {
+        const containsServiceLocationAAndBBlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A || input === SERVICE_LOCATION_B
+        };
+        const config = {
+            blacklistController: containsServiceLocationAAndBBlacklistController
+        };
+
+        const basicSelector = BasicSelector(context).create(config);
+
+        const selected = basicSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+});
+

--- a/test/streaming.BlacklistController.js
+++ b/test/streaming.BlacklistController.js
@@ -96,4 +96,3 @@ describe('BlacklistController', function () {
         expect(containsAfterReset).to.be.false; // jshint ignore:line
     });
 });
-

--- a/test/streaming.BlacklistController.js
+++ b/test/streaming.BlacklistController.js
@@ -1,0 +1,99 @@
+import BlacklistController from '../src/streaming/controllers/BlacklistController.js';
+import EventBus from '../src/core/EventBus.js';
+
+const chai = require('chai');
+const spies = require('chai-spies');
+const expect = chai.expect;
+
+chai.use(spies);
+
+describe('BlacklistController', function () {
+    const context = {};
+    const eventBus = EventBus(context).getInstance();
+
+    const SERVICE_LOCATION = 'testServiceLocation';
+    const EVENT_NAME = 'blacklistControllerTestEvent';
+
+    const defaultConfig = { updateEventName: '' };
+
+    it('should return false when calling contains after initialisation', () => {
+        const blacklistController = BlacklistController(context).create(defaultConfig);
+
+        const contains = blacklistController.contains('test');
+
+        expect(contains).to.be.false; // jshint ignore:line
+    });
+
+    it('should return false when calling contains with undefined', () => {
+        const blacklistController = BlacklistController(context).create(defaultConfig);
+
+        const contains = blacklistController.contains(undefined);
+
+        expect(contains).to.be.false; // jshint ignore:line
+    });
+
+    it('should return false when calling contains with zero-length string', () => {
+        const blacklistController = BlacklistController(context).create(defaultConfig);
+
+        const contains = blacklistController.contains('');
+
+        expect(contains).to.be.false; // jshint ignore:line
+    });
+
+    it('should return true when calling contains after calling add with same string', () => {
+        const blacklistController = BlacklistController(context).create(defaultConfig);
+
+        blacklistController.add(SERVICE_LOCATION);
+
+        const contains = blacklistController.contains(SERVICE_LOCATION);
+
+        expect(contains).to.be.true; // jshint ignore:line
+    });
+
+    it('should trigger an update event after calling add', () => {
+        const spy = chai.spy();
+        const config = { updateEventName: EVENT_NAME };
+        const blacklistController = BlacklistController(context).create(config);
+
+        eventBus.on(EVENT_NAME, spy);
+
+        blacklistController.add(SERVICE_LOCATION);
+
+        expect(spy).to.have.been.called.once; // jshint ignore:line
+
+        eventBus.off(EVENT_NAME, spy);
+    });
+
+    it('should add an entry to the blacklist on receiving load failed event', () => {
+        const config = {
+            updateEventName: '',
+            loadFailedEventName: EVENT_NAME
+        };
+        const blacklistController = BlacklistController(context).create(config);
+
+        eventBus.trigger(EVENT_NAME, {
+            error: new Error(''),
+            request: {
+                serviceLocation: SERVICE_LOCATION
+            }
+        });
+
+        const contains = blacklistController.contains(SERVICE_LOCATION);
+
+        expect(contains).to.be.true; // jshint ignore:line
+    });
+
+    it('should not contain an entry after reset', () => {
+        const config = { updateEventName: '' };
+        const blacklistController = BlacklistController(context).create(config);
+
+        blacklistController.add(SERVICE_LOCATION);
+        const containsBeforeReset = blacklistController.contains(SERVICE_LOCATION);
+        blacklistController.reset();
+        const containsAfterReset = blacklistController.contains(SERVICE_LOCATION);
+
+        expect(containsBeforeReset).to.be.true; // jshint ignore:line
+        expect(containsAfterReset).to.be.false; // jshint ignore:line
+    });
+});
+

--- a/test/streaming.DVBSelector.js
+++ b/test/streaming.DVBSelector.js
@@ -156,4 +156,3 @@ describe('BaseURLResolution/DVBSelector', function () {
         expect(fourthSelection).to.be.undefined;                // jshint ignore:line
     });
 });
-

--- a/test/streaming.DVBSelector.js
+++ b/test/streaming.DVBSelector.js
@@ -1,0 +1,159 @@
+import ObjectsHelper from './helpers/ObjectsHelper.js';
+import DVBSelector from '../src/streaming/rules/baseUrlResolution/DVBSelector.js';
+
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+
+const context = {};
+const objectsHelper = new ObjectsHelper();
+
+const defaultConfig = {
+    blacklistController: objectsHelper.getDummyBlacklistController()
+};
+
+const SERVICE_LOCATION_A = 'A';
+const SERVICE_LOCATION_B = 'B';
+
+const entryA = { serviceLocation: SERVICE_LOCATION_A };
+const entryB = { serviceLocation: SERVICE_LOCATION_B };
+
+describe('BaseURLResolution/DVBSelector', function () {
+    it('should return undefined when the input is undefined', () => {
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+        const selected = dvbSelector.select(undefined);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return undefined when the input is empty', () => {
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+        const selected = dvbSelector.select([]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return undefined when the blacklist contains the requested serviceLocation', () => {
+        const containsServiceLocationABlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A
+        };
+        const config = {
+            blacklistController: containsServiceLocationABlacklistController
+        };
+
+        const dvbSelector = DVBSelector(context).create(config);
+
+        const selected = dvbSelector.select([entryA]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should return the first entry in the list when the blacklist does not contain the requested serviceLocation', () => {
+
+        const containsServiceLocationBBlacklistController = {
+            contains: input => input === SERVICE_LOCATION_B
+        };
+        const config = {
+            blacklistController: containsServiceLocationBBlacklistController
+        };
+
+        const dvbSelector = DVBSelector(context).create(config);
+
+        const selected = dvbSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.equal(entryA); // jshint ignore:line
+    });
+
+    it('should return the next entry in the list when the blacklist contains the serviceLocation of the first', () => {
+        const containsServiceLocationABlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A
+        };
+        const config = {
+            blacklistController: containsServiceLocationABlacklistController
+        };
+
+        const dvbSelector = DVBSelector(context).create(config);
+
+        const selected = dvbSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.equal(entryB); // jshint ignore:line
+    });
+
+    it('should return undefined when the blacklist contains all the serviceLocations', () => {
+        const containsServiceLocationAAndBBlacklistController = {
+            contains: input => input === SERVICE_LOCATION_A || input === SERVICE_LOCATION_B
+        };
+        const config = {
+            blacklistController: containsServiceLocationAAndBBlacklistController
+        };
+
+        const dvbSelector = DVBSelector(context).create(config);
+
+        const selected = dvbSelector.select([
+            entryA,
+            entryB
+        ]);
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should select baseUrls as defined in the example in DVB A168 10.8.2.4', () => {
+        const baseUrls = [
+            { dvb_priority: 1,  dvb_weight: 10, serviceLocation: 'A' },
+            { dvb_priority: 1,  dvb_weight: 30, serviceLocation: 'B' },
+            { dvb_priority: 1,  dvb_weight: 60, serviceLocation: 'C' },
+            { dvb_priority: 3,  dvb_weight: 1,  serviceLocation: 'C' },
+            { dvb_priority: 4,  dvb_weight: 1,  serviceLocation: 'B' },
+            { dvb_priority: 5,  dvb_weight: 1,  serviceLocation: 'D' },
+            { dvb_priority: 5,  dvb_weight: 1,  serviceLocation: 'E' }
+        ];
+
+        // we need Math.random to be completely unrandom
+        const stub = sinon.stub(Math, 'random');
+
+        const blacklist = [];
+        const blacklistController = {
+            contains: input => blacklist.indexOf(input) !== -1
+        };
+
+        const config = {
+            blacklistController: blacklistController
+        };
+
+        const dvbSelector = DVBSelector(context).create(config);
+
+        // Math.random (called in select()) will return 0.3
+        stub.returns(0.3);
+
+        const firstSelection = dvbSelector.select(baseUrls);
+        expect(firstSelection.dvb_priority).to.equal(1);        // jshint ignore:line
+        expect(firstSelection.serviceLocation).to.equal('B');   // jshint ignore:line
+
+        blacklist.push(firstSelection.serviceLocation);
+
+        const secondSelection = dvbSelector.select(baseUrls);
+        expect(secondSelection.dvb_priority).to.equal(3);       // jshint ignore:line
+        expect(secondSelection.serviceLocation).to.equal('C');  // jshint ignore:line
+
+        // Math.random (called in select()) will return 1
+        stub.returns(1);
+
+        blacklist.push(secondSelection.serviceLocation);
+
+        const thirdSelection = dvbSelector.select(baseUrls);
+        expect(thirdSelection.dvb_priority).to.equal(5);        // jshint ignore:line
+        expect(thirdSelection.serviceLocation).to.equal('E');   // jshint ignore:line
+
+        blacklist.push(thirdSelection.serviceLocation);
+
+        const fourthSelection = dvbSelector.select(baseUrls);
+        expect(fourthSelection).to.be.undefined;                // jshint ignore:line
+    });
+});
+


### PR DESCRIPTION
This PR adds BaseURL support.

It currently has two modes - DVB and "Basic". Basic mode selects BaseURLs in the order they are specified in the manifest. DVB mode is compliant with DVB A168 section 10.8.2. DVB is automatically selected if the DVB profile is listed at the top level of the MPD, otherwise basic mode is used.

In all cases, if a BaseURL has failed it will not be retried. Failures are carried across manifest updates (unless the available BaseURLs have changed), but are reset at the end of a session.

BaseURL elements are supported at all levels of the manifest as specified in ISO23009-1.  Implementation of this, as well as DVB mode, has made the entire solution more complicated than it might have been, but has led to the most flexible solution.

I've done a reasonable amount of testing but will not have covered all use cases and manifests and could have missed something, so I'd appreciate any testing people can do.

I am out of the office until Thursday of next week so will be unable to respond until then, but I welcome feedback on this large, complex PR.