### PR TITLE
Xlink href must be HTTP-URL

### DIFF
--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -33,6 +33,7 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import X2JS from '../../../externals/xml2json';
+import URLUtils from '../utils/URLUtils';
 
 const RESOLVE_TYPE_ONLOAD = 'onLoad';
 const RESOLVE_TYPE_ONACTUATE = 'onActuate';
@@ -45,6 +46,7 @@ function XlinkController(config) {
 
     let context = this.context;
     let eventBus = EventBus(context).getInstance();
+    const urlUtils = URLUtils(context).getInstance();
 
     let instance,
         matchers,
@@ -108,7 +110,7 @@ function XlinkController(config) {
         }
         for (i = 0; i < resolveObject.elements.length; i++) {
             element = resolveObject.elements[i];
-            if (element.url.indexOf('http://') !== -1) {
+            if (urlUtils.isHTTPURL(element.url)) {
                 url = element.url;
             } else {
                 url = element.originalContent.BaseURL + element.url;

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -43,6 +43,7 @@ function URLUtils() {
     let instance;
 
     const absUrl = /^(?:(?:[a-z]+:)?\/)?\//i;
+    const httpUrlRegex = /^https?:\/\//i;
 
     /**
      * Returns a string that contains the Base URL of a URL, if determinable.
@@ -75,9 +76,23 @@ function URLUtils() {
         return !absUrl.test(url);
     }
 
+
+    /**
+     * Determines whether the url is an HTTP-URL as defined in ISO/IEC
+     * 23009-1:2014 3.1.15. ie URL with a fixed scheme of http or https
+     * @return {bool}
+     * @param {string} url
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function isHTTPURL(url) {
+        return httpUrlRegex.test(url);
+    }
+
     instance = {
         parseBaseUrl:   parseBaseUrl,
-        isRelative:     isRelative
+        isRelative:     isRelative,
+        isHTTPURL:      isHTTPURL
     };
 
     return instance;

--- a/test/streaming.utils.URLUtils.js
+++ b/test/streaming.utils.URLUtils.js
@@ -1,0 +1,92 @@
+import URLUtils from '../src/streaming/utils/URLUtils';
+
+const expect = require('chai').expect;
+
+const context = {};
+const urlUtils = URLUtils(context).getInstance();
+
+describe('URLUtils', function () {
+
+    describe('isHTTPURL', () => {
+        it('should return true for an url with http scheme', () => {
+            const httpUrl = 'http://www.example.com';
+
+            const result = urlUtils.isHTTPURL(httpUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return true for an url with https scheme', () => {
+            const httpsUrl = 'https://www.example.com';
+            const result = urlUtils.isHTTPURL(httpsUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return false for a non-HTTP-URL url', () => {
+            const ftpUrl = 'ftp://www.example.com';
+
+            const result = urlUtils.isHTTPURL(ftpUrl);
+
+            // Assert
+            expect(result).to.be.false; // jshint ignore:line
+        });
+    });
+
+    describe('isRelative', () => {
+        it('should return true for a relative url', () => {
+            const relativeUrl = 'path/to/some/file';
+
+            const result = urlUtils.isRelative(relativeUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return false for an absolute url', () => {
+            const absoluteUrl = 'https://www.example.com';
+
+            const result = urlUtils.isRelative(absoluteUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+    });
+
+    describe('parseBaseUrl', () => {
+        it('should return the base url of a valid url', () => {
+            const baseUrl = 'http://www.example.com/';
+            const pageUrl = 'index.html';
+            const url = baseUrl + pageUrl;
+
+            const result = urlUtils.parseBaseUrl(url);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return the base url if no relative portion', () => {
+            const baseUrl = 'http://www.example.com/';
+
+            const result = urlUtils.parseBaseUrl(baseUrl);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return the base url ignoring any query string', () => {
+            const baseUrl = 'http://www.example.com/';
+            const pageUrl = 'index.html';
+            const queryString = '?hasQueryString=true';
+            const url = baseUrl + pageUrl + queryString;
+
+            const result = urlUtils.parseBaseUrl(url);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return an empty string if argument is not a url', () => {
+            const arg = 'skjdlkasdhflkhasdlkfhl'
+
+            const result = urlUtils.parseBaseUrl(arg);
+
+            expect(result).to.be.empty; // jshint ignore:line
+        });
+    });
+});


### PR DESCRIPTION
Addresses first part of #1380, also allowing secure origins.