### PR TITLE
Enable HTML-rendered TTML in ref player if Firefox is at least v49

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -87,6 +87,23 @@ app.directive('chart', function() {
 
 app.controller('DashController', function($scope, sources, contributors) {
 
+    function doesTimeMarchesOn() {
+        var version;
+        var REQUIRED_VERSION = 49.0;
+
+        if (typeof navigator !== 'undefined') {
+            if (!navigator.userAgent.match(/Firefox/)) {
+                return true;
+            }
+
+            version = parseFloat(navigator.userAgent.match(/rv:([0-9.]+)/)[1]);
+
+            if (!isNaN(version) && version >= REQUIRED_VERSION){
+                return true;
+            }
+        }
+    }
+
     $scope.selectedItem = {url:"http://dash.edgesuite.net/akamai/bbb_30fps/bbb_30fps.mpd"};
     $scope.abrEnabled = true;
     $scope.toggleCCBubble = false;
@@ -143,8 +160,8 @@ app.controller('DashController', function($scope, sources, contributors) {
     $scope.player.initialize($scope.video, null, true);
     $scope.player.setFastSwitchEnabled(true);
     $scope.player.attachVideoContainer(document.getElementById("videoContainer"));
-    // Add HTML-rendered TTML subtitles except for Firefox (issue #1164)
-    if (typeof navigator !== 'undefined' && !navigator.userAgent.match(/Firefox/)) {
+    // Add HTML-rendered TTML subtitles except for Firefox < v49 (issue #1164)
+    if (doesTimeMarchesOn()) {
         $scope.player.attachTTMLRenderingDiv($("#video-caption")[0]);
     }
 


### PR DESCRIPTION
Firefox 49 was released a couple of days ago and now has the required functionality to fix #1164.

This PR adds a test to the existing UA sniffing to check if the Firefox version number is at least 49, and enables HTML-rendered TTML subtitles in that case, as well as the existing cases (ie !Firefox).