### PR TITLE
Fixes #1340 - make TTMLParser more permissive of non-EBU-TT-D

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -411,8 +411,8 @@ function TTMLParser() {
         lineHeight = {};
         linePadding = {};
         defaultLayoutProperties = {
-            'top': '85%;',
-            'left': '5%;',
+            'top': 'auto;',
+            'left': 'auto;',
             'width': '90%;',
             'height': '10%;',
             'align-items': 'flex-start;',
@@ -631,7 +631,7 @@ function TTMLParser() {
 
 
     // Compute the style properties to return an array with the cleaned properties.
-    function processStyle(cueStyle, cellUnit) {
+    function processStyle(cueStyle, cellUnit, includeRegionStyles) {
         var properties = [];
 
         // Clean up from the xml2json parsing:
@@ -762,6 +762,10 @@ function TTMLParser() {
             properties.push('text-decoration:' + cueStyle['text-decoration'] + ';');
         }
 
+        if (includeRegionStyles) {
+            properties = properties.concat(processRegion(cueStyle, cellUnit));
+        }
+
         // Handle white-space preserve
         if (ttml.tt.hasOwnProperty('xml:space')) {
             if (ttml.tt['xml:space'] === 'preserve') {
@@ -786,7 +790,7 @@ function TTMLParser() {
         return null;
     }
     // Return the computed style from a certain ID.
-    function getProcessedStyle(reference, cellUnit) {
+    function getProcessedStyle(reference, cellUnit, includeRegionStyles) {
         var styles = [];
         var ids = reference.match(/\S+/g);
         ids.forEach(function (id) {
@@ -795,7 +799,7 @@ function TTMLParser() {
             if (cueStyle) {
                 // Process the style for the cue in CSS form.
                 // Send a copy of the style object, so it does not modify the original by cleaning it.
-                var stylesFromId = processStyle(JSON.parse(JSON.stringify(cueStyle)), cellUnit);
+                var stylesFromId = processStyle(JSON.parse(JSON.stringify(cueStyle)), cellUnit, includeRegionStyles);
                 styles = styles.concat(stylesFromId);
             }
         });
@@ -848,7 +852,7 @@ function TTMLParser() {
         }
         // Style will give to the region the style properties from the style selected
         if ('style' in cueRegion) {
-            var styleFromID = getProcessedStyle(cueRegion.style, cellUnit);
+            var styleFromID = getProcessedStyle(cueRegion.style, cellUnit, true);
             properties = properties.concat(styleFromID);
         }
 


### PR DESCRIPTION
Two problems were found in #1340:

* if no `tts:origin` was set, the default values for `top` and `left` would attempt to place the text near the bottom. Set them to `auto` as specified in TTML1. @TobbeEdgeware, @nigelmegitt - do you agree this is sensible (esp. given that all compliant EBU-TT-D will have origin set)?

* even if `tts:origin` (or any other region-specific styling) was specified, this was only honoured if found as an inline attribute of region, as required by EBU-TT-D. This constraint is not applicable for TTML, so made parsing of referenced styles on regions more lenient (ie allowed region-specific styling non-inline).