### PR TITLE
Resolve relative BaseURLs more in line with the spec

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,6 +15,8 @@
     "predef" : [
         "it",
         "describe",
+        "beforeEach",
+        "afterEach",
         "kendo",
         "utils",
         "MediaPlayer",

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -136,7 +136,7 @@ function DashHandler(config) {
             serviceLocation = baseURL.serviceLocation;
 
             if (destination) {
-                url += destination;
+                url = urlUtils.resolve(destination, url);
             }
         }
 

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -96,7 +96,7 @@ function ManifestLoader(config) {
                     // xhr.responseURL above but it is not available for IE11
                     // baseUri must be absolute for BaseURL resolution later
                     if (urlUtils.isRelative(url)) {
-                        url = urlUtils.parseBaseUrl(window.location.href) + url;
+                        url = urlUtils.resolve(url, window.location.href);
                     }
 
                     baseUri = urlUtils.parseBaseUrl(url);

--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -73,13 +73,13 @@ function BaseURLController() {
             if (b) {
                 if (!urlUtils.isRelative(b.url)) {
                     if (urlUtils.isPathAbsolute(b.url)) {
-                        p.url = urlUtils.parseOrigin(p.url) + b.url;
+                        p.url = urlUtils.resolve(b.url, urlUtils.parseOrigin(p.url));
                     } else {
                         p.url = b.url;
                         p.serviceLocation = b.serviceLocation;
                     }
                 } else {
-                    p.url += b.url;
+                    p.url = urlUtils.resolve(b.url, p.url);
                 }
             }
 

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -40,11 +40,79 @@ import FactoryMaker from '../../core/FactoryMaker';
  */
 function URLUtils() {
 
-    let instance;
+    let resolveFunction;
 
     const absUrl = /^(?:(?:[a-z]+:)?\/)?\//i;
     const httpUrlRegex = /^https?:\/\//i;
     const originRegex = /^(https?:\/\/[^\/]+)\/?/i;
+
+    /**
+     * Resolves a url given an optional base url
+     * Uses window.URL to do the resolution.
+     *
+     * @param {string} url
+     * @param {string} [baseUrl]
+     * @return {string}
+     * @memberof module:URLUtils
+     * @instance
+     * @private
+     */
+    const nativeURLResolver = (url, baseUrl) => {
+        try {
+            // this will throw if baseurl is undefined, invalid etc
+            return new window.URL(url, baseUrl).toString();
+        } catch (e) {
+            return url;
+        }
+    };
+
+    /**
+     * Resolves a url given an optional base url
+     * Does not resolve ./, ../ etc but will do enough to construct something
+     * which will satisfy XHR etc when window.URL is not available ie
+     * IE11/node etc.
+     *
+     * @param {string} url
+     * @param {string} [baseUrl]
+     * @return {string}
+     * @memberof module:URLUtils
+     * @instance
+     * @private
+     */
+    const dumbURLResolver = (url, baseUrl) => {
+        var baseUrlParseFunc = parseBaseUrl;
+
+        if (!baseUrl) {
+            return url;
+        }
+
+        if (!isRelative(url)) {
+            if (isPathAbsolute(url)) {
+                baseUrlParseFunc = parseOrigin;
+            } else {
+                return url;
+            }
+        }
+
+        const base = baseUrlParseFunc(baseUrl);
+        const joinChar =
+              base.charAt(base.length - 1) !== '/' &&
+              url.charAt(0) !== '/' ?
+              '/' : '';
+
+        return [base, url].join(joinChar);
+    };
+
+    function setup() {
+        try {
+            const u = new window.URL('x', 'http://y'); //jshint ignore:line
+            resolveFunction = nativeURLResolver;
+        } catch (e) {
+            // must be IE11/Node etc
+        } finally {
+            resolveFunction = resolveFunction || dumbURLResolver;
+        }
+    }
 
     /**
      * Returns a string that contains the Base URL of a URL, if determinable.
@@ -54,16 +122,23 @@ function URLUtils() {
      * @instance
      */
     function parseBaseUrl(url) {
-        var base = '';
+        const slashIndex = url.indexOf('/');
+        const lastSlashIndex = url.lastIndexOf('/');
 
-        if (url.indexOf('/') !== -1) {
+        if (slashIndex !== -1) {
+            // if there is only '//'
+            if (lastSlashIndex === slashIndex + 1) {
+                return url;
+            }
+
             if (url.indexOf('?') !== -1) {
                 url = url.substring(0, url.indexOf('?'));
             }
-            base = url.substring(0, url.lastIndexOf('/') + 1);
+
+            return url.substring(0, lastSlashIndex + 1);
         }
 
-        return base;
+        return '';
     }
 
     /**
@@ -119,12 +194,27 @@ function URLUtils() {
         return httpUrlRegex.test(url);
     }
 
-    instance = {
+    /**
+     * Resolves a url given an optional base url
+     * @return {string}
+     * @param {string} url
+     * @param {string} [baseUrl]
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function resolve(url, baseUrl) {
+        return resolveFunction(url, baseUrl);
+    }
+
+    setup();
+
+    const instance = {
         parseBaseUrl:   parseBaseUrl,
         parseOrigin:    parseOrigin,
         isRelative:     isRelative,
         isPathAbsolute: isPathAbsolute,
-        isHTTPURL:      isHTTPURL
+        isHTTPURL:      isHTTPURL,
+        resolve:        resolve
     };
 
     return instance;

--- a/test/streaming.utils.URLUtils.js
+++ b/test/streaming.utils.URLUtils.js
@@ -78,7 +78,7 @@ describe('URLUtils', function () {
 
     describe('parseBaseUrl', () => {
         it('should return the base url of a valid url', () => {
-            const baseUrl = 'http://www.example.com/';
+            const baseUrl = 'http://www.example.com/blah/something/or/another/';
             const pageUrl = 'index.html';
             const url = baseUrl + pageUrl;
 
@@ -100,6 +100,16 @@ describe('URLUtils', function () {
             const pageUrl = 'index.html';
             const queryString = '?hasQueryString=true';
             const url = baseUrl + pageUrl + queryString;
+
+            const result = urlUtils.parseBaseUrl(url);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return the base url if scheme-relative and origin only', () => {
+            const baseUrl = '//www.example.com/';
+            const relative = 'example.html';
+            const url = baseUrl + relative;
 
             const result = urlUtils.parseBaseUrl(url);
 
@@ -136,12 +146,114 @@ describe('URLUtils', function () {
             expect(result).to.equal(baseUrl); // jshint ignore:line
         });
 
+        it('should return the original url if scheme and origin only', () => {
+            const baseUrl = 'http://www.example.com';
+
+            const result = urlUtils.parseOrigin(baseUrl);
+
+            expect(result).to.equal(baseUrl); // jshint ignore:line
+        });
+
+        it('should return an empty string if url is scheme-relative', () => {
+            const baseUrl = '//www.example.com';
+
+            const result = urlUtils.parseOrigin(baseUrl);
+
+            expect(result).to.be.empty; // jshint ignore:line
+        });
+
         it('should return an empty string if argument is not a url', () => {
             const arg = 'skjdlkasdhflkhasdlkfhl';
 
             const result = urlUtils.parseOrigin(arg);
 
             expect(result).to.be.empty; // jshint ignore:line
+        });
+    });
+
+    describe('resolve (fallback path)', () => {
+        it('should resolve a baseurl and relative url', () => {
+            const baseUrl = 'http://www.example.com/path/index.html';
+            const url = 'MPDs/example.mpd';
+            const expected = 'http://www.example.com/path/MPDs/example.mpd';
+
+            const result = urlUtils.resolve(url, baseUrl);
+
+            expect(result).to.equal(expected); // jshint ignore:line
+        });
+
+        it('should resolve a baseurl and path absolute url', () => {
+            const baseUrl = 'http://www.example.com/path/index.html';
+            const url = '/MPDs/example.mpd';
+            const expected = 'http://www.example.com/MPDs/example.mpd';
+
+            const result = urlUtils.resolve(url, baseUrl);
+
+            expect(result).to.equal(expected); // jshint ignore:line
+        });
+
+        it('should just return url if absolute', () => {
+            const baseUrl = 'http://www.example.com/path/index.html';
+            const absoluteUrl = 'http://www.anotherexample.com/path/index.html';
+
+            const result = urlUtils.resolve(absoluteUrl, baseUrl);
+
+            expect(result).to.equal(absoluteUrl); // jshint ignore:line
+        });
+
+        it('should resolve a baseurl with no slash and relative url', () => {
+            const baseUrl = 'http://www.example.com';
+            const url = 'MPDs/example.mpd';
+            const expected = 'http://www.example.com/MPDs/example.mpd';
+
+            const result = urlUtils.resolve(url, baseUrl);
+
+            expect(result).to.equal(expected); // jshint ignore:line
+        });
+
+        it('should return url if baseurl is undefined', () => {
+            const url = 'MPDs/example.mpd';
+
+            const result = urlUtils.resolve(url);
+
+            expect(result).to.equal(url); // jshint ignore:line
+        });
+    });
+
+    describe('resolve (native path)', () => {
+
+        global.window = {
+            URL: (a, b) => {
+                if (!a || !b) {
+                    throw new Error();
+                }
+
+                return {
+                    toString: () => {
+                        return b + a;
+                    }
+                };
+            }
+        };
+
+        // new instance on new context to pick up window.URL
+        const instance = URLUtils({}).getInstance();
+
+        it('should return url when baseurl is invalid', () => {
+            const url = 'test/index.html';
+            const result = instance.resolve(url);
+
+            expect(result).to.equal(url); // jshint ignore:line
+        });
+
+        it('should resolve correctly when input is valid', () => {
+            const baseUrl = 'http://www.example.com/';
+            const url = 'MPDs/example.mpd';
+            const expected = baseUrl + url;
+
+            const result = instance.resolve(url, baseUrl);
+
+            expect(result).to.equal(expected); // jshint ignore:line
         });
     });
 });


### PR DESCRIPTION
Most streams using BaseURLs that I have ever seen have sensible-looking urls which can simply be concatenated together.

Recently, I became aware of someone using an example like below (truncated for brevity):

```
<MPD>
   <BaseURL>http://www.example.com/manifest.mpd</BaseURL>
   <Period start="PT0S">
      <AdaptationSet>
         <SegmentTemplate media="video/v$RepresentationID$_$Number$.m4s" initialization="video/IS.mp4"/>
         <Representation id="1"/>
```

Whilst it looks ridiculous, according to the specification, URLs must be resolved according to RFC3986 to give e.g. `http://www.example.com/video/v1_1.m4s`, which is not what was happening.

This PR solves this by using the in-built browser URL parser, where available, to resolve URLs correctly with respect to a base URL. Where that URL parser is not available (IE11, Node), I have added a dumb parser which does enough to satisfy an XHR implementation for example.

I have added a number of tests, and have tested this change with as many BaseURL manifests as I could find on Chrome and Firefox (Win7), Edge and IE11 (Win10). NOTE: I have not been able to access a Mac to test this in Safari