### PR TITLE
Improve JSDoc compliance and add automated checking

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -21,5 +21,16 @@
     "validateParameterSeparator": ", ",
     "disallowMultipleVarDecl": {
         "allExcept": ["undefined"]
+    },
+    "jsDoc": {
+        "checkTypes": "strictNativeCase",
+        "checkParamExistence": true,
+        "checkParamNames": true,
+        "requireParamTypes": true,
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "checkTypes": true
     }
 }

--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -82,7 +82,7 @@ function Debug() {
     }
     /**
      * This method will allow you send log messages to either the browser's console and/or dispatch an event to capture at the media player level.
-     * @param arguments The message you want to log. The Arguments object is supported for this method so you can send in comma separated logging items.
+     * @param {...*} arguments The message you want to log. The Arguments object is supported for this method so you can send in comma separated logging items.
      * @memberof module:Debug
      * @instance
      */

--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * @Module FactoryMaker
+ * @module FactoryMaker
  */
 let FactoryMaker = (function () {
 
@@ -49,8 +49,8 @@ let FactoryMaker = (function () {
      * this.factory.getSingletonInstance(this.context, 'VideoModel')
      * will return the video model for use in the extended object.
      *
-     * @param context {Object} injected into extended object as this.context
-     * @param className {String} string name found in all dash.js objects
+     * @param {Object} context - injected into extended object as this.context
+     * @param {string} className - string name found in all dash.js objects
      * with name __dashjs_factory_name Will be at the bottom. Will be the same as the object's name.
      * @returns {*} Context aware instance of specified singleton name.
      * @memberof module:FactoryMaker
@@ -69,9 +69,9 @@ let FactoryMaker = (function () {
     /**
      * Use this method to add an singleton instance to the system.  Useful for unit testing to mock objects etc.
      *
-     * @param context
-     * @param className
-     * @param instance
+     * @param {Object} context
+     * @param {string} className
+     * @param {Object} instance
      * @memberof module:FactoryMaker
      * @instance
      */

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -35,7 +35,7 @@ import DashManifestModel from './models/DashManifestModel.js';
 import FactoryMaker from '../core/FactoryMaker.js';
 
 /**
- * @Module DashMetrics
+ * @module DashMetrics
  */
 function DashMetrics() {
 
@@ -60,8 +60,8 @@ function DashMetrics() {
 
     /**
      *
-     * @param representationId
-     * @param periodIdx
+     * @param {string} representationId
+     * @param {number} periodIdx
      * @returns {*}
      */
     function getIndexForRepresentation(representationId, periodIdx) {
@@ -76,9 +76,9 @@ function DashMetrics() {
     /**
      * This method returns the current max index based on what is defined in the MPD.
      *
-     * @param bufferType - String 'audio' or 'video',
-     * @param periodIdx - Make sure this is the period index not id
-     * @return int
+     * @param {string} bufferType - String 'audio' or 'video',
+     * @param {number} periodIdx - Make sure this is the period index not id
+     * @return {number}
      * @memberof module:DashMetrics
      * @instance
      */
@@ -95,9 +95,9 @@ function DashMetrics() {
      * This method returns the current max index correlated to the max allowed bitrate
      * explicitly set via the MediaPlayer's API setMaxAllowedBitrateFor.
      *
-     * @param bufferType - String 'audio' or 'video',
-     * @param periodId - Make sure this is the period id not index.
-     * @return int
+     * @param {string} bufferType - String 'audio' or 'video',
+     * @param {number} periodId - Make sure this is the period id not index.
+     * @return {number}
      * @see {@link module:MediaPlayer#setMaxAllowedBitrateFor setMaxAllowedBitrateFor()}
      * @see {@link DashMetrics#getMaxIndexForBufferType getMaxIndexForBufferType()}
      * @memberof module:DashMetrics
@@ -115,7 +115,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -142,7 +142,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -161,7 +161,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {number}
      * @memberof module:DashMetrics
      * @instance
@@ -180,7 +180,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {null|*|vo}
      * @memberof module:DashMetrics
      * @instance
@@ -190,7 +190,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -224,7 +224,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -238,7 +238,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -263,7 +263,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -289,7 +289,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -315,7 +315,7 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
+     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -341,8 +341,8 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
-     * @param id
+     * @param {MetricsList} metrics
+     * @param {string} id
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
@@ -372,8 +372,8 @@ function DashMetrics() {
     }
 
     /**
-     * @param metrics
-     * @param id
+     * @param {MetricsList} metrics
+     * @param {string} id
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -66,7 +66,7 @@ import DashMetrics from '../dash/DashMetrics.js';
 import TimelineConverter from '../dash/utils/TimelineConverter.js';
 
 /**
- * @Module MediaPlayer
+ * @module MediaPlayer
  * @description The MediaPlayer is the primary dash.js Module and a Facade to build your player around.
  * It will allow you access to all the important dash.js properties/methods via the public API and all the
  * events to build a robust DASH media player.
@@ -126,9 +126,9 @@ function MediaPlayer() {
      * ALL arguments are optional and there are individual methods to set each argument later on.
      * The args in this method are just for convenience and should only be used for a simple player setup.
      *
-     * @param {HTML5MediaElement} view - Optional arg to set the video element. {@link module:MediaPlayer#attachView attachView()}
-     * @param {string} source - Optional arg to set the media source. {@link module:MediaPlayer#attachSource attachSource()}
-     * @param {boolean} AutoPlay - Optional arg to set auto play. {@link module:MediaPlayer#setAutoPlay setAutoPlay()}
+     * @param {HTML5MediaElement=} view - Optional arg to set the video element. {@link module:MediaPlayer#attachView attachView()}
+     * @param {string=} source - Optional arg to set the media source. {@link module:MediaPlayer#attachSource attachSource()}
+     * @param {boolean=} AutoPlay - Optional arg to set auto play. {@link module:MediaPlayer#setAutoPlay setAutoPlay()}
      * @see {@link module:MediaPlayer#attachView attachView()}
      * @see {@link module:MediaPlayer#attachSource attachSource()}
      * @see {@link module:MediaPlayer#setAutoPlay setAutoPlay()}
@@ -299,6 +299,7 @@ function MediaPlayer() {
      * NaN is returned if an invalid type is requested, or if the presentation does not contain that type or if no arguments are passed and the
      * presentation doers not include any audio or video adaption sets.
      *
+     * @param {string} type - the media type of the buffer
      * @returns {number} The length of the buffer for the given media type, in seconds.
      * @memberof module:MediaPlayer
      * @instance
@@ -347,7 +348,7 @@ function MediaPlayer() {
      * NOTE - If you do not need the raw offset value (i.e. media analytics, tracking, etc) consider using the {@link module:MediaPlayer#seek seek()} method
      * which will calculate this value for you and set the video element's currentTime property all in one simple call.
      *
-     * @param value {number} A relative time, in seconds, based on the return value of the {@link module:MediaPlayer#duration duration()} method is expected.
+     * @param {number} value - A relative time, in seconds, based on the return value of the {@link module:MediaPlayer#duration duration()} method is expected.
      * @returns {number} A value that is relative the available range within the timeShiftBufferLength (DVR Window).
      * @see {@link module:MediaPlayer#seek seek()}
      * @memberof module:MediaPlayer
@@ -373,7 +374,7 @@ function MediaPlayer() {
      * Sets the currentTime property of the attached video element.  If it is a live stream with a
      * timeShiftBufferLength, then the DVR window offset will be automatically calculated.
      *
-     * @param value {number} A relative time, in seconds, based on the return value of the {@link module:MediaPlayer#duration duration()} method is expected
+     * @param {number} value - A relative time, in seconds, based on the return value of the {@link module:MediaPlayer#duration duration()} method is expected
      * @see {@link module:MediaPlayer#getDVRSeekOffset getDVRSeekOffset()}
      * @memberof module:MediaPlayer
      * @instance
@@ -393,7 +394,7 @@ function MediaPlayer() {
      * If called with no arguments then the returned time value is time elapsed since the start point of the first stream.
      * However if a stream ID is supplied then time is relative to the start of that stream, or is null if there is no such stream id in the manifest.
      *
-     * @param streamId The ID of a stream that the returned playhead time must be relative to the start of. If undefined, then playhead time is relative to the first stream.
+     * @param {string} streamId - The ID of a stream that the returned playhead time must be relative to the start of. If undefined, then playhead time is relative to the first stream.
      * @returns {number} The current playhead time of the media, or null.
      * @memberof module:MediaPlayer
      * @instance
@@ -496,7 +497,7 @@ function MediaPlayer() {
     /**
      * A utility method which converts seconds into TimeCode (i.e. 300 --> 05:00).
      *
-     * @param value {number} A number in seconds to be converted into a formatted time code.
+     * @param {number} value - A number in seconds to be converted into a formatted time code.
      * @returns {string} A formatted time code string.
      * @memberof module:MediaPlayer
      * @instance
@@ -516,7 +517,7 @@ function MediaPlayer() {
      * <ol>
      * <li>If you set override to true any public method or property in your custom object will
      * override the dash.js parent object's property(ies) and will be used instead but the
-     * dashj.s parent module will still be created.</li>
+     * dash.js parent module will still be created.</li>
      *
      * <li>If you set override to false your object will completely replace the dash.js object.
      * (Note: This is how it was in 1.x of Dash.js with Dijon).</li>
@@ -529,6 +530,9 @@ function MediaPlayer() {
      * </ul>
      * <b>You must call extend before you call initialize</b>
      * @see {@link module:MediaPlayer#initialize initialize()}
+     * @param {string} parentNameString - name of parent module
+     * @param {Object} childInstance - overriding object
+     * @param {boolean} override - replace only some methods (true) or the whole object (false)
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -539,7 +543,7 @@ function MediaPlayer() {
     /**
      * Use the on method to listen for public events found in MediaPlayer.events. {@link MediaPlayerEvents}
      *
-     * @param {String} type - {@link MediaPlayerEvents}
+     * @param {string} type - {@link MediaPlayerEvents}
      * @param {Function} listener - callback method when the event fires.
      * @param {Object} scope - context of the listener so it can be removed properly.
      * @memberof module:MediaPlayer
@@ -552,7 +556,7 @@ function MediaPlayer() {
     /**
      * Use the off method to remove listeners for public events found in MediaPlayer.events. {@link MediaPlayerEvents}
      *
-     * @param {String} type - {@link MediaPlayerEvents}
+     * @param {string} type - {@link MediaPlayerEvents}
      * @param {Function} listener - callback method when the event fires.
      * @param {Object} scope - context of the listener so it can be removed properly.
      * @memberof module:MediaPlayer
@@ -575,7 +579,7 @@ function MediaPlayer() {
     /**
      * Use this method to access the dash.js logging class.
      *
-     * @returns {@link module:Debug}
+     * @returns {Debug}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -592,7 +596,7 @@ function MediaPlayer() {
      * <li>{@link module:MediaPlayer#getTTMLRenderingDiv getTTMLRenderingDiv()}</li>
      * </ul>
      *
-     * @returns {@link VideoModel}
+     * @returns {VideoModel}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -608,7 +612,7 @@ function MediaPlayer() {
      * to define a time in seconds to delay a live stream from the live edge.</p>
      * <p>Lowering this value will lower latency but may decrease the player's ability to build a stable buffer.</p>
      *
-     * @param value {int} Represents how many segment durations to delay the live stream.
+     * @param {number} value - Represents how many segment durations to delay the live stream.
      * @default 4
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#useSuggestedPresentationDelay useSuggestedPresentationDelay()}
@@ -624,7 +628,7 @@ function MediaPlayer() {
      * <p>This value should be less than the manifest duration by a couple of segment durations to avoid playback issues</p>
      * <p>If set, this parameter will take precedence over setLiveDelayFragmentCount and manifest info</p>
      *
-     * @param value {int} Represents how many seconds to delay the live stream.
+     * @param {number} value - Represents how many seconds to delay the live stream.
      * @default undefined
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#useSuggestedPresentationDelay useSuggestedPresentationDelay()}
@@ -636,7 +640,7 @@ function MediaPlayer() {
 
     /**
      * <p>Set to true if you would like to override the default live delay and honor the SuggestedPresentationDelay attribute in by the manifest.</p>
-     * @param value {boolean}
+     * @param {boolean} value
      * @default false
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setLiveDelayFragmentCount setLiveDelayFragmentCount()}
@@ -653,8 +657,8 @@ function MediaPlayer() {
      * The default expiration is one hour, defined in milliseconds. If expired, the default initial bit rate (closest to 1000 kbps) will be used
      * for that session and a new bit rate will be stored during that session.
      *
-     * @param enable - Boolean - Will toggle if feature is enabled. True to enable, False to disable.
-     * @param ttl Number - (Optional) A value defined in milliseconds representing how long to cache the bit rate for. Time to live.
+     * @param {boolean} enable - Will toggle if feature is enabled. True to enable, False to disable.
+     * @param {number=} ttl - (Optional) A value defined in milliseconds representing how long to cache the bit rate for. Time to live.
      * @default enable = True, ttl = 360000 (1 hour)
      * @memberof module:MediaPlayer
      * @instance
@@ -671,8 +675,8 @@ function MediaPlayer() {
      * The default expiration is one hour, defined in milliseconds. If expired, the default settings will be used
      * for that session and a new settings will be stored during that session.
      *
-     * @param enable - Boolean - Will toggle if feature is enabled. True to enable, False to disable.
-     * @param ttl Number - (Optional) A value defined in milliseconds representing how long to cache the settings for. Time to live.
+     * @param {boolean} enable - Will toggle if feature is enabled. True to enable, False to disable.
+     * @param {number=} [ttl] - (Optional) A value defined in milliseconds representing how long to cache the settings for. Time to live.
      * @default enable = True, ttl = 360000 (1 hour)
      * @memberof module:MediaPlayer
      * @instance
@@ -693,8 +697,8 @@ function MediaPlayer() {
      *
      * This feature is typically used to reserve higher bitrates for playback only when the player is in large or full-screen format.
      *
-     * @param type {String} 'video' or 'audio' are the type options.
-     * @param value {int} Value in kbps representing the maximum bitrate allowed.
+     * @param {string} type - 'video' or 'audio' are the type options.
+     * @param {number} value - Value in kbps representing the maximum bitrate allowed.
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -703,7 +707,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type {string} 'video' or 'audio' are the type options.
+     * @param {string} type - 'video' or 'audio' are the type options.
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setMaxAllowedBitrateFor setMaxAllowedBitrateFor()}
      * @instance
@@ -724,8 +728,8 @@ function MediaPlayer() {
      *
      * This feature is typically used to reserve higher representations for playback only when connected over a fast connection.
      *
-     * @param type String 'video' or 'audio' are the type options.
-     * @param value number between 0 and 1, where 1 is allow all representations, and 0 is allow only the lowest.
+     * @param {string} type - 'video' or 'audio' are the type options.
+     * @param {number} value - number between 0 and 1, where 1 is allow all representations, and 0 is allow only the lowest.
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -734,7 +738,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type String 'video' or 'audio' are the type options.
+     * @param {string} type - 'video' or 'audio' are the type options.
      * @returns {number} The current representation ratio cap.
      * @memberof module:MediaPlayer
      * @see {@link MediaPlayer#setMaxAllowedRepresentationRatioFor setMaxAllowedRepresentationRatioFor()}
@@ -747,7 +751,7 @@ function MediaPlayer() {
     /**
      * <p>Set to false to prevent stream from auto-playing when the view is attached.</p>
      *
-     * @param value {boolean}
+     * @param {boolean} value
      * @default true
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#attachView attachView()}
@@ -772,7 +776,7 @@ function MediaPlayer() {
      * when the video element is paused.
      *
      * @default false
-     * @param value
+     * @param {boolean} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -797,7 +801,7 @@ function MediaPlayer() {
      * stored in dash.js
      *
      * @see {@link module:DashMetrics}
-     * @returns {object}
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -807,8 +811,8 @@ function MediaPlayer() {
 
     /**
      *
-     * @param type
-     * @returns {object}
+     * @param {string} type
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -817,8 +821,8 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
-     * @returns {object}
+     * @param {string} type
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -832,8 +836,8 @@ function MediaPlayer() {
     /**
      * Sets the current quality for media type instead of letting the ABR Heuristics automatically selecting it..
      *
-     * @param type
-     * @param value
+     * @param {string} type
+     * @param {number} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -855,7 +859,7 @@ function MediaPlayer() {
     /**
      * Sets whether to limit the representation used based on the size of the playback area
      *
-     * @param value
+     * @param {boolean} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -868,7 +872,7 @@ function MediaPlayer() {
      * Use this method to change the current text track for both external time text files and fragmented text tracks. There is no need to
      * set the track mode on the video object to switch a track when using this method.
      *
-     * @param idx - Index of track based on the order of the order the tracks are added Use -1 to disable all tracks. (turn captions off).  Use module:MediaPlayer#dashjs.MediaPlayer.events.TEXT_TRACK_ADDED.
+     * @param {number} idx - Index of track based on the order of the order the tracks are added Use -1 to disable all tracks. (turn captions off).  Use module:MediaPlayer#dashjs.MediaPlayer.events.TEXT_TRACK_ADDED.
      * @see {@link module:MediaPlayer#dashjs.MediaPlayer.events.TEXT_TRACK_ADDED}
      * @memberof module:MediaPlayer
      * @instance
@@ -899,7 +903,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @returns {Array}
      * @memberof module:MediaPlayer
      * @instance
@@ -915,8 +919,8 @@ function MediaPlayer() {
     /**
      * Use this method to explicitly set the starting bitrate for audio | video
      *
-     * @param type
-     * @param {number} value A value of the initial bitrate, kbps
+     * @param {string} type
+     * @param {number} value - A value of the initial bitrate, kbps
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -925,7 +929,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @returns {number} A value of the initial bitrate, kbps
      * @memberof module:MediaPlayer
      * @instance
@@ -938,8 +942,8 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
-     * @param {number} value A value of the initial Representation Ratio
+     * @param {string} type
+     * @param {number} value - A value of the initial Representation Ratio
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -948,7 +952,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @returns {number} A value of the initial Representation Ratio
      * @memberof module:MediaPlayer
      * @instance
@@ -959,7 +963,7 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available streams from a given manifest
-     * @param manifest
+     * @param {Object} manifest
      * @returns {Array} list of {@link StreamInfo}
      * @memberof module:MediaPlayer
      * @instance
@@ -973,7 +977,7 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available tracks for a given media type
-     * @param type
+     * @param {string} type
      * @returns {Array} list of {@link MediaInfo}
      * @memberof module:MediaPlayer
      * @instance
@@ -989,9 +993,9 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available tracks for a given media type and streamInfo from a given manifest
-     * @param type
-     * @param manifest
-     * @param streamInfo
+     * @param {string} type
+     * @param {Object} manifest
+     * @param {Object} streamInfo
      * @returns {Array} list of {@link MediaInfo}
      * @memberof module:MediaPlayer
      * @instance
@@ -1007,8 +1011,8 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type
-     * @returns {Object} {@link MediaInfo}
+     * @param {string} type
+     * @returns {Object|null} {@link MediaInfo}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1033,8 +1037,8 @@ function MediaPlayer() {
          *  role: roleValue}
      *
      *
-     * @param type
-     * @param value {Object}
+     * @param {string} type
+     * @param {Object} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1050,7 +1054,7 @@ function MediaPlayer() {
          *  audioChannelConfiguration: audioChannelConfigurationValue,
          *  accessibility: accessibilityValue,
          *  role: roleValue}
-     * @param type
+     * @param {string} type
      * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
@@ -1060,7 +1064,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param track instance of {@link MediaInfo}
+     * @param {MediaInfo} track - instance of {@link MediaInfo}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1074,8 +1078,8 @@ function MediaPlayer() {
     /**
      * This method returns the current track switch mode.
      *
-     * @param type
-     * @returns mode
+     * @param {string} type
+     * @returns {string} mode
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1092,8 +1096,8 @@ function MediaPlayer() {
      * MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE
      * (used to clear the buffered data (prior to current playback position) after track switch. Default for audio)
      *
-     * @param type
-     * @param mode
+     * @param {string} type
+     * @param {string} mode
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1111,7 +1115,7 @@ function MediaPlayer() {
      * MediaController.TRACK_SELECTION_MODE_WIDEST_RANGE
      * this mode makes the player select the track with a widest range of bitrates
      *
-     * @param mode
+     * @param {string} mode
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1122,7 +1126,7 @@ function MediaPlayer() {
     /**
      * This method returns the track selection mode.
      *
-     * @returns mode
+     * @returns {string} mode
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1144,7 +1148,7 @@ function MediaPlayer() {
      * Set to false to switch off adaptive bitrate switching.
      *
      * @deprecated since version 2.0 Instead use {@link module:MediaPlayer#setAutoSwitchQualityFor setAutoSwitchQualityFor()}.
-     * @param value {boolean}
+     * @param {boolean} value
      * @default {boolean} true
      * @memberof module:MediaPlayer
      * @instance
@@ -1155,7 +1159,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param type {string} 'audio' | 'video'
+     * @param {string} type - 'audio' | 'video'
      * @returns {boolean} Current state of adaptive bitrate switching
      * @memberof module:MediaPlayer
      * @instance
@@ -1167,8 +1171,8 @@ function MediaPlayer() {
     /**
      * Set to false to switch off adaptive bitrate switching.
      *
-     * @param type {string} 'audio' | 'video'
-     * @param value {boolean}
+     * @param {string} type - 'audio' | 'video'
+     * @param {boolean} value
      * @default {boolean} true
      * @memberof module:MediaPlayer
      * @instance
@@ -1186,7 +1190,7 @@ function MediaPlayer() {
      *
      * @see {@link http://arxiv.org/abs/1601.06748 BOLA WhitePaper.}
      * @see {@link https://github.com/Dash-Industry-Forum/dash.js/wiki/BOLA-status More details about the implementation status.}
-     * @param value {boolean}
+     * @param {boolean} value
      * @default false
      * @memberof module:MediaPlayer
      * @instance
@@ -1200,8 +1204,8 @@ function MediaPlayer() {
      * nous and
      * requires the app-provided callback function
      *
-     * @param url {string} url the manifest url
-     * @param callback {function} A Callback function provided when retrieving manifests
+     * @param {string} url - url the manifest url
+     * @param {function} callback - A Callback function provided when retrieving manifests
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1231,8 +1235,7 @@ function MediaPlayer() {
      * If UTCTiming is defined in the manifest, it will take precedence over any time source manually added.</p>
      * <p>If you have exposed the Date header, use the method {@link module:MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()}.
      * This will allow the date header on the manifest to be used instead of a time server</p>
-     * @param {string} schemeIdUri -
-     * <ul>
+     * @param {string} schemeIdUri - <ul>
      * <li>urn:mpeg:dash:utc:http-head:2014</li>
      * <li>urn:mpeg:dash:utc:http-xsdate:2014</li>
      * <li>urn:mpeg:dash:utc:http-iso:2014</li>
@@ -1321,6 +1324,7 @@ function MediaPlayer() {
      * use of the date header will happen only after the other timing source that take precedence fail or are omitted as described.
      * {@link module:MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()} </p>
      *
+     * @param {boolean} value - true to enable
      * @default {boolean} True
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#addUTCTimingSource addUTCTimingSource()}
@@ -1408,7 +1412,7 @@ function MediaPlayer() {
      *
      * @see {@link module:MediaPlayer#setBufferTimeAtTopQualityLongForm setBufferTimeAtTopQualityLongForm()}
      * @default 600 seconds (10 minutes).
-     * @param value
+     * @param {number} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1423,7 +1427,7 @@ function MediaPlayer() {
      * buffer level surpasses this value and while it remains greater than this value.
      *
      * @default 20 seconds
-     * @param value
+     * @param {number} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1437,7 +1441,7 @@ function MediaPlayer() {
      * measured throughput calculations will be. please use carefully. This will directly
      * affect the ABR logic in dash.js
      *
-     * @param value
+     * @param {number} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1507,7 +1511,7 @@ function MediaPlayer() {
 
     /**
      * Will override dash.js protection controller.
-     * @param {ProtectionController} [value] valid protection controller instance.
+     * @param {ProtectionController} value - valid protection controller instance.
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1516,7 +1520,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param {ProtectionData} [value] object containing
+     * @param {ProtectionData} value - object containing
      * property names corresponding to key system name strings and associated
      * values being instances of.
      * @memberof module:MediaPlayer
@@ -1529,7 +1533,7 @@ function MediaPlayer() {
     /**
      * This method serves to control captions z-index value. If 'true' is passed, the captions will have the highest z-index and be
      * displayed on top of other html elements. Default value is 'false' (z-index is not set).
-     * @param value {Boolean}
+     * @param {boolean} value
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1542,7 +1546,7 @@ function MediaPlayer() {
 
     /**
      * Returns instance of Video Container that was attached by calling attachVideoContainer()
-     * @returns {@link object}
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1553,7 +1557,7 @@ function MediaPlayer() {
     /**
      * Use this method to attach an HTML5 element that wraps the video element.
      *
-     * @param container The HTML5 element containing the video element.
+     * @param {HTMLElement} container - The HTML5 element containing the video element.
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1566,7 +1570,7 @@ function MediaPlayer() {
 
     /**
      * Returns instance of Video Element that was attached by calling attachView()
-     * @returns {object}
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1580,7 +1584,7 @@ function MediaPlayer() {
     /**
      * Use this method to attach an HTML5 VideoElement for dash.js to operate upon.
      *
-     * @param view An HTML5 VideoElement that has already been defined in the DOM.
+     * @param {Object} element - An HTMLMediaElement that has already been defined in the DOM (or equivalent stub).
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1601,7 +1605,7 @@ function MediaPlayer() {
 
     /**
      * Returns instance of Div that was attached by calling attachTTMLRenderingDiv()
-     * @returns {@link object}
+     * @returns {Object}
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1612,7 +1616,7 @@ function MediaPlayer() {
     /**
      * Use this method to attach an HTML5 div for dash.js to render rich TTML subtitles.
      *
-     * @param div An unstyled div placed after the video element. It will be styled to match the video size and overlay z-order.
+     * @param {HTMLDivElement} div - An unstyled div placed after the video element. It will be styled to match the video size and overlay z-order.
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1641,11 +1645,11 @@ function MediaPlayer() {
      * a previously downloaded and parsed manifest object.  Optionally, can
      * also provide protection information
      *
-     * @param {string | object} urlOrManifest A URL to a valid MPD manifest file, or a
+     * @param {string|Object} urlOrManifest - A URL to a valid MPD manifest file, or a
      * parsed manifest object.
      *
      *
-     * @throw "MediaPlayer not initialized!"
+     * @throws "MediaPlayer not initialized!"
      *
      * @memberof module:MediaPlayer
      * @instance

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -30,7 +30,7 @@
  */
 import EventsBase from '../core/events/EventsBase.js';
 /**
- * @Class
+ * @class
  *
  */
 class MediaPlayerEvents extends EventsBase {

--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -13,9 +13,10 @@ function MediaPlayerFactory() {
      *  a default DashContext is used. If no source is provided, the videoElement is interrogated to extract the first source whose
      *  type is application/dash+xml.
      * The autoplay property of the videoElement is preserved. Any preload attribute is ignored. This method should be called after the page onLoad event is dispatched.
-     * @param video
-     * @param source
-     * @returns {MediaPlayer}
+     * @param {HTMLMediaElement} video
+     * @param {HTMLSourceElement} source
+     * @param {Object} context
+     * @returns {MediaPlayer|null}
      */
     function create(video, source, context) {
         if (!video || video.nodeName !== 'VIDEO') return null;
@@ -54,8 +55,8 @@ function MediaPlayerFactory() {
      * A new MediaPlayer is instantiated for each matching video element and the appropriate source is assigned.
      * The autoplay property of the video element is preserved. Any preload attribute is ignored. This method should be called after the page onLoad event is dispatched.
      * Returns an array holding all the MediaPlayer instances that were added by this method.
-     * @param selector
-     * @param scope
+     * @param {string} selector - CSS selector
+     * @param {Object} scope
      * @returns {Array} an array of MediaPlayer objects
      */
     function createAll(selector, scope) {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -114,7 +114,7 @@ function Stream(config) {
 
     /**
      * Activates Stream by re-initializing some of its components
-     * @param mediaSource {MediaSource}
+     * @param {MediaSource} mediaSource
      * @memberof Stream#
      */
     function activate(mediaSource) {
@@ -203,7 +203,7 @@ function Stream(config) {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @returns {Array}
      * @memberof Stream#
      */

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -351,12 +351,12 @@ function TextSourceBuffer() {
     }
     /**
      * Extract CEA-608 data from a buffer of data.
-     * @parameter(data) ArrayBuffer of data
-     * @returns ccData corresponding to one segment.
+     * @param {ArrayBuffer} data
+     * @returns {Object|null} ccData corresponding to one segment.
     */
     function extractCea608Data(data) {
 
-        /** Insert [time, data] pairs in order into array. */
+        /* Insert [time, data] pairs in order into array. */
         var insertInOrder = function (arr, time, data) {
             var len = arr.length;
             if (len > 0) {

--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -316,7 +316,7 @@ function TextTracks() {
         }
     }
 
-    /**
+    /*
     * Add captions to track, store for later adding, or add captions added before
     */
     function addCaptions(trackIdx, timeOffset, captionData) {

--- a/src/streaming/VirtualBuffer.js
+++ b/src/streaming/VirtualBuffer.js
@@ -30,7 +30,7 @@
  */
 
 /**
- * Represents data structure to keep and drive {@link DataChunk}
+ * Represents data structure to keep and drive {DataChunk}
  */
 import MediaController from './controllers/MediaController.js';
 import CustomTimeRanges from './utils/CustomTimeRanges.js';
@@ -54,7 +54,7 @@ function VirtualBuffer() {
 
     /**
      * Adds DataChunk to array of chunks
-     * @param {@link DataChunk}
+     * @param {DataChunk} chunk
      * @memberof VirtualBuffer#
      */
     function append(chunk) {
@@ -76,8 +76,8 @@ function VirtualBuffer() {
 
     /**
      * Adds DataChunk to array of appended chunks and updates virual ranges of appended chunks
-     * @param {@link DataChunk}
-     * @param buffer {SourceBuffer}
+     * @param {DataChunk} chunk
+     * @param {SourceBuffer} buffer
      * @memberof VirtualBuffer#
      */
     function storeAppendedChunk(chunk, buffer) {
@@ -154,8 +154,8 @@ function VirtualBuffer() {
 
     /**
      * Updates virual ranges of appended chunks according to the given ranges
-     * @param filter
-     * @param ranges
+     * @param {Object} filter
+     * @param {Object} ranges
      * @memberof VirtualBuffer#
      */
     function updateBufferedRanges(filter, ranges) {
@@ -188,8 +188,8 @@ function VirtualBuffer() {
     }
 
     /**
-     * Finds and returns {@link DataChunk} that satisfies filtering options
-     * @param filter - an object that contains properties by which the method search for chunks
+     * Finds and returns {DataChunk} that satisfies filtering options
+     * @param {Object} filter - an object that contains properties by which the method search for chunks
      * @returns {Array}
      * @memberof VirtualBuffer#
      */
@@ -245,9 +245,9 @@ function VirtualBuffer() {
     }
 
     /**
-     * Finds and returns {@link DataChunk} that satisfies filtering options. Filtered chunks are removed
+     * Finds and returns {DataChunk} that satisfies filtering options. Filtered chunks are removed
      * from the original array
-     * @param filter - an object that contains properties by which the method search for chunks
+     * @param {Object} filter - an object that contains properties by which the method search for chunks
      * @returns {Array}
      * @memberof VirtualBuffer#
      */
@@ -258,8 +258,8 @@ function VirtualBuffer() {
 
     /**
      * Calculates total buffer size across all Periods
-     * @param {@link MediaInfo}
-     * @returns {Number}
+     * @param {MediaInfo} mediaInfo
+     * @returns {number}
      * @memberof VirtualBuffer#
      */
     function getTotalBufferLevel(mediaInfo) {

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -33,8 +33,9 @@ import FactoryMaker from '../core/FactoryMaker.js';
 import MediaPlayerModel from './models/MediaPlayerModel.js';
 
 /**
- * @Module XHRLoader
+ * @module XHRLoader
  * @description Manages download of resources via HTTP.
+ * @param {Object} cfg - dependancies from parent
  */
 function XHRLoader(cfg) {
     const context = this.context;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -127,7 +127,7 @@ function AbrController() {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @returns {number} A value of the initial bitrate, kbps
      * @memberof AbrController#
      */
@@ -157,7 +157,7 @@ function AbrController() {
     }
 
     /**
-     * @param type
+     * @param {string} type
      * @param {number} value A value of the initial bitrate, kbps
      * @memberof AbrController#
      */
@@ -292,8 +292,8 @@ function AbrController() {
     }
 
     /**
-     * @param mediaInfo
-     * @param bitrate A bitrate value, kbps
+     * @param {MediaInfo} mediaInfo
+     * @param {number} bitrate A bitrate value, kbps
      * @returns {number} A quality index <= for the given bitrate
      * @memberof AbrController#
      */
@@ -316,8 +316,8 @@ function AbrController() {
     }
 
     /**
-     * @param mediaInfo
-     * @returns {Array} A list of {@link BitrateInfo} objects
+     * @param {MediaInfo} mediaInfo
+     * @returns {Array|null} A list of {@link BitrateInfo} objects
      * @memberof AbrController#
      */
     function getBitrateList(mediaInfo) {

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -84,7 +84,7 @@ function EventController() {
 
     /**
      * Add events to the eventList. Events that are not in the mpd anymore but not triggered yet will still be deleted
-     * @param values
+     * @param {Array.<Object>} values
      */
     function addInlineEvents(values) {
         inlineEvents = {};
@@ -101,7 +101,7 @@ function EventController() {
 
     /**
      * i.e. processing of any one event message box with the same id is sufficient
-     * @param values
+     * @param {Array.<Object>} values
      */
     function addInbandEvents(values) {
         for (var i = 0; i < values.length; i++) {

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -73,8 +73,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @param streamInfo
+     * @param {string} type
+     * @param {StreamInfo} streamInfo
      * @memberof MediaController#
      */
     function checkInitialMediaSettingsForType(type, streamInfo) {
@@ -115,8 +115,8 @@ function MediaController() {
     }
 
     /**
-     * @param track
-     * @returns {Boolean}
+     * @param {MediaInfo} track
+     * @returns {boolean}
      * @memberof MediaController#
      */
     function addTrack(track) {
@@ -140,8 +140,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @param streamInfo
+     * @param {string} type
+     * @param {StreamInfo} streamInfo
      * @returns {Array}
      * @memberof MediaController#
      */
@@ -156,9 +156,9 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @param streamInfo
-     * @returns {Object}
+     * @param {string} type
+     * @param {StreamInfo} streamInfo
+     * @returns {Object|null}
      * @memberof MediaController#
      */
     function getCurrentTrackFor(type, streamInfo) {
@@ -168,8 +168,8 @@ function MediaController() {
     }
 
     /**
-     * @param track
-     * @returns {Boolean}
+     * @param {MediaInfo} track
+     * @returns {boolean}
      * @memberof MediaController#
      */
     function isCurrentTrack(track) {
@@ -180,7 +180,7 @@ function MediaController() {
     }
 
     /**
-     * @param track
+     * @param {MediaInfo} track
      * @memberof MediaController#
      */
     function setTrack(track) {
@@ -220,8 +220,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @param {Object}
+     * @param {string} type
+     * @param {Object} value
      * @memberof MediaController#
      */
     function setInitialSettings(type, value) {
@@ -231,8 +231,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @returns {Object}
+     * @param {string} type
+     * @returns {Object|null}
      * @memberof MediaController#
      */
     function getInitialSettings(type) {
@@ -242,8 +242,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @param mode
+     * @param {string} type
+     * @param {string} mode
      * @memberof MediaController#
      */
     function setSwitchMode(type, mode) {
@@ -258,8 +258,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @returns mode
+     * @param {string} type
+     * @returns {string} mode
      * @memberof MediaController#
      */
     function getSwitchMode(type) {
@@ -267,7 +267,7 @@ function MediaController() {
     }
 
     /**
-     * @param mode
+     * @param {string} mode
      * @memberof MediaController#
      */
     function setSelectionModeForInitialTrack(mode) {
@@ -281,7 +281,7 @@ function MediaController() {
     }
 
     /**
-     * @returns mode
+     * @returns {string} mode
      * @memberof MediaController#
      */
     function getSelectionModeForInitialTrack() {
@@ -289,8 +289,8 @@ function MediaController() {
     }
 
     /**
-     * @param type
-     * @returns {Boolean}
+     * @param {string} type
+     * @returns {boolean}
      * @memberof MediaController#
      */
     function isMultiTrackSupportedByType(type) {
@@ -298,9 +298,9 @@ function MediaController() {
     }
 
     /**
-     * @param t1 first track to compare
-     * @param t2 second track to compare
-     * @returns {Boolean}
+     * @param {MediaInfo} t1 - first track to compare
+     * @param {MediaInfo} t2 - second track to compare
+     * @returns {boolean}
      * @memberof MediaController#
      */
     function isTracksEqual(t1, t2) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -176,9 +176,11 @@ function PlaybackController() {
 
     /**
      * Computes the desirable delay for the live edge to avoid a risk of getting 404 when playing at the bleeding edge
-     * @returns {Number} object
+     * @param {number} fragmentDuration - seconds?
+     * @param {number} dvrWindowSize - seconds?
+     * @returns {number} object
      * @memberof PlaybackController#
-     * */
+     */
     function computeLiveDelay(fragmentDuration, dvrWindowSize) {
         var mpd = dashManifestModel.getMpd(manifestModel.getValue());
 
@@ -249,8 +251,8 @@ function PlaybackController() {
     }
 
     /**
-     * @param streamInfo object
-     * @returns {Number} object
+     * @param {boolean} ignoreStartOffset - ignore URL fragment start offset if true
+     * @returns {number} object
      * @memberof PlaybackController#
      */
     function getStreamStartTime(ignoreStartOffset) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -346,6 +346,9 @@ function StreamController() {
     /**
      * Returns a playhead time, in seconds, converted to be relative
      * to the start of an identified stream/period or null if no such stream
+     * @param {number} time
+     * @param {string} id
+     * @returns {number|null}
      */
     function getTimeRelativeToStreamId(time, id) {
         var stream = null;

--- a/src/streaming/controllers/TextController.js
+++ b/src/streaming/controllers/TextController.js
@@ -69,8 +69,8 @@ function TextController(config) {
     }
 
     /**
-     * @param mediaInfo object
-     * @returns SourceBuffer object
+     * @param {MediaInfo }mediaInfo
+     * @returns {Object} SourceBuffer object
      * @memberof BufferController#
      */
     function createBuffer(mediaInfo) {

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -73,7 +73,7 @@ function XlinkController(config) {
 
     /**
      * <p>Triggers the resolution of the xlink.onLoad attributes in the manifest file </p>
-     * @param manifest
+     * @param {Object} mpd - the manifest
      */
     function resolveManifestOnLoad(mpd) {
         var elements;

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -45,6 +45,7 @@ function MetricsReporting() {
 
     /**
      * Create a MetricsCollectionController, and a DVBErrorsTranslator
+     * @param {Object} config - dependancies from owner
      * @return {MetricsCollectionController} Metrics Collection Controller
      */
     function createMetricsReporting(config) {

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -116,7 +116,7 @@ function FragmentModel(config) {
      *
      * Gets an array of {@link FragmentRequest} objects
      *
-     * @param {object} filter The object with properties by which the method filters the requests to be returned.
+     * @param {Object} filter The object with properties by which the method filters the requests to be returned.
      *  the only mandatory property is state, which must be a value from
      *  other properties should match the properties of {@link FragmentRequest}. E.g.:
      *  getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, quality: 0}) - returns

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -36,8 +36,8 @@ class CommonEncryption {
      * Find and return the ContentProtection element in the given array
      * that indicates support for MPEG Common Encryption
      *
-     * @param cpArray array of content protection elements
-     * @returns the Common Encryption content protection element or
+     * @param {Array} cpArray array of content protection elements
+     * @returns {Object|null} the Common Encryption content protection element or
      * null if one was not found
      */
     static findCencContentProtection(cpArray) {
@@ -54,7 +54,7 @@ class CommonEncryption {
     /**
      * Returns just the data portion of a single PSSH
      *
-     * @param pssh {ArrayBuffer} the PSSH
+     * @param {ArrayBuffer} pssh - the PSSH
      * @return {ArrayBuffer} data portion of the PSSH
      */
     static getPSSHData(pssh) {
@@ -81,7 +81,7 @@ class CommonEncryption {
      * @param {KeySystem} keySystem the desired
      * key system
      * @param {ArrayBuffer} initData 'cenc' initialization data.  Concatenated list of PSSH.
-     * @returns {ArrayBuffer} The PSSH box data corresponding to the given key system
+     * @returns {ArrayBuffer|null} The PSSH box data corresponding to the given key system, null if not found
      * or null if a valid association could not be found.
      */
     static getPSSHForKeySystem(keySystem, initData) {
@@ -96,8 +96,8 @@ class CommonEncryption {
      * Parse a standard common encryption PSSH which contains a simple
      * base64-encoding of the init data
      *
-     * @param cpData the ContentProtection element
-     * @returns {ArrayBuffer} the init data or null if not found
+     * @param {Object} cpData the ContentProtection element
+     * @returns {ArrayBuffer|null} the init data or null if not found
      */
     static parseInitDataFromContentProtection(cpData) {
         if ('pssh' in cpData) {
@@ -109,9 +109,9 @@ class CommonEncryption {
     /**
      * Parses list of PSSH boxes into keysystem-specific PSSH data
      *
-     * @param data {ArrayBuffer} the concatenated list of PSSH boxes as provided by
+     * @param {ArrayBuffer} data - the concatenated list of PSSH boxes as provided by
      * CDM as initialization data when CommonEncryption content is detected
-     * @returns {object} an object that has a property named according to each of
+     * @returns {Object|Array} an object that has a property named according to each of
      * the detected key system UUIDs (e.g. 00000000-0000-0000-0000-0000000000)
      * and a ArrayBuffer (the entire PSSH box) as the property value
      */

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -109,6 +109,7 @@ function Protection() {
      * Create a ProtectionController and associated ProtectionModel for use with
      * a single piece of content.
      *
+     * @param {Object} config
      * @return {ProtectionController} protection controller
      *
      */

--- a/src/streaming/protection/ProtectionEvents.js
+++ b/src/streaming/protection/ProtectionEvents.js
@@ -30,7 +30,7 @@
  */
 import EventsBase from '../../core/events/EventsBase.js';
 /**
- * @Class
+ * @class
  *
  */
 class ProtectionEvents extends EventsBase {

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -36,7 +36,7 @@ import FactoryMaker from '../../../core/FactoryMaker.js';
 import Protection from '../Protection.js';
 
 /**
- * @Module ProtectionController
+ * @module ProtectionController
  * @description Provides access to media protection information and functionality.  Each
  * ProtectionController manages a single {@link MediaPlayer.models.ProtectionModel}
  * which encapsulates a set of protection information (EME APIs, selected key system,
@@ -46,6 +46,7 @@ import Protection from '../Protection.js';
  * @todo ProtectionController does almost all of its tasks automatically after init() is
  * called.  Applications might want more control over this process and want to go through
  * each step manually (key system selection, session creation, session maintenance).
+ * @param {Object} config
  */
 
 function ProtectionController(config) {
@@ -241,7 +242,7 @@ function ProtectionController(config) {
      * Sets the session type to use when creating key sessions.  Either "temporary" or
      * "persistent-license".  Default is "temporary".
      *
-     * @param {String} sessionType the session type
+     * @param {string} value the session type
      * @memberof module:ProtectionController
      * @instance
      */

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -83,7 +83,7 @@ function ProtectionKeyController() {
      * by this player (not necessarily those supported by the
      * user agent)
      *
-     * @returns {KeySystem[]} a prioritized
+     * @returns {Array.<KeySystem>} a prioritized
      * list of key systems
      * @memberof module:ProtectionKeyController
      * @instance
@@ -97,7 +97,7 @@ function ProtectionKeyController() {
      * name (i.e. 'org.w3.clearkey')
      *
      * @param {string} systemString the system string
-     * @returns {KeySystem} the key system
+     * @returns {KeySystem|null} the key system
      * or null if no supported key system is associated with the given key
      * system string
      * @memberof module:ProtectionKeyController
@@ -120,7 +120,7 @@ function ProtectionKeyController() {
      * must know if the system is ClearKey so that it can format the keys
      * according to the particular spec version.
      *
-     * @param keySystem the key
+     * @param {Object} keySystem the key
      * @returns {boolean} true if this is the ClearKey key system, false
      * otherwise
      * @memberof module:ProtectionKeyController
@@ -133,8 +133,8 @@ function ProtectionKeyController() {
     /**
      * Check equality of initData array buffers.
      *
-     * @param initData1 {ArrayBuffer} first initData
-     * @param initData2 {ArrayBuffer} second initData
+     * @param {ArrayBuffer} initData1 - first initData
+     * @param {ArrayBuffer} initData2 - second initData
      * @returns {boolean} true if the initData arrays are equal in size and
      * contents, false otherwise
      * @memberof module:ProtectionKeyController
@@ -161,15 +161,11 @@ function ProtectionKeyController() {
      * key systems that are supported by this player will be returned.
      * Key systems are returned in priority order (highest first).
      *
-     * @param {Object[]} cps array of content protection elements parsed
+     * @param {Array.<Object>} cps - array of content protection elements parsed
      * from the manifest
-     * @returns {Object[]} array of objects indicating which supported key
+     * @returns {Array.<Object>} array of objects indicating which supported key
      * systems were found.  Empty array is returned if no
      * supported key systems were found
-     * @returns {KeySystem} Object.ks the key
-     * system identified by the ContentProtection element
-     * @returns {ArrayBuffer} Object.initData the initialization data parsed
-     * from the ContentProtection element
      * @memberof module:ProtectionKeyController
      * @instance
      */
@@ -207,13 +203,9 @@ function ProtectionKeyController() {
      *
      * @param {ArrayBuffer} initData Concatenated PSSH data for all DRMs
      * supported by the content
-     * @returns {Object[]} array of objects indicating which supported key
+     * @returns {Array.<Object>} array of objects indicating which supported key
      * systems were found.  Empty array is returned if no
      * supported key systems were found
-     * @returns {KeySystem} Object.ks the key
-     * system
-     * @returns {ArrayBuffer} Object.initData the initialization data
-     * associated with the key system
      * @memberof module:ProtectionKeyController
      * @instance
      */
@@ -240,10 +232,10 @@ function ProtectionKeyController() {
      * associated with this license request
      * @param {ProtectionData} protData protection data to use for the
      * request
-     * @param {String} [messageType="license-request"] the message type associated with this
+     * @param {string} [messageType="license-request"] the message type associated with this
      * request.  Supported message types can be found
      * {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
-     * @return {LicenseServer} the license server
+     * @returns {LicenseServer|null} the license server
      * implementation that should be used for this request or null if the player should not
      * pass messages of the given type to a license server
      * @memberof module:ProtectionKeyController
@@ -278,7 +270,7 @@ function ProtectionKeyController() {
      * @param {ProtectionData} protData protection data to use for the
      * request
      * @param {ArrayBuffer} message the key message from the CDM
-     * @return {ClearKeyKeySet} the clear keys associated with
+     * @return {ClearKeyKeySet|null} the clear keys associated with
      * the request or null if no keys can be returned by this function
      * @memberof module:ProtectionKeyController
      * @instance

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -44,7 +44,7 @@ function KeySystemClearKey() {
     /**
      * Returns desired clearkeys (as specified in the CDM message) from protection data
      *
-     * @param {ProtectionData} protData the protection data
+     * @param {ProtectionData} protectionData the protection data
      * @param {ArrayBuffer} message the ClearKey CDM message
      * @returns {ClearKeyKeySet} the key set or null if none found
      * @throws {Error} if a keyID specified in the CDM message was not found in the

--- a/src/streaming/protection/models/ProtectionModel.js
+++ b/src/streaming/protection/models/ProtectionModel.js
@@ -55,7 +55,7 @@ let ProtectionModel = function () { };
  * @instance
  * @name getAllInitData
  * @memberof ProtectionModel
- * @returns {ArrayBuffer[]} an array of initialization data buffers
+ * @returns {Array.<ArrayBuffer>} an array of initialization data buffers
  */
 
 /**
@@ -68,7 +68,7 @@ let ProtectionModel = function () { };
  * @name requestKeySystemAccess
  * @memberof ProtectionModel
  *
- * @param {Object[]} ksConfigurations array of desired key system
+ * @param {Array.<Object>} ksConfigurations array of desired key system
  * configurations in priority order (highest priority first)
  * @param {MediaPlayer.dependencies.protection.KeySystem} ksConfigurations.ks
  * the key system

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -370,8 +370,8 @@ function ProtectionModel_01b(config) {
      * Helper function to retrieve the stored session token based on a given
      * sessionID value
      *
-     * @param sessionArray {Array} the array of sessions to search
-     * @param sessionID the sessionID to search for
+     * @param {Array} sessionArray - the array of sessions to search
+     * @param {*} sessionID - the sessionID to search for
      * @returns {*} the session token with the given sessionID
      */
     function findSessionByID(sessionArray, sessionID) {

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -246,7 +246,7 @@ function ProtectionModel_3Feb2014(config) {
      * Close the given session and release all associated keys.  Following
      * this call, the sessionToken becomes invalid
      *
-     * @param sessionToken the session token
+     * @param {Object} sessionToken - the session token
      */
     function closeKeySession(sessionToken) {
 

--- a/src/streaming/protection/servers/LicenseServer.js
+++ b/src/streaming/protection/servers/LicenseServer.js
@@ -55,7 +55,7 @@
  * @param {?string} url the initially established URL (from ProtectionData or initData)
  * @param {ArrayBuffer} message the CDM message which may be needed to generate the license
  * requests URL
- * @param {String} messageType the message type associated with this request.  Supported
+ * @param {string} messageType the message type associated with this request.  Supported
  * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the URL to use in license requests
  */
@@ -66,7 +66,7 @@
  *
  * @function
  * @name LicenseServer#getHTTPMethod
- * @param {String} messageType the message type associated with this request.  Supported
+ * @param {string} messageType the message type associated with this request.  Supported
  * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the HTTP method
  */
@@ -79,7 +79,7 @@
  * @param {string} keySystemStr the key system string representing the key system
  * associated with a license request.  Multi-DRM license servers may have different
  * response types depending on the key system.
- * @param {String} messageType the message type associated with this request.  Supported
+ * @param {string} messageType the message type associated with this request.  Supported
  * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} the response type
  */
@@ -93,7 +93,7 @@
  * @param {Object} serverResponse the response as returned in XMLHttpRequest.response
  * @param {string} keySystemStr the key system string representing the key system
  * associated with a license request.
- * @param {String} messageType the message type associated with this request.  Supported
+ * @param {string} messageType the message type associated with this request.  Supported
  * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {ArrayBuffer} message that will be sent to the CDM or null if no CDM message
  * was present in the response.
@@ -106,7 +106,7 @@
  * @function
  * @name LicenseServer#getErrorResponse
  * @param {Object} serverResponse the server response
- * @param {String} messageType the message type associated with this request.  Supported
+ * @param {string} messageType the message type associated with this request.  Supported
  * message types can be found {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @returns {string} an error message that indicates the reason for the failure
  */

--- a/src/streaming/protection/vo/KeyPair.js
+++ b/src/streaming/protection/vo/KeyPair.js
@@ -32,8 +32,8 @@
 /**
  * Represents a 128-bit keyID and 128-bit encryption key
  *
- * @param keyID {String} 128-bit key ID, base64 encoded, with no padding
- * @param key {String} 128-bit encryption key, base64 encoded, with no padding
+ * @param keyID {string} 128-bit key ID, base64 encoded, with no padding
+ * @param key {string} 128-bit encryption key, base64 encoded, with no padding
  * @class
  * @ignore
  */

--- a/src/streaming/protection/vo/KeySystemConfiguration.js
+++ b/src/streaming/protection/vo/KeySystemConfiguration.js
@@ -33,17 +33,17 @@
  * Represents a set of configurations that describe the capabilities desired for
  * support by a given CDM
  *
- * @param {MediaCapability[]} audioCapabilities array of
+ * @param {Array.<MediaCapability>} audioCapabilities array of
  * desired audio capabilities.  Higher preference capabilities should be placed earlier
  * in the array.
- * @param {MediaCapability[]} videoCapabilities array of
+ * @param {Array.<MediaCapability>} videoCapabilities array of
  * desired video capabilities.  Higher preference capabilities should be placed earlier
  * in the array.
- * @param {string} [distinctiveIdentifier="optional"] desired use of distinctive identifiers.
+ * @param {string} distinctiveIdentifier desired use of distinctive identifiers.
  * One of "required", "optional", or "not-allowed"
- * @param {string} [persistentState="optional"] desired support for persistent storage of
+ * @param {string} persistentState desired support for persistent storage of
  * key systems.  One of "required", "optional", or "not-allowed"
- * @param {string[]} [sessionTypes=["temporary"]] List of session types that must
+ * @param {Array.<string>} sessionTypes List of session types that must
  * be supported by the key system
  * @class
  */

--- a/src/streaming/protection/vo/LicenseRequestComplete.js
+++ b/src/streaming/protection/vo/LicenseRequestComplete.js
@@ -34,7 +34,7 @@
  *
  * @param {Uint8Array} message license response message
  * @param {SessionToken} sessionToken the session to
- * @param {String} [messageType="license-request"] the message type that is associated
+ * @param {string} [messageType="license-request"] the message type that is associated
  * with this object's response message.  Supported message types can be found
  * {@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|here}.
  * @constructor

--- a/src/streaming/protection/vo/NeedKey.js
+++ b/src/streaming/protection/vo/NeedKey.js
@@ -35,7 +35,7 @@
 class NeedKey {
     /**
      * @param {ArrayBuffer} initData the initialization data
-     * @param {String} [initDataType] initialization data type
+     * @param {string} [initDataType] initialization data type
      * @constructor
      */
     constructor(initData, initDataType) {

--- a/src/streaming/protection/vo/ProtectionData.js
+++ b/src/streaming/protection/vo/ProtectionData.js
@@ -33,7 +33,7 @@
  * Data provided for a particular piece of content to customize license server URLs,
  * license server HTTP request headers, clearkeys, or other content-specific data
  *
- * @param {string|object} serverURL a license server URL to use with this key system.
+ * @param {string|Object} serverURL a license server URL to use with this key system.
  * When specified as a string, a single URL will be used regardless of message type.
  * When specified as an object, the object will have property names for each message
  * type ({@link https://w3c.github.io/encrypted-media/#idl-def-MediaKeyMessageType|message
@@ -57,7 +57,7 @@ class ProtectionData {
  * License server URL
  *
  * @instance
- * @type string|object
+ * @type string|Object
  * @name ProtectionData.serverURL
  * @readonly
  * @memberof ProtectionData

--- a/src/streaming/protection/vo/SessionToken.js
+++ b/src/streaming/protection/vo/SessionToken.js
@@ -66,7 +66,7 @@ class SessionToken {}
  *
  * @function
  * @name SessionToken#getExpirationTime
- * @returns {Number} the expiration time or NaN if no expiration time exists
+ * @returns {number} the expiration time or NaN if no expiration time exists
  * for this session
  */
 
@@ -76,7 +76,7 @@ class SessionToken {}
  *
  * @function
  * @name SessionToken#getKeyStatuses
- * @returns {"maplike<BufferSource,MediaKeyStatus>"} the map of keys
+ * @returns {maplike<BufferSource,MediaKeyStatus>} the map of keys
  * in this session and their associated status
  */
 
@@ -86,7 +86,7 @@ class SessionToken {}
  *
  * @function
  * @name SessionToken#getSessionType
- * @returns {String} The session type
+ * @returns {string} The session type
  */
 
 export default SessionToken;

--- a/src/streaming/utils/BoxParser.js
+++ b/src/streaming/utils/BoxParser.js
@@ -40,7 +40,7 @@ function BoxParser(/*config*/) {
 
     /**
      * @param {ArrayBuffer} data
-     * @returns {@link IsoFile}
+     * @returns {IsoFile|null}
      * @memberof BoxParser#
      */
     function parse(data) {

--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -49,7 +49,7 @@ function IsoFile() {
 
     /**
     * @param {string} type
-    * @returns {@link IsoBox}
+    * @returns {IsoBox|null}
     * @memberof IsoFile#
     */
     function getBox(type) {
@@ -88,7 +88,7 @@ function IsoFile() {
     }
 
     /**
-    * @returns {@link IsoBox}
+    * @returns {IsoBox|null}
     * @memberof IsoFile#
     */
     function getLastBox() {
@@ -101,7 +101,7 @@ function IsoFile() {
     }
 
     /**
-    * @returns {Number}
+    * @returns {number}
     * @memberof IsoFile#
     */
     function getOffset() {

--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -32,7 +32,7 @@
 import FactoryMaker from '../../core/FactoryMaker.js';
 
 /**
- * @Module ObjectUtils
+ * @module ObjectUtils
  * @description Provides utility functions for objects
  */
 function ObjectUtils() {
@@ -43,6 +43,8 @@ function ObjectUtils() {
      * Returns true if objects resolve to the same string. Only really useful
      * when the user controls the object generation
      * @return {boolean}
+     * @param {object} obj1
+     * @param {object} obj2
      * @memberof module:ObjectUtils
      * @instance
      */

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -73,8 +73,11 @@ function TTMLParser() {
     /**
      * Parse the raw data and process it to return the HTML element representing the cue.
      * Return the region to be processed and controlled (hide/show) by the caption controller.
-     * @param data: raw data received from the TextSourceBuffer
-     **/
+     * @param {string} data - raw data received from the TextSourceBuffer
+     * @param {number} intervalStart
+     * @param {number} intervalEnd
+     *
+     */
 
     function parse(data, intervalStart, intervalEnd) {
         let tt, // Top element
@@ -1001,12 +1004,13 @@ function TTMLParser() {
         return cueInnerHTML;
     }
 
-    /*** Create the cue element
+    /*
+    * Create the cue element
      * I. The cues are text only:
      *      i) The cue contains a 'br' element
      *      ii) The cue contains a span element
      *      iii) The cue contains text
-     * ***/
+     */
 
     function constructCue(cueElements, cellUnit) {
         var cue = document.createElement('div');

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -32,7 +32,7 @@
 import FactoryMaker from '../../core/FactoryMaker.js';
 
 /**
- * @Module URLUtils
+ * @module URLUtils
  * @description Provides utility functions for operating on URLs.
  * Initially this is simply a method to determine the Base URL of a URL, but
  * should probably include other things provided all over the place such as
@@ -46,6 +46,7 @@ function URLUtils() {
 
     /**
      * Returns a string that contains the Base URL of a URL, if determinable.
+     * @param {string} url - full url
      * @return {string}
      * @memberof module:URLUtils
      * @instance

--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -145,9 +145,9 @@ function VTTParser() {
         return styleObject;
     }
 
-    /**
-        * VTT can have multiple lines to display per cuepoint.
-        * */
+    /*
+    * VTT can have multiple lines to display per cuepoint.
+    */
     function getSublines(data, idx) {
         var i = idx;
 

--- a/src/streaming/vo/metrics/PlayList.js
+++ b/src/streaming/vo/metrics/PlayList.js
@@ -70,7 +70,7 @@ PlayList.Trace = class {
     constructor() {
         /**
          * The value of the Representation@id of the Representation from which the samples were taken.
-         * @type {String}
+         * @type {string}
          * @public
          */
         this.representationid = null;
@@ -78,31 +78,31 @@ PlayList.Trace = class {
          * If not present, this metrics concerns the Representation as a whole.
          * If present, subreplevel indicates the greatest value of any
          * Subrepresentation@level being rendered.
-         * @type {Number}
+         * @type {number}
          * @public
          */
         this.subreplevel = null;
         /**
          * The time at which the first sample was rendered
-         * @type {Number}
+         * @type {number}
          * @public
          */
         this.start = null;
         /**
          * The presentation time of the first sample rendered.
-         * @type {Number}
+         * @type {number}
          * @public
          */
         this.mstart = null;
         /**
          * The duration of the continuously presented samples (which is the same in real time and media time). "Continuously presented" means that the media clock continued to advance at the playout speed throughout the interval. NOTE: the spec does not call out the units, but all other durations etc are in ms, and we use ms too.
-         * @type {Number}
+         * @type {number}
          * @public
          */
         this.duration = null;
         /**
          * The playback speed relative to normal playback speed (i.e.normal forward playback speed is 1.0).
-         * @type {Number}
+         * @type {number}
          * @public
          */
         this.playbackspeed = null;
@@ -116,7 +116,7 @@ PlayList.Trace = class {
          * end of content
          * end of a metrics collection period
          *
-         * @type {String}
+         * @type {string}
          * @public
          */
         this.stopreason = null;


### PR DESCRIPTION
This large PR has no functional changes, but makes the documentation more compliant with both the JSDoc3 standard, and the Google Closure standard.

Where it was missing I have tried to add type information etc.

I have also added JSDoc settings to the JSCS config so that any new documentation is automatically checked as it is added. I haven't put a great deal of though into the options, so am happy to change, add or remove options if anyone has any strong feelings.