### PR TITLE
Fix for #1437

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -46,7 +46,7 @@ const ABANDON_LOAD = 'abandonload';
 const ALLOW_LOAD = 'allowload';
 const DEFAULT_VIDEO_BITRATE = 1000;
 const DEFAULT_AUDIO_BITRATE = 100;
-const QUALITY_DEFAULT = -1;
+const QUALITY_DEFAULT = 0;
 
 function AbrController() {
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -92,14 +92,14 @@ function BufferController(config) {
         clearBufferTimeout;
 
     function setup() {
-        requiredQuality = -1;
-        currentQuality = -1;
+        requiredQuality = AbrController.QUALITY_DEFAULT;
+        currentQuality = AbrController.QUALITY_DEFAULT;
         isBufferingCompleted = false;
         bufferLevel = 0;
         bufferTarget = 0;
         criticalBufferLevel = Number.POSITIVE_INFINITY;
-        maxAppendedIndex = -1;
-        lastIndex = -1;
+        maxAppendedIndex = 0;
+        lastIndex = 0;
         buffer = null;
         bufferState = BUFFER_EMPTY;
         wallclockTicked = 0;
@@ -713,10 +713,10 @@ function BufferController(config) {
 
         criticalBufferLevel = Number.POSITIVE_INFINITY;
         bufferState = BUFFER_EMPTY;
-        currentQuality = -1;
-        lastIndex = -1;
-        maxAppendedIndex = -1;
-        requiredQuality = 0;
+        currentQuality = AbrController.QUALITY_DEFAULT;
+        requiredQuality = AbrController.QUALITY_DEFAULT;
+        lastIndex = 0;
+        maxAppendedIndex = 0;
         appendedBytesInfo = null;
         appendingMediaChunk = false;
         isBufferingCompleted = false;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -86,12 +86,14 @@ function ScheduleController(config) {
         bufferLevelRule,
         nextFragmentRequestRule,
         scheduleWhilePaused,
+        initialQualityChange,
         qualityChangeInProgress,
         renderTimeCheckInterval;
 
     function setup() {
         qualityChangeInProgress = false;
         initialPlayback = true;
+        initialQualityChange = true;
         isStopped = false;
         playListMetrics = null;
         playListTraceMetrics = null;
@@ -275,9 +277,11 @@ function ScheduleController(config) {
             throw new Error('Unexpected error! - currentRepresentationInfo is null or undefined');
         }
 
-        if (e.oldQuality !== AbrController.QUALITY_DEFAULT) { //blocks init quality change
+        if (!initialQualityChange) { //blocks init quality change
             qualityChangeInProgress = true;
             eventBus.trigger(Events.QUALITY_CHANGE_START, {mediaType: e.mediaType, newQuality: e.newQuality,  oldQuality: e.oldQuality});
+        } else {
+            initialQualityChange = false;
         }
 
         clearPlayListTraceMetrics(new Date(), PlayListTrace.REPRESENTATION_SWITCH_STOP_REASON);

--- a/test/helpers/SpecHelper.js
+++ b/test/helpers/SpecHelper.js
@@ -1,6 +1,5 @@
 class SpecHelper {
     constructor() {
-        this.DEFAULT_QUALITY = -1;
         this.EVENT_NOTIFICATION_DELAY = 200;
         this.TIMEOUT_DELAY = 2000;
         this.isHtmlRunner = false; //window.location.href.indexOf("runner.html") > 0;
@@ -26,10 +25,6 @@ class SpecHelper {
 
     getTimeoutDelay() {
         return this.TIMEOUT_DELAY;
-    }
-
-    getDefaultQuality() {
-        return this.DEFAULT_QUALITY;
     }
 
     getUnixTime() {

--- a/test/streaming.AbrControllerSpec.js
+++ b/test/streaming.AbrControllerSpec.js
@@ -8,7 +8,7 @@ describe("AbrController", function () {
     const context = {};
     const testType = 'video';
     const voHelper = new VoHelper();
-    const defaultQuality = new SpecHelper().getDefaultQuality();
+    const defaultQuality = AbrController.QUALITY_DEFAULT;
     const abrCtrl = AbrController(context).getInstance();
     const dummyMediaInfo = voHelper.getDummyMediaInfo('video');
     const representationCount = dummyMediaInfo.representationCount;


### PR DESCRIPTION
Cleaned up how other objects get the default setting for ABR quality.  Restored default back to 0 from -1.  
Both streams mentioned in issue #1437 are RTE free now and I maintained the original intent.