### PR TITLE
Fix for #1439 and much more!

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -58,7 +58,6 @@ class CoreEvents extends EventsBase {
         this.LOADING_PROGRESS = 'loadingProgress';
         this.MANIFEST_UPDATED = 'manifestUpdated';
         this.MEDIA_FRAGMENT_LOADED = 'mediaFragmentLoaded';
-        this.QUALITY_CHANGED = 'qualityChanged';
         this.QUOTA_EXCEEDED = 'quotaExceeded';
         this.REPRESENTATION_UPDATED = 'representationUpdated';
         this.SEGMENTS_LOADED = 'segmentsLoaded';

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -86,7 +86,7 @@ function RepresentationController() {
         dashMetrics = DashMetrics(context).getInstance();
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
 
-        eventBus.on(Events.QUALITY_CHANGED, onQualityChanged, instance);
+        eventBus.on(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, instance);
         eventBus.on(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.on(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);
@@ -127,7 +127,7 @@ function RepresentationController() {
 
     function reset() {
 
-        eventBus.off(Events.QUALITY_CHANGED, onQualityChanged, instance);
+        eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, instance);
         eventBus.off(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
         eventBus.off(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.off(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -108,15 +108,15 @@ class MediaPlayerEvents extends EventsBase {
 
         /**
          * Triggered when an ABR up /down switch is initialed; either by user in manual mode or auto mode via ABR rules.
-         * @event MediaPlayerEvents#QUALITY_CHANGE_START
+         * @event MediaPlayerEvents#QUALITY_CHANGED
          */
-        this.QUALITY_CHANGE_START = 'qualityChangeStart';
+        this.QUALITY_CHANGED = 'qualityChanged';
 
         /**
          * Triggered when the new ABR quality is being rendered on-screen.
-         * @event MediaPlayerEvents#QUALITY_CHANGE_COMPLETE
+         * @event MediaPlayerEvents#QUALITY_CHANGE_RENDERED
          */
-        this.QUALITY_CHANGE_COMPLETE = 'qualityChangeComplete';
+        this.QUALITY_CHANGE_RENDERED = 'qualityChangeRendered';
 
         /**
          * Triggered when the stream is setup and ready.

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -108,9 +108,9 @@ class MediaPlayerEvents extends EventsBase {
 
         /**
          * Triggered when an ABR up /down switch is initialed; either by user in manual mode or auto mode via ABR rules.
-         * @event MediaPlayerEvents#QUALITY_CHANGED
+         * @event MediaPlayerEvents#QUALITY_CHANGE_REQUESTED
          */
-        this.QUALITY_CHANGED = 'qualityChanged';
+        this.QUALITY_CHANGE_REQUESTED = 'qualityChangeRequested';
 
         /**
          * Triggered when the new ABR quality is being rendered on-screen.

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -288,7 +288,7 @@ function AbrController() {
 
     function changeQuality(type, streamInfo, oldQuality, newQuality, reason) {
         setQualityFor(type, streamInfo.id, newQuality);
-        eventBus.trigger(Events.QUALITY_CHANGED, {mediaType: type, streamInfo: streamInfo, oldQuality: oldQuality, newQuality: newQuality, reason: reason});
+        eventBus.trigger(Events.QUALITY_CHANGE_REQUESTED, {mediaType: type, streamInfo: streamInfo, oldQuality: oldQuality, newQuality: newQuality, reason: reason});
     }
 
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -124,7 +124,7 @@ function BufferController(config) {
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.on(Events.INIT_FRAGMENT_LOADED, onInitFragmentLoaded, this);
         eventBus.on(Events.MEDIA_FRAGMENT_LOADED, onMediaFragmentLoaded, this);
-        eventBus.on(Events.QUALITY_CHANGED, onQualityChanged, this);
+        eventBus.on(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
         eventBus.on(Events.STREAM_COMPLETED, onStreamCompleted, this);
         eventBus.on(Events.PLAYBACK_PROGRESS, onPlaybackProgression, this);
         eventBus.on(Events.PLAYBACK_TIME_UPDATED, onPlaybackProgression, this);
@@ -694,7 +694,7 @@ function BufferController(config) {
     function reset(errored) {
 
         eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
-        eventBus.off(Events.QUALITY_CHANGED, onQualityChanged, this);
+        eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
         eventBus.off(Events.INIT_FRAGMENT_LOADED, onInitFragmentLoaded, this);
         eventBus.off(Events.MEDIA_FRAGMENT_LOADED, onMediaFragmentLoaded, this);
         eventBus.off(Events.STREAM_COMPLETED, onStreamCompleted, this);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -292,7 +292,7 @@ function ScheduleController(config) {
     function completeQualityChange(trigger) {
         const item = fragmentModel.getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: playbackController.getTime(), threshold: 0})[0];
         if (item && playbackController.getTime() >= item.startTime ) {
-            if(item.quality !== lastQualityIndex && trigger) {
+            if (item.quality !== lastQualityIndex && trigger) {
                 eventBus.trigger(Events.QUALITY_CHANGE_RENDERED, {mediaType: type, oldQuality: lastQualityIndex, newQuality: item.quality});
             }
             lastQualityIndex = item.quality;
@@ -363,7 +363,7 @@ function ScheduleController(config) {
         // the executed requests for which playback time is inside the time interval that has been removed from the buffer
         fragmentModel.removeExecutedRequestsBeforeTime(e.to);
 
-        if (e.hasEnoughSpaceToAppend && !bufferConseektroller.getIsBufferingCompleted()) {
+        if (e.hasEnoughSpaceToAppend && !bufferController.getIsBufferingCompleted()) {
             start();
         }
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -134,7 +134,7 @@ function ScheduleController(config) {
         }
 
         eventBus.on(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, this);
-        eventBus.on(Events.QUALITY_CHANGED, onQualityChanged, this);
+        eventBus.on(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
         eventBus.on(Events.DATA_UPDATE_STARTED, onDataUpdateStarted, this);
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.on(Events.FRAGMENT_LOADING_COMPLETED, onFragmentLoadingCompleted, this);
@@ -498,7 +498,7 @@ function ScheduleController(config) {
         eventBus.off(Events.DATA_UPDATE_STARTED, onDataUpdateStarted, this);
         eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
-        eventBus.off(Events.QUALITY_CHANGED, onQualityChanged, this);
+        eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
         eventBus.off(Events.FRAGMENT_LOADING_COMPLETED, onFragmentLoadingCompleted, this);
         eventBus.off(Events.STREAM_COMPLETED, onStreamCompleted, this);
         eventBus.off(Events.STREAM_INITIALIZED, onStreamInitialized, this);

--- a/test/dash.RepresentationControllerSpec.js
+++ b/test/dash.RepresentationControllerSpec.js
@@ -5,6 +5,7 @@ import EventBus from '../src/core/EventBus';
 import RepresentationController from '../src/dash/controllers/RepresentationController';
 import ManifestModel from '../src/streaming/models/ManifestModel';
 import Events from '../src/core/events/Events';
+import MediaPlayerEvents from '../src/streaming/MediaPlayerEvents';
 import SpecHelper from './helpers/SpecHelper';
 import AbrController from '../src/streaming/controllers/AbrController';
 
@@ -29,6 +30,8 @@ describe("RepresentationController", function () {
     const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);
     const eventBus = EventBus(context).getInstance();
     const manifestModel = ManifestModel(context).getInstance();
+
+    Events.extend(MediaPlayerEvents);
 
     manifestModel.setValue(mpd);
 


### PR DESCRIPTION
**Important!!!  Event CONST and String name have changed for Quality Change.** 

2.1 and below we only had QUALITY_CHANGED event that was triggered when a change is requested, manual or ABR.  There was not a follow-up event for when the requested change actually was in the buffer and rendering. 

In 2.2 I added the other event showing the change was complete and being rendered. A bug was filed #1439 saying you should get a complete event for all start events IF they render on screen. 

* So in this PR I have changed both event names, removed duplication of one event and made it dispatch render event every time there is a render change on screen regardless of ABR or manual switching requested.  (E.g.  FastSwitch is not enabled and you have many qualities in the buffer, you seek back and you play and there is a render change with now switch request.  You will now get an QUALITY_CHANGE_RENDERED event in this case. )

**New Event Names**
MediaPlayerEvents (Public Player Facing)
* QUALITY_CHANGE_START is now QUALITY_CHANGE_REQUESTED
* QUALITY_CHANGE_COMPLETE is now QUALITY_CHANGE_RENDERED

(CoreEvents Internal )
* QUALITY_CHANGED has been removed and the internal system uses the same event 
* QUALITY_CHANGE_REQUESTED.

**Other PR Changes**
* This PR also fixes an untracked bug found during dev for this fix.  It applies only to FastSwitch.  If you switched up and then back down to lower quality before the higher quality "backfilled" the buffer from playhead to current buffer-level,  the client would append the lower quality in the incorrect place.  This was just inefficient and is fixed now - did not break playback.  Now it will append the lower quality at the end of the buffer.

* This PR also includes some refactoring of ABRController to use Es6 syntax in places and much cleanup in a few methods. 

