### PR TITLE
Fix #1517 - don't assume sidx is at offset zero in byte range

### DIFF
--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -237,7 +237,7 @@ function SegmentBaseLoader() {
         var len = refs.length;
         var timescale = sidx.timescale;
         var time = sidx.earliest_presentation_time;
-        var start = info.range.start + sidx.first_offset + sidx.size;
+        var start = info.range.start + sidx.offset + sidx.first_offset + sidx.size;
         var segments = [];
         var segment,
             end,


### PR DESCRIPTION
When the `indexRange` is unknown, dash.js will search for the sidx box. It possibly won't be at the start of the byte range.

This has been proven to fix loading of:
* http://dash.edgesuite.net/dash264/TestCasesMCA/dolby/1/1/ChID_voices_51_256_ddp.mpd

and proven not to break the following test vectors
* http://dash.edgesuite.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd (SegmentBase, no indexRange), 
* http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd (SegmentBase, indexRange and indexRangeExact='true' both present), and
* http://dash.edgesuite.net/dash264/TestCasesHEVC/1a/1/TOS_OnDemand_HEVC_MultiRate.mpd (SegmentBase, indexRange and indexRangeExact='true' both present, and Initialization@range present)

`indexRange` is mandated by the DASHIF IOP so this problem should never occur in compliant presentations.