### PR TITLE
Removed local test URL from sources

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -4,12 +4,6 @@
             "name":"VOD",
             "submenu":[
                 {
-                    "url":"http://localhost/~tobbe/dash/vod/trombone2/manifest.mpd",
-                    "name":"Image Subtitles trombone2",
-                    "browsers":"cdsbi",
-                    "moreInfo":"None"
-                },
-                {
                     "url":"http://rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd",
                     "name":"SegmentTemplate/Number, live profile",
                     "browsers":"cdsbi",


### PR DESCRIPTION
Simple fix to PR #1529 which was merged to early.
Styling of image subtitles is coming in a later PR as is a fix for the erroneous behavior that subtitles are not removed as content is reloaded.