### PR TITLE
Throw new Errors rather than strings

### DIFF
--- a/src/dash/DashParser.js
+++ b/src/dash/DashParser.js
@@ -322,7 +322,7 @@ function DashParser(/*config*/) {
             manifest = converter.xml_str2json(data);
 
             if (!manifest) {
-                throw 'parser error';
+                throw new Error('parser error');
             }
 
             json = new Date();

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -669,7 +669,7 @@ function DashManifestModel() {
                 if (eventStreams[i].hasOwnProperty('schemeIdUri')) {
                     eventStream.schemeIdUri = eventStreams[i].schemeIdUri;
                 } else {
-                    throw 'Invalid EventStream. SchemeIdUri has to be set';
+                    throw new Error('Invalid EventStream. SchemeIdUri has to be set');
                 }
                 if (eventStreams[i].hasOwnProperty('timescale')) {
                     eventStream.timescale = eventStreams[i].timescale;
@@ -712,7 +712,7 @@ function DashManifestModel() {
             if (inbandStreams[i].hasOwnProperty('schemeIdUri')) {
                 eventStream.schemeIdUri = inbandStreams[i].schemeIdUri;
             } else {
-                throw 'Invalid EventStream. SchemeIdUri has to be set';
+                throw new Error('Invalid EventStream. SchemeIdUri has to be set');
             }
             if (inbandStreams[i].hasOwnProperty('timescale')) {
                 eventStream.timescale = inbandStreams[i].timescale;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -275,7 +275,7 @@ function AbrController() {
         var quality = getQualityFor(type, streamInfo);
         var isInt = newPlaybackQuality !== null && !isNaN(newPlaybackQuality) && (newPlaybackQuality % 1 === 0);
 
-        if (!isInt) throw 'argument is not an integer';
+        if (!isInt) throw new Error('argument is not an integer');
 
         if (newPlaybackQuality !== quality && newPlaybackQuality >= 0 && newPlaybackQuality <= getTopQualityIndexFor(type, id)) {
             setInternalQuality(type, id, newPlaybackQuality);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -256,7 +256,7 @@ function ScheduleController(config) {
 
         currentRepresentationInfo = streamProcessor.getRepresentationInfoForQuality(e.newQuality);
         if (currentRepresentationInfo === null || currentRepresentationInfo === undefined) {
-            throw 'Unexpected error! - currentRepresentationInfo is null or undefined';
+            throw new Error('Unexpected error! - currentRepresentationInfo is null or undefined');
         }
 
         clearPlayListTraceMetrics(new Date(), PlayListTrace.REPRESENTATION_SWITCH_STOP_REASON);

--- a/src/streaming/metrics/utils/HandlerHelpers.js
+++ b/src/streaming/metrics/utils/HandlerHelpers.js
@@ -51,17 +51,17 @@ function HandlerHelpers() {
 
         validateN: function (n_ms) {
             if (!n_ms) {
-                throw 'missing n';
+                throw new Error('missing n');
             }
 
             if (isNaN(n_ms)) {
-                throw 'n is NaN';
+                throw new Error('n is NaN');
             }
 
             // n is a positive integer is defined to refer to the metric
             // in which the buffer level is recorded every n ms.
             if (n_ms < 0) {
-                throw 'n must be positive';
+                throw new Error('n must be positive');
             }
 
             return n_ms;

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -93,7 +93,7 @@ function TTMLParser() {
         ttml = converter.xml_str2json(data);
 
         if (!ttml) {
-            throw 'TTML document could not be parsed';
+            throw new Error('TTML document could not be parsed');
         }
 
         if (videoModel.getTTMLRenderingDiv()) {
@@ -111,11 +111,11 @@ function TTMLParser() {
         // Check the document and compare to the specification (TTML and EBU-TT-D).
         tt = ttml.tt;
         if (!tt) {
-            throw 'TTML document lacks tt element';
+            throw new Error('TTML document lacks tt element');
         }
         head = tt.head;
         if (!head) {
-            throw 'TTML document lacks head element';
+            throw new Error('TTML document lacks head element');
         }
         if (head.layout) {
             ttmlLayout = head.layout.region_asArray; //Mandatory in EBU-TT-D
@@ -125,7 +125,7 @@ function TTMLParser() {
         }
         body = tt.body;
         if (!body) {
-            throw 'TTML document lacks body element';
+            throw new Error('TTML document lacks body element');
         }
 
         // Extract the cellResolution information
@@ -191,7 +191,7 @@ function TTMLParser() {
                         spanEndTime = parseTimings(cue.span.end);
                     } else {
                         errorMsg = 'TTML document has incorrect timing value';
-                        throw errorMsg;
+                        throw new Error(errorMsg);
                     }
                     let cueStartTime = spanStartTime || pStartTime;
                     let cueEndTime = spanEndTime || pEndTime;
@@ -245,7 +245,7 @@ function TTMLParser() {
                         // TODO: check with the specification what is allowed.
                         if ((isNaN(pStartTime) || isNaN(pEndTime)) && (isNaN(spanStartTime) || isNaN(spanEndTime))) {
                             errorMsg = 'TTML document has incorrect timing value';
-                            throw errorMsg;
+                            throw new Error(errorMsg);
                         }
 
                         /**
@@ -401,7 +401,7 @@ function TTMLParser() {
         if (captionArray.length > 0) {
             return captionArray;
         } else {
-            throw errorMsg;
+            throw new Error(errorMsg);
         }
     }
 


### PR DESCRIPTION
Whilst debugging some TTML streams I noticed that the parser logged any exceptions as `undefined`. Turns out this is because the parser throws strings and logging code was looking for `e.message` of an Error object which is obviously undefined if you throw a string. Fix was to change all string throws to new Error throws.

Throwing strings seems pretty bad form - Errors allow for stack tracing etc - so I changed all the other instances for good measure.