### PR TITLE
clean up minBufferTime in BufferController

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -76,7 +76,6 @@ function BufferController(config) {
         lastIndex,
         type,
         buffer,
-        minBufferTime,
         bufferState,
         appendedBytesInfo,
         wallclockTicked,
@@ -546,7 +545,9 @@ function BufferController(config) {
         eventBus.trigger(Events.BUFFER_CLEARED, {sender: instance, from: e.from, to: e.to, hasEnoughSpaceToAppend: hasEnoughSpaceToAppend()});
         if (hasEnoughSpaceToAppend()) return;
 
-        setTimeout(clearBuffer(getClearRange()), minBufferTime * 1000);
+        setTimeout(function () {
+            clearBuffer(getClearRange());
+        }, streamProcessor.getStreamInfo().manifestInfo.minBufferTime * 1000);
     }
 
     function updateBufferTimestampOffset(MSETimeOffset) {
@@ -598,15 +599,7 @@ function BufferController(config) {
         if (e.sender.getStreamProcessor() !== streamProcessor) return;
         if (e.error) return;
 
-        var bufferLength;
-
         updateBufferTimestampOffset(e.currentRepresentation.MSETimeOffset);
-
-        bufferLength = streamProcessor.getStreamInfo().manifestInfo.minBufferTime;
-        //log("Min Buffer time: " + bufferLength);
-        if (minBufferTime !== bufferLength) {
-            setMinBufferTime(bufferLength);
-        }
     }
 
     function onStreamCompleted(e) {
@@ -681,14 +674,6 @@ function BufferController(config) {
         return bufferLevel;
     }
 
-    function getMinBufferTime() {
-        return minBufferTime;
-    }
-
-    function setMinBufferTime(value) {
-        minBufferTime = value;
-    }
-
     function getCriticalBufferLevel() {
         return criticalBufferLevel;
     }
@@ -728,7 +713,6 @@ function BufferController(config) {
 
         criticalBufferLevel = Number.POSITIVE_INFINITY;
         bufferState = BUFFER_EMPTY;
-        minBufferTime = null;
         currentQuality = -1;
         lastIndex = -1;
         maxAppendedIndex = -1;
@@ -761,8 +745,6 @@ function BufferController(config) {
         getBuffer: getBuffer,
         setBuffer: setBuffer,
         getBufferLevel: getBufferLevel,
-        getMinBufferTime: getMinBufferTime,
-        setMinBufferTime: setMinBufferTime,
         getCriticalBufferLevel: getCriticalBufferLevel,
         setMediaSource: setMediaSource,
         getMediaSource: getMediaSource,


### PR DESCRIPTION
Cleaned up leftovers around `minBufferTime` in `BufferController`:
- public getter and setter were unused
- the only part of the code where it was used was [here](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/BufferController.js#L549)
- it was only set to `manifestInfo.minBufferTime` [here](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/BufferController.js#L608)

:warning: WARNING: 
- the [setTimeout](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/BufferController.js#L549) was never executed because `clearBuffer(getClearRange())` is not not a function. My pull request will allow it to execute again but it might have side effects if this behavior was actually not wanted anymore (not tested)
- I set the timeout delay to `streamProcessor.getStreamInfo().manifestInfo.minBufferTime * 1000` because that's what it was set at in practice. I don't really understand this value as it seems we only get in that part of the code if we're about to trigger a `QUOTA_EXCEEDED_ERROR` on MSE, so why not do another round of cleaning right away?
- Additionally to last point, I didn't check if `streamProcessor.getStreamInfo().manifestInfo.minBufferTime` was always defined when we got in that part of the code. I suppose it is, but why not set this timeout delay to a short and constant amount of time? 