### PR TITLE
Fixes #1323

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -87,10 +87,18 @@ function ManifestLoader(config) {
                 var baseUri;
 
                 // Handle redirects for the MPD - as per RFC3986 Section 5.1.3
+                // also handily resolves relative MPD URLs to absolute
                 if (xhr.responseURL && xhr.responseURL !== url) {
                     baseUri = urlUtils.parseBaseUrl(xhr.responseURL);
                     actualUrl = xhr.responseURL;
                 } else {
+                    // usually this case will be caught and resolved by
+                    // xhr.responseURL above but it is not available for IE11
+                    // baseUri must be absolute for BaseURL resolution later
+                    if (urlUtils.isRelative(url)) {
+                        url = urlUtils.parseBaseUrl(window.location.href) + url;
+                    }
+
                     baseUri = urlUtils.parseBaseUrl(url);
                 }
 

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -176,7 +176,7 @@ function XHRLoader(cfg) {
                 handleLoaded(true);
 
                 if (config.success) {
-                    config.success(xhr.response, xhr.statusText, request);
+                    config.success(xhr.response, xhr.statusText, xhr);
                 }
 
                 if (config.complete) {


### PR DESCRIPTION
See #1323 for discussion.

07fe4f0 absolutely must go in to 2.1.0 in my opinion - this is a serious regression and a spec violation if it does not work.

a5673fa ought to go in as otherwise IE11 will fail to do anything useful in the rare case that a relative MPD URL is used.