### PR TITLE
Fix for issue #1257 and partial fix for #1033 

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -40,7 +40,6 @@ class CoreEvents extends EventsBase {
         this.AST_IN_FUTURE = 'astinfuture';
         this.BUFFERING_COMPLETED = 'bufferingCompleted';
         this.BUFFER_CLEARED = 'bufferCleared';
-        this.BUFFER_LEVEL_STATE_CHANGED = 'bufferStateChanged';
         this.BUFFER_LEVEL_UPDATED = 'bufferLevelUpdated';
         this.BYTES_APPENDED = 'bytesAppended';
         this.CHECK_FOR_EXISTENCE_COMPLETED = 'checkForExistenceCompleted';

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -42,14 +42,23 @@ class MediaPlayerEvents extends EventsBase {
         super();
         /**
          * Triggered when the video element's buffer state changes to stalled.
+         * Check mediaType in payload to determine type (Video, Audio, FragmentedText).
          * @event MediaPlayerEvents#BUFFER_EMPTY
          */
         this.BUFFER_EMPTY = 'bufferstalled';
         /**
          * Triggered when the video element's buffer state changes to loaded.
+         * Check mediaType in payload to determine type (Video, Audio, FragmentedText).
          * @event MediaPlayerEvents#BUFFER_LOADED
          */
         this.BUFFER_LOADED = 'bufferloaded';
+
+        /**
+         * Triggered when the video element's buffer state changes, either stalled or loaded. Check payload for state.
+         * @event MediaPlayerEvents#BUFFER_LOADED
+         */
+        this.BUFFER_LEVEL_STATE_CHANGED = 'bufferStateChanged';
+
         /**
          * Triggered when
          * @event MediaPlayerEvents#ERROR

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -234,10 +234,6 @@ function BufferController(config) {
         }
 
         if (chunk.quality === currentQuality) {
-
-            //TODO May need this for MP buffer switch as buffer will be null while new SB established.  But returning here and blocking progression may require validate to be called.
-            //if (!buffer || isAppendingInProgress || !hasEnoughSpaceToAppend()) return;
-
             appendingMediaChunk = false;
             appendToBuffer(chunk);
         }
@@ -408,6 +404,8 @@ function BufferController(config) {
         bufferState = state;
         addBufferMetrics();
         eventBus.trigger(Events.BUFFER_LEVEL_STATE_CHANGED, {sender: instance, state: state, mediaType: type, streamInfo: streamProcessor.getStreamInfo()});
+        let eventType = state === BUFFER_LOADED ? Events.BUFFER_LOADED : Events.BUFFER_EMPTY;
+        eventBus.trigger(eventType, {mediaType: type});
         log(state === BUFFER_LOADED ? ('Got enough buffer to start.') : ('Waiting for more buffer before starting playback.'));
     }
 
@@ -652,7 +650,7 @@ function BufferController(config) {
     }
 
     function onPlaybackRateChanged() {
-        checkIfSufficientBuffer();
+        //checkIfSufficientBuffer();
     }
 
     function getType() {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -650,7 +650,7 @@ function BufferController(config) {
     }
 
     function onPlaybackRateChanged() {
-        //checkIfSufficientBuffer();
+        checkIfSufficientBuffer();
     }
 
     function getType() {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -129,7 +129,6 @@ function StreamController() {
         eventBus.on(Events.PLAYBACK_STARTED, onPlaybackStarted, this);
         eventBus.on(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdated, this);
-        eventBus.on(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
     }
 
     function flushPlaylistMetrics(reason, time) {
@@ -253,6 +252,7 @@ function StreamController() {
     }
 
     function onEnded(/*e*/) {
+
         var nextStream = getNextStream();
 
         switchStream(activeStream, nextStream, NaN);
@@ -298,12 +298,14 @@ function StreamController() {
 
     /*
      * Handles the current stream buffering end moment to start the next stream buffering
-     */
+     * Removing this for now, we removing the complexity of buffering into next period for now.
+     * this handler's logic caused Firefox and Safari to not period switch since the end event did not fire due to this.
+     * We single end of stream in BufferController. No reason to do it twice.  I will remove all the code once proven it is not needed.
+     *
     function onStreamBufferingCompleted(e) {
         var nextStream = getNextStream();
         var isLast = e.streamInfo.isLast;
-
-        // buffering has been completed, now we can signal end of stream
+         buffering has been completed, now we can signal end of stream
         if (mediaSource && isLast) {
             mediaSourceController.signalEndOfStream(mediaSource);
         }
@@ -312,6 +314,7 @@ function StreamController() {
 
         nextStream.activate(mediaSource);
     }
+     */
 
     function getNextStream() {
         var start = activeStream.getStreamInfo().start;
@@ -731,7 +734,6 @@ function StreamController() {
         eventBus.off(Events.PLAYBACK_STARTED, onPlaybackStarted, this);
         eventBus.off(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.off(Events.PLAYBACK_ENDED, onEnded, this);
-        eventBus.off(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
         eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdated, this);
 
         baseURLController.reset();

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -42,7 +42,7 @@ import Debug from '../../core/Debug.js';
 
 function StreamController() {
 
-    const STREAM_END_THRESHOLD = 0.2;
+    const STREAM_END_THRESHOLD = 0.5;
 
     let context = this.context;
     let log = Debug(context).getInstance().log;
@@ -129,6 +129,7 @@ function StreamController() {
         eventBus.on(Events.PLAYBACK_STARTED, onPlaybackStarted, this);
         eventBus.on(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdated, this);
+        eventBus.on(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
     }
 
     function flushPlaylistMetrics(reason, time) {
@@ -251,17 +252,15 @@ function StreamController() {
         }
     }
 
-    function onEnded(/*e*/) {
+    function onEnded() {
 
-        var nextStream = getNextStream();
+        let nextStream = getNextStream();
 
-        switchStream(activeStream, nextStream, NaN);
+        if (nextStream) {
+            switchStream(activeStream, nextStream, NaN);
+        }
 
-        flushPlaylistMetrics(
-            nextStream ?
-                PlayList.Trace.END_OF_PERIOD_STOP_REASON :
-                PlayList.Trace.END_OF_CONTENT_STOP_REASON
-        );
+        flushPlaylistMetrics(nextStream ? PlayList.Trace.END_OF_PERIOD_STOP_REASON : PlayList.Trace.END_OF_CONTENT_STOP_REASON);
     }
 
     function onPlaybackSeeking(e) {
@@ -298,23 +297,20 @@ function StreamController() {
 
     /*
      * Handles the current stream buffering end moment to start the next stream buffering
-     * Removing this for now, we removing the complexity of buffering into next period for now.
+     * Removing MP logic from this for now, we removing the complexity of buffering into next period for now.
      * this handler's logic caused Firefox and Safari to not period switch since the end event did not fire due to this.
-     * We single end of stream in BufferController. No reason to do it twice.  I will remove all the code once proven it is not needed.
-     *
+     */
     function onStreamBufferingCompleted(e) {
-        var nextStream = getNextStream();
+        //var nextStream = getNextStream();
         var isLast = e.streamInfo.isLast;
-         buffering has been completed, now we can signal end of stream
+
         if (mediaSource && isLast) {
             mediaSourceController.signalEndOfStream(mediaSource);
         }
-
-        if (!nextStream) return;
-
-        nextStream.activate(mediaSource);
+        //if (!nextStream) return;
+        //nextStream.activate(mediaSource);
     }
-     */
+
 
     function getNextStream() {
         var start = activeStream.getStreamInfo().start;
@@ -735,6 +731,7 @@ function StreamController() {
         eventBus.off(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.off(Events.PLAYBACK_ENDED, onEnded, this);
         eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdated, this);
+        eventBus.off(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
 
         baseURLController.reset();
         manifestUpdater.reset();


### PR DESCRIPTION
Added discrete event for loaded/empty parallel to BufferStateChange. So now you have maximum versatility.

```js

mediaPlayer.on(dashjs.MediaPlayer.events.BUFFER_EMPTY, onBufferEmpty)
mediaPlayer.on(dashjs.MediaPlayer.events.BUFFER_LOADED, onBufferLoaded)
mediaPlayer.on(dashjs.MediaPlayer.events.BUFFER_LEVEL_STATE_CHANGED, onBufferStateChange)

function onBufferStateChange(e) {
    if (e.mediaType === "video") {
        console.log("onBufferStateChange", e.state);
    }
}
function onBufferLoaded(e) {
    if (e.mediaType === "video") {
        console.log("onBufferLoaded");
    }
}
function onBufferEmpty(e) {
    if (e.mediaType === "video") {
        console.log("onBufferEmpty");
    }
}
``` 


Another change committed in this PR is part of the fix for #1033 