### PR TITLE
Don't fire progress events when deliberately aborting xhrs

### DIFF
--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -278,7 +278,7 @@ function XHRLoader(cfg) {
             // abort will trigger onloadend which we don't want
             // when deliberately aborting inflight requests -
             // set them to undefined so they are not called
-            x.onloadend = x.onerror = undefined;
+            x.onloadend = x.onerror = x.onprogress = undefined;
             x.abort();
         });
         xhrs = [];


### PR DESCRIPTION
xhr.abort will trigger onprogress which we don't want when deliberately aborting inflight requests - set it to undefined so it's not called. Already done for onloadend and onerror.

Caused an infrequent race condition if a higher level app was listening on for metrics changes.