### PR TITLE
Import modules without the .js extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import MediaPlayer from './src/streaming/MediaPlayer.js';
-import Protection from './src/streaming/protection/Protection.js';
-import MetricsReporting from './src/streaming/metrics/MetricsReporting.js';
-import MediaPlayerFactory from './src/streaming/MediaPlayerFactory.js';
+import MediaPlayer from './src/streaming/MediaPlayer';
+import Protection from './src/streaming/protection/Protection';
+import MetricsReporting from './src/streaming/metrics/MetricsReporting';
+import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
 
 
 // Shove both of these into the global scope

--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from './EventBus.js';
-import Events from './events/Events.js';
-import FactoryMaker from './FactoryMaker.js';
+import EventBus from './EventBus';
+import Events from './events/Events';
+import FactoryMaker from './FactoryMaker';
 
 /**
  * @module Debug

--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from './FactoryMaker.js';
+import FactoryMaker from './FactoryMaker';
 
 function EventBus() {
 

--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventsBase from './EventsBase.js';
+import EventsBase from './EventsBase';
 
 /**
  * @class

--- a/src/core/events/Events.js
+++ b/src/core/events/Events.js
@@ -32,7 +32,7 @@
  * @class
  * @ignore
  */
-import CoreEvents from './CoreEvents.js';
+import CoreEvents from './CoreEvents';
 class Events extends CoreEvents {
 }
 let events = new Events();

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -29,13 +29,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import TrackInfo from '../streaming/vo/TrackInfo.js';
-import MediaInfo from '../streaming/vo/MediaInfo.js';
-import StreamInfo from '../streaming/vo/StreamInfo.js';
-import ManifestInfo from '../streaming/vo/ManifestInfo.js';
-import Event from './vo/Event.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import cea608parser from '../../externals/cea608-parser.js';
+import TrackInfo from '../streaming/vo/TrackInfo';
+import MediaInfo from '../streaming/vo/MediaInfo';
+import StreamInfo from '../streaming/vo/StreamInfo';
+import ManifestInfo from '../streaming/vo/ManifestInfo';
+import Event from './vo/Event';
+import FactoryMaker from '../core/FactoryMaker';
+import cea608parser from '../../externals/cea608-parser';
 
 const METRIC_LIST = {
     //TODO need to refactor all that reference to be able to export like all other const on factory object.

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -28,17 +28,17 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FragmentRequest from '../streaming/vo/FragmentRequest.js';
-import Error from '../streaming/vo/Error.js';
-import HTTPRequest from '../streaming/vo/metrics/HTTPRequest.js';
-import Events from '../core/events/Events.js';
-import EventBus from '../core/EventBus.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
-import URLUtils from '../streaming/utils/URLUtils.js';
+import FragmentRequest from '../streaming/vo/FragmentRequest';
+import Error from '../streaming/vo/Error';
+import HTTPRequest from '../streaming/vo/metrics/HTTPRequest';
+import Events from '../core/events/Events';
+import EventBus from '../core/EventBus';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
+import URLUtils from '../streaming/utils/URLUtils';
 
-import {replaceTokenForTemplate, getTimeBasedSegment, getSegmentByIndex} from './utils/SegmentsUtils.js';
-import SegmentsGetter from './utils/SegmentsGetter.js';
+import {replaceTokenForTemplate, getTimeBasedSegment, getSegmentByIndex} from './utils/SegmentsUtils';
+import SegmentsGetter from './utils/SegmentsGetter';
 
 const SEGMENTS_UNAVAILABLE_ERROR_CODE = 1;
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from '../streaming/vo/metrics/HTTPRequest.js';
-import AbrController from '../streaming/controllers/AbrController.js';
-import ManifestModel from '../streaming/models/ManifestModel.js';
-import DashManifestModel from './models/DashManifestModel.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import HTTPRequest from '../streaming/vo/metrics/HTTPRequest';
+import AbrController from '../streaming/controllers/AbrController';
+import ManifestModel from '../streaming/models/ManifestModel';
+import DashManifestModel from './models/DashManifestModel';
+import FactoryMaker from '../core/FactoryMaker';
 
 /**
  * @module DashMetrics

--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import ErrorHandler from '../streaming/utils/ErrorHandler.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
-import ObjectIron from '../../externals/objectiron.js';
-import X2JS from '../../externals/xml2json.js';
+import ErrorHandler from '../streaming/utils/ErrorHandler';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
+import ObjectIron from '../../externals/objectiron';
+import X2JS from '../../externals/xml2json';
 
 function DashParser(/*config*/) {
 

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -28,15 +28,15 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import RequestModifier from '../streaming/utils/RequestModifier.js';
-import Segment from './vo/Segment.js';
-import Error from '../streaming/vo/Error.js';
-import ErrorHandler from '../streaming/utils/ErrorHandler.js';
-import Events from '../core/events/Events.js';
-import EventBus from '../core/EventBus.js';
-import BoxParser from '../streaming/utils/BoxParser.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
+import RequestModifier from '../streaming/utils/RequestModifier';
+import Segment from './vo/Segment';
+import Error from '../streaming/vo/Error';
+import ErrorHandler from '../streaming/utils/ErrorHandler';
+import Events from '../core/events/Events';
+import EventBus from '../core/EventBus';
+import BoxParser from '../streaming/utils/BoxParser';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
 
 function SegmentBaseLoader() {
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -28,20 +28,20 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import DashManifestModel from '../models/DashManifestModel.js';
-import DashMetrics from '../DashMetrics.js';
-import TimelineConverter from '../utils/TimelineConverter.js';
-import AbrController from '../../streaming/controllers/AbrController.js';
-import PlaybackController from '../../streaming/controllers/PlaybackController.js';
-import StreamController from '../../streaming/controllers/StreamController.js';
-import ManifestModel from '../../streaming/models/ManifestModel.js';
-import MetricsModel from '../../streaming/models/MetricsModel.js';
-import MediaPlayerModel from '../../streaming/models/MediaPlayerModel.js';
-import DOMStorage from '../../streaming/utils/DOMStorage.js';
-import Error from '../../streaming/vo/Error.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import DashManifestModel from '../models/DashManifestModel';
+import DashMetrics from '../DashMetrics';
+import TimelineConverter from '../utils/TimelineConverter';
+import AbrController from '../../streaming/controllers/AbrController';
+import PlaybackController from '../../streaming/controllers/PlaybackController';
+import StreamController from '../../streaming/controllers/StreamController';
+import ManifestModel from '../../streaming/models/ManifestModel';
+import MetricsModel from '../../streaming/models/MetricsModel';
+import MediaPlayerModel from '../../streaming/models/MediaPlayerModel';
+import DOMStorage from '../../streaming/utils/DOMStorage';
+import Error from '../../streaming/vo/Error';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function RepresentationController() {
 

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -29,17 +29,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Representation from '../vo/Representation.js';
-import AdaptationSet from '../vo/AdaptationSet.js';
-import Period from '../vo/Period.js';
-import Mpd from '../vo/Mpd.js';
-import UTCTiming from '../vo/UTCTiming.js';
-import TimelineConverter from '../utils/TimelineConverter.js';
-import Event from '../vo/Event.js';
-import BaseURL from '../vo/BaseURL.js';
-import EventStream from '../vo/EventStream.js';
-import URLUtils from '../../streaming/utils/URLUtils.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import Representation from '../vo/Representation';
+import AdaptationSet from '../vo/AdaptationSet';
+import Period from '../vo/Period';
+import Mpd from '../vo/Mpd';
+import UTCTiming from '../vo/UTCTiming';
+import TimelineConverter from '../utils/TimelineConverter';
+import Event from '../vo/Event';
+import BaseURL from '../vo/BaseURL';
+import EventStream from '../vo/EventStream';
+import URLUtils from '../../streaming/utils/URLUtils';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function DashManifestModel() {
 

--- a/src/dash/utils/FragmentedTextBoxParser.js
+++ b/src/dash/utils/FragmentedTextBoxParser.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function FragmentedTextBoxParser() {
 

--- a/src/dash/utils/ListSegmentsGetter.js
+++ b/src/dash/utils/ListSegmentsGetter.js
@@ -29,9 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
-import {getIndexBasedSegment, decideSegmentListRangeForTemplate} from './SegmentsUtils.js';
+import {getIndexBasedSegment, decideSegmentListRangeForTemplate} from './SegmentsUtils';
 
 function ListSegmentsGetter(config, isDynamic) {
 

--- a/src/dash/utils/SegmentsGetter.js
+++ b/src/dash/utils/SegmentsGetter.js
@@ -29,10 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
-import TimelineSegmentsGetter from './TimelineSegmentsGetter.js';
-import TemplateSegmentsGetter from './TemplateSegmentsGetter.js';
-import ListSegmentsGetter from './ListSegmentsGetter.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import TimelineSegmentsGetter from './TimelineSegmentsGetter';
+import TemplateSegmentsGetter from './TemplateSegmentsGetter';
+import ListSegmentsGetter from './ListSegmentsGetter';
 
 function SegmentsGetter(config, isDynamic) {
 

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Segment from './../vo/Segment.js';
+import Segment from './../vo/Segment';
 
 function zeroPadToLength(numStr, minStrLength) {
     while (numStr.length < minStrLength) {

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -29,9 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
-import {replaceTokenForTemplate, getIndexBasedSegment, decideSegmentListRangeForTemplate} from './SegmentsUtils.js';
+import {replaceTokenForTemplate, getIndexBasedSegment, decideSegmentListRangeForTemplate} from './SegmentsUtils';
 
 function TemplateSegmentsGetter(config, isDynamic) {
 

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -28,10 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function TimelineConverter() {
 

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -29,9 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
-import {getTimeBasedSegment, decideSegmentListRangeForTimeline} from './SegmentsUtils.js';
+import {getTimeBasedSegment, decideSegmentListRangeForTimeline} from './SegmentsUtils';
 
 function TimelineSegmentsGetter(config, isDynamic) {
 

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -28,12 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import XHRLoader from './XHRLoader.js';
-import HeadRequest from './vo/HeadRequest.js';
-import Error from './vo/Error.js';
-import EventBus from './../core/EventBus.js';
-import Events from './../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import XHRLoader from './XHRLoader';
+import HeadRequest from './vo/HeadRequest';
+import Error from './vo/Error';
+import EventBus from './../core/EventBus';
+import Events from './../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
 
 const FRAGMENT_LOADER_ERROR_LOADING_FAILURE = 1;
 const FRAGMENT_LOADER_ERROR_NULL_REQUEST = 2;

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -28,15 +28,15 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import XlinkController from './controllers/XlinkController.js';
-import XHRLoader from './XHRLoader.js';
-import URLUtils from './utils/URLUtils.js';
-import TextRequest from './vo/TextRequest.js';
-import Error from './vo/Error.js';
-import HTTPRequest from './vo/metrics/HTTPRequest.js';
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import XlinkController from './controllers/XlinkController';
+import XHRLoader from './XHRLoader';
+import URLUtils from './utils/URLUtils';
+import TextRequest from './vo/TextRequest';
+import Error from './vo/Error';
+import HTTPRequest from './vo/metrics/HTTPRequest';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
 
 const MANIFEST_LOADER_ERROR_PARSING_FAILURE = 1;
 const MANIFEST_LOADER_ERROR_LOADING_FAILURE = 2;

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -28,10 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
 
 function ManifestUpdater() {
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -28,42 +28,42 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import UTCTiming from '../dash/vo/UTCTiming.js';
-import PlaybackController from './controllers/PlaybackController.js';
-import StreamController from './controllers/StreamController.js';
-import MediaController from './controllers/MediaController.js';
-import ManifestLoader from './ManifestLoader.js';
-import LiveEdgeFinder from './utils/LiveEdgeFinder.js';
-import ErrorHandler from './utils/ErrorHandler.js';
-import Capabilities from './utils/Capabilities.js';
-import TextTracks from './TextTracks.js';
-import SourceBufferController from './controllers/SourceBufferController.js';
-import VirtualBuffer from './VirtualBuffer.js';
-import RequestModifier from './utils/RequestModifier.js';
-import TextSourceBuffer from './TextSourceBuffer.js';
-import URIQueryAndFragmentModel from './models/URIQueryAndFragmentModel.js';
-import ManifestModel from './models/ManifestModel.js';
-import MediaPlayerModel from './models/MediaPlayerModel.js';
-import MetricsModel from './models/MetricsModel.js';
-import AbrController from './controllers/AbrController.js';
-import TimeSyncController from './controllers/TimeSyncController.js';
-import ABRRulesCollection from './rules/abr/ABRRulesCollection.js';
-import VideoModel from './models/VideoModel.js';
-import RulesController from './rules/RulesController.js';
-import SynchronizationRulesCollection from './rules/synchronization/SynchronizationRulesCollection.js';
-import MediaSourceController from './controllers/MediaSourceController.js';
-import BaseURLController from './controllers/BaseURLController.js';
-import Debug from './../core/Debug.js';
-import EventBus from './../core/EventBus.js';
-import Events from './../core/events/Events.js';
-import MediaPlayerEvents from './MediaPlayerEvents.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import UTCTiming from '../dash/vo/UTCTiming';
+import PlaybackController from './controllers/PlaybackController';
+import StreamController from './controllers/StreamController';
+import MediaController from './controllers/MediaController';
+import ManifestLoader from './ManifestLoader';
+import LiveEdgeFinder from './utils/LiveEdgeFinder';
+import ErrorHandler from './utils/ErrorHandler';
+import Capabilities from './utils/Capabilities';
+import TextTracks from './TextTracks';
+import SourceBufferController from './controllers/SourceBufferController';
+import VirtualBuffer from './VirtualBuffer';
+import RequestModifier from './utils/RequestModifier';
+import TextSourceBuffer from './TextSourceBuffer';
+import URIQueryAndFragmentModel from './models/URIQueryAndFragmentModel';
+import ManifestModel from './models/ManifestModel';
+import MediaPlayerModel from './models/MediaPlayerModel';
+import MetricsModel from './models/MetricsModel';
+import AbrController from './controllers/AbrController';
+import TimeSyncController from './controllers/TimeSyncController';
+import ABRRulesCollection from './rules/abr/ABRRulesCollection';
+import VideoModel from './models/VideoModel';
+import RulesController from './rules/RulesController';
+import SynchronizationRulesCollection from './rules/synchronization/SynchronizationRulesCollection';
+import MediaSourceController from './controllers/MediaSourceController';
+import BaseURLController from './controllers/BaseURLController';
+import Debug from './../core/Debug';
+import EventBus from './../core/EventBus';
+import Events from './../core/events/Events';
+import MediaPlayerEvents from './MediaPlayerEvents';
+import FactoryMaker from '../core/FactoryMaker';
 //Dash
-import DashAdapter from '../dash/DashAdapter.js';
-import DashParser from '../dash/DashParser.js';
-import DashManifestModel from '../dash/models/DashManifestModel.js';
-import DashMetrics from '../dash/DashMetrics.js';
-import TimelineConverter from '../dash/utils/TimelineConverter.js';
+import DashAdapter from '../dash/DashAdapter';
+import DashParser from '../dash/DashParser';
+import DashManifestModel from '../dash/models/DashManifestModel';
+import DashMetrics from '../dash/DashMetrics';
+import TimelineConverter from '../dash/utils/TimelineConverter';
 
 /**
  * @module MediaPlayer

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventsBase from '../core/events/EventsBase.js';
+import EventsBase from '../core/events/EventsBase';
 /**
  * @class
  *

--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -1,4 +1,4 @@
-import MediaPlayer from './MediaPlayer.js';
+import MediaPlayer from './MediaPlayer';
 
 function MediaPlayerFactory() {
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -28,23 +28,23 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import LiveEdgeFinder from './utils/LiveEdgeFinder.js';
-import StreamProcessor from './StreamProcessor.js';
-import MediaController from './controllers/MediaController.js';
-import EventController from './controllers/EventController.js';
-import FragmentController from './controllers/FragmentController.js';
-import AbrController from './controllers/AbrController.js';
-import VideoModel from './models/VideoModel.js';
-import MetricsModel from './models/MetricsModel.js';
-import PlaybackController from './controllers/PlaybackController.js';
-import DashHandler from '../dash/DashHandler.js';
-import SegmentBaseLoader from '../dash/SegmentBaseLoader.js';
-import DashMetrics from '../dash/DashMetrics.js';
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import Debug from '../core/Debug.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import TextSourceBuffer from './TextSourceBuffer.js';
+import LiveEdgeFinder from './utils/LiveEdgeFinder';
+import StreamProcessor from './StreamProcessor';
+import MediaController from './controllers/MediaController';
+import EventController from './controllers/EventController';
+import FragmentController from './controllers/FragmentController';
+import AbrController from './controllers/AbrController';
+import VideoModel from './models/VideoModel';
+import MetricsModel from './models/MetricsModel';
+import PlaybackController from './controllers/PlaybackController';
+import DashHandler from '../dash/DashHandler';
+import SegmentBaseLoader from '../dash/SegmentBaseLoader';
+import DashMetrics from '../dash/DashMetrics';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import Debug from '../core/Debug';
+import FactoryMaker from '../core/FactoryMaker';
+import TextSourceBuffer from './TextSourceBuffer';
 
 function Stream(config) {
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -29,26 +29,26 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import AbrController from './controllers/AbrController.js';
-import BufferController from './controllers/BufferController.js';
-import StreamController from './controllers/StreamController.js';
-import MediaController from './controllers/MediaController.js';
-import TextController from './controllers/TextController.js';
-import ScheduleController from './controllers/ScheduleController.js';
-import RulesController from './rules/RulesController.js';
-import MediaPlayerModel from './models/MediaPlayerModel.js';
-import MetricsModel from './models/MetricsModel.js';
-import FragmentLoader from './FragmentLoader.js';
-import RequestModifier from './utils/RequestModifier.js';
+import AbrController from './controllers/AbrController';
+import BufferController from './controllers/BufferController';
+import StreamController from './controllers/StreamController';
+import MediaController from './controllers/MediaController';
+import TextController from './controllers/TextController';
+import ScheduleController from './controllers/ScheduleController';
+import RulesController from './rules/RulesController';
+import MediaPlayerModel from './models/MediaPlayerModel';
+import MetricsModel from './models/MetricsModel';
+import FragmentLoader from './FragmentLoader';
+import RequestModifier from './utils/RequestModifier';
 import SourceBufferController from './controllers/SourceBufferController';
-import TextSourceBuffer from './TextSourceBuffer.js';
-import VirtualBuffer from './VirtualBuffer.js';
-import MediaSourceController from './controllers/MediaSourceController.js';
-import DashManifestModel from '../dash/models/DashManifestModel.js';
-import DashMetrics from '../dash/DashMetrics.js';
-import RepresentationController from '../dash/controllers/RepresentationController.js';
-import ErrorHandler from './utils/ErrorHandler.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import TextSourceBuffer from './TextSourceBuffer';
+import VirtualBuffer from './VirtualBuffer';
+import MediaSourceController from './controllers/MediaSourceController';
+import DashManifestModel from '../dash/models/DashManifestModel';
+import DashMetrics from '../dash/DashMetrics';
+import RepresentationController from '../dash/controllers/RepresentationController';
+import ErrorHandler from './utils/ErrorHandler';
+import FactoryMaker from '../core/FactoryMaker';
 
 function StreamProcessor(config) {
 

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -28,16 +28,16 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import TextTrackInfo from './vo/TextTrackInfo.js';
-import FragmentedTextBoxParser from '../dash/utils/FragmentedTextBoxParser.js';
-import BoxParser from './utils/BoxParser.js';
-import CustomTimeRanges from './utils/CustomTimeRanges.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
-import VideoModel from './models/VideoModel.js';
-import TextTracks from './TextTracks.js';
+import TextTrackInfo from './vo/TextTrackInfo';
+import FragmentedTextBoxParser from '../dash/utils/FragmentedTextBoxParser';
+import BoxParser from './utils/BoxParser';
+import CustomTimeRanges from './utils/CustomTimeRanges';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
+import VideoModel from './models/VideoModel';
+import TextTracks from './TextTracks';
 import ISOBoxer from 'codem-isoboxer';
-import cea608parser from '../../externals/cea608-parser.js';
+import cea608parser from '../../externals/cea608-parser';
 
 function TextSourceBuffer() {
 

--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -28,10 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import Debug from '../core/Debug.js';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
+import Debug from '../core/Debug';
 
 function TextTracks() {
 

--- a/src/streaming/VirtualBuffer.js
+++ b/src/streaming/VirtualBuffer.js
@@ -32,12 +32,12 @@
 /**
  * Represents data structure to keep and drive {DataChunk}
  */
-import MediaController from './controllers/MediaController.js';
-import CustomTimeRanges from './utils/CustomTimeRanges.js';
-import HTTPRequest from './vo/metrics/HTTPRequest.js';
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import MediaController from './controllers/MediaController';
+import CustomTimeRanges from './utils/CustomTimeRanges';
+import HTTPRequest from './vo/metrics/HTTPRequest';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
 
 function VirtualBuffer() {
 

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from './vo/metrics/HTTPRequest.js';
-import FactoryMaker from '../core/FactoryMaker.js';
-import MediaPlayerModel from './models/MediaPlayerModel.js';
+import HTTPRequest from './vo/metrics/HTTPRequest';
+import FactoryMaker from '../core/FactoryMaker';
+import MediaPlayerModel from './models/MediaPlayerModel';
 
 /**
  * @module XHRLoader

--- a/src/streaming/XlinkLoader.js
+++ b/src/streaming/XlinkLoader.js
@@ -28,13 +28,13 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import Error from './vo/Error.js';
-import XHRLoader from './XHRLoader.js';
-import HTTPRequest from './vo/metrics/HTTPRequest.js';
-import TextRequest from './vo/TextRequest.js';
-import EventBus from '../core/EventBus.js';
-import Events from '../core/events/Events.js';
-import FactoryMaker from '../core/FactoryMaker.js';
+import Error from './vo/Error';
+import XHRLoader from './XHRLoader';
+import HTTPRequest from './vo/metrics/HTTPRequest';
+import TextRequest from './vo/TextRequest';
+import EventBus from '../core/EventBus';
+import Events from '../core/events/Events';
+import FactoryMaker from '../core/FactoryMaker';
 
 const XLINK_LOADER_ERROR_LOADING_FAILURE = 1;
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -30,17 +30,17 @@
  */
 
 import SwitchRequest from '../rules/SwitchRequest';
-import BitrateInfo from '../vo/BitrateInfo.js';
-import DOMStorage from '../utils/DOMStorage.js';
-import ABRRulesCollection from '../rules/abr/ABRRulesCollection.js';
-import MediaPlayerModel from '../models/MediaPlayerModel.js';
-import FragmentModel from '../models/FragmentModel.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import ManifestModel from '../models/ManifestModel.js';
-import DashManifestModel from '../../dash/models/DashManifestModel.js';
-import VideoModel from '../models/VideoModel.js';
+import BitrateInfo from '../vo/BitrateInfo';
+import DOMStorage from '../utils/DOMStorage';
+import ABRRulesCollection from '../rules/abr/ABRRulesCollection';
+import MediaPlayerModel from '../models/MediaPlayerModel';
+import FragmentModel from '../models/FragmentModel';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import ManifestModel from '../models/ManifestModel';
+import DashManifestModel from '../../dash/models/DashManifestModel';
+import VideoModel from '../models/VideoModel';
 
 const ABANDON_LOAD = 'abandonload';
 const ALLOW_LOAD = 'allowload';

--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -29,13 +29,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import BaseURLTreeModel from '../models/BaseURLTreeModel.js';
-import BaseURLSelector from '../utils/BaseURLSelector.js';
-import URLUtils from '../utils/URLUtils.js';
-import BaseURL from '../../dash/vo/BaseURL.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
+import BaseURLTreeModel from '../models/BaseURLTreeModel';
+import BaseURLSelector from '../utils/BaseURLSelector';
+import URLUtils from '../utils/URLUtils';
+import BaseURL from '../../dash/vo/BaseURL';
+import FactoryMaker from '../../core/FactoryMaker';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
 
 function BaseURLController() {
 

--- a/src/streaming/controllers/BlacklistController.js
+++ b/src/streaming/controllers/BlacklistController.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
-import EventBus from '../../core/EventBus.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import EventBus from '../../core/EventBus';
 
 function BlackListController(config) {
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -29,19 +29,19 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FragmentModel from '../models/FragmentModel.js';
-import MediaPlayerModel from '../models/MediaPlayerModel.js';
-import HTTPRequest from '../vo/metrics/HTTPRequest.js';
-import SourceBufferController from './SourceBufferController.js';
-import AbrController from './AbrController.js';
-import PlaybackController from './PlaybackController.js';
-import MediaController from './MediaController.js';
-import CustomTimeRanges from '../utils/CustomTimeRanges.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import BoxParser from '../utils/BoxParser.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import FragmentModel from '../models/FragmentModel';
+import MediaPlayerModel from '../models/MediaPlayerModel';
+import HTTPRequest from '../vo/metrics/HTTPRequest';
+import SourceBufferController from './SourceBufferController';
+import AbrController from './AbrController';
+import PlaybackController from './PlaybackController';
+import MediaController from './MediaController';
+import CustomTimeRanges from '../utils/CustomTimeRanges';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import BoxParser from '../utils/BoxParser';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 const BUFFER_LOADED = 'bufferLoaded';
 const BUFFER_EMPTY = 'bufferStalled';

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -29,10 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import PlaybackController from '../controllers/PlaybackController.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
-import EventBus from '../../core/EventBus.js';
+import PlaybackController from '../controllers/PlaybackController';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
+import EventBus from '../../core/EventBus';
 
 function EventController() {
 

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -28,14 +28,14 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from '../vo/metrics/HTTPRequest.js';
-import DataChunk from '../vo/DataChunk.js';
-import FragmentModel from '../models/FragmentModel.js';
-import MetricsModel from '../models/MetricsModel.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import HTTPRequest from '../vo/metrics/HTTPRequest';
+import DataChunk from '../vo/DataChunk';
+import FragmentModel from '../models/FragmentModel';
+import MetricsModel from '../models/MetricsModel';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 function FragmentController(/*config*/) {
 

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -28,12 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import Events from '../../core/events/Events.js';
-import EventBus from '../../core/EventBus.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
-import TextSourceBuffer from '../TextSourceBuffer.js';
-import DOMStorage from '../utils/DOMStorage.js';
+import Events from '../../core/events/Events';
+import EventBus from '../../core/EventBus';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
+import TextSourceBuffer from '../TextSourceBuffer';
+import DOMStorage from '../utils/DOMStorage';
 
 const TRACK_SWITCH_MODE_NEVER_REPLACE = 'neverReplace';
 const TRACK_SWITCH_MODE_ALWAYS_REPLACE = 'alwaysReplace';

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function MediaSourceController() {
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -28,13 +28,13 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import BufferController from './BufferController.js';
-import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel.js';
-import MediaPlayerModel from '../../streaming/models/MediaPlayerModel.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import BufferController from './BufferController';
+import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel';
+import MediaPlayerModel from '../../streaming/models/MediaPlayerModel';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 function PlaybackController() {
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -29,23 +29,23 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import PlayList from '../vo/metrics/PlayList.js';
-import PlaybackController from './PlaybackController.js';
-import AbrController from './AbrController.js';
-import BufferController from './BufferController.js';
-import BufferLevelRule from '../rules/scheduling/BufferLevelRule.js';
-import NextFragmentRequestRule from '../rules/scheduling/NextFragmentRequestRule.js';
-import TextSourceBuffer from '../TextSourceBuffer.js';
-import MetricsModel from '../models/MetricsModel.js';
-import DashMetrics from '../../dash/DashMetrics.js';
-import DashAdapter from '../../dash/DashAdapter.js';
-import SourceBufferController from '../controllers/SourceBufferController.js';
-import VirtualBuffer from '../VirtualBuffer.js';
-import LiveEdgeFinder from '../utils/LiveEdgeFinder.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import PlayList from '../vo/metrics/PlayList';
+import PlaybackController from './PlaybackController';
+import AbrController from './AbrController';
+import BufferController from './BufferController';
+import BufferLevelRule from '../rules/scheduling/BufferLevelRule';
+import NextFragmentRequestRule from '../rules/scheduling/NextFragmentRequestRule';
+import TextSourceBuffer from '../TextSourceBuffer';
+import MetricsModel from '../models/MetricsModel';
+import DashMetrics from '../../dash/DashMetrics';
+import DashAdapter from '../../dash/DashAdapter';
+import SourceBufferController from '../controllers/SourceBufferController';
+import VirtualBuffer from '../VirtualBuffer';
+import LiveEdgeFinder from '../utils/LiveEdgeFinder';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 function ScheduleController(config) {
 

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -28,19 +28,19 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import TextSourceBuffer from '../TextSourceBuffer.js';
-import MediaController from './MediaController.js';
-import DashAdapter from '../../dash/DashAdapter.js';
-import ErrorHandler from '../utils/ErrorHandler.js';
-import StreamController from './StreamController.js';
-import TextTracks from '../TextTracks.js';
-import VTTParser from '../utils/VTTParser.js';
-import TTMLParser from '../utils/TTMLParser.js';
-import VideoModel from '../models/VideoModel.js';
-import Error from '../vo/Error.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import TextSourceBuffer from '../TextSourceBuffer';
+import MediaController from './MediaController';
+import DashAdapter from '../../dash/DashAdapter';
+import ErrorHandler from '../utils/ErrorHandler';
+import StreamController from './StreamController';
+import TextTracks from '../TextTracks';
+import VTTParser from '../utils/VTTParser';
+import TTMLParser from '../utils/TTMLParser';
+import VideoModel from '../models/VideoModel';
+import Error from '../vo/Error';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
 
 
 const QUOTA_EXCEEDED_ERROR_CODE = 22;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -28,17 +28,17 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import PlaybackController from './PlaybackController.js';
-import Stream from '../Stream.js';
-import ManifestUpdater from '../ManifestUpdater.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel.js';
-import VideoModel from '../models/VideoModel.js';
-import MediaPlayerModel from '../models/MediaPlayerModel.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import PlayList from '../vo/metrics/PlayList.js';
-import Debug from '../../core/Debug.js';
+import PlaybackController from './PlaybackController';
+import Stream from '../Stream';
+import ManifestUpdater from '../ManifestUpdater';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel';
+import VideoModel from '../models/VideoModel';
+import MediaPlayerModel from '../models/MediaPlayerModel';
+import FactoryMaker from '../../core/FactoryMaker';
+import PlayList from '../vo/metrics/PlayList';
+import Debug from '../../core/Debug';
 
 function StreamController() {
 

--- a/src/streaming/controllers/TextController.js
+++ b/src/streaming/controllers/TextController.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function TextController(config) {
 

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Error from './../vo/Error.js';
-import EventBus from './../../core/EventBus.js';
-import Events from './../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import Error from './../vo/Error';
+import EventBus from './../../core/EventBus';
+import Events from './../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 const TIME_SYNC_FAILED_ERROR_CODE = 1;
 const HTTP_TIMEOUT_MS = 5000;

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import XlinkLoader from '../XlinkLoader.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import X2JS from '../../../externals/xml2json.js';
+import XlinkLoader from '../XlinkLoader';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import X2JS from '../../../externals/xml2json';
 
 const RESOLVE_TYPE_ONLOAD = 'onLoad';
 const RESOLVE_TYPE_ONACTUATE = 'onActuate';

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -29,12 +29,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import DVBErrorsTranslator from './utils/DVBErrorsTranslator.js';
-import MetricsReportingEvents from './MetricsReportingEvents.js';
-import MetricsCollectionController from './controllers/MetricsCollectionController.js';
-import MetricsHandlerFactory from './metrics/MetricsHandlerFactory.js';
-import ReportingFactory from './reporting/ReportingFactory.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import DVBErrorsTranslator from './utils/DVBErrorsTranslator';
+import MetricsReportingEvents from './MetricsReportingEvents';
+import MetricsCollectionController from './controllers/MetricsCollectionController';
+import MetricsHandlerFactory from './metrics/MetricsHandlerFactory';
+import ReportingFactory from './reporting/ReportingFactory';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function MetricsReporting() {
 

--- a/src/streaming/metrics/MetricsReportingEvents.js
+++ b/src/streaming/metrics/MetricsReportingEvents.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventsBase from '../../core/events/EventsBase.js';
+import EventsBase from '../../core/events/EventsBase';
 
 class MetricsReportingEvents extends EventsBase {
     constructor () {

--- a/src/streaming/metrics/controllers/MetricsCollectionController.js
+++ b/src/streaming/metrics/controllers/MetricsCollectionController.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import MetricsController from './MetricsController.js';
-import ManifestParsing from '../utils/ManifestParsing.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import MetricsReportingEvents from '../MetricsReportingEvents.js';
-import Events from '../../../core/events/Events.js';
+import MetricsController from './MetricsController';
+import ManifestParsing from '../utils/ManifestParsing';
+import FactoryMaker from '../../../core/FactoryMaker';
+import MetricsReportingEvents from '../MetricsReportingEvents';
+import Events from '../../../core/events/Events';
 
 function MetricsCollectionController(config) {
 

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -29,10 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import RangeController from './RangeController.js';
-import ReportingController from './ReportingController.js';
-import MetricsHandlersController from './MetricsHandlersController.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import RangeController from './RangeController';
+import ReportingController from './ReportingController';
+import MetricsHandlersController from './MetricsHandlersController';
 
 function MetricsController(config) {
 

--- a/src/streaming/metrics/controllers/MetricsHandlersController.js
+++ b/src/streaming/metrics/controllers/MetricsHandlersController.js
@@ -29,9 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import MetricsHandlerFactory from '../metrics/MetricsHandlerFactory.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import MediaPlayerEvents from '../../MediaPlayerEvents.js';
+import MetricsHandlerFactory from '../metrics/MetricsHandlerFactory';
+import FactoryMaker from '../../../core/FactoryMaker';
+import MediaPlayerEvents from '../../MediaPlayerEvents';
 
 function MetricsHandlersController(config) {
     let handlers = [];

--- a/src/streaming/metrics/controllers/RangeController.js
+++ b/src/streaming/metrics/controllers/RangeController.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import CustomTimeRanges from '../../utils/CustomTimeRanges.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import CustomTimeRanges from '../../utils/CustomTimeRanges';
 
 function RangeController(config) {
 

--- a/src/streaming/metrics/controllers/ReportingController.js
+++ b/src/streaming/metrics/controllers/ReportingController.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import ReportingFactory from '../reporting/ReportingFactory.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import ReportingFactory from '../reporting/ReportingFactory';
 
 function ReportingController(config) {
 

--- a/src/streaming/metrics/metrics/MetricsHandlerFactory.js
+++ b/src/streaming/metrics/metrics/MetricsHandlerFactory.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import BufferLevel from './handlers/BufferLevelHandler.js';
-import DVBErrors from './handlers/DVBErrorsHandler.js';
-import HttpList from './handlers/HttpListHandler.js';
-import GenericMetricHandler from './handlers/GenericMetricHandler.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import BufferLevel from './handlers/BufferLevelHandler';
+import DVBErrors from './handlers/DVBErrorsHandler';
+import HttpList from './handlers/HttpListHandler';
+import GenericMetricHandler from './handlers/GenericMetricHandler';
 
 function MetricsHandlerFactory(config) {
 

--- a/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
+++ b/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../../core/FactoryMaker.js';
-import HandlerHelpers from '../../utils/HandlerHelpers.js';
+import FactoryMaker from '../../../../core/FactoryMaker';
+import HandlerHelpers from '../../utils/HandlerHelpers';
 
 function BufferLevelHandler() {
 

--- a/src/streaming/metrics/metrics/handlers/DVBErrorsHandler.js
+++ b/src/streaming/metrics/metrics/handlers/DVBErrorsHandler.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../../core/FactoryMaker.js';
-import MetricsReportingEvents from '../../MetricsReportingEvents.js';
+import FactoryMaker from '../../../../core/FactoryMaker';
+import MetricsReportingEvents from '../../MetricsReportingEvents';
 
 function DVBErrorsHandler(config) {
 

--- a/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
+++ b/src/streaming/metrics/metrics/handlers/GenericMetricHandler.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../../core/FactoryMaker';
 
 function GenericMetricHandler() {
 

--- a/src/streaming/metrics/metrics/handlers/HttpListHandler.js
+++ b/src/streaming/metrics/metrics/handlers/HttpListHandler.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../../core/FactoryMaker.js';
-import HandlerHelpers from '../../utils/HandlerHelpers.js';
+import FactoryMaker from '../../../../core/FactoryMaker';
+import HandlerHelpers from '../../utils/HandlerHelpers';
 
 function HttpListHandler() {
 

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import DVBReporting from './reporters/DVBReporting.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import DVBReporting from './reporters/DVBReporting';
 
 function ReportingFactory(config) {
 

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../../../core/FactoryMaker.js';
-import MetricSerialiser from '../../utils/MetricSerialiser.js';
-import RNG from '../../utils/RNG.js';
+import FactoryMaker from '../../../../core/FactoryMaker';
+import MetricSerialiser from '../../utils/MetricSerialiser';
+import RNG from '../../utils/RNG';
 
 function DVBReporting() {
     let instance;

--- a/src/streaming/metrics/utils/DVBErrorsTranslator.js
+++ b/src/streaming/metrics/utils/DVBErrorsTranslator.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import DVBErrors from '../vo/DVBErrors.js';
-import Events from '../../../core/events/Events.js';
-import MediaPlayerEvents from '../../MediaPlayerEvents.js';
-import MetricsReportingEvents from '../MetricsReportingEvents.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import DVBErrors from '../vo/DVBErrors';
+import Events from '../../../core/events/Events';
+import MediaPlayerEvents from '../../MediaPlayerEvents';
+import MetricsReportingEvents from '../MetricsReportingEvents';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function DVBErrorsTranslator(config) {
 

--- a/src/streaming/metrics/utils/HandlerHelpers.js
+++ b/src/streaming/metrics/utils/HandlerHelpers.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function HandlerHelpers() {
     return {

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -1,7 +1,7 @@
-import Metrics from '../vo/Metrics.js';
-import Range from '../vo/Range.js';
-import Reporting from '../vo/Reporting.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import Metrics from '../vo/Metrics';
+import Range from '../vo/Range';
+import Reporting from '../vo/Reporting';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function ManifestParsing (config) {
     let instance;

--- a/src/streaming/metrics/utils/MetricSerialiser.js
+++ b/src/streaming/metrics/utils/MetricSerialiser.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function MetricSerialiser() {
 

--- a/src/streaming/metrics/utils/RNG.js
+++ b/src/streaming/metrics/utils/RNG.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function RNG() {
 

--- a/src/streaming/models/BaseURLTreeModel.js
+++ b/src/streaming/models/BaseURLTreeModel.js
@@ -29,9 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import DashManifestModel from '../../dash/models/DashManifestModel.js';
-import ObjectUtils from '../utils/ObjectUtils.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import DashManifestModel from '../../dash/models/DashManifestModel';
+import ObjectUtils from '../utils/ObjectUtils';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const DEFAULT_INDEX = NaN;
 

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -30,11 +30,11 @@
  */
 
 
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import FragmentRequest from '../vo/FragmentRequest.js';
-import Debug from '../../core/Debug.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import FragmentRequest from '../vo/FragmentRequest';
+import Debug from '../../core/Debug';
 
 const FRAGMENT_MODEL_LOADING = 'loading';
 const FRAGMENT_MODEL_EXECUTED = 'executed';

--- a/src/streaming/models/ManifestModel.js
+++ b/src/streaming/models/ManifestModel.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function ManifestModel() {
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -28,8 +28,8 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
-import HTTPRequest from '../vo/metrics/HTTPRequest.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import HTTPRequest from '../vo/metrics/HTTPRequest';
 
 const DEFAULT_UTC_TIMING_SOURCE = { scheme: 'urn:mpeg:dash:utc:http-xsdate:2014', value: 'http://time.akamai.com/?iso' };
 const LIVE_DELAY_FRAGMENT_COUNT = 4;

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -28,21 +28,21 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import MetricsList from '../vo/MetricsList.js';
-import TCPConnection from '../vo/metrics/TCPConnection.js';
-import HTTPRequest from '../vo/metrics/HTTPRequest.js';
-import TrackSwitch from '../vo/metrics/RepresentationSwitch.js';
-import BufferLevel from '../vo/metrics/BufferLevel.js';
-import BufferState from '../vo/metrics/BufferState.js';
-import DVRInfo from '../vo/metrics/DVRInfo.js';
-import DroppedFrames from '../vo/metrics/DroppedFrames.js';
-import ManifestUpdate from '../vo/metrics/ManifestUpdate.js';
-import SchedulingInfo from '../vo/metrics/SchedulingInfo.js';
-import EventBus from '../../core/EventBus.js';
-import RequestsQueue from '../vo/metrics/RequestsQueue.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
-import BolaState from '../vo/metrics/BolaState.js';
+import MetricsList from '../vo/MetricsList';
+import TCPConnection from '../vo/metrics/TCPConnection';
+import HTTPRequest from '../vo/metrics/HTTPRequest';
+import TrackSwitch from '../vo/metrics/RepresentationSwitch';
+import BufferLevel from '../vo/metrics/BufferLevel';
+import BufferState from '../vo/metrics/BufferState';
+import DVRInfo from '../vo/metrics/DVRInfo';
+import DroppedFrames from '../vo/metrics/DroppedFrames';
+import ManifestUpdate from '../vo/metrics/ManifestUpdate';
+import SchedulingInfo from '../vo/metrics/SchedulingInfo';
+import EventBus from '../../core/EventBus';
+import RequestsQueue from '../vo/metrics/RequestsQueue';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
+import BolaState from '../vo/metrics/BolaState';
 
 function MetricsModel() {
 

--- a/src/streaming/models/URIQueryAndFragmentModel.js
+++ b/src/streaming/models/URIQueryAndFragmentModel.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import URIFragmentData from '../vo/URIFragmentData.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import URIFragmentData from '../vo/URIFragmentData';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function URIQueryAndFragmentModel() {
 

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function VideoModel() {
 

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import BASE64 from '../../../externals/base64.js';
+import BASE64 from '../../../externals/base64';
 
 class CommonEncryption {
     /**

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -28,13 +28,13 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import ProtectionController from './controllers/ProtectionController.js';
-import ProtectionKeyController from './controllers/ProtectionKeyController.js';
-import ProtectionEvents from './ProtectionEvents.js';
-import ProtectionModel_21Jan2015 from './models/ProtectionModel_21Jan2015.js';
-import ProtectionModel_3Feb2014 from './models/ProtectionModel_3Feb2014.js';
-import ProtectionModel_01b from './models/ProtectionModel_01b.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import ProtectionController from './controllers/ProtectionController';
+import ProtectionKeyController from './controllers/ProtectionKeyController';
+import ProtectionEvents from './ProtectionEvents';
+import ProtectionModel_21Jan2015 from './models/ProtectionModel_21Jan2015';
+import ProtectionModel_3Feb2014 from './models/ProtectionModel_3Feb2014';
+import ProtectionModel_01b from './models/ProtectionModel_01b';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const APIS_ProtectionModel_01b = [
     // Un-prefixed as per spec

--- a/src/streaming/protection/ProtectionEvents.js
+++ b/src/streaming/protection/ProtectionEvents.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventsBase from '../../core/events/EventsBase.js';
+import EventsBase from '../../core/events/EventsBase';
 /**
  * @class
  *

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -28,12 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import CommonEncryption from '../CommonEncryption.js';
-import Events from '../../../core/events/Events.js';
-import MediaCapability from '../vo/MediaCapability.js';
-import KeySystemConfiguration from '../vo/KeySystemConfiguration.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Protection from '../Protection.js';
+import CommonEncryption from '../CommonEncryption';
+import Events from '../../../core/events/Events';
+import MediaCapability from '../vo/MediaCapability';
+import KeySystemConfiguration from '../vo/KeySystemConfiguration';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Protection from '../Protection';
 
 /**
  * @module ProtectionController

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -28,15 +28,15 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import CommonEncryption from './../CommonEncryption.js';
-import KeySystemClearKey from './../drm/KeySystemClearKey.js';
-import KeySystemWidevine from './../drm/KeySystemWidevine.js';
-import KeySystemPlayReady from './../drm/KeySystemPlayReady.js';
-import DRMToday from './../servers/DRMToday.js';
-import PlayReady from './../servers/PlayReady.js';
-import Widevine from './../servers/Widevine.js';
-import ClearKey from './../servers/ClearKey.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import CommonEncryption from './../CommonEncryption';
+import KeySystemClearKey from './../drm/KeySystemClearKey';
+import KeySystemWidevine from './../drm/KeySystemWidevine';
+import KeySystemPlayReady from './../drm/KeySystemPlayReady';
+import DRMToday from './../servers/DRMToday';
+import PlayReady from './../servers/PlayReady';
+import Widevine from './../servers/Widevine';
+import ClearKey from './../servers/ClearKey';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 /**
  * @module ProtectionKeyController

--- a/src/streaming/protection/drm/KeySystemAdobeAccess.js
+++ b/src/streaming/protection/drm/KeySystemAdobeAccess.js
@@ -35,7 +35,7 @@
  * @class
  * @implements KeySystem
  */
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 //TODO implement
 function KeySystemAdobeAccess() {

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -29,10 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import KeyPair from '../vo/KeyPair.js';
-import ClearKeyKeySet from '../vo/ClearKeyKeySet.js';
-import CommonEncryption from '../CommonEncryption.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import KeyPair from '../vo/KeyPair';
+import ClearKeyKeySet from '../vo/ClearKeyKeySet';
+import CommonEncryption from '../CommonEncryption';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 const uuid = '1077efec-c0b2-4d02-ace3-3c1e52e2fb4b';
 const systemString = 'org.w3.clearkey';

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -35,11 +35,11 @@
  * @class
  * @implements KeySystem
  */
-import CommonEncryption from '../CommonEncryption.js';
-import Error from '../../vo/Error.js';
+import CommonEncryption from '../CommonEncryption';
+import Error from '../../vo/Error';
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import BASE64 from '../../../../externals/base64.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import BASE64 from '../../../../externals/base64';
 
 const uuid = '9a04f079-9840-4286-ab92-e65be0885f95';
 const systemString = 'com.microsoft.playready';

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -36,8 +36,8 @@
  * @implements MediaPlayer.dependencies.protection.KeySystem
  */
 
-import CommonEncryption from '../CommonEncryption.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import CommonEncryption from '../CommonEncryption';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 const uuid = 'edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
 const systemString = 'com.widevine.alpha';

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -37,15 +37,15 @@
  * @implements ProtectionModel
  * @class
  */
-import ProtectionKeyController from '../controllers/ProtectionKeyController.js';
-import NeedKey from '../vo/NeedKey.js';
-import KeyError from '../vo/KeyError.js';
-import KeyMessage from '../vo/KeyMessage.js';
-import KeySystemConfiguration from '../vo/KeySystemConfiguration.js';
-import KeySystemAccess from '../vo/KeySystemAccess.js';
-import Events from '../../../core/events/Events.js';
-import ErrorHandler from '../../utils/ErrorHandler.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import ProtectionKeyController from '../controllers/ProtectionKeyController';
+import NeedKey from '../vo/NeedKey';
+import KeyError from '../vo/KeyError';
+import KeyMessage from '../vo/KeyMessage';
+import KeySystemConfiguration from '../vo/KeySystemConfiguration';
+import KeySystemAccess from '../vo/KeySystemAccess';
+import Events from '../../../core/events/Events';
+import ErrorHandler from '../../utils/ErrorHandler';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function ProtectionModel_01b(config) {
 

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -37,13 +37,13 @@
  * @implements ProtectionModel
  * @class
  */
-import ProtectionKeyController from '../controllers/ProtectionKeyController.js';
-import NeedKey from '../vo/NeedKey.js';
-import KeyError from '../vo/KeyError.js';
-import KeyMessage from '../vo/KeyMessage.js';
-import KeySystemAccess from '../vo/KeySystemAccess.js';
-import Events from '../../../core/events/Events.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import ProtectionKeyController from '../controllers/ProtectionKeyController';
+import NeedKey from '../vo/NeedKey';
+import KeyError from '../vo/KeyError';
+import KeyMessage from '../vo/KeyMessage';
+import KeySystemAccess from '../vo/KeySystemAccess';
+import Events from '../../../core/events/Events';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function ProtectionModel_21Jan2015(config) {
 

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -38,14 +38,14 @@
  * @class
  */
 
-import ProtectionKeyController from '../controllers/ProtectionKeyController.js';
-import NeedKey from '../vo/NeedKey.js';
-import KeyError from '../vo/KeyError.js';
-import KeyMessage from '../vo/KeyMessage.js';
-import KeySystemConfiguration from '../vo/KeySystemConfiguration.js';
-import KeySystemAccess from '../vo/KeySystemAccess.js';
-import Events from '../../../core/events/Events.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import ProtectionKeyController from '../controllers/ProtectionKeyController';
+import NeedKey from '../vo/NeedKey';
+import KeyError from '../vo/KeyError';
+import KeyMessage from '../vo/KeyMessage';
+import KeySystemConfiguration from '../vo/KeySystemConfiguration';
+import KeySystemAccess from '../vo/KeySystemAccess';
+import Events from '../../../core/events/Events';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function ProtectionModel_3Feb2014(config) {
 

--- a/src/streaming/protection/servers/ClearKey.js
+++ b/src/streaming/protection/servers/ClearKey.js
@@ -38,9 +38,9 @@
  * @implements LicenseServer
  * @class
  */
-import KeyPair from '../vo/KeyPair.js';
-import ClearKeyKeySet from '../vo/ClearKeyKeySet.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import KeyPair from '../vo/KeyPair';
+import ClearKeyKeySet from '../vo/ClearKeyKeySet';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function ClearKey() {
 

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -35,8 +35,8 @@
  * @implements LicenseServer
  * @class
  */
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import BASE64 from '../../../../externals/base64.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import BASE64 from '../../../../externals/base64';
 
 function DRMToday() {
 

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -37,7 +37,7 @@
  * @implements LicenseServer
  * @class
  */
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function PlayReady() {
 

--- a/src/streaming/protection/servers/Widevine.js
+++ b/src/streaming/protection/servers/Widevine.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function Widevine() {
 

--- a/src/streaming/rules/RulesContext.js
+++ b/src/streaming/rules/RulesContext.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function RulesContext(config) {
 

--- a/src/streaming/rules/RulesController.js
+++ b/src/streaming/rules/RulesController.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import RulesContext from './RulesContext.js';
-import SwitchRequest from './SwitchRequest.js';
-import ABRRulesCollection from './abr/ABRRulesCollection.js';
-import SynchronizationRulesCollection from './synchronization/SynchronizationRulesCollection.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import RulesContext from './RulesContext';
+import SwitchRequest from './SwitchRequest';
+import ABRRulesCollection from './abr/ABRRulesCollection';
+import SynchronizationRulesCollection from './synchronization/SynchronizationRulesCollection';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const ABR_RULE = 0;
 const SYNC_RULE = 1;

--- a/src/streaming/rules/SwitchRequest.js
+++ b/src/streaming/rules/SwitchRequest.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const NO_CHANGE = 999;
 const DEFAULT = 0.5;

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -28,16 +28,16 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import ThroughputRule from './ThroughputRule.js';
-import BufferOccupancyRule from './BufferOccupancyRule.js';
-import InsufficientBufferRule from './InsufficientBufferRule.js';
-import AbandonRequestsRule from './AbandonRequestsRule.js';
-import BolaRule from './BolaRule.js';
-import BolaAbandonRule from './BolaAbandonRule.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import MetricsModel from '../../models/MetricsModel.js';
-import DashMetrics from '../../../dash/DashMetrics.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import ThroughputRule from './ThroughputRule';
+import BufferOccupancyRule from './BufferOccupancyRule';
+import InsufficientBufferRule from './InsufficientBufferRule';
+import AbandonRequestsRule from './AbandonRequestsRule';
+import BolaRule from './BolaRule';
+import BolaAbandonRule from './BolaAbandonRule';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import MetricsModel from '../../models/MetricsModel';
+import DashMetrics from '../../../dash/DashMetrics';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 const QUALITY_SWITCH_RULES = 'qualitySwitchRules';
 const ABANDON_FRAGMENT_RULES = 'abandonFragmentRules';

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -28,10 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Debug from '../../../core/Debug.js';
+import SwitchRequest from '../SwitchRequest';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Debug from '../../../core/Debug';
 
 const GRACE_TIME_THRESHOLD = 500;
 const ABANDON_MULTIPLIER = 1.5;

--- a/src/streaming/rules/abr/BolaAbandonRule.js
+++ b/src/streaming/rules/abr/BolaAbandonRule.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Debug from '../../../core/Debug.js';
-import BolaRule from './BolaRule.js';
+import SwitchRequest from '../SwitchRequest';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Debug from '../../../core/Debug';
+import BolaRule from './BolaRule';
 
 function BolaAbandonRule(config) {
 

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -31,15 +31,15 @@
 
 // For a description of the BOLA adaptive bitrate (ABR) algorithm, see http://arxiv.org/abs/1601.06748
 
-import SwitchRequest from '../SwitchRequest.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import PlaybackController from '../../controllers/PlaybackController.js';
-import HTTPRequest from '../../vo/metrics/HTTPRequest.js';
-import DashAdapter from '../../../dash/DashAdapter.js';
-import EventBus from '../../../core/EventBus.js';
-import Events from '../../../core/events/Events.js';
-import Debug from '../../../core/Debug.js';
+import SwitchRequest from '../SwitchRequest';
+import FactoryMaker from '../../../core/FactoryMaker';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import PlaybackController from '../../controllers/PlaybackController';
+import HTTPRequest from '../../vo/metrics/HTTPRequest';
+import DashAdapter from '../../../dash/DashAdapter';
+import EventBus from '../../../core/EventBus';
+import Events from '../../../core/events/Events';
+import Debug from '../../../core/Debug';
 
 // BOLA_STATE_ONE_BITRATE   : If there is only one bitrate (or initialization failed), always return NO_CHANGE.
 // BOLA_STATE_STARTUP       : Download fragments at most recently measured throughput.

--- a/src/streaming/rules/abr/BufferOccupancyRule.js
+++ b/src/streaming/rules/abr/BufferOccupancyRule.js
@@ -28,11 +28,11 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import AbrController from '../../controllers/AbrController.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Debug from '../../../core/Debug.js';
+import SwitchRequest from '../SwitchRequest';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import AbrController from '../../controllers/AbrController';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Debug from '../../../core/Debug';
 
 function BufferOccupancyRule(config) {
 

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -28,12 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import BufferController from '../../controllers/BufferController.js';
-import EventBus from '../../../core/EventBus.js';
-import Events from '../../../core/events/Events.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Debug from '../../../core/Debug.js';
+import SwitchRequest from '../SwitchRequest';
+import BufferController from '../../controllers/BufferController';
+import EventBus from '../../../core/EventBus';
+import Events from '../../../core/events/Events';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Debug from '../../../core/Debug';
 
 function InsufficientBufferRule(config) {
 

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -28,13 +28,13 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import BufferController from '../../controllers/BufferController.js';
-import AbrController from '../../controllers/AbrController.js';
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import HTTPRequest from '../../vo/metrics/HTTPRequest.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import Debug from '../../../core/Debug.js';
+import SwitchRequest from '../SwitchRequest';
+import BufferController from '../../controllers/BufferController';
+import AbrController from '../../controllers/AbrController';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import HTTPRequest from '../../vo/metrics/HTTPRequest';
+import FactoryMaker from '../../../core/FactoryMaker';
+import Debug from '../../../core/Debug';
 
 function ThroughputRule(config) {
 

--- a/src/streaming/rules/baseUrlResolution/BasicSelector.js
+++ b/src/streaming/rules/baseUrlResolution/BasicSelector.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function BasicSelector(config) {
 

--- a/src/streaming/rules/baseUrlResolution/DVBSelector.js
+++ b/src/streaming/rules/baseUrlResolution/DVBSelector.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function DVBSelector(config) {
 

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import MediaPlayerModel from '../../models/MediaPlayerModel.js';
-import PlaybackController from '../../controllers/PlaybackController.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import MediaPlayerModel from '../../models/MediaPlayerModel';
+import PlaybackController from '../../controllers/PlaybackController';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function BufferLevelRule(config) {
 

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -28,8 +28,8 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import Debug from '../../../core/Debug.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import Debug from '../../../core/Debug';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function NextFragmentRequestRule(config) {
 

--- a/src/streaming/rules/synchronization/LiveEdgeBinarySearchRule.js
+++ b/src/streaming/rules/synchronization/LiveEdgeBinarySearchRule.js
@@ -28,10 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SwitchRequest from '../SwitchRequest.js';
-import EventBus from '../../../core/EventBus.js';
-import Events from '../../../core/events/Events.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import SwitchRequest from '../SwitchRequest';
+import EventBus from '../../../core/EventBus';
+import Events from '../../../core/events/Events';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 const SEARCH_TIME_SPAN = 12 * 60 * 60; // set the time span that limits our search range to a 12 hours in seconds
 

--- a/src/streaming/rules/synchronization/LiveEdgeWithTimeSynchronizationRule.js
+++ b/src/streaming/rules/synchronization/LiveEdgeWithTimeSynchronizationRule.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import SwitchRequest from '../SwitchRequest.js';
-import FactoryMaker from '../../../core/FactoryMaker.js';
+import SwitchRequest from '../SwitchRequest';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 function LiveEdgeWithTimeSynchronizationRule(config) {
 

--- a/src/streaming/rules/synchronization/SynchronizationRulesCollection.js
+++ b/src/streaming/rules/synchronization/SynchronizationRulesCollection.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../../core/FactoryMaker.js';
-import TimelineConverter from '../../../dash/utils/TimelineConverter.js';
-import LiveEdgeBinarySearchRule from './LiveEdgeBinarySearchRule.js';
-import LiveEdgeWithTimeSynchronizationRule from './LiveEdgeWithTimeSynchronizationRule.js';
-import DashAdapter from '../../../dash/DashAdapter.js';
+import FactoryMaker from '../../../core/FactoryMaker';
+import TimelineConverter from '../../../dash/utils/TimelineConverter';
+import LiveEdgeBinarySearchRule from './LiveEdgeBinarySearchRule';
+import LiveEdgeWithTimeSynchronizationRule from './LiveEdgeWithTimeSynchronizationRule';
+import DashAdapter from '../../../dash/DashAdapter';
 
 
 const TIME_SYNCHRONIZED_RULES = 'withAccurateTimeSourceRules';

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -29,13 +29,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import DashManifestModel from '../../dash/models/DashManifestModel.js';
-import BlacklistController from '../controllers/BlacklistController.js';
-import DVBSelector from '../rules/baseUrlResolution/DVBSelector.js';
-import BasicSelector from '../rules/baseUrlResolution/BasicSelector.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import DashManifestModel from '../../dash/models/DashManifestModel';
+import BlacklistController from '../controllers/BlacklistController';
+import DVBSelector from '../rules/baseUrlResolution/DVBSelector';
+import BasicSelector from '../rules/baseUrlResolution/BasicSelector';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = 1;
 const URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE = 'Failed to resolve a valid URL';

--- a/src/streaming/utils/BoxParser.js
+++ b/src/streaming/utils/BoxParser.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import IsoFile from './IsoFile.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import IsoFile from './IsoFile';
+import FactoryMaker from '../../core/FactoryMaker';
 import ISOBoxer from 'codem-isoboxer';
 
 function BoxParser(/*config*/) {

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function Capabilities() {
 

--- a/src/streaming/utils/CustomTimeRanges.js
+++ b/src/streaming/utils/CustomTimeRanges.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * The copyright in this software is being made available under the BSD License,
 * included below. This software may be subject to other third party and contributor
 * rights, including patent rights, and no such rights are granted under this license.
@@ -28,7 +28,7 @@
 *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 */
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function CustomTimeRanges(/*config*/) {
     let customTimeRangeArray = [];

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
-import MediaPlayerModel from '../models/MediaPlayerModel.js';
-import Debug from '../../core/Debug.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import MediaPlayerModel from '../models/MediaPlayerModel';
+import Debug from '../../core/Debug';
 
 const legacyKeysAndReplacements = [
     { oldKey: 'dashjs_vbitrate',  newKey: 'dashjs_video_bitrate' },

--- a/src/streaming/utils/ErrorHandler.js
+++ b/src/streaming/utils/ErrorHandler.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const CAPABILITY_ERROR_MEDIASOURCE      = 'mediasource';
 const CAPABILITY_ERROR_MEDIAKEYS        = 'mediakeys';

--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -29,8 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import IsoBox from '../vo/IsoBox.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import IsoBox from '../vo/IsoBox';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function IsoFile() {
 

--- a/src/streaming/utils/LiveEdgeFinder.js
+++ b/src/streaming/utils/LiveEdgeFinder.js
@@ -28,12 +28,12 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import SynchronizationRulesCollection from '../rules/synchronization/SynchronizationRulesCollection.js';
-import Error from '../vo/Error.js';
-import EventBus from '../../core/EventBus.js';
-import Events from '../../core/events/Events.js';
-import RulesController from '../rules/RulesController.js';
-import FactoryMaker from '../../core/FactoryMaker.js';
+import SynchronizationRulesCollection from '../rules/synchronization/SynchronizationRulesCollection';
+import Error from '../vo/Error';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import RulesController from '../rules/RulesController';
+import FactoryMaker from '../../core/FactoryMaker';
 
 const LIVE_EDGE_NOT_FOUND_ERROR_CODE = 1;
 

--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 /**
  * @module ObjectUtils

--- a/src/streaming/utils/RequestModifier.js
+++ b/src/streaming/utils/RequestModifier.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 function RequestModifier() {
 

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -28,9 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
-import X2JS from '../../../externals/xml2json.js';
-import Debug from '../../core/Debug.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import X2JS from '../../../externals/xml2json';
+import Debug from '../../core/Debug';
 
 const SECONDS_IN_HOUR = 60 * 60; // Expression of an hour in seconds
 const SECONDS_IN_MIN = 60; // Expression of a minute in seconds

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import FactoryMaker from '../../core/FactoryMaker.js';
+import FactoryMaker from '../../core/FactoryMaker';
 
 /**
  * @module URLUtils

--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -28,8 +28,8 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import FactoryMaker from '../../core/FactoryMaker.js';
-import Debug from '../../core/Debug.js';
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
 
 function VTTParser() {
     let context = this.context;

--- a/src/streaming/vo/HeadRequest.js
+++ b/src/streaming/vo/HeadRequest.js
@@ -32,7 +32,7 @@
  * @class
  * @ignore
  */
-import FragmentRequest from './FragmentRequest.js';
+import FragmentRequest from './FragmentRequest';
 
 class HeadRequest extends FragmentRequest {
     constructor(url) {

--- a/src/streaming/vo/TextRequest.js
+++ b/src/streaming/vo/TextRequest.js
@@ -32,7 +32,7 @@
  * @class
  * @ignore
  */
-import FragmentRequest from './FragmentRequest.js';
+import FragmentRequest from './FragmentRequest';
 
 class TextRequest extends FragmentRequest {
     constructor(url, type) {

--- a/src/streaming/vo/metrics/BufferState.js
+++ b/src/streaming/vo/metrics/BufferState.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import BufferController from '../../controllers/BufferController.js';
+import BufferController from '../../controllers/BufferController';
 /**
  * @class
  */

--- a/test/dash.DashHandlerSpec.js
+++ b/test/dash.DashHandlerSpec.js
@@ -1,6 +1,6 @@
-import ObjectsHelper from './helpers/ObjectsHelper.js';
-import VoHelper from './helpers/VOHelper.js';
-import DashHandler from '../src/dash/DashHandler.js';
+import ObjectsHelper from './helpers/ObjectsHelper';
+import VoHelper from './helpers/VOHelper';
+import DashHandler from '../src/dash/DashHandler';
 
 const expect = require('chai').expect;
 

--- a/test/dash.DashManifestModel.js
+++ b/test/dash.DashManifestModel.js
@@ -1,5 +1,5 @@
-import DashManifestModel from '../src/dash/models/DashManifestModel.js';
-import BaseURL from '../src/dash/vo/BaseURL.js';
+import DashManifestModel from '../src/dash/models/DashManifestModel';
+import BaseURL from '../src/dash/vo/BaseURL';
 
 const expect = require('chai').expect;
 

--- a/test/dash.RepresentationControllerSpec.js
+++ b/test/dash.RepresentationControllerSpec.js
@@ -1,12 +1,12 @@
-import ObjectsHelper from './helpers/ObjectsHelper.js';
-import VoHelper from './helpers/VOHelper.js';
-import MpdHelper from './helpers/MPDHelper.js';
-import EventBus from '../src/core/EventBus.js';
-import RepresentationController from '../src/dash/controllers/RepresentationController.js';
-import ManifestModel from '../src/streaming/models/ManifestModel.js';
-import Events from '../src/core/events/Events.js';
-import SpecHelper from './helpers/SpecHelper.js';
-import AbrController from '../src/streaming/controllers/AbrController.js';
+import ObjectsHelper from './helpers/ObjectsHelper';
+import VoHelper from './helpers/VOHelper';
+import MpdHelper from './helpers/MPDHelper';
+import EventBus from '../src/core/EventBus';
+import RepresentationController from '../src/dash/controllers/RepresentationController';
+import ManifestModel from '../src/streaming/models/ManifestModel';
+import Events from '../src/core/events/Events';
+import SpecHelper from './helpers/SpecHelper';
+import AbrController from '../src/streaming/controllers/AbrController';
 
 const chai = require('chai'),
       spies = require('chai-spies');

--- a/test/dash.TimeLineConverterSpec.js
+++ b/test/dash.TimeLineConverterSpec.js
@@ -1,9 +1,9 @@
-import LiveEdgeFinder from '../src/streaming/utils/LiveEdgeFinder.js';
-import EventBus from '../src/core/EventBus.js';
-import VoHelper from './helpers/VOHelper.js';
-import TimeLineConverter from '../src/dash/utils/TimelineConverter.js';
-import Events from '../src/core/events/Events.js';
-import SpecHelper from './helpers/SpecHelper.js';
+import LiveEdgeFinder from '../src/streaming/utils/LiveEdgeFinder';
+import EventBus from '../src/core/EventBus';
+import VoHelper from './helpers/VOHelper';
+import TimeLineConverter from '../src/dash/utils/TimelineConverter';
+import Events from '../src/core/events/Events';
+import SpecHelper from './helpers/SpecHelper';
 
 const expect = require('chai').expect;
 const sinon = require('sinon');

--- a/test/helpers/VOHelper.js
+++ b/test/helpers/VOHelper.js
@@ -1,10 +1,10 @@
-import StreamInfo from '../../src/streaming/vo/StreamInfo.js';
-import MediaInfo from '../../src/streaming/vo/MediaInfo.js';
-import MpdHelper from './MPDHelper.js';
-import SpecHelper from './SpecHelper.js';
-import Representation from '../../src/dash/vo/Representation.js';
-import FragmentRequest from '../../src/streaming/vo/FragmentRequest.js';
-import HTTPRequest from '../../src/streaming/vo/metrics/HTTPRequest.js';
+import StreamInfo from '../../src/streaming/vo/StreamInfo';
+import MediaInfo from '../../src/streaming/vo/MediaInfo';
+import MpdHelper from './MPDHelper';
+import SpecHelper from './SpecHelper';
+import Representation from '../../src/dash/vo/Representation';
+import FragmentRequest from '../../src/streaming/vo/FragmentRequest';
+import HTTPRequest from '../../src/streaming/vo/metrics/HTTPRequest';
 
 class VoHelper {
     constructor() {

--- a/test/streaming.AbrControllerSpec.js
+++ b/test/streaming.AbrControllerSpec.js
@@ -1,6 +1,6 @@
-import SpecHelper from './helpers/SpecHelper.js';
-import VoHelper from './helpers/VOHelper.js';
-import AbrController from '../src/streaming/controllers/AbrController.js';
+import SpecHelper from './helpers/SpecHelper';
+import VoHelper from './helpers/VOHelper';
+import AbrController from '../src/streaming/controllers/AbrController';
 
 const expect = require('chai').expect;
 

--- a/test/streaming.BasicSelector.js
+++ b/test/streaming.BasicSelector.js
@@ -1,5 +1,5 @@
-import ObjectsHelper from './helpers/ObjectsHelper.js';
-import BasicSelector from '../src/streaming/rules/baseUrlResolution/BasicSelector.js';
+import ObjectsHelper from './helpers/ObjectsHelper';
+import BasicSelector from '../src/streaming/rules/baseUrlResolution/BasicSelector';
 
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/streaming.BlacklistController.js
+++ b/test/streaming.BlacklistController.js
@@ -1,5 +1,5 @@
-import BlacklistController from '../src/streaming/controllers/BlacklistController.js';
-import EventBus from '../src/core/EventBus.js';
+import BlacklistController from '../src/streaming/controllers/BlacklistController';
+import EventBus from '../src/core/EventBus';
 
 const chai = require('chai');
 const spies = require('chai-spies');

--- a/test/streaming.DVBSelector.js
+++ b/test/streaming.DVBSelector.js
@@ -1,5 +1,5 @@
-import ObjectsHelper from './helpers/ObjectsHelper.js';
-import DVBSelector from '../src/streaming/rules/baseUrlResolution/DVBSelector.js';
+import ObjectsHelper from './helpers/ObjectsHelper';
+import DVBSelector from '../src/streaming/rules/baseUrlResolution/DVBSelector';
 
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/streaming.FragmentControllerSpec.js
+++ b/test/streaming.FragmentControllerSpec.js
@@ -1,7 +1,7 @@
-import VoHelper from './helpers/VOHelper.js';
-import Events from '../src/core/events/Events.js';
-import MediaPlayerEvents from '../src/streaming/MediaPlayerEvents.js';
-import FragmentController from '../src/streaming/controllers/FragmentController.js';
+import VoHelper from './helpers/VOHelper';
+import Events from '../src/core/events/Events';
+import MediaPlayerEvents from '../src/streaming/MediaPlayerEvents';
+import FragmentController from '../src/streaming/controllers/FragmentController';
 
 const expect = require('chai').expect;
 

--- a/test/streaming.FragmentModelSpec.js
+++ b/test/streaming.FragmentModelSpec.js
@@ -1,8 +1,8 @@
-import SpecHelper from './helpers/SpecHelper.js';
-import VoHelper from './helpers/VOHelper.js';
-import EventBus from '../src/core/EventBus.js';
-import Events from '../src/core/events/Events.js';
-import FragmentModel from '../src/streaming/models/FragmentModel.js';
+import SpecHelper from './helpers/SpecHelper';
+import VoHelper from './helpers/VOHelper';
+import EventBus from '../src/core/EventBus';
+import Events from '../src/core/events/Events';
+import FragmentModel from '../src/streaming/models/FragmentModel';
 
 const chai = require('chai');
 const spies = require('chai-spies');


### PR DESCRIPTION
Looking at other projects, and in-line with other module systems, it seems to be best practice to omit the .js extension when importing modules.

In our case, since relative path names end up in the minified output, this has the additional benefit of saving approx 3.5k in the minified output for no effort.

Closure Compiler refuses to import ES6 modules unless the extension is omitted (https://github.com/google/closure-compiler/wiki/JS-Modules), so this would be a prerequisite if we wished to try that.