### PR TITLE
Fix #1321 - relative MPD@BaseURL are not resolved correctly

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -132,8 +132,12 @@ function DashHandler(config) {
         if (!baseURL || (destination === baseURL.url) || (!urlUtils.isRelative(destination))) {
             url = destination;
         } else {
-            url = baseURL.url + destination;
+            url = baseURL.url;
             serviceLocation = baseURL.serviceLocation;
+
+            if (destination) {
+                url += destination;
+            }
         }
 
         if (urlUtils.isRelative(url)) {

--- a/test/dash.DashManifestModel.js
+++ b/test/dash.DashManifestModel.js
@@ -7,6 +7,7 @@ const context = {};
 const dashManifestModel = DashManifestModel(context).getInstance();
 
 const TEST_URL = 'http://www.example.com/';
+const RELATIVE_TEST_URL = './';
 const SERVICE_LOCATION = 'testServiceLocation';
 
 describe('DashManifestModel', function () {
@@ -80,6 +81,26 @@ describe('DashManifestModel', function () {
         expect(obj[0].serviceLocation).to.equal(TEST_URL);  // jshint ignore:line
     });
 
+    it('returns an Array of BaseURLs with length 1 when multiple relative BaseUrls were specified', () => {
+        const node = {
+            BaseURL_asArray: [
+                {
+                    __text: RELATIVE_TEST_URL + '0'
+                },
+                {
+                    __text: RELATIVE_TEST_URL + '1'
+                }
+            ]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                    // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                        // jshint ignore:line
+        expect(obj[0]).to.be.instanceOf(BaseURL);               // jshint ignore:line
+        expect(obj[0].url).to.equal(RELATIVE_TEST_URL + '0');   // jshint ignore:line
+    });
+
     it('returns an Array of BaseURLs when multiple BaseUrls were specified', () => {
         const node = {
             BaseURL_asArray: [
@@ -132,5 +153,66 @@ describe('DashManifestModel', function () {
         expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
         expect(obj[0].dvb_priority).to.equal(BaseURL.DEFAULT_DVB_PRIORITY); // jshint ignore:line
         expect(obj[0].dvb_weight).to.equal(BaseURL.DEFAULT_DVB_WEIGHT);     // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] having correct priority and weight for DVB extensions when specified', () => {
+        const TEST_PRIORITY = 3;
+        const TEST_WEIGHT = 2;
+        const node = {
+            BaseURL_asArray: [{
+                __text:         TEST_URL,
+                'dvb:priority': TEST_PRIORITY,
+                'dvb:weight':   TEST_WEIGHT
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
+        expect(obj[0].dvb_priority).to.equal(TEST_PRIORITY);                // jshint ignore:line
+        expect(obj[0].dvb_weight).to.equal(TEST_WEIGHT);                    // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] resolved to the document base uri when the base uri is specified and the input url is relative', () => {
+        const node = {
+            baseUri: TEST_URL,
+            BaseURL_asArray: [{
+                __text: RELATIVE_TEST_URL
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL + RELATIVE_TEST_URL);          // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] ignoring the document base uri when the base uri is specified and the input url is absolute', () => {
+        const node = {
+            baseUri: TEST_URL,
+            BaseURL_asArray: [{
+                __text: TEST_URL
+            }]
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL);                              // jshint ignore:line
+    });
+
+    it('returns an Array of BaseURLs with BaseURL[0] resolved to the document base uri when the base uri is specified but no other urls', () => {
+        const node = {
+            baseUri: TEST_URL
+        };
+
+        const obj = dashManifestModel.getBaseURLsFromElement(node);
+
+        expect(obj).to.be.instanceOf(Array);                                // jshint ignore:line
+        expect(obj).to.have.lengthOf(1);                                    // jshint ignore:line
+        expect(obj[0].url).to.equal(TEST_URL);                              // jshint ignore:line
     });
 });


### PR DESCRIPTION
See #1321 for discussion. Also added some tests for the same issue and others.

Also noticed that http://dash.edgesuite.net/akamai/test/caption_test/ElephantsDream/elephants_dream_480p_heaac5_1.mpd no longer played back correctly. I'm not convinced the signalling in the manifest is legal, but it used to work so made it work again.

I would recommend this gets pulled in for 2.1.0.