### PR TITLE
Add check in `pruneBuffer`if SourceBuffer is defined

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -366,6 +366,7 @@ function BufferController(config) {
 
     /* prune buffer on our own in background to avoid browsers pruning buffer silently */
     function pruneBuffer() {
+        if (!buffer) return;
         if (type === 'fragmentedText') return;
         const start = buffer.buffered.length ? buffer.buffered.start(0) : 0;
         const bufferToPrune = playbackController.getTime() - start - mediaPlayerModel.getBufferToKeep();


### PR DESCRIPTION
This fixes an exception occurring here when a SourceBuffer is undefined in case `SourceBufferController.createSourceBuffer` returns `null`