### PR TITLE
Fix #1618 for setScheduleWhilePaused(false)

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -379,7 +379,7 @@ function ScheduleController(config) {
     }
 
     function onPlaybackStarted() {
-        if (isStopped) {
+        if (isStopped || !scheduleWhilePaused) {
             start();
         }
     }


### PR DESCRIPTION
Looks like this stopped working after 636f4f9, because ScheduleController.start() isn't called. This fixes it, but @AkamaiDASH might want to check it doesn't undo any of his fix from that commit.