### PR TITLE
Fix #1224 - only set non-empty MediaCapabilities on MediaKeySystemConfiguration

### DIFF
--- a/src/streaming/protection/vo/KeySystemConfiguration.js
+++ b/src/streaming/protection/vo/KeySystemConfiguration.js
@@ -52,8 +52,12 @@ class KeySystemConfiguration {
      */
     constructor(audioCapabilities, videoCapabilities, distinctiveIdentifier, persistentState, sessionTypes) {
         this.initDataTypes = [ 'cenc' ];
-        this.audioCapabilities = audioCapabilities;
-        this.videoCapabilities = videoCapabilities;
+        if (audioCapabilities && audioCapabilities.length) {
+            this.audioCapabilities = audioCapabilities;
+        }
+        if (videoCapabilities && videoCapabilities.length) {
+            this.videoCapabilities = videoCapabilities;
+        }
         this.distinctiveIdentifier = distinctiveIdentifier;
         this.persistentState = persistentState;
         this.sessionTypes = sessionTypes;


### PR DESCRIPTION
It seems that passing `[]` as a `MediaKeySystemMediaCapability` in `MediaKeySystemConfiguration` causes the `requestMediaKeySystemAccess` call to fail with NotSupportedError.

See #1224 and discussion on Slack today (19/9/2016) for background.

This PR checks whether the capabilities are empty and does not include them in the configuration object in that case.

I have tested this on Chrome with both clearkey and widevine. It'd be great if someone could take a look with other UA/CDM instances.