### PR TITLE
Add option to force live latency to a given number of seconds

### DIFF
--- a/samples/live-streaming/live-delay-comparison-alternate-config.html
+++ b/samples/live-streaming/live-delay-comparison-alternate-config.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8"/>
+        <title>Live delay comparison</title>
+
+        <script src="../../dist/dash.all.debug.js"></script>
+        <!--dash.all.min.js should be used in production over dash.all.debug.js
+Debug files are not compressed or obfuscated making the file size much larger compared with dash.all.min.js-->
+        <!--<script src="../../dist/dash.all.min.js"></script>-->
+
+        <script>
+            function init()
+            {
+                var player1,player2,player3,player4,player5,player6, video;
+                var MPD_2S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_2s/Manifest.mpd";
+                var MPD_6S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_6s/Manifest.mpd";
+
+
+                video = document.querySelector("#video1");
+                player1 = dashjs.MediaPlayer().create();
+                player1.initialize(video,MPD_2S_SEGMENTS ,true);
+                player1.setLiveDelay(2);
+
+                video = document.querySelector("#video2");
+                player2 = dashjs.MediaPlayer().create();
+                player2.initialize(video,MPD_2S_SEGMENTS ,true);
+                player2.setLiveDelay(4);
+
+                video = document.querySelector("#video3");
+                player3 = dashjs.MediaPlayer().create();
+                player3.initialize(video,MPD_2S_SEGMENTS ,true);
+                player3.setLiveDelay(8);
+
+                video = document.querySelector("#video4");
+                player4 = dashjs.MediaPlayer().create();
+                player4.initialize(video,MPD_6S_SEGMENTS ,true);
+                player4.setLiveDelay(6);
+
+                video = document.querySelector("#video5");
+                player5 = dashjs.MediaPlayer().create();
+                player5.initialize(video,MPD_6S_SEGMENTS ,true);
+                player5.setLiveDelay(12);
+
+                video = document.querySelector("#video6");
+                player6 = dashjs.MediaPlayer().create();
+                player6.initialize(video,MPD_6S_SEGMENTS ,true);
+                player6.setLiveDelay(24);
+
+
+                setInterval( function() {
+                    var d = new Date();
+                    var seconds = d.getSeconds();
+                    document.querySelector("#sec").innerHTML = ( seconds < 10 ? "0" : "" ) + seconds;
+                    var minutes = d.getMinutes();
+                    document.querySelector("#min").innerHTML = ( minutes < 10 ? "0" : "" ) + minutes;
+                    for (var i=1;i < 7;i++)
+                    {
+                        var p = eval("player"+i);
+                        document.querySelector("#video" + i + "delay").innerHTML = Math.round((d.getTime()/1000) - Number(p.timeAsUTC()));
+                        document.querySelector("#video" + i + "buffer").innerHTML = p.getBufferLength()+ "s";
+                    }
+
+
+                },1000);
+
+            }
+        </script>
+        <style>
+
+            table {
+                border-spacing: 10px;
+            }
+            video {
+                width: 320px;
+                height: 180px;
+            }
+            .clock { border:1px solid #333; color:#000; font-size: 60pt}
+        </style>
+    </head>
+
+    <body onload="init()">
+        This sample illustrates the combined effects of segment duration and the "setLiveDelayFragmentCount" MediaPlayer method on the latency of live stream playback.
+        The upper layer of videos are all playing a live stream with 2s segment duration. The lower layer use 6s segment duration. For each stream, the playback position
+        behind live is varied between 0, 2 and 4 segments. Note that the default value for dash.js is 4 segments, which is a trade off between stability and latency.
+        Lowest latency is achieved with shorter segments and with a lower liveDelayFragmentCount. Higher stability/robustness is achieved with a higher liveDelayFragmentCount.
+        <table>
+            <tr><td>
+                2s segment, 2s target latency<br/>
+                <video id="video1" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video1delay"></span><br/>
+                Buffer length: <span id="video1buffer"></span>
+                </td><td>
+                2s segment, 4s target latency<br/>
+                <video id="video2" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video2delay"></span><br/>
+                Buffer length: <span id="video2buffer"></span>
+                </td><td>
+                2s segment,  8s target latency<br/>
+                <video id="video3" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video3delay"></span><br/>
+                Buffer length: <span id="video3buffer"></span>
+                </td>
+                <td>Wall clock time
+                    <div class="clock">
+                        <span id="min"> </span>:<span id="sec"></span>
+                    </div>
+                </td></tr>
+            <tr><td>
+                6s segment,  6s target latency<br/>
+                <video id="video4" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video4delay"></span><br/>
+                Buffer length: <span id="video4buffer"></span>
+                </td><td>
+                6s segment,  12s target latency<br/>
+                <video id="video5" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video5delay"></span><br/>
+                Buffer length: <span id="video5buffer"></span>
+                </td><td>
+                6s segment,  24s target latency<br/>
+                <video id="video6" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video6delay"></span><br/>
+                Buffer length: <span id="video6buffer"></span>
+                </td></tr>
+        </table>
+    </body>
+</html>
+

--- a/samples/live-streaming/live-delay-comparison.html
+++ b/samples/live-streaming/live-delay-comparison.html
@@ -77,6 +77,7 @@
         }
         .clock { border:1px solid #333; color:#000; font-size: 60pt}
     </style>
+</head>
 
 <body onload="init()">
 This sample illustrates the combined effects of segment duration and the "setLiveDelayFragmentCount" MediaPlayer method on the latency of live stream playback.
@@ -127,8 +128,7 @@ Lowest latency is achieved with shorter segments and with a lower liveDelayFragm
         Seconds behind live: <span id="video6delay"></span><br/>
         Buffer length: <span id="video6buffer"></span>
     </td></tr>
-    </div>
-</div>
+</table>
 </body>
 </html>
 

--- a/samples/live-streaming/live-delay-comparison.html
+++ b/samples/live-streaming/live-delay-comparison.html
@@ -1,134 +1,134 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8"/>
-    <title>Live delay comparison</title>
+    <head>
+        <meta charset="utf-8"/>
+        <title>Live delay comparison</title>
 
-    <script src="../../dist/dash.all.debug.js"></script>
-    <!--dash.all.min.js should be used in production over dash.all.debug.js
-        Debug files are not compressed or obfuscated making the file size much larger compared with dash.all.min.js-->
-    <!--<script src="../../dist/dash.all.min.js"></script>-->
+        <script src="../../dist/dash.all.debug.js"></script>
+        <!--dash.all.min.js should be used in production over dash.all.debug.js
+Debug files are not compressed or obfuscated making the file size much larger compared with dash.all.min.js-->
+        <!--<script src="../../dist/dash.all.min.js"></script>-->
 
-    <script>
-        function init()
-        {
-            var player1,player2,player3,player4,player5,player6, video;
-            var MPD_2S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_2s/Manifest.mpd";
-            var MPD_6S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_6s/Manifest.mpd";
-
-
-            video = document.querySelector("#video1");
-            player1 = dashjs.MediaPlayer().create();
-            player1.initialize(video,MPD_2S_SEGMENTS ,true);
-            player1.setLiveDelayFragmentCount(0);
-
-            video = document.querySelector("#video2");
-            player2 = dashjs.MediaPlayer().create();
-            player2.initialize(video,MPD_2S_SEGMENTS ,true);
-            player2.setLiveDelayFragmentCount(2);
-
-            video = document.querySelector("#video3");
-            player3 = dashjs.MediaPlayer().create();
-            player3.initialize(video,MPD_2S_SEGMENTS ,true);
-            player3.setLiveDelayFragmentCount(4);
-
-            video = document.querySelector("#video4");
-            player4 = dashjs.MediaPlayer().create();
-            player4.initialize(video,MPD_6S_SEGMENTS ,true);
-            player4.setLiveDelayFragmentCount(0);
-
-            video = document.querySelector("#video5");
-            player5 = dashjs.MediaPlayer().create();
-            player5.initialize(video,MPD_6S_SEGMENTS ,true);
-            player5.setLiveDelayFragmentCount(2);
-
-            video = document.querySelector("#video6");
-            player6 = dashjs.MediaPlayer().create();
-            player6.initialize(video,MPD_6S_SEGMENTS ,true);
-            player6.setLiveDelayFragmentCount(4);
+        <script>
+            function init()
+            {
+                var player1,player2,player3,player4,player5,player6, video;
+                var MPD_2S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_2s/Manifest.mpd";
+                var MPD_6S_SEGMENTS = "http://vm2.dashif.org/livesim/testpic_6s/Manifest.mpd";
 
 
-            setInterval( function() {
-                var d = new Date();
-                var seconds = d.getSeconds();
-                document.querySelector("#sec").innerHTML = ( seconds < 10 ? "0" : "" ) + seconds;
-                var minutes = d.getMinutes();
-                document.querySelector("#min").innerHTML = ( minutes < 10 ? "0" : "" ) + minutes;
-                for (var i=1;i < 7;i++)
-                {
-                    var p = eval("player"+i);
-                    document.querySelector("#video" + i + "delay").innerHTML = Math.round((d.getTime()/1000) - Number(p.timeAsUTC()));
-                    document.querySelector("#video" + i + "buffer").innerHTML = p.getBufferLength()+ "s";
-                }
+                video = document.querySelector("#video1");
+                player1 = dashjs.MediaPlayer().create();
+                player1.initialize(video,MPD_2S_SEGMENTS ,true);
+                player1.setLiveDelayFragmentCount(0);
+
+                video = document.querySelector("#video2");
+                player2 = dashjs.MediaPlayer().create();
+                player2.initialize(video,MPD_2S_SEGMENTS ,true);
+                player2.setLiveDelayFragmentCount(2);
+
+                video = document.querySelector("#video3");
+                player3 = dashjs.MediaPlayer().create();
+                player3.initialize(video,MPD_2S_SEGMENTS ,true);
+                player3.setLiveDelayFragmentCount(4);
+
+                video = document.querySelector("#video4");
+                player4 = dashjs.MediaPlayer().create();
+                player4.initialize(video,MPD_6S_SEGMENTS ,true);
+                player4.setLiveDelayFragmentCount(0);
+
+                video = document.querySelector("#video5");
+                player5 = dashjs.MediaPlayer().create();
+                player5.initialize(video,MPD_6S_SEGMENTS ,true);
+                player5.setLiveDelayFragmentCount(2);
+
+                video = document.querySelector("#video6");
+                player6 = dashjs.MediaPlayer().create();
+                player6.initialize(video,MPD_6S_SEGMENTS ,true);
+                player6.setLiveDelayFragmentCount(4);
 
 
-            },1000);
+                setInterval( function() {
+                    var d = new Date();
+                    var seconds = d.getSeconds();
+                    document.querySelector("#sec").innerHTML = ( seconds < 10 ? "0" : "" ) + seconds;
+                    var minutes = d.getMinutes();
+                    document.querySelector("#min").innerHTML = ( minutes < 10 ? "0" : "" ) + minutes;
+                    for (var i=1;i < 7;i++)
+                    {
+                        var p = eval("player"+i);
+                        document.querySelector("#video" + i + "delay").innerHTML = Math.round((d.getTime()/1000) - Number(p.timeAsUTC()));
+                        document.querySelector("#video" + i + "buffer").innerHTML = p.getBufferLength()+ "s";
+                    }
 
-        }
-    </script>
-    <style>
 
-        table {
-            border-spacing: 10px;
-        }
-        video {
-            width: 320px;
-            height: 180px;
-        }
-        .clock { border:1px solid #333; color:#000; font-size: 60pt}
-    </style>
-</head>
+                },1000);
 
-<body onload="init()">
-This sample illustrates the combined effects of segment duration and the "setLiveDelayFragmentCount" MediaPlayer method on the latency of live stream playback.
-The upper layer of videos are all playing a live stream with 2s segment duration. The lower layer use 6s segment duration. For each stream, the playback position
-behind live is varied between 0, 2 and 4 segments. Note that the default value for dash.js is 4 segments, which is a trade off between stability and latency.
-Lowest latency is achieved with shorter segments and with a lower liveDelayFragmentCount. Higher stability/robustness is achieved with a higher liveDelayFragmentCount.
-<table>
-    <tr><td>
-    2s segment, 0 segments behind live<br/>
-        <video id="video1" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video1delay"></span><br/>
-        Buffer length: <span id="video1buffer"></span>
-    </td><td>
-        2s segment, 2 segments behind live<br/>
-        <video id="video2" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video2delay"></span><br/>
-        Buffer length: <span id="video2buffer"></span>
-    </td><td>
-        2s segment, 4 segments behind live (default)<br/>
-        <video id="video3" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video3delay"></span><br/>
-        Buffer length: <span id="video3buffer"></span>
-    </td>
-    <td>Wall clock time
-        <div class="clock">
-            <span id="min"> </span>:<span id="sec"></span>
-        </div>
-    </td></tr>
-    <tr><td>
-        6s segment, 0 segments behind live<br/>
-        <video id="video4" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video4delay"></span><br/>
-        Buffer length: <span id="video4buffer"></span>
-    </td><td>
-        6s segment, 2 segments behind live<br/>
-        <video id="video5" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video5delay"></span><br/>
-        Buffer length: <span id="video5buffer"></span>
-    </td><td>
-        6s segment, 4 segments behind live (default)<br/>
-        <video id="video6" controls="true">
-        </video><br/>
-        Seconds behind live: <span id="video6delay"></span><br/>
-        Buffer length: <span id="video6buffer"></span>
-    </td></tr>
-</table>
-</body>
+            }
+        </script>
+        <style>
+
+            table {
+                border-spacing: 10px;
+            }
+            video {
+                width: 320px;
+                height: 180px;
+            }
+            .clock { border:1px solid #333; color:#000; font-size: 60pt}
+        </style>
+    </head>
+
+    <body onload="init()">
+        This sample illustrates the combined effects of segment duration and the "setLiveDelayFragmentCount" MediaPlayer method on the latency of live stream playback.
+        The upper layer of videos are all playing a live stream with 2s segment duration. The lower layer use 6s segment duration. For each stream, the playback position
+        behind live is varied between 0, 2 and 4 segments. Note that the default value for dash.js is 4 segments, which is a trade off between stability and latency.
+        Lowest latency is achieved with shorter segments and with a lower liveDelayFragmentCount. Higher stability/robustness is achieved with a higher liveDelayFragmentCount.
+        <table>
+            <tr><td>
+                2s segment, 0 segments behind live<br/>
+                <video id="video1" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video1delay"></span><br/>
+                Buffer length: <span id="video1buffer"></span>
+                </td><td>
+                2s segment, 2 segments behind live<br/>
+                <video id="video2" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video2delay"></span><br/>
+                Buffer length: <span id="video2buffer"></span>
+                </td><td>
+                2s segment, 4 segments behind live (default)<br/>
+                <video id="video3" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video3delay"></span><br/>
+                Buffer length: <span id="video3buffer"></span>
+                </td>
+                <td>Wall clock time
+                    <div class="clock">
+                        <span id="min"> </span>:<span id="sec"></span>
+                    </div>
+                </td></tr>
+            <tr><td>
+                6s segment, 0 segments behind live<br/>
+                <video id="video4" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video4delay"></span><br/>
+                Buffer length: <span id="video4buffer"></span>
+                </td><td>
+                6s segment, 2 segments behind live<br/>
+                <video id="video5" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video5delay"></span><br/>
+                Buffer length: <span id="video5buffer"></span>
+                </td><td>
+                6s segment, 4 segments behind live (default)<br/>
+                <video id="video6" controls="true">
+                </video><br/>
+                Seconds behind live: <span id="video6delay"></span><br/>
+                Buffer length: <span id="video6buffer"></span>
+                </td></tr>
+        </table>
+    </body>
 </html>
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -289,7 +289,8 @@ function RepresentationController() {
         {
             var segmentAvailabilityTimePeriod = r.segmentAvailabilityRange.end - r.segmentAvailabilityRange.start;
             // We must put things to sleep unless till e.g. the startTime calculation in ScheduleController.onLiveEdgeSearchCompleted fall after the segmentAvailabilityRange.start
-            postponeTimePeriod = ((currentRepresentation.segmentDuration * mediaPlayerModel.getLiveDelayFragmentCount()) - segmentAvailabilityTimePeriod) * 1000;
+            let liveDelay = mediaPlayerModel.getLiveDelay() || currentRepresentation.segmentDuration * mediaPlayerModel.getLiveDelayFragmentCount();
+            postponeTimePeriod = (liveDelay - segmentAvailabilityTimePeriod) * 1000;
         }
 
         if (postponeTimePeriod > 0) {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -609,6 +609,22 @@ function MediaPlayer() {
     }
 
     /**
+     * <p>Equivalent in seconds of setLiveDelayFragmentCount</p>
+     * <p>Lowering this value will lower latency but may decrease the player's ability to build a stable buffer.</p>
+     * <p>This value should be less than the manifest duration by a couple of segment durations to avoid playback issues</p>
+     * <p>If set, this parameter will take precedence over setLiveDelayFragmentCount and manifest info</p>
+     *
+     * @param value {int} Represents how many seconds to delay the live stream.
+     * @default undefined
+     * @memberof module:MediaPlayer
+     * @see {@link module:MediaPlayer#useSuggestedPresentationDelay useSuggestedPresentationDelay()}
+     * @instance
+     */
+    function setLiveDelay(value) {
+        mediaPlayerModel.setLiveDelay(value);
+    }
+
+    /**
      * <p>Set to true if you would like to override the default live delay and honor the SuggestedPresentationDelay attribute in by the manifest.</p>
      * @param value {boolean}
      * @default false
@@ -1876,6 +1892,7 @@ function MediaPlayer() {
         getVideoElement: getVideoElement,
         getSource: getSource,
         setLiveDelayFragmentCount: setLiveDelayFragmentCount,
+        setLiveDelay: setLiveDelay,
         useSuggestedPresentationDelay: useSuggestedPresentationDelay,
         enableLastBitrateCaching: enableLastBitrateCaching,
         enableLastMediaSettingsCaching: enableLastMediaSettingsCaching,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -381,7 +381,7 @@ function ScheduleController(config) {
 
         let liveEdgeTime = e.liveEdge;
         let manifestInfo = currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo;
-        let startTime = liveEdgeTime - Math.min((playbackController.getLiveDelay(currentRepresentationInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2);
+        let startTime = liveEdgeTime - playbackController.computeLiveDelay(currentRepresentationInfo.fragmentDuration, manifestInfo.DVRWindowSize / 2);
         let metrics = metricsModel.getMetricsFor('stream');
         let manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(metrics);
         let currentLiveStart = playbackController.getLiveStartTime();

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -67,6 +67,7 @@ function MediaPlayerModel() {
         useSuggestedPresentationDelay,
         UTCTimingSources,
         liveDelayFragmentCount,
+        liveDelay,
         scheduleWhilePaused,
         bufferToKeep,
         bufferPruningInterval,
@@ -93,6 +94,7 @@ function MediaPlayerModel() {
         lastBitrateCachingInfo = {enabled: true , ttl: DEFAULT_LOCAL_STORAGE_BITRATE_EXPIRATION};
         lastMediaSettingsCachingInfo = {enabled: true , ttl: DEFAULT_LOCAL_STORAGE_MEDIA_SETTINGS_EXPIRATION};
         liveDelayFragmentCount = LIVE_DELAY_FRAGMENT_COUNT;
+        liveDelay = undefined; // Explicitly state that default is undefined
         bufferToKeep = BUFFER_TO_KEEP;
         bufferPruningInterval = BUFFER_PRUNING_INTERVAL;
         stableBufferTime = DEFAULT_MIN_BUFFER_TIME;
@@ -281,8 +283,16 @@ function MediaPlayerModel() {
         liveDelayFragmentCount = value;
     }
 
+    function setLiveDelay(value) {
+        liveDelay = value;
+    }
+
     function getLiveDelayFragmentCount() {
         return liveDelayFragmentCount;
+    }
+
+    function getLiveDelay() {
+        return liveDelay;
     }
 
     function setUseManifestDateHeaderTimeSource(value) {
@@ -355,6 +365,8 @@ function MediaPlayerModel() {
         setUseSuggestedPresentationDelay: setUseSuggestedPresentationDelay,
         setLiveDelayFragmentCount: setLiveDelayFragmentCount,
         getLiveDelayFragmentCount: getLiveDelayFragmentCount,
+        getLiveDelay: getLiveDelay,
+        setLiveDelay: setLiveDelay,
         setUseManifestDateHeaderTimeSource: setUseManifestDateHeaderTimeSource,
         getUseManifestDateHeaderTimeSource: getUseManifestDateHeaderTimeSource,
         setUTCTimingSources: setUTCTimingSources,

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -56,10 +56,8 @@ function BufferLevelRule(config) {
         let mediaType = mediaInfo.type;
         let metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
         let bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
-        let fragmentCount;
 
-        fragmentCount = bufferLevel < getBufferTarget(streamProcessor, mediaType) ? 1 : 0;
-        return fragmentCount === 1;
+        return bufferLevel < getBufferTarget(streamProcessor, mediaType);
     }
 
     function reset() {}


### PR DESCRIPTION
There's currently no easy way to specify how many seconds of latency you want for live streams:
-  `setLiveDelayFragmentCount` will result in random latency if segments have variable durations
- if I understand it right, the maximum latency is [limited to a half manifest duration](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/ScheduleController.js#L384)

I introduced an additional setter which specifies the target latency in seconds.
- If set, this target latency will take precedence over `setLiveDelayFragmentCount`, DVRWindowSize and so on
- if not set, the current behavior is used