### PR TITLE
Publish ES5 files for node.js import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ _SpecRunner.html
 reports
 jsdoc
 dist
-es5
-temp
+build/temp
+build/es5
 coverage
 
 #################

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 samples
 docs
-build
+build/temp
+build/jsdoc
 test
 .travis.yml
 mochahook.js

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dashjs",
   "version": "2.3.0",
   "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
-  "main": "dist/es5/index.js",
+  "main": "build/es5/index.js",
   "scripts": {
     "test": "mocha --require mochahook",
     "prepublish": "grunt prepublish",


### PR DESCRIPTION
This PR is in response to #1509. The babelified source files will live in `build/es5/` 