### PR TITLE
Fix #521 - properly support path-absolute BaseURLs

### DIFF
--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -72,8 +72,12 @@ function BaseURLController() {
 
             if (b) {
                 if (!urlUtils.isRelative(b.url)) {
-                    p.url = b.url;
-                    p.serviceLocation = b.serviceLocation;
+                    if (urlUtils.isPathAbsolute(b.url)) {
+                        p.url = urlUtils.parseOrigin(p.url) + b.url;
+                    } else {
+                        p.url = b.url;
+                        p.serviceLocation = b.serviceLocation;
+                    }
                 } else {
                     p.url += b.url;
                 }

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -44,6 +44,7 @@ function URLUtils() {
 
     const absUrl = /^(?:(?:[a-z]+:)?\/)?\//i;
     const httpUrlRegex = /^https?:\/\//i;
+    const originRegex = /^(https?:\/\/[^\/]+)\/?/i;
 
     /**
      * Returns a string that contains the Base URL of a URL, if determinable.
@@ -66,6 +67,24 @@ function URLUtils() {
     }
 
     /**
+     * Returns a string that contains the scheme and origin of a URL,
+     * if determinable.
+     * @param {string} url - full url
+     * @return {string}
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function parseOrigin(url) {
+        const matches = url.match(originRegex);
+
+        if (matches) {
+            return matches[1];
+        }
+
+        return '';
+    }
+
+    /**
      * Determines whether the url is relative.
      * @return {bool}
      * @param {string} url
@@ -76,6 +95,17 @@ function URLUtils() {
         return !absUrl.test(url);
     }
 
+
+    /**
+     * Determines whether the url is path-absolute.
+     * @return {bool}
+     * @param {string} url
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function isPathAbsolute(url) {
+        return absUrl.test(url) && url.charAt(0) === '/';
+    }
 
     /**
      * Determines whether the url is an HTTP-URL as defined in ISO/IEC
@@ -91,7 +121,9 @@ function URLUtils() {
 
     instance = {
         parseBaseUrl:   parseBaseUrl,
+        parseOrigin:    parseOrigin,
         isRelative:     isRelative,
+        isPathAbsolute: isPathAbsolute,
         isHTTPURL:      isHTTPURL
     };
 

--- a/test/streaming.utils.URLUtils.js
+++ b/test/streaming.utils.URLUtils.js
@@ -28,7 +28,6 @@ describe('URLUtils', function () {
 
             const result = urlUtils.isHTTPURL(ftpUrl);
 
-            // Assert
             expect(result).to.be.false; // jshint ignore:line
         });
     });
@@ -46,6 +45,32 @@ describe('URLUtils', function () {
             const absoluteUrl = 'https://www.example.com';
 
             const result = urlUtils.isRelative(absoluteUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+    });
+
+    describe('isPathAbsolute', () => {
+        it('should return true for a path-absolute url', () => {
+            const pathAbsoluteUrl = '/path/to/some/file';
+
+            const result = urlUtils.isPathAbsolute(pathAbsoluteUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return false for a relative url', () => {
+            const relativeUrl = 'path/to/some/file';
+
+            const result = urlUtils.isPathAbsolute(relativeUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+
+        it('should return false for an absolute url', () => {
+            const absoluteUrl = 'https://www.example.com';
+
+            const result = urlUtils.isPathAbsolute(absoluteUrl);
 
             expect(result).to.be.false; // jshint ignore:line
         });
@@ -82,9 +107,39 @@ describe('URLUtils', function () {
         });
 
         it('should return an empty string if argument is not a url', () => {
-            const arg = 'skjdlkasdhflkhasdlkfhl'
+            const arg = 'skjdlkasdhflkhasdlkfhl';
 
             const result = urlUtils.parseBaseUrl(arg);
+
+            expect(result).to.be.empty; // jshint ignore:line
+        });
+    });
+
+    describe('parseOrigin', () => {
+        it('should return the scheme and origin url of a valid url', () => {
+            const schemeAndOrigin = 'http://www.example.com';
+            const pathAbsolute = '/MPDs/index.html';
+            const url = schemeAndOrigin + pathAbsolute;
+
+            const result = urlUtils.parseOrigin(url);
+
+            expect(result).to.equal(schemeAndOrigin); // jshint ignore:line
+        });
+
+        it('should return the scheme and origin url if no relative portion', () => {
+            const baseUrl = 'http://www.example.com';
+            const slash = '/';
+            const url = baseUrl + slash;
+
+            const result = urlUtils.parseOrigin(url);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return an empty string if argument is not a url', () => {
+            const arg = 'skjdlkasdhflkhasdlkfhl';
+
+            const result = urlUtils.parseOrigin(arg);
 
             expect(result).to.be.empty; // jshint ignore:line
         });


### PR DESCRIPTION
#1280 caused a regression to the fix for #521.

This patch restores correct joining of origin and path-absolute URIs.