### PR TITLE
For SegmentTemplate, only include available segments in DVRInfo

### DIFF
--- a/src/dash/utils/SegmentsGetter.js
+++ b/src/dash/utils/SegmentsGetter.js
@@ -74,6 +74,9 @@ function SegmentsGetter(config, isDynamic) {
     }
 
     function isSegmentListUpdateRequired(representation, index) {
+        if (isDynamic) {
+            return true;
+        }
         var segments = representation.segments;
         var updateRequired = false;
 

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -247,15 +247,14 @@ export function decideSegmentListRangeForTimeline(timelineConverter, isDynamic, 
 
 export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, representation, requestedTime, index, givenAvailabilityUpperLimit) {
     var duration = representation.segmentDuration;
-    var minBufferTime = representation.adaptation.period.mpd.manifest.minBufferTime;
-    var availabilityWindow = representation.segmentAvailabilityRange;
+    var availabilityWindow = timelineConverter.calcSegmentAvailabilityRange(representation, isDynamic, true);
     var periodRelativeRange = {
         start: timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, availabilityWindow.start),
         end: timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, availabilityWindow.end)
     };
     var currentSegmentList = representation.segments;
-    var availabilityLowerLimit = 2 * duration;
-    var availabilityUpperLimit = givenAvailabilityUpperLimit || Math.max(2 * minBufferTime, 10 * duration);
+    var availabilityLowerLimit = periodRelativeRange.start;
+    var availabilityUpperLimit = givenAvailabilityUpperLimit || periodRelativeRange.end;
 
     var originAvailabilityTime = NaN;
     var originSegment = null;
@@ -299,5 +298,3 @@ export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, 
 
     return range;
 }
-
-

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -254,7 +254,7 @@ export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, 
     };
     var currentSegmentList = representation.segments;
     var availabilityLowerLimit = periodRelativeRange.start;
-    var availabilityUpperLimit = givenAvailabilityUpperLimit || periodRelativeRange.end;
+    var availabilityUpperLimit = givenAvailabilityUpperLimit >= 0 ? givenAvailabilityUpperLimit : periodRelativeRange.end;
 
     var originAvailabilityTime = NaN;
     var originSegment = null;

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -221,7 +221,7 @@ export function getSegmentByIndex(index, representation) {
 
 export function decideSegmentListRangeForTimeline(timelineConverter, isDynamic, requestedTime, index, givenAvailabilityUpperLimit) {
     var availabilityLowerLimit = 2;
-    var availabilityUpperLimit = givenAvailabilityUpperLimit || 10;
+    var availabilityUpperLimit = givenAvailabilityUpperLimit >= 0 ? givenAvailabilityUpperLimit : 10;
     var firstIdx = 0;
     var lastIdx = Number.POSITIVE_INFINITY;
 

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -130,18 +130,19 @@ function TimelineConverter() {
 
         if (isDynamic) {
             suggestedPresentationDelay = segment.representation.adaptation.period.mpd.suggestedPresentationDelay;
-            displayStartTime = segment.presentationStartTime + suggestedPresentationDelay;
-            wallTime = new Date(segment.availabilityStartTime.getTime() + (displayStartTime * 1000));
+            displayStartTime = segment.availabilityStartTime.getTime() + suggestedPresentationDelay;
+            wallTime = new Date(displayStartTime);
         }
 
         return wallTime;
     }
 
-    function calcSegmentAvailabilityRange(representation, isDynamic) {
+    function calcSegmentAvailabilityRange(representation, isDynamic, disableSnapToSegmentBoundary) {
         var start = representation.adaptation.period.start;
         var end = start + representation.adaptation.period.duration;
         var range = { start: start, end: end };
         var d = representation.segmentDuration || ((representation.segments && representation.segments.length) ? representation.segments[representation.segments.length - 1].duration : 0);
+        var availableSegmentsEndTime = representation.segments && representation.segments.length && representation.segments[representation.segments.length - 1].availabilityStartTime.getTime() / 1000;
 
         var checkTime,
             now;
@@ -161,6 +162,9 @@ function TimelineConverter() {
         var timeAnchor = (isNaN(checkTime) ? now : Math.min(checkTime, now));
         var periodEnd = representation.adaptation.period.start + representation.adaptation.period.duration;
         end = (timeAnchor >= periodEnd  && (timeAnchor - d) < periodEnd ? periodEnd : timeAnchor) - d;
+        if (!disableSnapToSegmentBoundary && availableSegmentsEndTime && end > availableSegmentsEndTime) {
+            end = availableSegmentsEndTime;
+        }
         //end = (isNaN(checkTime) ? now : Math.min(checkTime, now)) - d;
         range = {start: start, end: end};
 

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -141,8 +141,10 @@ function TimelineConverter() {
         var start = representation.adaptation.period.start;
         var end = start + representation.adaptation.period.duration;
         var range = { start: start, end: end };
-        var d = representation.segmentDuration || ((representation.segments && representation.segments.length) ? representation.segments[representation.segments.length - 1].duration : 0);
-        var availableSegmentsEndTime = representation.segments && representation.segments.length && representation.segments[representation.segments.length - 1].availabilityStartTime.getTime() / 1000;
+        var hasSegments = representation.segments && representation.segments.length;
+        var d = representation.segmentDuration || (hasSegments ? representation.segments[representation.segments.length - 1].duration : 0);
+        var availableSegmentsStartTime = hasSegments && representation.segments[0].availabilityStartTime.getTime() / 1000;
+        var availableSegmentsEndTime = hasSegments && representation.segments[representation.segments.length - 1].availabilityStartTime.getTime() / 1000;
 
         var checkTime,
             now;
@@ -162,8 +164,13 @@ function TimelineConverter() {
         var timeAnchor = (isNaN(checkTime) ? now : Math.min(checkTime, now));
         var periodEnd = representation.adaptation.period.start + representation.adaptation.period.duration;
         end = (timeAnchor >= periodEnd  && (timeAnchor - d) < periodEnd ? periodEnd : timeAnchor) - d;
-        if (!disableSnapToSegmentBoundary && availableSegmentsEndTime && end > availableSegmentsEndTime) {
-            end = availableSegmentsEndTime;
+        if (!disableSnapToSegmentBoundary) {
+            if (availableSegmentsEndTime && end > availableSegmentsEndTime) {
+                end = availableSegmentsEndTime;
+            }
+            if (availableSegmentsEndTime && start < availableSegmentsStartTime) {
+                start = availableSegmentsStartTime;
+            }
         }
         //end = (isNaN(checkTime) ? now : Math.min(checkTime, now)) - d;
         range = {start: start, end: end};


### PR DESCRIPTION
This PR resolves #1362. Currently, the DVRInfo event only uses the current available time and the dvrwindowlength to derive the available start/end times.

By checking the AST of the first segment currently available and the AET of the last segment currently available, we ensure we only report times that are actually currently available.