### PR TITLE
Fix #1682 - correctly test for absolute URLs

### DIFF
--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -72,12 +72,8 @@ function BaseURLController() {
 
             if (b) {
                 if (!urlUtils.isRelative(b.url)) {
-                    if (urlUtils.isPathAbsolute(b.url)) {
-                        p.url = urlUtils.resolve(b.url, urlUtils.parseOrigin(p.url));
-                    } else {
-                        p.url = b.url;
-                        p.serviceLocation = b.serviceLocation;
-                    }
+                    p.url = b.url;
+                    p.serviceLocation = b.serviceLocation;
                 } else {
                     p.url = urlUtils.resolve(b.url, p.url);
                 }

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -42,9 +42,9 @@ function URLUtils() {
 
     let resolveFunction;
 
-    const absUrl = /^(?:(?:[a-z]+:)?\/)?\//i;
+    const schemeRegex = /^[a-z][a-z0-9+\-.]*:/i;
     const httpUrlRegex = /^https?:\/\//i;
-    const originRegex = /^(https?:\/\/[^\/]+)\/?/i;
+    const originRegex = /^([a-z][a-z0-9+\-.]*:\/\/[^\/]+)\/?/i;
 
     /**
      * Resolves a url given an optional base url
@@ -87,11 +87,11 @@ function URLUtils() {
         }
 
         if (!isRelative(url)) {
-            if (isPathAbsolute(url)) {
-                baseUrlParseFunc = parseOrigin;
-            } else {
-                return url;
-            }
+            return url;
+        }
+
+        if (isPathAbsolute(url)) {
+            baseUrlParseFunc = parseOrigin;
         }
 
         const base = baseUrlParseFunc(baseUrl);
@@ -167,7 +167,7 @@ function URLUtils() {
      * @instance
      */
     function isRelative(url) {
-        return !absUrl.test(url);
+        return !schemeRegex.test(url);
     }
 
 
@@ -179,7 +179,7 @@ function URLUtils() {
      * @instance
      */
     function isPathAbsolute(url) {
-        return absUrl.test(url) && url.charAt(0) === '/';
+        return isRelative(url) && url.charAt(0) === '/';
     }
 
     /**

--- a/test/streaming.utils.URLUtils.js
+++ b/test/streaming.utils.URLUtils.js
@@ -48,6 +48,22 @@ describe('URLUtils', function () {
 
             expect(result).to.be.false; // jshint ignore:line
         });
+
+        it('should return true for a path-absolute url', () => {
+            const pathAbsoluteUrl = '/path/to/some/file';
+
+            const result = urlUtils.isRelative(pathAbsoluteUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return true for a protocol-relative url', () => {
+            const protocolRelativeUrl = '//path/to/some/file';
+
+            const result = urlUtils.isRelative(protocolRelativeUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
     });
 
     describe('isPathAbsolute', () => {


### PR DESCRIPTION
I have tested this against various MPDs from other BaseURL issues, the Twitter MPD from the issue, and also checked all the previous tests still pass as well as the new tests.