### PR TITLE
Minor fix for prod data and controller

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1676,6 +1676,8 @@ function MediaPlayer() {
     function reset() {
         attachSource(null);
         attachView(null);
+        protectionData = null;
+        protectionController = null;
     }
 
     //***********************************
@@ -1693,8 +1695,6 @@ function MediaPlayer() {
             mediaController.reset();
             streamController = null;
             metricsReportingController = null;
-            protectionController = null;
-            protectionData = null;
             if (isReady()) {
                 initializePlayback();
             }


### PR DESCRIPTION
Moving where we set the protection vars to null. Works fine if you set new prod data, switch streams or DRM or key systems etc.

Before fix you could not “reload” any given protected content due to nulling out info.