### PR TITLE
imsc1 image subtitle support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,6 +37,7 @@
 * @JaapHaitsma
 * @72lions [Thodoris Tsiridis, 72lions]
 * @TobbeMobiTV [Torbjörn Einarsson, MobiTV]
+* @TobbeEdgeware [Torbjörn Einarsson, Edgeware]
 * @mstorsjo [Martin Storsjö]
 * @Hyddan [Daniel Hedenius]
 * @qjia7

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uglify-js": "^2.4.21"
   },
   "dependencies": {
-    "codem-isoboxer": "0.2.2",
+    "codem-isoboxer": "0.2.7",
     "round10": "^1.0.3"
   },
   "repository": {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -100,9 +100,14 @@
           "moreInfo": "http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/"
         },
         {
+          "url": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd",
+          "name": "IMSC1 (CMAF) Image Subtitles",
+          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_info.html"
+        },
+        {
           "name": "TTML Image Subtitles embedded (VoD)",
           "url": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd",
-          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_info.txt"
+          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img_subs_info.html"
         }
       ]
     },
@@ -1239,7 +1244,7 @@
         {
           "name": "Microsoft Cenc #1",
           "url": "http://wams.edgesuite.net/media/SintelTrailer_Smooth_from_WAME_720p_Main_Profile_CENC/CENC/sintel_trailer-720p.ism/manifest(format=mpd-time-csf)"
-          
+
         },
         {
           "name": "Microsoft Cenc #4",

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -1244,7 +1244,6 @@
         {
           "name": "Microsoft Cenc #1",
           "url": "http://wams.edgesuite.net/media/SintelTrailer_Smooth_from_WAME_720p_Main_Profile_CENC/CENC/sintel_trailer-720p.ism/manifest(format=mpd-time-csf)"
-
         },
         {
           "name": "Microsoft Cenc #4",

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -66,8 +66,9 @@ function DashManifestModel() {
 
         if ((adaptation.Representation_asArray.length > 0) &&
             (adaptation.Representation_asArray[0].hasOwnProperty('codecs'))) {
+            // Just check the start of the codecs string
             var codecs = adaptation.Representation_asArray[0].codecs;
-            if (codecs === 'stpp' || codecs === 'wvtt') {
+            if (codecs.search('stpp') === 0 || codecs.search('wvtt') === 0) {
                 return type === 'fragmentedText';
             }
         }

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -63,14 +63,15 @@ function SourceBufferController() {
             // it definitely doesn't understand 'application/mp4;codecs="stpp"'
             // - currently no browser does, so check for it and use our own
             // implementation. The same is true for codecs="wvtt".
-            if (codec.match(/application\/mp4;\s*codecs="(stpp|wvtt)"/i)) {
+            if (codec.match(/application\/mp4;\s*codecs="(stpp|wvtt).*"/i)) {
                 throw new Error('not really supported');
             }
 
             buffer = mediaSource.addSourceBuffer(codec);
 
         } catch (ex) {
-            if ((mediaInfo.isText) || (codec.indexOf('codecs="stpp"') !== -1) ||  (codec.indexOf('codecs="wvtt"') !== -1) ) {
+            // Note that in the following, the quotes are open to allow for extra text after stpp and wvtt
+            if ((mediaInfo.isText) || (codec.indexOf('codecs="stpp') !== -1) ||  (codec.indexOf('codecs="wvtt') !== -1) ) {
                 buffer = TextSourceBuffer(context).getInstance();
                 buffer.setConfig({
                     errHandler: ErrorHandler(context).getInstance(),

--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -42,6 +42,7 @@ function IsoFile() {
         emsgProps,
         mdhdProps,
         mfhdProps,
+        subsProps,
         tfhdProps,
         tfdtProps,
         trunProps,
@@ -146,6 +147,10 @@ function IsoFile() {
             sequence_number: 'sequence_number'
         };
 
+        subsProps = {
+            samples_with_subsamples: 'samples_with_subsamples'
+        };
+
         tfhdProps = {
             base_data_offset: 'base_data_offset',
             sample_description_index: 'sample_description_index',
@@ -212,6 +217,9 @@ function IsoFile() {
                 break;
             case 'mfhd':
                 copyProps(boxData, box, mfhdProps);
+                break;
+            case 'subs':
+                copyProps(boxData, box, subsProps);
                 break;
             case 'tfhd':
                 copyProps(boxData, box, tfhdProps);

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -206,10 +206,10 @@ function TTMLParser() {
      * @param {string} data - raw data received from the TextSourceBuffer
      * @param {number} intervalStart
      * @param {number} intervalEnd
-     *
+     * @param {array} imageArray - images represented as binary strings
      */
 
-    function parse(data, intervalStart, intervalEnd) {
+    function parse(data, intervalStart, intervalEnd, imageArray) {
         let tt, // Top element
             head, // head in tt
             body, // body in tt
@@ -257,8 +257,19 @@ function TTMLParser() {
             ttmlStyling = head.styling.style_asArray; // Mandatory in EBU-TT-D
         }
 
-        let embeddedImages = tt.head.metadata.image_asArray; // Handle embedded images
         let imageDataUrls = {};
+
+        if (imageArray) {
+            for (i = 0; i < imageArray.length; i++) {
+                let key = 'urn:mpeg:14496-30:subs:' + (i + 1).toString() + '.png';
+                let imageType = 'png';
+                let dataUrl = 'data:image/' + imageType + ';base64,' + btoa(imageArray[i]);
+                imageDataUrls[key] = dataUrl;
+            }
+        }
+
+        let embeddedImages = tt.head.metadata.image_asArray; // Handle embedded images
+
         if (embeddedImages) {
             for (i = 0; i < embeddedImages.length; i++) {
                 let key = '#' + embeddedImages[i]['xml:id'];
@@ -324,7 +335,7 @@ function TTMLParser() {
                 }
 
                 let imgKey = div['smpte:backgroundImage'];
-                if (imgKey !== undefined) {
+                if (imgKey !== undefined && imageDataUrls[imgKey] !== undefined) {
                     captionArray.push({
                         start: divInterval[0],
                         end: divInterval[1],

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -261,9 +261,8 @@ function TTMLParser() {
 
         if (imageArray) {
             for (i = 0; i < imageArray.length; i++) {
-                let key = 'urn:mpeg:14496-30:subs:' + (i + 1).toString() + '.png';
-                let imageType = 'png';
-                let dataUrl = 'data:image/' + imageType + ';base64,' + btoa(imageArray[i]);
+                let key = 'urn:mpeg:14496-30:subs:' + (i + 1).toString();
+                let dataUrl = 'data:image/png;base64,' + btoa(imageArray[i]);
                 imageDataUrls[key] = dataUrl;
             }
         }


### PR DESCRIPTION
Implementation of #1418.

An extension to support image subtitles packaged as ISOBMFF segments with png images in subsamples in the same sample as the TTML document. This required the implementation of a new box `subs` in the iso parser including codem-isoboxer.

This follows IMSC1 which disallows the base64-encoded embedded images in the TTML documents.

Support was also added to handle the extended codecs value `stpp.ttml.im1i` which what CMAF DIS lists as the proper value.

A new test asset has been produced and added to the reference player:
http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd

