### PR TITLE
Fix Edge malformed start tag warning

### DIFF
--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -165,7 +165,7 @@
                     <label>Audio:</label>
                     <input type="text" class="form-control" placeholder="initial lang, e.g. 'en'" ng-model="initialSettings.audio">
                     <label>Video:</label>
-                    <input type="text" class="form-control" placeholder="initial role, e.g. 'alternate'"ng-model="initialSettings.video">
+                    <input type="text" class="form-control" placeholder="initial role, e.g. 'alternate'" ng-model="initialSettings.video">
                     <label data-toggle="tooltip" data-placement="right"
                            title="When a track is switched, the portion of the buffer that contains old track data is cleared">
                         <input  type="radio" id="always-replace" autocomplete="off" name="track-switch" checked="checked" ng-click="changeTrackSwitchMode('alwaysReplace', 'video')" >


### PR DESCRIPTION
"Attributes should be seperated by whitespace" said the warning text.