### PR TITLE
fixed audio only buffer targets for longform etc...

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -46,6 +46,7 @@ import LiveEdgeFinder from '../utils/LiveEdgeFinder';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
+import StreamController from '../controllers/StreamController';
 import Debug from '../../core/Debug';
 
 function ScheduleController(config) {
@@ -80,6 +81,7 @@ function ScheduleController(config) {
         playbackController,
         abrController,
         streamProcessor,
+        streamController,
         fragmentController,
         liveEdgeFinder,
         bufferController,
@@ -109,6 +111,7 @@ function ScheduleController(config) {
         liveEdgeFinder = LiveEdgeFinder(context).getInstance();
         playbackController = PlaybackController(context).getInstance();
         abrController = AbrController(context).getInstance();
+        streamController = StreamController(context).getInstance();
         fragmentController = streamProcessor.getFragmentController();
         bufferController = streamProcessor.getBufferController();
         fragmentModel = fragmentController.getModel(this);
@@ -243,7 +246,7 @@ function ScheduleController(config) {
             }
         }
 
-        let readyToLoad = bufferLevelRule.execute(streamProcessor);
+        let readyToLoad = bufferLevelRule.execute(streamProcessor, streamController.isVideoTrackPresent());
         if (readyToLoad && !isFragmentLoading &&
             (dashManifestModel.getIsTextTrack(type) || !bufferController.getIsAppendingInProgress()) ) {
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -79,7 +79,8 @@ function StreamController() {
         mediaPlayerModel,
         isPaused,
         initialPlayback,
-        playListMetrics;
+        playListMetrics,
+        videoTrackDetected;
 
     function setup() {
         protectionController = null;
@@ -415,6 +416,7 @@ function StreamController() {
         from.deactivate();
         activeStream = to;
         playbackController.initialize(activeStream.getStreamInfo());
+        videoTrackDetected = checkVideoPresence();
         setupMediaSource(onMediaSourceReady);
     }
 
@@ -628,6 +630,24 @@ function StreamController() {
         }
     }
 
+
+    function isVideoTrackPresent() {
+        if (videoTrackDetected === undefined) {
+            videoTrackDetected = checkVideoPresence();
+        }
+        return videoTrackDetected;
+    }
+
+    function checkVideoPresence() {
+        let isVideoDetected = false;
+        activeStream.getProcessors().forEach(p => {
+            if (p.getMediaInfo().type === 'video') {
+                isVideoDetected = true;
+            }
+        });
+        return isVideoDetected;
+    }
+
     function getAutoPlay() {
         return autoPlay;
     }
@@ -744,6 +764,7 @@ function StreamController() {
         activeStream = null;
         hasMediaError = false;
         hasInitialisationError = false;
+        videoTrackDetected = undefined;
         initialPlayback = true;
         isPaused = false;
 
@@ -769,6 +790,7 @@ function StreamController() {
         getAutoPlay: getAutoPlay,
         getActiveStreamInfo: getActiveStreamInfo,
         isStreamActive: isStreamActive,
+        isVideoTrackPresent: isVideoTrackPresent,
         getStreamById: getStreamById,
         getTimeRelativeToStreamId: getTimeRelativeToStreamId,
         load: load,


### PR DESCRIPTION
This change adds helper method into streamcontroller for video track detection.   In bufferelevel rule we look at if video track is detected and do audio video evenness for buffer target to prevent audio from getting too far ahead of video.   If audio only stream we use same logic for audio as we do for video. 

  