### PR TITLE
missing 'getIsBufferingCompleted' function in TextController

### DIFF
--- a/src/streaming/controllers/TextController.js
+++ b/src/streaming/controllers/TextController.js
@@ -41,6 +41,7 @@ function TextController(config) {
     let errHandler = config.errHandler;
 
     let instance,
+        isBufferingCompleted,
         initialized,
         mediaSource,
         buffer,
@@ -56,6 +57,7 @@ function TextController(config) {
         type = null;
         streamProcessor = null;
         representationController = null;
+        isBufferingCompleted = false;
 
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.on(Events.INIT_FRAGMENT_LOADED, onInitFragmentLoaded, this);
@@ -127,12 +129,17 @@ function TextController(config) {
         sourceBufferController.append(buffer, e.chunk);
     }
 
+    function getIsBufferingCompleted() {
+        return isBufferingCompleted;
+    }
+
     instance = {
         initialize: initialize,
         createBuffer: createBuffer,
         getBuffer: getBuffer,
         setBuffer: setBuffer,
         getStreamProcessor: getStreamProcessor,
+        getIsBufferingCompleted: getIsBufferingCompleted,
         setMediaSource: setMediaSource,
         reset: reset
     };


### PR DESCRIPTION
add in TextController, the 'getIsBufferingCompleted' function.
in a dash content with a TTML file, this function was missing.
In the start function of the SchedulleController, an error was reported.