### PR TITLE
Improve test coverage for BaseURL

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -789,7 +789,9 @@ function DashManifestModel() {
 
     function getBaseURLsFromElement(node) {
         let baseUrls = [];
-        let entries = node.BaseURL_asArray || [node.baseUri] || [];
+        // if node.BaseURL_asArray and node.baseUri are undefined entries
+        // will be [undefined] which entries.some will just skip
+        let entries = node.BaseURL_asArray || [node.baseUri];
         let earlyReturn = false;
 
         entries.some(entry => {

--- a/test/streaming.BlacklistController.js
+++ b/test/streaming.BlacklistController.js
@@ -83,6 +83,21 @@ describe('BlacklistController', function () {
         expect(contains).to.be.true; // jshint ignore:line
     });
 
+    it('should not trigger an update event if a duplicate entry is added', () => {
+        const spy = chai.spy();
+        const config = { updateEventName: EVENT_NAME };
+        const blacklistController = BlacklistController(context).create(config);
+
+        eventBus.on(EVENT_NAME, spy);
+
+        blacklistController.add(SERVICE_LOCATION);
+        blacklistController.add(SERVICE_LOCATION);
+
+        expect(spy).to.have.been.called.once; // jshint ignore:line
+
+        eventBus.off(EVENT_NAME, spy);
+    });
+
     it('should not contain an entry after reset', () => {
         const config = { updateEventName: '' };
         const blacklistController = BlacklistController(context).create(config);

--- a/test/streaming.DVBSelector.js
+++ b/test/streaming.DVBSelector.js
@@ -155,4 +155,27 @@ describe('BaseURLResolution/DVBSelector', function () {
         const fourthSelection = dvbSelector.select(baseUrls);
         expect(fourthSelection).to.be.undefined;                // jshint ignore:line
     });
+
+    it('should not select baseUrls with invalid priority when there is another option', () => {
+        const baseUrls = [
+            { serviceLocation: 'A', dvb_priority: 1,        dvb_weight: 1 },
+            { serviceLocation: 'B', dvb_priority: 'STRING', dvb_weight: 100000000 }
+        ];
+
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+        const firstSelection = dvbSelector.select(baseUrls);
+
+        expect(firstSelection.serviceLocation).to.equal('A');   // jshint ignore:line
+    });
+
+    it('should select baseUrls with invalid priority if there is no other option', () => {
+        const baseUrls = [
+            { serviceLocation: 'B', dvb_priority: 'STRING', dvb_weight: 1 }
+        ];
+
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+        const firstSelection = dvbSelector.select(baseUrls);
+
+        expect(firstSelection.serviceLocation).to.equal('B');   // jshint ignore:line
+    });
 });


### PR DESCRIPTION
This small change removes an unused section of code, with a corresponding comment to clarify what is happening. This also increases the test coverage for getBaseURLsFromElement to 100%.

The additional tests for BlacklistController and DVBSelector brings the test coverage for those modules to 100% (even though, in theory, the cases dealt with in DVBSelector should never be able to occur).