### PR TITLE
Fix ttml span timing + moved image subtitles to div level

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -609,9 +609,9 @@ function TextSourceBuffer() {
         for (r = 0; r < regions.length; ++r) {
             let region = regions[r];
 
-            let cueID = 'sub_' + (captionId++);
+            let cueID = 'sub_cea608_' + (captionId++);
             let finalDiv = document.createElement('div');
-            finalDiv.id = 'subtitle_' + cueID;
+            finalDiv.id = cueID;
             let cueRegionProperties = getRegionProperties(region);
             finalDiv.style.cssText = 'position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;' + cueRegionProperties;
 

--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -87,6 +87,7 @@ function TextTracks() {
         } else if (document.mozFullScreen) { // Firefox
             fullscreenAttribute = 'mozFullScreen';
         }
+
     }
 
     function createTrackForUserAgent (i) {
@@ -407,6 +408,7 @@ function TextTracks() {
 
                 cue.onenter =  function () {
                     if (track.mode == 'showing') {
+                        log('Cue ' + this.startTime + '-' + this.endTime + ' : ' + this.cueHTMLElement.id + ' : ' + this.cueHTMLElement.innerText);
                         captionContainer.appendChild(this.cueHTMLElement);
                         scaleCue.call(self, this);
                     }
@@ -415,7 +417,7 @@ function TextTracks() {
                 cue.onexit =  function () {
                     var divs = captionContainer.childNodes;
                     for (var i = 0; i < divs.length; ++i) {
-                        if (divs[i].id == 'subtitle_' + this.cueID) {
+                        if (divs[i].id === this.cueID) {
                             captionContainer.removeChild(divs[i]);
                         }
                     }
@@ -464,7 +466,7 @@ function TextTracks() {
 
     function setCurrentTrackIdx(idx) {
         currentTrackIdx = idx;
-        clearCues.call(this);
+        clearCaptionContainer.call(this);
         if (idx >= 0) {
             var track = video.textTracks[idx];
             if (track.renderingType === 'html') {
@@ -512,7 +514,7 @@ function TextTracks() {
             clearInterval(videoSizeCheckInterval);
             videoSizeCheckInterval = null;
         }
-        clearCues.call(this);
+        clearCaptionContainer.call(this);
     }
 
     function deleteTextTrack(idx) {
@@ -548,7 +550,7 @@ function TextTracks() {
         }
     }
 
-    function clearCues() {
+    function clearCaptionContainer() {
         if (captionContainer) {
             while (captionContainer.firstChild) {
                 captionContainer.removeChild(captionContainer.firstChild);

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -189,12 +189,10 @@ function TTMLParser() {
      * Check if entity timing has some overlap with interval
      */
     function inIntervalOrNoTiming(entity, interval) {
-        let inInterval = false;
+        let inInterval = true;
         if (entity.hasOwnProperty('span')) {
             let entityInterval = getInterval(entity.span);
-            if (entityInterval === null) { // No timing
-                inInterval = true;
-            } else {
+            if (entityInterval !== null) { //Timing
                 inInterval = (entityInterval[0] < interval[1] && entityInterval[1] > interval[0]);
             }
         }
@@ -294,7 +292,7 @@ function TTMLParser() {
             let div = divs[k];
             let divInterval = null; // This is mainly for image subtitles.
 
-            if (null !== (divInterval = getInterval(div))) {
+            if (null !== (divInterval = getInterval(div.div))) {
                 // Timing on div level is not allowed by EBU-TT-D.
                 // We only use it for IMSC-1 image subtitle profile.
 


### PR DESCRIPTION
Fixes #920 by checking if there is timing information in the span elements and using them to create extra cues.
Checked with all other subtitle/caption content in the reference player and with the content mention in #1168 which needs clipping.

Also moved check for image-based subtitling out to the div level as a first step towards supporting IMSC-1 subtitles (#1418).