### PR TITLE
Fix for regression of FF and Multiperiods test stream startup

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -435,7 +435,7 @@ function PlaybackController() {
         let bufferedStart = Math.max(ranges.start(0), streamInfo.start);
         let earliestTime = commonEarliestTime[streamInfo.id] === undefined ? bufferedStart : Math.max(commonEarliestTime[streamInfo.id], bufferedStart);
         if (earliestTime === commonEarliestTime[streamInfo.id]) return;
-        if (!isDynamic && !streamInfo.isFirst && getStreamStartTime(true) < earliestTime) {
+        if (!isDynamic  && getStreamStartTime(true) < earliestTime) {
             seek(earliestTime);
         }
         commonEarliestTime[streamInfo.id] = earliestTime;


### PR DESCRIPTION
Found issue with this line.  I added the isFirst but the return statement check solves the reason why I add isFirst check in the first place. With check some streams in some browsers do not start if non 0 pst

This resolves this.
Test thoroughly.