### PR TITLE
implemented Event MediaPlayerEvents.PLAYBACK_NOT_ALLOWED

### DIFF
--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -155,6 +155,11 @@ class MediaPlayerEvents extends EventsBase {
          */
         this.PLAYBACK_ERROR = 'playbackError';
         /**
+         * Sent when playback is not allowed (for example if user gesture is needed).
+         * @event MediaPlayerEvents#PLAYBACK_NOT_ALLOWED
+         */
+        this.PLAYBACK_NOT_ALLOWED = 'playbackNotAllowed';
+        /**
          * The media's metadata has finished loading; all attributes now
          * contain as much useful information as they're going to.
          * @event MediaPlayerEvents#PLAYBACK_METADATA_LOADED

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -117,6 +117,9 @@ function PlaybackController() {
             const p = element.play();
             if (p && (typeof Promise !== 'undefined') && (p instanceof Promise)) {
                 p.catch((e) => {
+                    if (e.name === 'NotAllowedError') {
+                        eventBus.trigger(Events.PLAYBACK_NOT_ALLOWED);
+                    }
                     log(`Caught pending play exception - continuing (${e})`);
                 });
             }


### PR DESCRIPTION
will solve issue/feature #1541 by adding new event: MediaPlayerEvents.PLAYBACK_NOT_ALLOWED