### PR TITLE
Fix #1521 - add banner with version, git sha1, build time and date to uglified JS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,12 @@ module.exports = function (grunt) {
     require('time-grunt')(grunt);
 
     grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        githash: {
+            dist: {
+            }
+        },
+
         clean: {
             build: ['build/temp'],
             dist: ['dist/*']
@@ -17,6 +23,7 @@ module.exports = function (grunt) {
 
         uglify: {
             options: {
+                banner: '/*! v<%= pkg.version %>-<%= githash.dist.short %>, <%= grunt.template.today("isoUtcDateTime") %> */',
                 sourceMap: true,
                 sourceMapIncludeSources: true,
                 sourceMapRoot: './src/',
@@ -242,7 +249,7 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
     grunt.registerTask('default',   ['dist', 'test']);
     grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:reporting', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
-    grunt.registerTask('minimize',  ['exorcise', 'uglify']);
+    grunt.registerTask('minimize',  ['exorcise', 'githash', 'uglify']);
     grunt.registerTask('test',      ['mocha_istanbul:test']);
     grunt.registerTask('watch',     ['browserify:watch']);
     grunt.registerTask('release',   ['default', 'jsdoc']);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exorcise": "^2.1.0",
+    "grunt-githash": "^0.1.3",
     "grunt-githooks": "^0.5.0",
     "grunt-jscs": "^2.5.0",
     "grunt-jsdoc": "^0.6.0",


### PR DESCRIPTION
To avoid confusion over which version is deployed on the nightly server/anywhere.

Adds (e.g) `/*! v2.4.0-905c978, 2016-10-04T08:28:27Z */` at the top of all uglified output.