### PR TITLE
Removes forcing preload to auto

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -80,7 +80,7 @@ function VideoModel() {
     function setElement(value) {
         element = value;
         // Workaround to force Firefox to fire the canplay event.
-        element.preload = 'auto';
+        // element.preload = 'auto';
     }
 
     function setSource(source) {


### PR DESCRIPTION
- Ignores warning about Firefox not throwing _canplay_ event