### PR TITLE
Allow xhr.withCredentials to be set per request type

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1565,15 +1565,43 @@ function MediaPlayer() {
     }
 
     /**
-     * Sets whether withCredentials on XHR requests is true or false
+     * Sets whether withCredentials on all XHR requests is true or false
      *
      * @default false
      * @param {boolean} value
      * @memberof module:MediaPlayer
      * @instance
+     * @deprecated since version 2.4 - use setXHRWithCredentialsForType
      */
     function setXHRWithCredentials(value) {
-        mediaPlayerModel.setXHRWithCredentials(value);
+        setXHRWithCredentialsForType(undefined, value);
+    }
+
+    /**
+     * Sets whether withCredentials on XHR requests for a particular request
+     * type is true or false
+     *
+     * @default false
+     * @param {string} type - one of HTTPRequest.*_TYPE
+     * @param {boolean} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setXHRWithCredentialsForType(type, value) {
+        mediaPlayerModel.setXHRWithCredentialsForType(type, value);
+    }
+
+    /**
+     * Gets whether withCredentials on XHR requests for a particular request
+     * type is true or false
+     *
+     * @param {string} type - one of HTTPRequest.*_TYPE
+     * @return {boolean}
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getXHRWithCredentialsForType(type) {
+        return mediaPlayerModel.getXHRWithCredentialsForType(type);
     }
 
     /**
@@ -2037,6 +2065,8 @@ function MediaPlayer() {
         setFragmentLoaderRetryAttempts: setFragmentLoaderRetryAttempts,
         setFragmentLoaderRetryInterval: setFragmentLoaderRetryInterval,
         setXHRWithCredentials: setXHRWithCredentials,
+        setXHRWithCredentialsForType: setXHRWithCredentialsForType,
+        getXHRWithCredentialsForType: getXHRWithCredentialsForType,
         setBufferTimeAtTopQualityLongForm: setBufferTimeAtTopQualityLongForm,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setRichBufferThreshold: setRichBufferThreshold,

--- a/src/streaming/XHRLoader.js
+++ b/src/streaming/XHRLoader.js
@@ -207,7 +207,7 @@ function XHRLoader(cfg) {
 
             xhr = requestModifier.modifyRequestHeader(xhr);
 
-            xhr.withCredentials = mediaPlayerModel.getXHRWithCredentials();
+            xhr.withCredentials = mediaPlayerModel.getXHRWithCredentialsForType(request.type);
 
             xhr.onload = onload;
             xhr.onloadend = onloadend;

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -111,7 +111,7 @@ function MediaPlayerModel() {
         bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
-        xhrWithCredentials = DEFAULT_XHR_WITH_CREDENTIALS;
+        xhrWithCredentials = { default: DEFAULT_XHR_WITH_CREDENTIALS };
 
 
         retryAttempts = {
@@ -327,13 +327,26 @@ function MediaPlayerModel() {
         return UTCTimingSources;
     }
 
-    function setXHRWithCredentials(value) {
-        xhrWithCredentials = !!value;
+    function setXHRWithCredentialsForType(type, value) {
+        if (!type) {
+            Object.keys(xhrWithCredentials).forEach(key => {
+                setXHRWithCredentialsForType(key, value);
+            });
+        } else {
+            xhrWithCredentials[type] = !!value;
+        }
     }
 
-    function getXHRWithCredentials() {
-        return xhrWithCredentials;
+    function getXHRWithCredentialsForType(type) {
+        const useCreds = xhrWithCredentials[type];
+
+        if (useCreds === undefined) {
+            return xhrWithCredentials.default;
+        }
+
+        return useCreds;
     }
+
 
     function getFastSwitchEnabled() {
         return fastSwitchEnabled;
@@ -395,8 +408,8 @@ function MediaPlayerModel() {
         getUseManifestDateHeaderTimeSource: getUseManifestDateHeaderTimeSource,
         setUTCTimingSources: setUTCTimingSources,
         getUTCTimingSources: getUTCTimingSources,
-        setXHRWithCredentials: setXHRWithCredentials,
-        getXHRWithCredentials: getXHRWithCredentials,
+        setXHRWithCredentialsForType: setXHRWithCredentialsForType,
+        getXHRWithCredentialsForType: getXHRWithCredentialsForType,
         setFastSwitchEnabled: setFastSwitchEnabled,
         getFastSwitchEnabled: getFastSwitchEnabled,
         reset: reset


### PR DESCRIPTION
As requested by Trevor Hunsaker on Slack.