### PR TITLE
Optionally set withCredentials on XHR requests

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1502,6 +1502,18 @@ function MediaPlayer() {
     }
 
     /**
+     * Sets whether withCredentials on XHR requests is true or false
+     *
+     * @default false
+     * @param {boolean} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setXHRWithCredentials(value) {
+        mediaPlayerModel.setXHRWithCredentials(value);
+    }
+
+    /**
      * Detects if Protection is included and returns an instance of ProtectionController.js
      * @memberof module:MediaPlayer
      * @instance
@@ -1963,6 +1975,7 @@ function MediaPlayer() {
         setBufferTimeAtTopQuality: setBufferTimeAtTopQuality,
         setFragmentLoaderRetryAttempts: setFragmentLoaderRetryAttempts,
         setFragmentLoaderRetryInterval: setFragmentLoaderRetryInterval,
+        setXHRWithCredentials: setXHRWithCredentials,
         setBufferTimeAtTopQualityLongForm: setBufferTimeAtTopQualityLongForm,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setRichBufferThreshold: setRichBufferThreshold,

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -207,6 +207,8 @@ function XHRLoader(cfg) {
 
             xhr = requestModifier.modifyRequestHeader(xhr);
 
+            xhr.withCredentials = mediaPlayerModel.getXHRWithCredentials();
+
             xhr.onload = onload;
             xhr.onloadend = onloadend;
             xhr.onerror = onloadend;

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -60,6 +60,8 @@ const XLINK_RETRY_INTERVAL = 500;
 //This value influences the startup time for live (in ms).
 const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
 
+const DEFAULT_XHR_WITH_CREDENTIALS = false;
+
 function MediaPlayerModel() {
 
     let instance,
@@ -83,7 +85,8 @@ function MediaPlayerModel() {
         retryAttempts,
         retryIntervals,
         wallclockTimeUpdateInterval,
-        bufferOccupancyABREnabled;
+        bufferOccupancyABREnabled,
+        xhrWithCredentials;
 
     function setup() {
         UTCTimingSources = [];
@@ -105,6 +108,7 @@ function MediaPlayerModel() {
         bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
+        xhrWithCredentials = DEFAULT_XHR_WITH_CREDENTIALS;
 
         retryAttempts = {
             [HTTPRequest.MPD_TYPE]:                         MANIFEST_RETRY_ATTEMPTS,
@@ -319,6 +323,14 @@ function MediaPlayerModel() {
         return UTCTimingSources;
     }
 
+    function setXHRWithCredentials(value) {
+        xhrWithCredentials = !!value;
+    }
+
+    function getXHRWithCredentials() {
+        return xhrWithCredentials;
+    }
+
     function reset() {
         //TODO need to figure out what props to persist across sessions and which to reset if any.
         //setup();
@@ -371,6 +383,8 @@ function MediaPlayerModel() {
         getUseManifestDateHeaderTimeSource: getUseManifestDateHeaderTimeSource,
         setUTCTimingSources: setUTCTimingSources,
         getUTCTimingSources: getUTCTimingSources,
+        setXHRWithCredentials: setXHRWithCredentials,
+        getXHRWithCredentials: getXHRWithCredentials,
         reset: reset
     };
 


### PR DESCRIPTION
Added a new API on MediaPlayer: `setXHRWithCredentials`. Pass it a boolean which is used to set `XHR.withCredentials`.

Defaults to false.

NOTE: I **have not** tested this on any browser other than to check it does not break anything when set to false which I have verified in Chrome at least. Could those who want this feature (@kamranhameedpl, @ShanePhelan etc) please pull locally and test across all UAs, OS etc. I would not recommend pulling this until we have some feedback.

Addresses #1006.