### PR TITLE
Enable querying time relative to arbitrary Period start time

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -42,3 +42,4 @@
 * @qjia7
 * @waqarz
 * @WMSPanel [WMSPanel Team]
+* @matt-hammond-bbc [Matt Hammond, BBC R&D]

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1872,6 +1872,7 @@ function MediaPlayer() {
         duration: duration,
         timeAsUTC: timeAsUTC,
         durationAsUTC: durationAsUTC,
+        getActiveStream: getActiveStream,
         getDVRWindowSize: getDVRWindowSize,
         getDVRSeekOffset: getDVRSeekOffset,
         convertToTimeCode: convertToTimeCode,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -389,15 +389,24 @@ function MediaPlayer() {
     /**
      * Current time of the playhead, in seconds.
      *
-     * @returns {number} The current playhead time of the media.
+     * If called with no arguments then the returned time value is time elapsed since the start point of the first stream.
+     * However if a stream ID is supplied then time is relative to the start of that stream, or is null if there is no such stream id in the manifest.
+     *
+     * @param streamId The ID of a stream that the returned playhead time must be relative to the start of. If undefined, then playhead time is relative to the first stream.
+     * @returns {number} The current playhead time of the media, or null.
      * @memberof module:MediaPlayer
      * @instance
      */
-    function time() {
+    function time(streamId) {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
         var t = getVideoElement().currentTime;
+
+        if (streamId !== undefined) {
+            t = streamController.getTimeRelativeToStreamId(t, streamId);
+        }
+
         if (playbackController.getIsDynamic()) {
             var metric = getDVRInfoMetric();
             t = (metric === null) ? 0 : duration() - (metric.range.end - metric.time);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -343,6 +343,41 @@ function StreamController() {
         return null;
     }
 
+    /**
+     * Returns a playhead time, in seconds, converted to be relative
+     * to the start of an identified stream/period or null if no such stream
+     */
+    function getTimeRelativeToStreamId(time, id) {
+        var stream = null;
+        var baseStart = 0;
+        var streamStart = 0;
+        var streamDur = null;
+
+        var ln = streams.length;
+
+        for (var i = 0; i < ln; i++) {
+            stream = streams[i];
+            streamStart = stream.getStartTime();
+            streamDur = stream.getDuration();
+
+            // use start time, if not undefined or NaN or similar
+            if (Number.isFinite(streamStart)) {
+                baseStart = streamStart;
+            }
+
+            if (stream.getId() === id) {
+                return time - baseStart;
+            } else {
+                // use duration if not undefined or NaN or similar
+                if (Number.isFinite(streamDur)) {
+                    baseStart += streamDur;
+                }
+            }
+        }
+
+        return null;
+    }
+
     function getActiveStreamCommonEarliestTime() {
         let commonEarliestTime = [];
         activeStream.getProcessors().forEach(p => {
@@ -727,6 +762,7 @@ function StreamController() {
         getActiveStreamInfo: getActiveStreamInfo,
         isStreamActive: isStreamActive,
         getStreamById: getStreamById,
+        getTimeRelativeToStreamId: getTimeRelativeToStreamId,
         load: load,
         loadWithManifest: loadWithManifest,
         getActiveStreamCommonEarliestTime: getActiveStreamCommonEarliestTime,


### PR DESCRIPTION
Change to MediaPlayer.time() as suggested in https://groups.google.com/forum/#!topic/dashjs/Zk0nzEfYNi0

Logic was put into a new function StreamController.getTimeRelativeToStreamId() to keep it grouped with other stream processing related logic.