### PR TITLE
Don't throw TypeError if Load clicked in ref player when no URL specified

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -669,6 +669,11 @@ app.controller('DashController', function($scope, Sources, Notes, Contributors, 
 
     $scope.doLoad = function () {
         var protData = null;
+
+        if (!$scope.selectedItem) {
+            return;
+        }
+
         if ($scope.selectedItem.hasOwnProperty("protData")) {
             protData = $scope.selectedItem.protData;
         }


### PR DESCRIPTION
Fairly pointless, but gives one less potential red exclamation mark while I was trying some other things out.