### PR TITLE
Fixes #1393 - don't use Number.MAX_SAFE_INTEGER

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "uglify-js": "^2.4.21"
   },
   "dependencies": {
-    "codem-isoboxer": "0.2.2"
+    "codem-isoboxer": "0.2.2",
+    "round10": "^1.0.3"
   },
   "repository": {
     "type": "git",

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -33,7 +33,7 @@ import ManifestModel from '../streaming/models/ManifestModel';
 import DashManifestModel from './models/DashManifestModel';
 import FactoryMaker from '../core/FactoryMaker';
 import * as MetricsList from './constants/DashMetricsList';
-const round10 = require('round10').round10;
+import { round10 } from 'round10';
 
 /**
  * @module DashMetrics

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -33,6 +33,7 @@ import ManifestModel from '../streaming/models/ManifestModel';
 import DashManifestModel from './models/DashManifestModel';
 import FactoryMaker from '../core/FactoryMaker';
 import * as MetricsList from './constants/DashMetricsList';
+const round10 = require('round10').round10;
 
 /**
  * @module DashMetrics
@@ -121,7 +122,7 @@ function DashMetrics() {
         const vo = getLatestBufferLevelVO(metrics);
 
         if (vo) {
-            return vo.level / 1000;
+            return round10(vo.level / 1000, -3);
         }
 
         return 0;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -295,34 +295,33 @@ function MediaPlayer() {
     }
 
     /**
-     * The length of the buffer for a given media type, in seconds. Valid media types are "video", "audio" and "fragmentedText". If no type
-     * is passed in, then the minimum of the video and the audio buffer length is returned. The value is returned to a precision of two decimal places.
-     * NaN is returned if an invalid type is requested, or if the presentation does not contain that type or if no arguments are passed and the
-     * presentation doers not include any audio or video adaption sets.
+     * The length of the buffer for a given media type, in seconds. Valid media
+     * types are "video", "audio" and "fragmentedText". If no type is passed
+     * in, then the minimum of video, audio and fragmentedText buffer length is
+     * returned. NaN is returned if an invalid type is requested, the
+     * presentation does not contain that type, or if no arguments are passed
+     * and the presentation does not include any adaption sets of valid media
+     * type.
      *
      * @param {string} type - the media type of the buffer
-     * @returns {number} The length of the buffer for the given media type, in seconds.
+     * @returns {number} The length of the buffer for the given media type, in
+     *  seconds, or NaN
      * @memberof module:MediaPlayer
      * @instance
      */
     function getBufferLength(type) {
-
-        if (!type)
-        {
-            let videoBuffer = getTracksFor('video').length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor('video')) : Number.MAX_SAFE_INTEGER;
-            let audioBuffer = getTracksFor('audio').length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor('audio')) : Number.MAX_SAFE_INTEGER;
-            let textBuffer = getTracksFor('fragmentedText').length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor('fragmentedText')) : Number.MAX_SAFE_INTEGER;
-            return Math.min(videoBuffer,audioBuffer,textBuffer).toPrecision(3);
-        }
-        else
-        {
-            if (type === 'video' || type === 'audio' || type === 'fragmentedText')
-            {
-                let buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));
-                return buffer ? buffer.toPrecision(3) : NaN;
-            }
-            else
-            {
+        const types = ['video', 'audio', 'fragmentedText'];
+        if (!type) {
+            return types.map(
+                t => getTracksFor(t).length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor(t)) : Number.MAX_VALUE
+            ).reduce(
+                (p, c) => Math.min(p, c)
+            );
+        } else {
+            if (types.indexOf(type) !== -1) {
+                const buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));
+                return buffer ? buffer : NaN;
+            } else {
                 log('Warning  - getBufferLength requested for invalid type');
                 return NaN;
             }


### PR DESCRIPTION
This is fairly uncontroversial - see discussion in #1393.

I have used a module from npm which we have done with isoboxer but not something we do all the time in this project, and I'm not really sure why. Perhaps the project grandees have an opinion.