### PR TITLE
Use dash.all.debug.js in scte ad insertion sample site

### DIFF
--- a/samples/ad-insertion/scte.html
+++ b/samples/ad-insertion/scte.html
@@ -7,7 +7,7 @@
 
 <head>
     <title>Fraunhofer Fokus - Ad Insertion Sample</title>
-    <script src="../../dist/dash.all.min.js"></script>
+    <script src="../../dist/dash.all.debug.js"></script>
     <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/main.css" rel="stylesheet">


### PR DESCRIPTION
Fix a wrong reference to the dash.js library in the scte ad insertion sample site