### PR TITLE
Do not send request to know init index range when the information has been set in the manifest

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -430,6 +430,7 @@ function DashManifestModel() {
                     representation.initialization = initialization.sourceURL;
                 } else if (initialization.hasOwnProperty('range')) {
                     representation.range = initialization.range;
+                    representation.initialization = r.BaseURL;
                 }
             } else if (r.hasOwnProperty('mimeType') && getIsTextTrack(r.mimeType)) {
                 representation.range = 0;


### PR DESCRIPTION
if in the dash manifest, the range for initialization is set, use the baseUrl for initialization request.