### PR TITLE
Metrics Reporting: fix List type serialisation and add a couple of tests

### DIFF
--- a/src/streaming/metrics/utils/MetricSerialiser.js
+++ b/src/streaming/metrics/utils/MetricSerialiser.js
@@ -72,7 +72,7 @@ function MetricSerialiser() {
                         obj.push(isBuiltIn ? v : serialise(v));
                     });
 
-                    value = encodeURIComponent(obj.join(','));
+                    value = obj.map(encodeURIComponent).join(',');
                 } else if (typeof value === 'string') {
                     value = encodeURIComponent(value);
                 } else if (value instanceof Date) {

--- a/test/streaming.metrics.utils.MetricsSerialiser.js
+++ b/test/streaming.metrics.utils.MetricsSerialiser.js
@@ -1,0 +1,29 @@
+import MetricSerialiser from '../src/streaming/metrics/utils/MetricSerialiser.js';
+
+const expect = require('chai').expect;
+
+const context = {};
+const metricSerialiser = MetricSerialiser(context).getInstance();
+
+describe('MetricSerialiser', function () {
+
+    describe('serialise', () => {
+        it('should correctly serialise a List', () => {
+            const list = {'key': [{'a': 'x'}, {'b': 'y'}]};
+            const expected = 'key=a%3Dx,b%3Dy';
+
+            const actual = metricSerialiser.serialise(list);
+
+            expect(actual).to.equal(expected); // jshint ignore:line
+        });
+
+        it('should not serialise keys starting with _', () => {
+            const entry = {'_key': 'value'};
+            const expected = '';
+
+            const actual = metricSerialiser.serialise(entry);
+
+            expect(actual).to.equal(expected); // jshint ignore:line
+        });
+    });
+});


### PR DESCRIPTION
We noticed during some metrics gathering we have been doing that the reporting format did not quite match the DVB specification.

Fixed and added a couple of tests for the serialiser.