### PR TITLE
Refactor metrics VOs which contained multiple definitions so all are exported individually

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -30,7 +30,7 @@
  */
 import FragmentRequest from '../streaming/vo/FragmentRequest';
 import Error from '../streaming/vo/Error';
-import HTTPRequest from '../streaming/vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import Events from '../core/events/Events';
 import EventBus from '../core/EventBus';
 import FactoryMaker from '../core/FactoryMaker';

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from '../streaming/vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import AbrController from '../streaming/controllers/AbrController';
 import ManifestModel from '../streaming/models/ManifestModel';
 import DashManifestModel from './models/DashManifestModel';

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -33,7 +33,7 @@ import XHRLoader from './XHRLoader';
 import URLUtils from './utils/URLUtils';
 import TextRequest from './vo/TextRequest';
 import Error from './vo/Error';
-import HTTPRequest from './vo/metrics/HTTPRequest';
+import {HTTPRequest} from './vo/metrics/HTTPRequest';
 import EventBus from '../core/EventBus';
 import Events from '../core/events/Events';
 import FactoryMaker from '../core/FactoryMaker';

--- a/src/streaming/VirtualBuffer.js
+++ b/src/streaming/VirtualBuffer.js
@@ -34,7 +34,7 @@
  */
 import MediaController from './controllers/MediaController';
 import CustomTimeRanges from './utils/CustomTimeRanges';
-import HTTPRequest from './vo/metrics/HTTPRequest';
+import {HTTPRequest} from './vo/metrics/HTTPRequest';
 import EventBus from '../core/EventBus';
 import Events from '../core/events/Events';
 import FactoryMaker from '../core/FactoryMaker';

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from './vo/metrics/HTTPRequest';
+import {HTTPRequest} from './vo/metrics/HTTPRequest';
 import FactoryMaker from '../core/FactoryMaker';
 import MediaPlayerModel from './models/MediaPlayerModel';
 

--- a/src/streaming/XlinkLoader.js
+++ b/src/streaming/XlinkLoader.js
@@ -30,7 +30,7 @@
  */
 import Error from './vo/Error';
 import XHRLoader from './XHRLoader';
-import HTTPRequest from './vo/metrics/HTTPRequest';
+import {HTTPRequest} from './vo/metrics/HTTPRequest';
 import TextRequest from './vo/TextRequest';
 import EventBus from '../core/EventBus';
 import Events from '../core/events/Events';

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -31,7 +31,7 @@
 
 import FragmentModel from '../models/FragmentModel';
 import MediaPlayerModel from '../models/MediaPlayerModel';
-import HTTPRequest from '../vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 import SourceBufferController from './SourceBufferController';
 import AbrController from './AbrController';
 import PlaybackController from './PlaybackController';

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -28,7 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import HTTPRequest from '../vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 import DataChunk from '../vo/DataChunk';
 import FragmentModel from '../models/FragmentModel';
 import MetricsModel from '../models/MetricsModel';

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import PlayList from '../vo/metrics/PlayList';
+import {PlayListTrace} from '../vo/metrics/PlayList';
 import PlaybackController from './PlaybackController';
 import AbrController from './AbrController';
 import BufferController from './BufferController';
@@ -259,7 +259,7 @@ function ScheduleController(config) {
             throw 'Unexpected error! - currentRepresentationInfo is null or undefined';
         }
 
-        clearPlayListTraceMetrics(new Date(), PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON);
+        clearPlayListTraceMetrics(new Date(), PlayListTrace.REPRESENTATION_SWITCH_STOP_REASON);
         addPlaylistTraceMetrics();
     }
 
@@ -328,7 +328,7 @@ function ScheduleController(config) {
     function onBufferLevelStateChanged(e) {
         if ((e.sender.getStreamProcessor() === streamProcessor) && e.state === BufferController.BUFFER_EMPTY && !playbackController.isSeeking()) {
             log('Stalling Buffer');
-            clearPlayListTraceMetrics(new Date(), PlayList.Trace.REBUFFERING_REASON);
+            clearPlayListTraceMetrics(new Date(), PlayListTrace.REBUFFERING_REASON);
         }
     }
 
@@ -346,7 +346,7 @@ function ScheduleController(config) {
         if (playListMetrics && playListTraceMetricsClosed === true && currentRepresentationInfo) {
             playListTraceMetricsClosed = false;
 
-            playListTraceMetrics = new PlayList.Trace();
+            playListTraceMetrics = new PlayListTrace();
             playListTraceMetrics.representationid = currentRepresentationInfo.id;
             playListTraceMetrics.start = new Date();
             playListTraceMetrics.mstart = playbackController.getTime() * 1000;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -37,7 +37,7 @@ import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel';
 import VideoModel from '../models/VideoModel';
 import MediaPlayerModel from '../models/MediaPlayerModel';
 import FactoryMaker from '../../core/FactoryMaker';
-import PlayList from '../vo/metrics/PlayList';
+import {PlayList, PlayListTrace} from '../vo/metrics/PlayList';
 import Debug from '../../core/Debug';
 
 function StreamController() {
@@ -260,17 +260,17 @@ function StreamController() {
             switchStream(activeStream, nextStream, NaN);
         }
 
-        flushPlaylistMetrics(nextStream ? PlayList.Trace.END_OF_PERIOD_STOP_REASON : PlayList.Trace.END_OF_CONTENT_STOP_REASON);
+        flushPlaylistMetrics(nextStream ? PlayListTrace.END_OF_PERIOD_STOP_REASON : PlayListTrace.END_OF_CONTENT_STOP_REASON);
     }
 
     function onPlaybackSeeking(e) {
         var seekingStream = getStreamForTime(e.seekTime);
 
         if (seekingStream && seekingStream !== activeStream) {
-            flushPlaylistMetrics(PlayList.Trace.END_OF_PERIOD_STOP_REASON);
+            flushPlaylistMetrics(PlayListTrace.END_OF_PERIOD_STOP_REASON);
             switchStream(activeStream, seekingStream, e.seekTime);
         } else {
-            flushPlaylistMetrics(PlayList.Trace.USER_REQUEST_STOP_REASON);
+            flushPlaylistMetrics(PlayListTrace.USER_REQUEST_STOP_REASON);
         }
 
         addPlaylistMetrics(PlayList.SEEK_START_REASON);
@@ -291,7 +291,7 @@ function StreamController() {
     function onPlaybackPaused(e) {
         if (!e.ended) {
             isPaused = true;
-            flushPlaylistMetrics(PlayList.Trace.USER_REQUEST_STOP_REASON);
+            flushPlaylistMetrics(PlayListTrace.USER_REQUEST_STOP_REASON);
         }
     }
 
@@ -709,8 +709,8 @@ function StreamController() {
 
         flushPlaylistMetrics(
             hasMediaError || hasInitialisationError ?
-                PlayList.Trace.FAILURE_STOP_REASON :
-                PlayList.Trace.USER_REQUEST_STOP_REASON
+                PlayListTrace.FAILURE_STOP_REASON :
+                PlayListTrace.USER_REQUEST_STOP_REASON
         );
 
         for (let i = 0, ln = streams.length; i < ln; i++) {

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../../core/FactoryMaker';
-import HTTPRequest from '../vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 
 const DEFAULT_UTC_TIMING_SOURCE = { scheme: 'urn:mpeg:dash:utc:http-xsdate:2014', value: 'http://time.akamai.com/?iso' };
 const LIVE_DELAY_FRAGMENT_COUNT = 4;

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -30,13 +30,13 @@
  */
 import MetricsList from '../vo/MetricsList';
 import TCPConnection from '../vo/metrics/TCPConnection';
-import HTTPRequest from '../vo/metrics/HTTPRequest';
+import {HTTPRequest, HTTPRequestTrace} from '../vo/metrics/HTTPRequest';
 import TrackSwitch from '../vo/metrics/RepresentationSwitch';
 import BufferLevel from '../vo/metrics/BufferLevel';
 import BufferState from '../vo/metrics/BufferState';
 import DVRInfo from '../vo/metrics/DVRInfo';
 import DroppedFrames from '../vo/metrics/DroppedFrames';
-import ManifestUpdate from '../vo/metrics/ManifestUpdate';
+import {ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateTrackInfo} from '../vo/metrics/ManifestUpdate';
 import SchedulingInfo from '../vo/metrics/SchedulingInfo';
 import EventBus from '../../core/EventBus';
 import RequestsQueue from '../vo/metrics/RequestsQueue';
@@ -131,7 +131,7 @@ function MetricsModel() {
     }
 
     function appendHttpTrace(httpRequest, s, d, b) {
-        var vo = new HTTPRequest.Trace();
+        var vo = new HTTPRequestTrace();
 
         vo.s = s;
         vo.d = d;
@@ -344,7 +344,7 @@ function MetricsModel() {
 
     function addManifestUpdateStreamInfo(manifestUpdate, id, index, start, duration) {
         if (manifestUpdate) {
-            var vo = new ManifestUpdate.StreamInfo();
+            var vo = new ManifestUpdateStreamInfo();
 
             vo.id = id;
             vo.index = index;
@@ -361,7 +361,7 @@ function MetricsModel() {
 
     function addManifestUpdateRepresentationInfo(manifestUpdate, id, index, streamIndex, mediaType, presentationTimeOffset, startNumber, fragmentInfoType) {
         if (manifestUpdate) {
-            var vo = new ManifestUpdate.TrackInfo();
+            var vo = new ManifestUpdateTrackInfo();
 
             vo.id = id;
             vo.index = index;

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -35,7 +35,7 @@ import SwitchRequest from '../SwitchRequest';
 import FactoryMaker from '../../../core/FactoryMaker';
 import MediaPlayerModel from '../../models/MediaPlayerModel';
 import PlaybackController from '../../controllers/PlaybackController';
-import HTTPRequest from '../../vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import DashAdapter from '../../../dash/DashAdapter';
 import EventBus from '../../../core/EventBus';
 import Events from '../../../core/events/Events';

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -32,7 +32,7 @@ import SwitchRequest from '../SwitchRequest';
 import BufferController from '../../controllers/BufferController';
 import AbrController from '../../controllers/AbrController';
 import MediaPlayerModel from '../../models/MediaPlayerModel';
-import HTTPRequest from '../../vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -29,13 +29,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * @class
+ * @classdesc This Object holds reference to the HTTPRequest for manifest, fragment and xlink loading.
+ * Members which are not defined in ISO23009-1 Annex D should be prefixed by a _ so that they are ignored
+ * by Metrics Reporting code.
  */
 class HTTPRequest {
     /**
-     * @description This Object holds reference to the HTTPRequest for manifest, fragment and xlink loading.
-     * Members which are not defined in ISO23009-1 Annex D should be prefixed by a _ so that they are ignored
-     * by Metrics Reporting code.
+     * @class
      */
     constructor() {
         /**
@@ -125,10 +125,13 @@ class HTTPRequest {
     }
 }
 
-HTTPRequest.Trace = class {
+/**
+ * @classdesc This Object holds reference to the progress of the HTTPRequest.
+ */
+class HTTPRequestTrace {
     /**
-     * @description This Object holds reference to the progress of the HTTPRequest.
-     */
+    * @class
+    */
     constructor() {
         /**
          * Real-Time | Measurement stream start.
@@ -146,7 +149,7 @@ HTTPRequest.Trace = class {
          */
         this.b = [];
     }
-};
+}
 
 HTTPRequest.MPD_TYPE = 'MPD';
 HTTPRequest.XLINK_EXPANSION_TYPE = 'XLinkExpansion';
@@ -156,4 +159,4 @@ HTTPRequest.MEDIA_SEGMENT_TYPE = 'MediaSegment';
 HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'BitstreamSwitchingSegment';
 HTTPRequest.OTHER_TYPE = 'other';
 
-export default HTTPRequest;
+export { HTTPRequest, HTTPRequestTrace };

--- a/src/streaming/vo/metrics/ManifestUpdate.js
+++ b/src/streaming/vo/metrics/ManifestUpdate.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * @class
+ * @classdesc This Object holds reference to the manifest update information.
  */
 class ManifestUpdate {
     /**
-     * @description This Object holds reference to the manifest update information.
+     * @class
      */
     constructor() {
 
@@ -101,9 +101,12 @@ class ManifestUpdate {
     }
 }
 
-ManifestUpdate.StreamInfo = class {
+/**
+ * @classdesc This Object holds reference to the current period's stream information when the manifest was updated.
+ */
+class ManifestUpdateStreamInfo {
     /**
-     * @description This Object holds reference to the current period's stream information when the manifest was updated.
+     * @class
      */
     constructor() {
         /**
@@ -127,12 +130,14 @@ ManifestUpdate.StreamInfo = class {
          */
         this.duration = null;
     }
-};
+}
 
-ManifestUpdate.TrackInfo = class {
-
+/**
+ * @classdesc This Object holds reference to the current representation's info when the manifest was updated.
+ */
+class ManifestUpdateTrackInfo {
     /**
-     * @description This Object holds reference to the current representation's info when the manifest was updated.
+     * @class
      */
     constructor() {
         /**
@@ -171,6 +176,6 @@ ManifestUpdate.TrackInfo = class {
          */
         this.fragmentInfoType = null;
     }
-};
-//TODO we need exports for all the sub objects.  These should all be class VO
-export default ManifestUpdate;
+}
+
+export { ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateTrackInfo };

--- a/src/streaming/vo/metrics/PlayList.js
+++ b/src/streaming/vo/metrics/PlayList.js
@@ -29,11 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * @class
+ * @classdesc a PlayList from ISO23009-1 Annex D, this Object holds reference to the playback session information
  */
 class PlayList {
     /**
-     * @description This Object holds reference to the playback session information
+     * @class
      */
     constructor() {
 
@@ -62,11 +62,22 @@ class PlayList {
          * @public
          */
         this.trace = [];
-
     }
 }
 
-PlayList.Trace = class {
+/* Public Static Constants */
+PlayList.INITIAL_PLAYOUT_START_REASON = 'initial_playout';
+PlayList.SEEK_START_REASON = 'seek';
+PlayList.RESUME_FROM_PAUSE_START_REASON = 'resume';
+PlayList.METRICS_COLLECTION_START_REASON = 'metrics_collection_start';
+
+/**
+ * @classdesc a PlayList.Trace from ISO23009-1 Annex D
+ */
+class PlayListTrace {
+    /**
+     * @class
+     */
     constructor() {
         /**
          * The value of the Representation@id of the Representation from which the samples were taken.
@@ -121,21 +132,14 @@ PlayList.Trace = class {
          */
         this.stopreason = null;
     }
-};
+}
 
+PlayListTrace.REPRESENTATION_SWITCH_STOP_REASON = 'representation_switch';
+PlayListTrace.REBUFFERING_REASON = 'rebuffering';
+PlayListTrace.USER_REQUEST_STOP_REASON = 'user_request';
+PlayListTrace.END_OF_PERIOD_STOP_REASON = 'end_of_period';
+PlayListTrace.END_OF_CONTENT_STOP_REASON = 'end_of_content';
+PlayListTrace.METRICS_COLLECTION_STOP_REASON = 'metrics_collection_end';
+PlayListTrace.FAILURE_STOP_REASON = 'failure';
 
-/* Public Static Constants */
-PlayList.INITIAL_PLAYOUT_START_REASON = 'initial_playout';
-PlayList.SEEK_START_REASON = 'seek';
-PlayList.RESUME_FROM_PAUSE_START_REASON = 'resume';
-PlayList.METRICS_COLLECTION_START_REASON = 'metrics_collection_start';
-
-PlayList.Trace.REPRESENTATION_SWITCH_STOP_REASON = 'representation_switch';
-PlayList.Trace.REBUFFERING_REASON = 'rebuffering';
-PlayList.Trace.USER_REQUEST_STOP_REASON = 'user_request';
-PlayList.Trace.END_OF_PERIOD_STOP_REASON = 'end_of_period';
-PlayList.Trace.END_OF_CONTENT_STOP_REASON = 'end_of_content';
-PlayList.Trace.METRICS_COLLECTION_STOP_REASON = 'metrics_collection_end';
-PlayList.Trace.FAILURE_STOP_REASON = 'failure';
-
-export default PlayList;
+export { PlayList, PlayListTrace };

--- a/test/helpers/VOHelper.js
+++ b/test/helpers/VOHelper.js
@@ -4,7 +4,7 @@ import MpdHelper from './MPDHelper';
 import SpecHelper from './SpecHelper';
 import Representation from '../../src/dash/vo/Representation';
 import FragmentRequest from '../../src/streaming/vo/FragmentRequest';
-import HTTPRequest from '../../src/streaming/vo/metrics/HTTPRequest';
+import {HTTPRequest} from '../../src/streaming/vo/metrics/HTTPRequest';
 
 class VoHelper {
     constructor() {


### PR DESCRIPTION
Based on the comment: `//TODO we need exports for all the sub objects.  These should all be class VO`, these classes are now exported individually.