### PR TITLE
additional undefined checks before referencing window

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ import {getVersionString} from './src/core/Version';
 
 
 // Shove both of these into the global scope
-var context = window || global;
+var context = (typeof window !== 'undefined' && window) || global;
 
 var dashjs = context.dashjs;
 if (!dashjs) {

--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -100,9 +100,9 @@ function loadHandler() {
     instance.createAll();
 }
 
-let avoidAutoCreate = window && window.dashjs && window.dashjs.skipAutoCreate;
+let avoidAutoCreate = typeof window !== 'undefined' && window && window.dashjs && window.dashjs.skipAutoCreate;
 
-if (!avoidAutoCreate && window && window.addEventListener) {
+if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.addEventListener) {
     if (window.document.readyState === 'complete') {
         instance.createAll();
     } else {


### PR DESCRIPTION
Added additional undefined checks before referencing window, so dash.js can be used in module form in non-browser environments.

Primary example for this would be a server side rendered view that includes dash.js.

Not a frequent OSS contributor so let me know how I can help get this through :^)