### PR TITLE
Report MediaError.message if it exists (eg Firefox)

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -571,6 +571,10 @@ function StreamController() {
 
         hasMediaError = true;
 
+        if (e.error.message) {
+            msg += ' (' + e.error.message + ')';
+        }
+
         if (e.error.msExtendedCode) {
             msg += ' (0x' + (e.error.msExtendedCode >>> 0).toString(16).toUpperCase() + ')';
         }


### PR DESCRIPTION
I recently became aware that Firefox has added a `message` attribute to the `MediaError` which gives potentially useful information about the cause of playback errors.

Example: `0x80004005: IsInitSegmentPresent: Invalid Box:gsme`

It makes sense to report this if it exists to aid diagnosis of issues (cf `MediaError.msExtendedCode`).