### PR TITLE
Image subtitles with layout

### DIFF
--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -63,20 +63,6 @@
     }
 }
 
-
-
-.cue-image{
-    z-index: 2147483648 ;
-    pointer-events: none ;
-    display: block; 
-    left: 0px; 
-    width: 100%; 
-    height: 100%; 
-    top: 0px; 
-    visibility: visible !important; 
-    position: relative !important;
-}
-
 body {
     background: #eee;
     overflow-x: hidden;

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -743,6 +743,12 @@
                     "url":"http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-snake.mpd",
                     "browsers":"cdsbi",
                     "moreInfo":"http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/"
+                },
+                {
+                    "name":"TTML Image Subtitles embedded (VoD)",
+                    "url":"http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd",
+                    "browsers":"cdsbi",
+                    "moreInfo":"http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_info.txt"
                 }
             ]
         },

--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -250,8 +250,7 @@ function TextTracks() {
         }
     }
 
-    function convertToPixels(percentageString, pixelMeasure) {
-        let percentage = parseInt(percentageString.substring(0, percentageString.length - 1));
+    function convertToPixels(percentage, pixelMeasure) {
         let percentString = Math.round(0.01 * percentage * pixelMeasure).toString() + 'px';
         return percentString;
     }
@@ -264,13 +263,12 @@ function TextTracks() {
             return; //At least one of the measures is still zero
         }
 
-        if ('layout' in activeCue) {
-            let originParts = activeCue.layout.origin.split(/\s/);
-            let extentParts = activeCue.layout.extent.split(/\s/);
-            let left = convertToPixels(originParts[0], videoWidth);
-            let top = convertToPixels(originParts[1], videoHeight);
-            let width = convertToPixels(extentParts[0], videoWidth);
-            let height = convertToPixels(extentParts[1], videoHeight);
+        if (activeCue.layout) {
+            let layout = activeCue.layout;
+            let left = convertToPixels(layout.left, videoWidth);
+            let top = convertToPixels(layout.top, videoHeight);
+            let width = convertToPixels(layout.width, videoWidth);
+            let height = convertToPixels(layout.height, videoHeight);
             captionContainer.style.left = left;
             captionContainer.style.top = top;
             captionContainer.style.width = width;
@@ -390,13 +388,15 @@ function TextTracks() {
                     if (!captionContainer) { // Does not support image captions without a container
                         return;
                     }
-                    var img = new Image();
-                    img.id = 'ttmlImage_' + this.id;
-                    img.src = this.image;
-                    //img.className = 'cue-image';
-                    img.style.cssText = 'z-index: 2147483648; pointer-events: none; display: block; visibility: visible !important; position: relative !important;';
-                    captionContainer.appendChild(img);
-                    scaleImageCue.call(self, this);
+                    if (track.mode === 'showing') {
+                        var img = new Image();
+                        img.id = 'ttmlImage_' + this.id;
+                        img.src = this.image;
+                        //img.className = 'cue-image';
+                        img.style.cssText = 'z-index: 2147483648; pointer-events: none; display: block; visibility: visible !important; position: relative !important;';
+                        captionContainer.appendChild(img);
+                        scaleImageCue.call(self, this);
+                    }
                 };
 
                 cue.onexit =  function () {

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -319,6 +319,8 @@ function SourceBufferController() {
         try {
             if (mediaSource.readyState === 'open') {
                 buffer.abort();
+            } else if (buffer.setTextTrack && mediaSource.readyState === 'ended') {
+                buffer.abort(); //The cues need to be removed from the TextSourceBuffer via a call to abort()
             }
         } catch (ex) {
         }

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -229,19 +229,20 @@ function TTMLParser() {
             type = 'html';
         }
 
-        // Get the namespace if there is one defined in the JSON object.
-        var ttNS = getNamespacePrefix(ttml, 'http://www.w3.org/ns/ttml');
-
-        // Remove the namespace before each node if it exists:
-        if (ttNS) {
-            removeNamespacePrefix(ttml, ttNS);
-        }
-
         // Check the document and compare to the specification (TTML and EBU-TT-D).
         tt = ttml.tt;
         if (!tt) {
             throw new Error('TTML document lacks tt element');
         }
+
+        // Get the namespace if there is one defined in the JSON object.
+        var ttNS = getNamespacePrefix(tt, 'http://www.w3.org/ns/ttml');
+
+        // Remove the namespace before each node if it exists:
+        if (ttNS) {
+            removeNamespacePrefix(tt, ttNS);
+        }
+
         head = tt.head;
         if (!head) {
             throw new Error('TTML document lacks head element');


### PR DESCRIPTION
Support for embedded image subtitles with positioning and scaling.
The layout support is for `origin and extent` in region in units of either % or px. In the latter case, the px are used relative to `extent` specified in the `<tt>`element.
There is also support for `origin and extent` specified in the `<div>` element, which is not according to standard.

A test sequence http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd has all three types of layout specified as different tracks.

