### PR TITLE
Fixes #1282

### DIFF
--- a/samples/dash-if-reference-player-beta/index.html
+++ b/samples/dash-if-reference-player-beta/index.html
@@ -238,14 +238,14 @@
                                autocomplete="off"
                                name="track-switch"
                                checked="checked"
-                               ng-click="changeTrackSwitchMode('ALWAYS_REPLACE', 'video')"> always replace
+                               ng-click="changeTrackSwitchMode('alwaysReplace', 'video')"> always replace
                     </label>
                     <label>
                         <input type="radio" 
                                id="never-replace" 
                                autocomplete="off" 
                                name="track-switch"
-                               ng-click="changeTrackSwitchMode('NEVER_REPLACE', 'video')"> never replace
+                               ng-click="changeTrackSwitchMode('neverReplace', 'video')"> never replace
                     </label>
                 </div>
             </div>

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -253,8 +253,8 @@
                         <li class="dropdown">
                             <a href="#" id="videoTrackSwitchModeDropdown" class="dropdown-toggle" data-toggle="dropdown">Track switch mode<b class="caret"></b></a>
                             <ul class="dropdown-menu" role="menu">
-                                <li ng-click="changeTrackSwitchMode('ALWAYS_REPLACE', 'video')"><a>always replace</a></li>
-                                <li ng-click="changeTrackSwitchMode('NEVER_REPLACE', 'video')"><a>never replace</a></li>
+                                <li ng-click="changeTrackSwitchMode('alwaysReplace', 'video')"><a>always replace</a></li>
+                                <li ng-click="changeTrackSwitchMode('neverReplace', 'video')"><a>never replace</a></li>
                             </ul>
                         </li>
                         <input type="text" class="form-control" placeholder="initial role, e.g. 'alternate'" ng-model="initialSettings.video">
@@ -301,8 +301,8 @@
                         <li class="dropdown">
                             <a href="#" id="audioTrackSwitchModeDropdown" class="dropdown-toggle" data-toggle="dropdown">Track switch mode<b class="caret"></b></a>
                             <ul class="dropdown-menu" role="menu">
-                                <li ng-click="changeTrackSwitchMode('ALWAYS_REPLACE', 'audio')"><a>always replace</a></li>
-                                <li ng-click="changeTrackSwitchMode('NEVER_REPLACE', 'audio')"><a>never replace</a></li>
+                                <li ng-click="changeTrackSwitchMode('alwaysReplace', 'audio')"><a>always replace</a></li>
+                                <li ng-click="changeTrackSwitchMode('neverReplace', 'audio')"><a>never replace</a></li>
                             </ul>
                         </li>
                         <input type="text" class="form-control" placeholder="initial lang, e.g. 'en'" ng-model="initialSettings.audio">

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1105,10 +1105,10 @@ function MediaPlayer() {
      * This method sets the selection mode for the initial track. This mode defines how the initial track will be selected
      * if no initial media settings are set. If initial media settings are set this parameter will be ignored. Available options are:
      *
-     * MediaPlayer.dependencies.MediaController.trackSelectionModes.HIGHEST_BITRATE
+     * MediaController.TRACK_SELECTION_MODE_HIGHEST_BITRATE
      * this mode makes the player select the track with a highest bitrate. This mode is a default mode.
      *
-     * MediaPlayer.dependencies.MediaController.trackSelectionModes.WIDEST_RANGE
+     * MediaController.TRACK_SELECTION_MODE_WIDEST_RANGE
      * this mode makes the player select the track with a widest range of bitrates
      *
      * @param mode

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -56,6 +56,16 @@ function MediaController() {
         switchMode,
         errHandler;
 
+    const validTrackSwitchModes = [
+        TRACK_SWITCH_MODE_ALWAYS_REPLACE,
+        TRACK_SWITCH_MODE_NEVER_REPLACE
+    ];
+
+    const validTrackSelectionModes = [
+        TRACK_SELECTION_MODE_HIGHEST_BITRATE,
+        TRACK_SELECTION_MODE_WIDEST_RANGE
+    ];
+
     function initialize() {
         tracks = {};
         resetInitialSettings();
@@ -237,7 +247,7 @@ function MediaController() {
      * @memberof MediaController#
      */
     function setSwitchMode(type, mode) {
-        var isModeSupported = !!MediaController[mode];
+        const isModeSupported = (validTrackSwitchModes.indexOf(mode) !== -1);
 
         if (!isModeSupported) {
             log('track switch mode is not supported: ' + mode);
@@ -261,7 +271,7 @@ function MediaController() {
      * @memberof MediaController#
      */
     function setSelectionModeForInitialTrack(mode) {
-        var isModeSupported = !!MediaController.trackSelectionModes[mode];
+        const isModeSupported = (validTrackSelectionModes.indexOf(mode) !== -1);
 
         if (!isModeSupported) {
             log('track selection mode is not supported: ' + mode);


### PR DESCRIPTION
`MediaController[mode]` only works externally when you `import MediaController` in other modules - you can't use it within the module definition.

`MediaController.trackSelectionModes[mode]` doesn't work for the same reason and also because `MediaController.trackSelectionModes` is not defined.

Given the comments in `MediaPlayer` (fixed), this looks like a hangover from v1.

Also fixed the ref player which had outdated strings so wouldn't have worked anyway.