### PR TITLE
fix crash on chromecast android senders

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -315,7 +315,7 @@ function DashManifestModel() {
         if (manifest.hasOwnProperty('mediaPresentationDuration')) {
             mpdDuration = manifest.mediaPresentationDuration;
         } else {
-            mpdDuration = Number.MAX_SAFE_INTEGER;
+            mpdDuration = Number.MAX_SAFE_INTEGER || Number.MAX_VALUE;
         }
 
         return mpdDuration;

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -315,7 +315,7 @@ function DashManifestModel() {
         if (manifest.hasOwnProperty('mediaPresentationDuration')) {
             mpdDuration = manifest.mediaPresentationDuration;
         } else {
-            mpdDuration = Number.MAX_VALUE;
+            mpdDuration = Number.MAX_SAFE_INTEGER;
         }
 
         return mpdDuration;


### PR DESCRIPTION
I'm working on a custom Chromecast receiver using dash.js
When video.duration is equal to Number.MAX_VALUE there is a crash on android senders(SDK V3) which trying to cast a live stream.

My PR fix the bug but i'm not sur if the Number.MAX_SAFE_INTEGER is a good choice to describe a live duration. Other solution could be the buffer length

error android : 
```java
java.lang.StackOverflowError: stack size 8MB
at com.google.android.gms.cast.internal.zzn.getStreamDuration(Unknown Source)
at com.google.android.gms.cast.framework.media.RemoteMediaClient.getStreamDuration(Unknown Source)
at com.google.android.gms.cast.framework.CastSession.getSessionRemainingTimeMs(Unknown Source)
at com.google.android.gms.cast.framework.Session$zza.getSessionRemainingTimeMs(Unknown Source)
at com.google.android.gms.cast.framework.zzq$zza.onTransact(Unknown Source)
at android.os.Binder.transact(Binder.java:387)
at aba.c(:com.google.android.gms.DynamiteModulesC:231)
at abi.n(:com.google.android.gms.DynamiteModulesC:362)
```