### PR TITLE
Bug fix image subtitles

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -100,14 +100,14 @@
           "moreInfo": "http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/"
         },
         {
-          "url": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd",
+          "url": "http://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img.mpd",
           "name": "IMSC1 (CMAF) Image Subtitles",
-          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_info.html"
+          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img_subs_info.html"
         },
         {
           "name": "TTML Image Subtitles embedded (VoD)",
           "url": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd",
-          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img_subs_info.html"
+          "moreInfo": "http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_info.html"
         }
       ]
     },

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -267,14 +267,15 @@ function TTMLParser() {
             }
         }
 
-        let embeddedImages = tt.head.metadata.image_asArray; // Handle embedded images
-
-        if (embeddedImages) {
-            for (i = 0; i < embeddedImages.length; i++) {
-                let key = '#' + embeddedImages[i]['xml:id'];
-                let imageType = embeddedImages[i].imagetype.toLowerCase();
-                let dataUrl = 'data:image/' + imageType + ';base64,' + embeddedImages[i].__text;
-                imageDataUrls[key] = dataUrl;
+        if (head.metadata) {
+            let embeddedImages = head.metadata.image_asArray; // Handle embedded images
+            if (embeddedImages) {
+                for (i = 0; i < embeddedImages.length; i++) {
+                    let key = '#' + embeddedImages[i]['xml:id'];
+                    let imageType = embeddedImages[i].imagetype.toLowerCase();
+                    let dataUrl = 'data:image/' + imageType + ';base64,' + embeddedImages[i].__text;
+                    imageDataUrls[key] = dataUrl;
+                }
             }
         }
 


### PR DESCRIPTION
Fix of minor bug introduced with IMSC1 image subtitle commit.
Made TTML subtitles without metadata not working, such as
http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-snake.mpd
