### PR TITLE
[BaseURL] serviceLocation is a request attribute, not an event attribute

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -350,7 +350,7 @@ function ScheduleController(config) {
             isFragmentProcessingInProgress = false;
         }
 
-        if (e.error && e.serviceLocation && !isStopped) {
+        if (e.error && e.request.serviceLocation && !isStopped) {
             replaceRequest(e.request);
         }
     }


### PR DESCRIPTION
We are currently testing BaseURL switching and it seems to be fairly broken by some changes that have happened in the ScheduleController since BaseURL was originally implemented. More details to follow as we have them, and I'll open a holding issue now.

This one, though, has always been there and is definitely incorrect. The `serviceLocation` attribute belongs to a `request` and will never be found on the `event`. Without this fix, failed requests will never be retried on a new BaseURL. With it, for now, they still won't be rerequested as there are other problems with request replacement.