### PR TITLE
Only seek forward on PST check

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -435,7 +435,7 @@ function PlaybackController() {
         let bufferedStart = Math.max(ranges.start(0), streamInfo.start);
         let earliestTime = commonEarliestTime[streamInfo.id] === undefined ? bufferedStart : Math.max(commonEarliestTime[streamInfo.id], bufferedStart);
         if (earliestTime === commonEarliestTime[streamInfo.id]) return;
-        if (!isDynamic  && getStreamStartTime(true) < earliestTime) {
+        if (!isDynamic && getStreamStartTime(true) < earliestTime && getTime() < earliestTime) {
             seek(earliestTime);
         }
         commonEarliestTime[streamInfo.id] = earliestTime;


### PR DESCRIPTION
Fixes #1333, this prevents the check that enables a first period to start after 0 cause a seek back once buffer is pruned, whilst still allowing forward seeks.