### PR TITLE
Support t as well as s in URL fragments, seeing as t is the standard

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -257,7 +257,8 @@ function PlaybackController() {
      */
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
-        let startTimeOffset = !ignoreStartOffset ? parseInt(URIQueryAndFragmentModel(context).getInstance().getURIFragmentData().s, 10) : NaN;
+        let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
+        let startTimeOffset = !ignoreStartOffset ? parseInt(fragData.s || fragData.t, 10) : NaN;
 
         if (isDynamic) {
             if (!isNaN(startTimeOffset) && startTimeOffset > 1262304000) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -258,7 +258,13 @@ function PlaybackController() {
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
         let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
-        let startTimeOffset = !ignoreStartOffset ? parseInt(fragData.s || fragData.t, 10) : NaN;
+        let fragS = parseInt(fragData.s, 10);
+        let fragT = parseInt(fragData.t, 10);
+        let startTimeOffset = NaN;
+
+        if (!ignoreStartOffset) {
+            startTimeOffset = !isNaN(fragS) ? fragS : fragT;
+        }
 
         if (isDynamic) {
             if (!isNaN(startTimeOffset) && startTimeOffset > 1262304000) {


### PR DESCRIPTION
This partially resolves #1361. It doesn't deal with period/as/track.