### PR TITLE
getActualPresentationTime returns nearest DVRWindow edge 

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -350,10 +350,10 @@ function DashHandler(config) {
             log('Getting the request for ' + type + ' time : ' + time);
         }
 
+        updateSegments(representation);
         index = getIndexForSegments(time, representation, timeThreshold);
         //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
         if (index < 0) {
-            updateSegments(representation);
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -352,8 +352,8 @@ function DashHandler(config) {
 
         index = getIndexForSegments(time, representation, timeThreshold);
         //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
-        updateSegments(representation);
         if (index < 0) {
+            updateSegments(representation);
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -304,12 +304,13 @@ function PlaybackController() {
         var actualTime;
 
         if (!DVRWindow) return NaN;
-
-        if ((currentTime >= DVRWindow.start) && (currentTime <= DVRWindow.end)) {
+        if (currentTime > DVRWindow.end) {
+            actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
+        } else if (currentTime < DVRWindow.start) {
+            actualTime = DVRWindow.start;
+        } else {
             return currentTime;
         }
-
-        actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
 
         return actualTime;
     }


### PR DESCRIPTION
When trying to play from a currentTime outside of a live stream's availability window, getActualPresentationTime previously shifted to the live-edge. Now it will return trailing-edge if requested time < window start.

Play live steam -> pause -> drift outside of DVRWindow -> try to play -> be moved to start of window

This works well for BBC where live-rewind window is 2 hrs. For much shorter windows, perhaps an option to force playback from live edge regardless may be preferred?

930717e fixed issue where segments were updated out of order such that previously fetched index was no longer valid.