### PR TITLE
Fixes three issues found while testing RC1 v2.3.0

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -42,7 +42,6 @@ import FragmentLoader from './FragmentLoader';
 import RequestModifier from './utils/RequestModifier';
 import SourceBufferController from './controllers/SourceBufferController';
 import TextSourceBuffer from './TextSourceBuffer';
-import MediaSourceController from './controllers/MediaSourceController';
 import DashManifestModel from '../dash/models/DashManifestModel';
 import DashMetrics from '../dash/DashMetrics';
 import RepresentationController from '../dash/controllers/RepresentationController';
@@ -267,7 +266,6 @@ function StreamProcessor(config) {
                 manifestModel: manifestModel,
                 sourceBufferController: SourceBufferController(context).getInstance(),
                 errHandler: ErrorHandler(context).getInstance(),
-                mediaSourceController: MediaSourceController(context).getInstance(),
                 streamController: StreamController(context).getInstance(),
                 mediaController: MediaController(context).getInstance(),
                 adapter: adapter,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -277,7 +277,7 @@ function BufferController(config) {
         const isLastIdxAppended = maxAppendedIndex === (lastIndex - 1);
         if (isLastIdxAppended && !isBufferingCompleted) {
             isBufferingCompleted = true;
-            mediaSourceController.signalEndOfStream(mediaSource);
+            //mediaSourceController.signalEndOfStream(mediaSource);
             eventBus.trigger(Events.BUFFERING_COMPLETED, {sender: instance, streamInfo: streamProcessor.getStreamInfo()});
         }
     }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -55,7 +55,6 @@ function BufferController(config) {
     const manifestModel = config.manifestModel;
     const sourceBufferController = config.sourceBufferController;
     const errHandler = config.errHandler;
-    const mediaSourceController = config.mediaSourceController;
     const streamController = config.streamController;
     const mediaController = config.mediaController;
     const adapter = config.adapter;
@@ -253,6 +252,8 @@ function BufferController(config) {
     // START Buffer Level, State & Sufficiency Handling.
     //**********************************************************************
     function onPlaybackSeeking() {
+        lastIndex = 0;
+        isBufferingCompleted = false;
         onPlaybackProgression();
     }
 
@@ -277,7 +278,6 @@ function BufferController(config) {
         const isLastIdxAppended = maxAppendedIndex === (lastIndex - 1);
         if (isLastIdxAppended && !isBufferingCompleted) {
             isBufferingCompleted = true;
-            //mediaSourceController.signalEndOfStream(mediaSource);
             eventBus.trigger(Events.BUFFERING_COMPLETED, {sender: instance, streamInfo: streamProcessor.getStreamInfo()});
         }
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -195,7 +195,6 @@ function ScheduleController(config) {
         const readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent());
 
         if (readyToLoad || isReplacement) {
-
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;
@@ -308,6 +307,7 @@ function ScheduleController(config) {
     function onStreamCompleted(e) {
         if (e.fragmentModel !== fragmentModel) return;
         stop();
+        isFragmentProcessingInProgress = false;
         log('Stream is complete');
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -192,15 +192,12 @@ function StreamController() {
     }
 
     function onPlaybackError(e) {
-        if (!e.error) {
-            // not a media error!
-            return;
-        }
 
-        var code = e.error.code;
-        var msg = '';
+        if (!e.error) return;
 
-        switch (code) {
+        let msg = '';
+
+        switch (e.error.code) {
             case 1:
                 msg = 'MEDIA_ERR_ABORTED';
                 break;
@@ -242,7 +239,7 @@ function StreamController() {
     function onPlaybackTimeUpdated(e) {
 
         if (isVideoTrackPresent()) {
-            var playbackQuality = videoModel.getPlaybackQuality();
+            const playbackQuality = videoModel.getPlaybackQuality();
             if (playbackQuality) {
                 metricsModel.addDroppedFrames('video', playbackQuality);
             }
@@ -250,26 +247,23 @@ function StreamController() {
         // Sometimes after seeking timeUpdateHandler is called before seekingHandler and a new stream starts
         // from beginning instead of from a chosen position. So we do nothing if the player is in the seeking state
         if (playbackController.isSeeking()) return;
-
-        // check if stream end is reached
         if (e.timeToEnd < STREAM_END_THRESHOLD) {
+            //This is only used for multiperiod content.
+            // The main call to signalEndOfStream is driven by BUFFERING_COMPLETED event
             mediaSourceController.signalEndOfStream(mediaSource);
         }
     }
 
     function onEnded() {
-
-        let nextStream = getNextStream();
-
+        const nextStream = getNextStream();
         if (nextStream) {
             switchStream(activeStream, nextStream, NaN);
         }
-
         flushPlaylistMetrics(nextStream ? PlayListTrace.END_OF_PERIOD_STOP_REASON : PlayListTrace.END_OF_CONTENT_STOP_REASON);
     }
 
     function onPlaybackSeeking(e) {
-        var seekingStream = getStreamForTime(e.seekTime);
+        const seekingStream = getStreamForTime(e.seekTime);
 
         if (seekingStream && seekingStream !== activeStream) {
             flushPlaylistMetrics(PlayListTrace.END_OF_PERIOD_STOP_REASON);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -306,14 +306,9 @@ function StreamController() {
      * this handler's logic caused Firefox and Safari to not period switch since the end event did not fire due to this.
      */
     function onStreamBufferingCompleted(e) {
-        //var nextStream = getNextStream();
-        var isLast = e.streamInfo.isLast;
-
-        if (mediaSource && isLast) {
+        if (mediaSource && e.streamInfo.isLast) {
             mediaSourceController.signalEndOfStream(mediaSource);
         }
-        //if (!nextStream) return;
-        //nextStream.activate(mediaSource);
     }
 
 


### PR DESCRIPTION
1. Multiperiod duration was getting set with call to source signalEnd at non last period stream. 
2. cleans up hack for calling signalEnd from buffercontroller by setting the value to the event is fired the second time a stream is complete if replayed not reloaded
3. Allows replay of stream if play is called after complete event with new schedule logic. 
4. Cleaned up some old es5 code in areas I made adjustments but then stopped doing that since it is code freeze.  I left in what I started as it was minor.

All changes are pretty minor but solve some critical stuff. 