### PR TITLE
Adding two new livesim samples to ref player

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -69,6 +69,16 @@
                     "url":"http://irtdashreference-i.akamaihd.net/dash/live/901161/bfs/manifestARD.mpd",
                     "name":"IRT reference with EBU-TT-D subtitles",
                     "browsers":"cdsbi"
+                },
+                {
+                    "url":" http://vm2.dashif.org/livesim-dev/ato_10/testpic_2s/Manifest.mpd",
+                    "name":"10 seconds availabilityTimeOffset (livesim)",
+                    "browsers":"cdsbi"
+                },
+                {
+                    "url":"http://vm2.dashif.org/livesim-dev/ato_inf/testpic_2s/Manifest.mpd",
+                    "name":"Infinite offset - all segments available at availability start (livesim)",
+                    "browsers":"cdsbi"
                 }
             ]
         },


### PR DESCRIPTION
1. 10 seconds availabilityTimeOffset:
http://vm2.dashif.org/livesim-dev/ato_10/testpic_2s/Manifest.mpd

2. Infinite offset (all segments available at availability start):
http://vm2.dashif.org/livesim-dev/ato_inf/testpic_2s/Manifest.mpd

Thanks to Waqar for posting, Yi for implementing and Torbjörn for integration.
