### PR TITLE
Fix #1447 - Wait for data before updating element playbackRate

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -44,9 +44,19 @@ function VideoModel() {
         stalledStreams = [];
     }
 
+    function onPlaybackCanPlay() {
+        element.playbackRate = previousPlaybackRate || 1;
+        element.removeEventListener('canplay', onPlaybackCanPlay);
+    }
+
     function setPlaybackRate(value) {
-        if (!element || element.readyState < 2) return;
-        element.playbackRate = value;
+        if (!element) return;
+        if (element.readyState <= 2 && value > 0) {
+            // If media element hasn't loaded enough data to play yet, wait until it has
+            element.addEventListener('canplay', onPlaybackCanPlay);
+        } else {
+            element.playbackRate = value;
+        }
     }
 
     //TODO Move the DVR window calculations from MediaPlayer to Here.


### PR DESCRIPTION
When the player buffers during playback, stream is stalled. Seeking removes the stalled stream, and updates the playbackRate. However, setPlaybackRate was being called before enough data was loaded to play (ready state 3, "HAVE_FUTURE_DATA").

Now, if readyState<3, an event listener is added to update playbackRate once "canplay" is triggered.

Similar issue when trying play/pause during buffer is fixed by #1616.
