### PR TITLE
Fixes #1372 - catch pending play request exceptions

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -114,7 +114,12 @@ function PlaybackController() {
     function play() {
         if (element) {
             element.autoplay = true;
-            element.play();
+            const p = element.play();
+            if (p && (typeof Promise !== 'undefined') && (p instanceof Promise)) {
+                p.catch((e) => {
+                    log(`Caught pending play exception - continuing (${e})`);
+                });
+            }
         } else {
             playOnceInitialized = true;
         }


### PR DESCRIPTION
I have tested this in Chrome (where it seems to fix the issue) and Firefox (where it is, correctly, ignored because `play` does not return a `Promise`).

It would be good if someone can test this in Edge, IE11 and Safari.

This is probably a sticking plaster - we should possibly consider refactoring all the play/pause/load operations so this exception is not thrown.

(Note: The commit message is strictly incorrect as the catch is not silent - a log message is printed)