### PR TITLE
MPD xs:string parse fix

### DIFF
--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -140,6 +140,7 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
             result.__children = children;
 			
 			// Attributes
+            var nodeLocalName = getNodeLocalName(node);
 			for(var aidx=0; aidx <node.attributes.length; aidx++) {
 				var attr = node.attributes.item(aidx); // [aidx];
 				result.__cnt++;
@@ -147,7 +148,7 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
 				var value2 = attr.value;
 				for(var m=0, ml=matchers.length; m < ml; m++) {
 				    var matchobj = matchers[m];
-				    if (matchobj.test(attr)) {
+				    if (matchobj.test(attr, nodeLocalName)) {
 						value2 = matchobj.converter(attr.value);
 					}
 				}

--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -140,7 +140,7 @@ function X2JS(matchers, attrPrefix, ignoreRoot) {
             result.__children = children;
 			
 			// Attributes
-            var nodeLocalName = getNodeLocalName(node);
+			var nodeLocalName = getNodeLocalName(node);
 			for(var aidx=0; aidx <node.attributes.length; aidx++) {
 				var attr = node.attributes.item(aidx); // [aidx];
 				result.__cnt++;

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -33,6 +33,7 @@ import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import ObjectIron from '../../../externals/objectiron';
 import X2JS from '../../../externals/xml2json';
+import StringMatcher from './matchers/StringMatcher';
 import DurationMatcher from './matchers/DurationMatcher';
 import DateTimeMatcher from './matchers/DateTimeMatcher';
 import NumericMatcher from './matchers/NumericMatcher';
@@ -54,7 +55,8 @@ function DashParser(/*config*/) {
         matchers = [
             new DurationMatcher(),
             new DateTimeMatcher(),
-            new NumericMatcher()
+            new NumericMatcher(),
+            new StringMatcher()   // last in list to take precedence over NumericMatcher
         ];
 
         converter = new X2JS(matchers, '', true);

--- a/src/dash/parser/matchers/StringMatcher.js
+++ b/src/dash/parser/matchers/StringMatcher.js
@@ -1,0 +1,84 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @classdesc Matches and converts xs:string to string, but only for specific attributes on specific nodes
+ */
+import BaseMatcher from './BaseMatcher';
+
+class StringMatcher extends BaseMatcher {
+    constructor() {
+        super(
+            (attr, nodeName) => {
+                const stringAttrsInElements = {
+                    'MPD':                        [ 'id', 'profiles' ],
+                    'Period':                     [ 'id', ],
+                    'BaseURL':                    [ 'serviceLocation', 'byteRange' ],
+                    'SegmentBase':                [ 'indexRange' ],
+                    'Initialization':             [ 'range' ],
+                    'RepresentationIndex':        [ 'range' ],
+                    'SegmentList':                [ 'indexRange' ],
+                    'BitstreamSwitching':         [ 'range' ],
+                    'SegmentURL':                 [ 'mediaRange', 'indexRange' ],
+                    'SegmentTemplate':            [ 'indexRange', 'media', 'index', 'initialization', 'bitstreamSwitching' ],
+                    'AssetIdentifier':            [ 'value', 'id' ],
+                    'EventStream':                [ 'value' ],
+                    'AdaptationSet':              [ 'profiles', 'mimeType', 'segmentProfiles', 'codecs', 'contentType' ],
+                    'FramePacking':               [ 'value', 'id' ],
+                    'AudioChannelConfiguration':  [ 'value', 'id' ],
+                    'ContentProtection':          [ 'value', 'id' ],
+                    'EssentialProperty':          [ 'value', 'id' ],
+                    'SupplementalProperty':       [ 'value', 'id' ],
+                    'InbandEventStream':          [ 'value', 'id' ],
+                    'Accessibility':              [ 'value', 'id' ],
+                    'Role':                       [ 'value', 'id' ],
+                    'Rating':                     [ 'value', 'id' ],
+                    'Viewpoint':                  [ 'value', 'id' ],
+                    'ContentComponent':           [ 'contentType' ],
+                    'Subset':                     [ 'id' ],
+                    'Metrics':                    [ 'metrics' ],
+                    'Reporting':                  [ 'value', 'id' ]
+                };
+                if (stringAttrsInElements.hasOwnProperty(nodeName)) {
+                    var attrNames = stringAttrsInElements[nodeName];
+                    if (attrNames !== undefined) {
+                        return attrNames.indexOf(attr.name) >= 0;
+                    } else {
+                        return false;
+                    }
+                }
+                return false;
+            },
+            str => String(str)
+        );
+    }
+}
+
+export default StringMatcher;

--- a/src/dash/parser/matchers/StringMatcher.js
+++ b/src/dash/parser/matchers/StringMatcher.js
@@ -62,6 +62,7 @@ class StringMatcher extends BaseMatcher {
                     'Rating':                     [ 'value', 'id' ],
                     'Viewpoint':                  [ 'value', 'id' ],
                     'ContentComponent':           [ 'contentType' ],
+                    'Representation':             [ 'id', 'dependencyId', 'mediaStreamStructureId' ],
                     'Subset':                     [ 'id' ],
                     'Metrics':                    [ 'metrics' ],
                     'Reporting':                  [ 'value', 'id' ]


### PR DESCRIPTION
This PR is intended to fix #1573 . It adds a `StringMatcher` to the DASH parser.

The issue identified the specific case of `Period@id` attributes, however there are many other attributes in the DASH MPD that, according to the schema, are also type `xs:string`. `StringMatcher` therefore contains a mapping table listing every attribute I could find the the schema that is defined as being of type `xs:string`.

The `StringMatcher` needs to know the name of the node as well as the name of the attribute. `xml2json.js` was therefore modified to provide this as an argument to the test method. Although attributes currently have an `ownerElement` property that would provide this information (without needing to modify `xml2json.js`) this will eventually be deprecated in DOM4+ according to https://developer.mozilla.org/en-US/docs/Web/API/Attr