### PR TITLE
AST_IN_FUTURE should be a public event.

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -37,7 +37,6 @@ import EventsBase from './EventsBase';
 class CoreEvents extends EventsBase {
     constructor () {
         super();
-        this.AST_IN_FUTURE = 'astinfuture';
         this.BUFFERING_COMPLETED = 'bufferingCompleted';
         this.BUFFER_CLEARED = 'bufferCleared';
         this.BUFFER_LEVEL_UPDATED = 'bufferLevelUpdated';

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -41,6 +41,7 @@ import DOMStorage from '../../streaming/utils/DOMStorage';
 import Error from '../../streaming/vo/Error';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
+import MediaPlayerEvents from '../../streaming/MediaPlayerEvents';
 import FactoryMaker from '../../core/FactoryMaker';
 
 function RepresentationController() {
@@ -266,7 +267,7 @@ function RepresentationController() {
         };
 
         updating = false;
-        eventBus.trigger(Events.AST_IN_FUTURE, { delay: delay });
+        eventBus.trigger(MediaPlayerEvents.AST_IN_FUTURE, { delay: delay });
         setTimeout(update, delay);
     }
 

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -41,6 +41,12 @@ class MediaPlayerEvents extends EventsBase {
     constructor () {
         super();
         /**
+         * Triggered when playback will not start yet
+         * as the MPD's availabilityStartTime is in the future.
+         * Check delay property in payload to determine time before playback will start.
+         */
+        this.AST_IN_FUTURE = 'astinfuture';
+        /**
          * Triggered when the video element's buffer state changes to stalled.
          * Check mediaType in payload to determine type (Video, Audio, FragmentedText).
          * @event MediaPlayerEvents#BUFFER_EMPTY


### PR DESCRIPTION
The astinfuture event was created with the intention for players to use it to identify when playback will not start until a later point.

So it should probably be public so players can use it.