### PR TITLE
Fixing namespaced TTML malfunction

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -693,9 +693,13 @@ function TTMLParser() {
                         removeNamespacePrefix(json[key][i], nsPrefix);
                     }
                 }
-                var newKey = key.slice(key.indexOf(nsPrefix) + nsPrefix.length + 1);
-                json[newKey] = json[key];
-                delete json[key];
+                var fullNsPrefix = nsPrefix + ':';
+                var nsPrefixPos = key.indexOf(fullNsPrefix);
+                if (nsPrefixPos >= 0) {
+                    var newKey = key.slice(key.indexOf(nsPrefix) + fullNsPrefix.length);
+                    json[newKey] = json[key];
+                    delete json[key];
+                }
             }
         }
     }

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -696,7 +696,7 @@ function TTMLParser() {
                 var fullNsPrefix = nsPrefix + ':';
                 var nsPrefixPos = key.indexOf(fullNsPrefix);
                 if (nsPrefixPos >= 0) {
-                    var newKey = key.slice(key.indexOf(nsPrefix) + fullNsPrefix.length);
+                    var newKey = key.slice(nsPrefixPos + fullNsPrefix.length);
                     json[newKey] = json[key];
                     delete json[key];
                 }


### PR DESCRIPTION
Dash.js wasn't playing any TTML that had explicit namespacing. The problem lay with the removeNamespacePrefix function on 2 points: it cancelled parsing and afterwards it turned out to not have catered for tt being a substring of tts so it removed tt and so the :extent region attribute was born. 

The test framework needs examples of EBU-TT-D with and without default namespace to prevent such an error hiding.