### PR TITLE
Allow immediate switching when top quality index changes

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -182,7 +182,7 @@ function ScheduleController(config) {
     function hasTopQualityChanged(type, id) {
 
         topQualityIndex[id] = topQualityIndex[id] || {};
-        let newTopQualityIndex = abrController.getTopQualityIndexFor(type,id);
+        const newTopQualityIndex = abrController.getTopQualityIndexFor(type,id);
 
         if ( topQualityIndex[id][type] != newTopQualityIndex ) {
             log('Top quality'  + type + ' index has changed from ' + topQualityIndex[id][type] + ' to ' + newTopQualityIndex);
@@ -199,10 +199,10 @@ function ScheduleController(config) {
 
         validateExecutedFragmentRequest();
 
-        let isReplacement, topQualityChanged, readyToLoad;
-        if ( (isReplacement = replaceRequestArray.length > 0) ||
-             (topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id)) ||
-             (readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent()))
+        const isReplacement = replaceRequestArray.length > 0;
+        if ( isReplacement ||
+             hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id) ||
+             bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())
            ) {
 
             const getNextFragment = function () {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -199,17 +199,17 @@ function ScheduleController(config) {
 
         validateExecutedFragmentRequest();
 
-        const isReplacement = replaceRequestArray.length > 0;
-        const readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent());
-        const topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id);
+        let isReplacement, topQualityChanged, readyToLoad;
+        if ( (isReplacement = replaceRequestArray.length > 0) ||
+             (topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id)) ||
+             (readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent()))
+           ) {
 
-        if (readyToLoad || isReplacement || topQualityChanged) {
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;
                     bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality);
                 } else {
-
                     const request = nextFragmentRequestRule.execute(streamProcessor, replaceRequestArray.shift());
                     if (request) {
                         fragmentModel.executeRequest(request);


### PR DESCRIPTION
When the max representation available to ABR changes because of updateQuality or Portal Bitrate change, the Buffer Level rule prevents switching because the buffer is larger than the stable bitrate buffer target (12 or 20s). The previous "top quality" target buffer size of 60s means that any appending to the buffer is suppressed for 48s so the user sees their buffer collapse.

Any change in getTopQualityIndexFor() now allows an immediate update of the rules. This should prevent the buffer near exhausting when quality changes and therefore reduce risk, especially as this happens whenever a user goes fullscreen.

Expensive bufferLevelRule is also not called now if getNextFragment is already triggered by isReplacement or topQualityChanged.