### PR TITLE
Use device pixel ratio to calculate size of portal for max representation size (with API)

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -868,6 +868,26 @@ function MediaPlayer() {
         abrController.setLimitBitrateByPortal(value);
     }
 
+    /**
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getUsePixelRatioInLimitBitrateByPortal() {
+        return abrController.getUsePixelRatioInLimitBitrateByPortal();
+    }
+
+    /**
+     * Sets whether to take into account the device's pixel ratio when defining the portal dimensions.
+     * Useful on, for example, retina displays.
+     *
+     * @param {boolean} value
+     * @memberof module:MediaPlayer
+     * @instance
+     * @default {boolean} false
+     */
+    function setUsePixelRatioInLimitBitrateByPortal(value) {
+        abrController.setUsePixelRatioInLimitBitrateByPortal(value);
+    }
 
     /**
      * Use this method to change the current text track for both external time text files and fragmented text tracks. There is no need to
@@ -1939,6 +1959,8 @@ function MediaPlayer() {
         setQualityFor: setQualityFor,
         getLimitBitrateByPortal: getLimitBitrateByPortal,
         setLimitBitrateByPortal: setLimitBitrateByPortal,
+        getUsePixelRatioInLimitBitrateByPortal: getUsePixelRatioInLimitBitrateByPortal,
+        setUsePixelRatioInLimitBitrateByPortal: setUsePixelRatioInLimitBitrateByPortal,
         setTextTrack: setTextTrack,
         getBitrateInfoListFor: getBitrateInfoListFor,
         setInitialBitrateFor: setInitialBitrateFor,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -67,6 +67,7 @@ function AbrController() {
         abandonmentStateDict,
         abandonmentTimeout,
         limitBitrateByPortal,
+        usePixelRatioInLimitBitrateByPortal,
         manifestModel,
         dashManifestModel,
         videoModel,
@@ -84,6 +85,7 @@ function AbrController() {
         abandonmentStateDict = {};
         streamProcessorDict = {};
         limitBitrateByPortal = false;
+        usePixelRatioInLimitBitrateByPortal = false;
         domStorage = DOMStorage(context).getInstance();
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
@@ -217,6 +219,14 @@ function AbrController() {
 
     function setLimitBitrateByPortal(value) {
         limitBitrateByPortal = value;
+    }
+
+    function getUsePixelRatioInLimitBitrateByPortal() {
+        return usePixelRatioInLimitBitrateByPortal;
+    }
+
+    function setUsePixelRatioInLimitBitrateByPortal(value) {
+        usePixelRatioInLimitBitrateByPortal = value;
     }
 
     function getPlaybackQuality(streamProcessor, completedCallback) {
@@ -444,12 +454,14 @@ function AbrController() {
             return idx;
         }
 
-        let element = videoModel.getElement();
-        let elementWidth = element.clientWidth;
-        let elementHeight = element.clientHeight;
-        let manifest = manifestModel.getValue();
-        let representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
-        let newIdx = idx;
+        var hasPixelRatio = usePixelRatioInLimitBitrateByPortal && window.hasOwnProperty('devicePixelRatio');
+        var pixelRatio = hasPixelRatio ? window.devicePixelRatio : 1;
+        var element = videoModel.getElement();
+        var elementWidth = element.clientWidth * pixelRatio;
+        var elementHeight = element.clientHeight * pixelRatio;
+        var manifest = manifestModel.getValue();
+        var representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
+        var newIdx = idx;
 
         if (elementWidth > 0 && elementHeight > 0) {
             while (
@@ -530,6 +542,8 @@ function AbrController() {
         getAutoSwitchBitrateFor: getAutoSwitchBitrateFor,
         setLimitBitrateByPortal: setLimitBitrateByPortal,
         getLimitBitrateByPortal: getLimitBitrateByPortal,
+        getUsePixelRatioInLimitBitrateByPortal: getUsePixelRatioInLimitBitrateByPortal,
+        setUsePixelRatioInLimitBitrateByPortal: setUsePixelRatioInLimitBitrateByPortal,
         getConfidenceFor: getConfidenceFor,
         getQualityFor: getQualityFor,
         getAbandonmentStateFor: getAbandonmentStateFor,


### PR DESCRIPTION
This supersedes PR #1030 by @nickygerritsen - resolving the conflicts and adding an API to control the feature.