### PR TITLE
Only check element clientWidth on window resize

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -858,6 +858,20 @@ function MediaPlayer() {
     }
 
     /**
+     * Update the video element size variables
+     * Should be called on window resize (or any other time player is resized). Fullscreen does trigger a window resize event.
+     *
+     * Once windowResizeEventCalled = true, abrController.checkPortalSize() will use element size variables rather than querying clientWidth every time.
+     *
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function updatePortalSize() {
+        abrController.setElementSize();
+        abrController.setWindowResizeEventCalled(true);
+    }
+
+    /**
      * @memberof module:MediaPlayer
      * @instance
      */
@@ -1994,6 +2008,7 @@ function MediaPlayer() {
         getMetricsFor: getMetricsFor,
         getQualityFor: getQualityFor,
         setQualityFor: setQualityFor,
+        updatePortalSize: updatePortalSize,
         getLimitBitrateByPortal: getLimitBitrateByPortal,
         setLimitBitrateByPortal: setLimitBitrateByPortal,
         getUsePixelRatioInLimitBitrateByPortal: getUsePixelRatioInLimitBitrateByPortal,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -90,7 +90,9 @@ function AbrController() {
         streamProcessorDict = {};
         limitBitrateByPortal = false;
         usePixelRatioInLimitBitrateByPortal = false;
-        if (windowResizeEventCalled === undefined) windowResizeEventCalled = false;
+        if (windowResizeEventCalled === undefined) {
+            windowResizeEventCalled = false;
+        }
         domStorage = DOMStorage(context).getInstance();
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
@@ -103,7 +105,9 @@ function AbrController() {
         abandonmentStateDict[type] = abandonmentStateDict[type] || {};
         abandonmentStateDict[type].state = ALLOW_LOAD;
         eventBus.on(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
-        if (type == 'video') setElementSize();
+        if (type == 'video') {
+            setElementSize();
+        }
     }
 
     function setConfig(config) {
@@ -469,7 +473,9 @@ function AbrController() {
             return idx;
         }
 
-        if (!windowResizeEventCalled) setElementSize();
+        if (!windowResizeEventCalled) {
+            setElementSize();
+        }
 
         var manifest = manifestModel.getValue();
         var representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -90,7 +90,7 @@ function AbrController() {
         streamProcessorDict = {};
         limitBitrateByPortal = false;
         usePixelRatioInLimitBitrateByPortal = false;
-        if(windowResizeEventCalled === undefined) windowResizeEventCalled = false;
+        if (windowResizeEventCalled === undefined) windowResizeEventCalled = false;
         domStorage = DOMStorage(context).getInstance();
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
@@ -456,7 +456,7 @@ function AbrController() {
 
     function setElementSize() {
         var element = videoModel.getElement();
-        if( element !== undefined ){
+        if (element !== undefined) {
             var hasPixelRatio = usePixelRatioInLimitBitrateByPortal && window.hasOwnProperty('devicePixelRatio');
             var pixelRatio = hasPixelRatio ? window.devicePixelRatio : 1;
             elementWidth = element.clientWidth * pixelRatio;
@@ -470,7 +470,7 @@ function AbrController() {
             return idx;
         }
 
-        if(!windowResizeEventCalled) setElementSize();
+        if (!windowResizeEventCalled) setElementSize();
 
         var manifest = manifestModel.getValue();
         var representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -461,7 +461,6 @@ function AbrController() {
             var pixelRatio = hasPixelRatio ? window.devicePixelRatio : 1;
             elementWidth = element.clientWidth * pixelRatio;
             elementHeight = element.clientHeight * pixelRatio;
-            console.log('Portal resize: ' + elementWidth + ' ' + elementHeight);
         }
     }
 


### PR DESCRIPTION
checkPortalSize got the clientWidth of the video element, which caused an expensive reflow and potential for dropped frames. Only get the clientWidth when the element resizes.