### PR TITLE
Solves various ABR issues based on #1530.  

### DIFF
--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -33,22 +33,24 @@ import MediaPlayerModel from '../../models/MediaPlayerModel';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 
-const GRACE_TIME_THRESHOLD = 500;
-const ABANDON_MULTIPLIER = 1.5;
+function AbandonRequestsRule() {
 
-function AbandonRequestsRule(/*config*/) {
+    const ABANDON_MULTIPLIER = 1.8;
+    const GRACE_TIME_THRESHOLD = 500;
+    const MIN_LENGTH_TO_AVERAGE = 5;
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
 
-    let instance,
-        fragmentDict,
+    let fragmentDict,
         abandonDict,
+        throughputArray,
         mediaPlayerModel;
 
     function setup() {
         fragmentDict = {};
         abandonDict = {};
+        throughputArray = [];
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
     }
 
@@ -57,21 +59,23 @@ function AbandonRequestsRule(/*config*/) {
         fragmentDict[type][id] = fragmentDict[type][id] || {};
     }
 
+    function storeLastRequestThroughputByType(type, throughput) {
+        throughputArray[type] = throughputArray[type] || [];
+        throughputArray[type].push(throughput);
+    }
+
     function execute(rulesContext, callback) {
-        var fragmentInfo;
-        var now = new Date().getTime();
-        var mediaInfo = rulesContext.getMediaInfo();
-        var mediaType = mediaInfo.type;
-        var progressEvent = rulesContext.getCurrentValue();
-        var representationInfo = rulesContext.getTrackInfo();
-        var req = progressEvent.request;
-        var abrController = rulesContext.getStreamProcessor().getABRController();
-        var switchRequest = SwitchRequest(context).create(SwitchRequest.NO_CHANGE, SwitchRequest.WEAK, {name: AbandonRequestsRule.__dashjs_factory_name});
+
+        const mediaInfo = rulesContext.getMediaInfo();
+        const mediaType = mediaInfo.type;
+        const req = rulesContext.getCurrentValue().request;
+        const switchRequest = SwitchRequest(context).create(SwitchRequest.NO_CHANGE, SwitchRequest.WEAK, {name: AbandonRequestsRule.__dashjs_factory_name});
 
         if (!isNaN(req.index)) {
-            setFragmentRequestDict(mediaType, req.index);
-            fragmentInfo = fragmentDict[mediaType][req.index];
 
+            setFragmentRequestDict(mediaType, req.index);
+
+            const fragmentInfo = fragmentDict[mediaType][req.index];
             if (fragmentInfo === null || req.firstByteDate === null || abandonDict.hasOwnProperty(fragmentInfo.id)) {
                 callback(switchRequest);
                 return;
@@ -79,35 +83,50 @@ function AbandonRequestsRule(/*config*/) {
 
             //setup some init info based on first progress event
             if (fragmentInfo.firstByteTime === undefined) {
+                throughputArray[mediaType] = [];
                 fragmentInfo.firstByteTime = req.firstByteDate.getTime();
                 fragmentInfo.segmentDuration = req.duration;
                 fragmentInfo.bytesTotal = req.bytesTotal;
                 fragmentInfo.id = req.index;
-                //log("FRAG ID : " ,fragmentInfo.id, " *****************");
             }
-            //update info base on subsequent progress events until completed.
             fragmentInfo.bytesLoaded = req.bytesLoaded;
-            fragmentInfo.elapsedTime = now - fragmentInfo.firstByteTime;
+            fragmentInfo.elapsedTime = new Date().getTime() - fragmentInfo.firstByteTime;
 
-            if (fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal &&
-                fragmentInfo.elapsedTime >= GRACE_TIME_THRESHOLD) {
+            if (fragmentInfo.bytesLoaded > 0 && fragmentInfo.elapsedTime > 0) {
+                storeLastRequestThroughputByType(mediaType, Math.round(fragmentInfo.bytesLoaded * 8 / fragmentInfo.elapsedTime));
+            }
 
-                fragmentInfo.measuredBandwidthInKbps = Math.round(fragmentInfo.bytesLoaded * 8 / fragmentInfo.elapsedTime);
-                fragmentInfo.estimatedTimeOfDownload = (fragmentInfo.bytesTotal * 8 * 0.001 / fragmentInfo.measuredBandwidthInKbps).toFixed(2);
-                //log("id: ",fragmentInfo.id,  "kbps: ", fragmentInfo.measuredBandwidthInKbps, "etd: ",fragmentInfo.estimatedTimeOfDownload, "et: ", fragmentInfo.elapsedTime/1000);
+            if (throughputArray[mediaType].length >= MIN_LENGTH_TO_AVERAGE &&
+                fragmentInfo.elapsedTime > GRACE_TIME_THRESHOLD &&
+                fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal) {
 
-                if (fragmentInfo.estimatedTimeOfDownload < (fragmentInfo.segmentDuration * ABANDON_MULTIPLIER) || representationInfo.quality === 0) {
+                const totalSampledValue = throughputArray[mediaType].reduce((a, b) => a + b, 0);
+                fragmentInfo.measuredBandwidthInKbps = Math.round(totalSampledValue / throughputArray[mediaType].length);
+                fragmentInfo.estimatedTimeOfDownload = ((fragmentInfo.bytesTotal * 8 / fragmentInfo.measuredBandwidthInKbps) / 1000).toFixed(2);
+                //log("id:",fragmentInfo.id, "kbps:", fragmentInfo.measuredBandwidthInKbps, "etd:",fragmentInfo.estimatedTimeOfDownload, fragmentInfo.bytesLoaded);
+
+                if (fragmentInfo.estimatedTimeOfDownload < fragmentInfo.segmentDuration * ABANDON_MULTIPLIER || rulesContext.getTrackInfo().quality === 0 ) {
+
                     callback(switchRequest);
                     return;
-                }else if (!abandonDict.hasOwnProperty(fragmentInfo.id)) {
-                    var newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps * mediaPlayerModel.getBandwidthSafetyFactor());
-                    switchRequest.value = newQuality;
-                    switchRequest.priority = SwitchRequest.STRONG;
-                    switchRequest.reason.throughput = fragmentInfo.measuredBandwidthInKbps;
 
-                    abandonDict[fragmentInfo.id] = fragmentInfo;
-                    log('AbandonRequestsRule ( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
-                    delete fragmentDict[mediaType][fragmentInfo.id];
+                } else if (!abandonDict.hasOwnProperty(fragmentInfo.id)) {
+
+                    const abrController = rulesContext.getStreamProcessor().getABRController();
+                    const bytesRemaining = fragmentInfo.bytesTotal - fragmentInfo.bytesLoaded;
+                    const bitrateList = abrController.getBitrateList(mediaInfo);
+                    const newQuality = abrController.getQualityForBitrate(mediaInfo, fragmentInfo.measuredBandwidthInKbps * mediaPlayerModel.getBandwidthSafetyFactor());
+                    const estimateOtherBytesTotal = fragmentInfo.bytesTotal * bitrateList[newQuality].bitrate / bitrateList[abrController.getQualityFor(mediaType, mediaInfo.streamInfo)].bitrate;
+
+                    if (bytesRemaining > estimateOtherBytesTotal) {
+
+                        switchRequest.value = newQuality;
+                        switchRequest.priority = SwitchRequest.STRONG;
+                        switchRequest.reason.throughput = fragmentInfo.measuredBandwidthInKbps;
+                        abandonDict[fragmentInfo.id] = fragmentInfo;
+                        log('AbandonRequestsRule ( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
+                        delete fragmentDict[mediaType][fragmentInfo.id];
+                    }
                 }
             }else if (fragmentInfo.bytesLoaded === fragmentInfo.bytesTotal) {
                 delete fragmentDict[mediaType][fragmentInfo.id];
@@ -118,11 +137,10 @@ function AbandonRequestsRule(/*config*/) {
     }
 
     function reset() {
-        fragmentDict = {};
-        abandonDict = {};
+        setup();
     }
 
-    instance = {
+    const instance = {
         execute: execute,
         reset: reset
     };

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -38,110 +38,115 @@ import Debug from '../../../core/Debug';
 
 function ThroughputRule(config) {
 
-    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE = 2;
-    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD = 3;
+    const MAX_MEASUREMENTS_TO_KEEP = 20;
+    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE = 3;
+    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD = 4;
+    const CACHE_LOAD_THRESHOLD_VIDEO = 50;
+    const CACHE_LOAD_THRESHOLD_AUDIO = 5;
+    const THROUGHPUT_DECREASE_SCALE = 1.3;
+    const THROUGHPUT_INCREASE_SCALE = 1.3;
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let dashMetrics = config.dashMetrics;
-    let metricsModel = config.metricsModel;
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
+    const dashMetrics = config.dashMetrics;
+    const metricsModel = config.metricsModel;
 
-    let instance,
-        throughputArray,
+    let throughputArray,
+        cacheLoadDict,
         mediaPlayerModel;
 
     function setup() {
         throughputArray = [];
+        cacheLoadDict = {audio: {threshold: CACHE_LOAD_THRESHOLD_AUDIO, value: NaN}, video: {threshold: CACHE_LOAD_THRESHOLD_VIDEO, value: NaN}};//threshold is in milliseconds
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
     }
 
-    function storeLastRequestThroughputByType(type, lastRequestThroughput) {
+    function storeLastRequestThroughputByType(type, throughput) {
         throughputArray[type] = throughputArray[type] || [];
-        if (lastRequestThroughput !== Infinity &&
-            lastRequestThroughput !== throughputArray[type][throughputArray[type].length - 1]) {
-            throughputArray[type].push(lastRequestThroughput);
+        throughputArray[type].push(throughput);
+    }
+
+    function getSample(type, isDynamic) {
+        let size = Math.min(throughputArray[type].length, isDynamic ? AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE : AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD);
+        const sampleArray = throughputArray[type].slice(size * -1, throughputArray[type].length);
+        if (sampleArray.length > 1) {
+            sampleArray.reduce((a, b) => {
+                if (a * THROUGHPUT_INCREASE_SCALE <= b || a >= b * THROUGHPUT_DECREASE_SCALE) {
+                    size++;
+                }
+                return b;
+            });
         }
+        size = Math.min(throughputArray[type].length, size);
+        return throughputArray[type].slice(size * -1, throughputArray[type].length);
     }
 
     function getAverageThroughput(type, isDynamic) {
-        var averageThroughput = 0;
-        var sampleAmount = isDynamic ? AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE : AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD;
-        var arr = throughputArray[type];
-        var len = arr ? arr.length : 0;
-
-        sampleAmount = len < sampleAmount ? len : sampleAmount;
-
-        if (len > 0) {
-            var startValue = len - sampleAmount;
-            var totalSampledValue = 0;
-
-            for (var i = startValue; i < len; i++) {
-                totalSampledValue += arr[i];
-            }
-            averageThroughput = totalSampledValue / sampleAmount;
-
-            if (arr.length > sampleAmount) {
-                arr.shift();
-            }
+        const sample = getSample(type, isDynamic);
+        let averageThroughput = 0;
+        if (sample.length > 0) {
+            const totalSampledValue = sample.reduce((a, b) => a + b, 0);
+            averageThroughput = totalSampledValue / sample.length;
         }
-
+        if (throughputArray[type].length >= MAX_MEASUREMENTS_TO_KEEP) {
+            throughputArray[type].shift();
+        }
         return (averageThroughput / 1000 ) * mediaPlayerModel.getBandwidthSafetyFactor();
     }
 
     function execute (rulesContext, callback) {
-        var downloadTime;
-        var bytes;
-        var averageThroughput;
-        var lastRequestThroughput;
 
-        var mediaInfo = rulesContext.getMediaInfo();
-        var mediaType = mediaInfo.type;
-        var current = rulesContext.getCurrentValue();
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        var streamProcessor = rulesContext.getStreamProcessor();
-        var abrController = streamProcessor.getABRController();
-        var isDynamic = streamProcessor.isDynamic();
-        var lastRequest = dashMetrics.getCurrentHttpRequest(metrics);
-        var bufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
-        var bufferLevelVO = (metrics.BufferLevel.length > 0) ? metrics.BufferLevel[metrics.BufferLevel.length - 1] : null;
-        var switchRequest = SwitchRequest(context).create(SwitchRequest.NO_CHANGE, SwitchRequest.WEAK, {name: ThroughputRule.__dashjs_factory_name});
+        const mediaInfo = rulesContext.getMediaInfo();
+        const mediaType = mediaInfo.type;
+        const currentQuality = rulesContext.getCurrentValue();
+        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const streamProcessor = rulesContext.getStreamProcessor();
+        const abrController = streamProcessor.getABRController();
+        const isDynamic = streamProcessor.isDynamic();
+        const lastRequest = dashMetrics.getCurrentHttpRequest(metrics);
+        const bufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
+        const switchRequest = SwitchRequest(context).create(SwitchRequest.NO_CHANGE, SwitchRequest.WEAK, {name: ThroughputRule.__dashjs_factory_name});
 
-        if (!metrics || !lastRequest || lastRequest.type !== HTTPRequest.MEDIA_SEGMENT_TYPE ||
-            !bufferStateVO || !bufferLevelVO ) {
-
+        if (!metrics || !lastRequest || lastRequest.type !== HTTPRequest.MEDIA_SEGMENT_TYPE || !bufferStateVO ) {
             callback(switchRequest);
             return;
-
         }
+
+        let downloadTimeInMilliseconds;
 
         if (lastRequest.trace && lastRequest.trace.length) {
-            downloadTime = (lastRequest._tfinish.getTime() - lastRequest.tresponse.getTime()) / 1000;
 
-            bytes = lastRequest.trace.reduce(function (a, b) {
-                return a + b.b[0];
-            }, 0);
+            downloadTimeInMilliseconds = lastRequest._tfinish.getTime() - lastRequest.tresponse.getTime() + 1; //Make sure never 0 we divide by this value. Avoid infinity!
 
-            lastRequestThroughput = Math.round(bytes * 8) / downloadTime;
-            storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
+            const bytes = lastRequest.trace.reduce((a, b) => a + b.b[0], 0);
+            const lastRequestThroughput = Math.round((bytes * 8) / (downloadTimeInMilliseconds / 1000));
+
+            //Prevent cached fragment loads from skewing the average throughput value - allow first even if cached to set allowance for ABR rules..
+            if (downloadTimeInMilliseconds <= cacheLoadDict[mediaType].threshold) {
+                cacheLoadDict[mediaType].value = lastRequestThroughput / 1000;
+            } else {
+                cacheLoadDict[mediaType].value = NaN;
+                storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
+            }
         }
 
-        averageThroughput = Math.round(getAverageThroughput(mediaType, isDynamic));
-        abrController.setAverageThroughput(mediaType, averageThroughput);
+        const throughput = Math.round(!isNaN(cacheLoadDict[mediaType].value) ? cacheLoadDict[mediaType].value  : getAverageThroughput(mediaType, isDynamic));
+        abrController.setAverageThroughput(mediaType, throughput);
 
         if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
 
             if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
-                var newQuality = abrController.getQualityForBitrate(mediaInfo, averageThroughput);
+                const newQuality = abrController.getQualityForBitrate(mediaInfo, throughput);
                 streamProcessor.getScheduleController().setTimeToLoadDelay(0);
                 switchRequest.value = newQuality;
                 switchRequest.priority = SwitchRequest.DEFAULT;
-                switchRequest.reason.throughput = averageThroughput;
+                switchRequest.reason.throughput = throughput;
             }
 
-            if (switchRequest.value !== SwitchRequest.NO_CHANGE && switchRequest.value !== current) {
+            if (switchRequest.value !== SwitchRequest.NO_CHANGE && switchRequest.value !== currentQuality) {
                 log('ThroughputRule requesting switch to index: ', switchRequest.value, 'type: ',mediaType, ' Priority: ',
                     switchRequest.priority === SwitchRequest.DEFAULT ? 'Default' :
-                        switchRequest.priority === SwitchRequest.STRONG ? 'Strong' : 'Weak', 'Average throughput', Math.round(averageThroughput), 'kbps');
+                        switchRequest.priority === SwitchRequest.STRONG ? 'Strong' : 'Weak', 'Average throughput', Math.round(throughput), 'kbps');
             }
         }
 
@@ -152,7 +157,7 @@ function ThroughputRule(config) {
         setup();
     }
 
-    instance = {
+    const instance = {
         execute: execute,
         reset: reset
     };


### PR DESCRIPTION
Added cache detection to TP rule, fixes issues with Abandonment rules.  Fixes issues on transfer from cached to not cached sections of presentation.  Solves major oscillation issue in TP rule.  All changes were confirmed with the ABR testing tool.   

For Oscillations we now have an algorithm to detect variation in the average array and will increase or decrease the sample amount based on variation.  
 
Some results:  BOLA vs Traditional after major improvements in both ABR.

ABR							bola	               default
rebuffers (low/other quality)	        0 (0/0)		0 (0/0)
average rebuffer seconds		0.000		0.000
up switches (in Mbps)			4 (70.582)	9 (34.184)
down switches (in Mbps)		6 (56.410)	5 (25.030)
oscillations within 10s			9			1
average bitrate in Mbps			11.222		10.724
count q=0 (0.254Mbps)			0			0
count q=1 (0.507Mbps)			2			0
count q=2 (0.760Mbps)			1			1
count q=3 (1.013Mbps)			0			1
count q=4 (1.255Mbps)			0			0
count q=5 (1.884Mbps)			0			0
count q=6 (3.134Mbps)			2			1
count q=7 (4.953Mbps)			8			5
count q=8 (9.915Mbps)			27			45
count q=9 (14.932Mbps)		36			22


Cache Pollution solution.   We now keep a last load if cached measurement VS the aver thoughput array.  This allows ABR to still switch up if chunks are cached but will react much quicker once not cached.  It will also allow us to not switch up if a few cache chunks skew the average.   
Average   Time  
----------------	

1468109   0.037 
1468109   0.033 
1468109   0.025 
1468109   0.034 
1468109   0.04  
1468109   1.026 
 752526   1.061  FALSE reading
 516388   1.025 FALSE reading
  41997   0.836 
  43450   0.871 
  44535   0.946 
  
__________________

1575767   33.001 
1505165   34.001 
1475513   26.001 
1528010   30.001 
 -- NON CACHED CHUNKS  - Immediately shows accurate info with no step down.
20784 	  2186.001 
20769 	  1941.001 
20780 	  1977.001 
20764 	  2326.001 
20778 	  1914.001 
20779 	  2069.001