### PR TITLE
Fix #1680: Prevent MediaPlayerFactory creating elements if dashjs hasn't loaded

### DIFF
--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -102,7 +102,7 @@ function loadHandler() {
 
 let avoidAutoCreate = typeof window !== 'undefined' && window && window.dashjs && window.dashjs.skipAutoCreate;
 
-if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.addEventListener) {
+if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.dashjs && window.addEventListener) {
     if (window.document.readyState === 'complete') {
         instance.createAll();
     } else {


### PR DESCRIPTION
Quick fix to guard against creating elements before dashjs has loaded. Assumes there's no expectation for MediaPlayerFactory to create elements if loaded dynamically (as in #1680).