### PR TITLE
Include babelified files in the dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,21 @@ module.exports = function (grunt) {
                 }
             }
         },
+
+        babel: {
+            options: {
+                sourceMap: true,
+                presets: ['es2015']
+            },
+            es5: {
+                files: [{
+                    expand: true,
+                    src: ['index.js', 'src/**/*.js', 'externals/**/*.js'],
+                    dest: 'dist/es5/',
+                }]
+            }
+        },
+
         browserify: {
             mediaplayer: {
                 files: {
@@ -227,7 +242,7 @@ module.exports = function (grunt) {
 
     require('load-grunt-tasks')(grunt);
     grunt.registerTask('default',   ['dist', 'test']);
-    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:reporting', 'browserify:all', 'minimize', 'copy:dist']);
+    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:reporting', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
     grunt.registerTask('minimize',  ['exorcise', 'uglify']);
     grunt.registerTask('test',      ['mocha_istanbul:test']);
     grunt.registerTask('watch',     ['browserify:watch']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,8 +117,7 @@ module.exports = function (grunt) {
 
         babel: {
             options: {
-                sourceMap: true,
-                presets: ['es2015']
+                sourceMap: true
             },
             es5: {
                 files: [{

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chai": "^3.4.1",
     "chai-spies": "^0.7.1",
     "grunt": "^0.4.5",
-    "grunt-babel": "^6.0.0",
+    "grunt-babel": "^5.0.3",
     "grunt-browserify": "^4.0.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dashjs",
   "version": "2.3.0",
   "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
-  "main": "index.js",
+  "main": "dist/es5/index.js",
   "scripts": {
     "test": "mocha --require mochahook",
     "prepublish": "grunt prepublish",
@@ -17,6 +17,7 @@
     "chai": "^3.4.1",
     "chai-spies": "^0.7.1",
     "grunt": "^0.4.5",
+    "grunt-babel": "^6.0.0",
     "grunt-browserify": "^4.0.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
The intent of this PR is to provide an ES5 version of the source files for use in Browserify workflows (this would resolve #1483).

cb8978673ebfbe447da6e40c45d062cf1e303d7a does add a way for Browserify to work but it currently requires the user to have babel and babelify as dependencies.