### PR TITLE
Allow providing protData without requiring serverURL

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -460,17 +460,16 @@ function ProtectionController(config) {
 
         // Determine license server URL
         var url = null;
-        if (protData) {
-            if (protData.serverURL) {
-                var serverURL = protData.serverURL;
-                if (typeof serverURL === 'string' && serverURL !== '') {
-                    url = serverURL;
-                } else if (typeof serverURL === 'object' && serverURL.hasOwnProperty(messageType)) {
-                    url = serverURL[messageType];
-                }
-            } else if (protData.laURL && protData.laURL !== '') { // TODO: Deprecated!
-                url = protData.laURL;
+        if (protData && protData.serverURL) {
+            var serverURL = protData.serverURL;
+            if (typeof serverURL === 'string' && serverURL !== '') {
+                url = serverURL;
+            } else if (typeof serverURL === 'object' && serverURL.hasOwnProperty(messageType)) {
+                url = serverURL[messageType];
             }
+        } else if (protData && protData.laURL && protData.laURL !== '') {
+            // TODO: Deprecated!
+            url = protData.laURL;
         } else {
             url = keySystem.getLicenseServerURLFromInitData(CommonEncryption.getPSSHData(sessionToken.initData));
             if (!url) {


### PR DESCRIPTION
Currently if the end user provides any protection data for the Key System
our library no longer retrieves the license server URL from the initData.

The above combines with the fact that the ProtectionKeyController skips Key
Systems without protection data if protection data is provided for any
key system in a bad way.

The end result is that if you want to provide some
data for one key system you can't get the serverUrl from the initData for
a different key system. This ensures that even if protection data was passed,
if no serverURL or laURL is provided we try to get the url from the initData.