### PR TITLE
Fixes #1291

### DIFF
--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -262,7 +262,13 @@ function XHRLoader(cfg) {
         delayedXhrs.forEach(x => clearTimeout(x.delayTimeout));
         delayedXhrs = [];
 
-        xhrs.forEach(x => x.abort());
+        xhrs.forEach(x => {
+            // abort will trigger onloadend which we don't want
+            // when deliberately aborting inflight requests -
+            // set them to undefined so they are not called
+            x.onloadend = x.onerror = undefined;
+            x.abort();
+        });
         xhrs = [];
     }
 


### PR DESCRIPTION
Clear onloadend so aborted xhrs are not rescheduled. See #1291 for discussion.