### PR TITLE
Prevent low values attempting to use representation -1

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -141,7 +141,8 @@ function AbrController() {
                 let representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
 
                 if (Array.isArray(representation)) {
-                    bitrateDict[type] = representation[Math.round(representation.length * ratioDict[type]) - 1].bandwidth;
+                    let repIdx = Math.max(Math.round(representation.length * ratioDict[type]) - 1, 0);
+                    bitrateDict[type] = representation[repIdx].bandwidth;
                 } else {
                     bitrateDict[type] = 0;
                 }


### PR DESCRIPTION
I don't think this is urgent enough to require being included in any future RC3 (i.e. this PR can wait until 2.2).