### PR TITLE
Fix #1702 - ensure replacements are rerequested on failure

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -210,12 +210,18 @@ function ScheduleController(config) {
                     lastInitQuality = currentRepresentationInfo.quality;
                     bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality);
                 } else {
-                    const request = nextFragmentRequestRule.execute(streamProcessor, replaceRequestArray.shift());
-                    if (request) {
-                        fragmentModel.executeRequest(request);
-                    } else { //Use case - Playing at the bleeding live edge and frag is not available yet. Cycle back around.
-                        isFragmentProcessingInProgress = false;
-                        startScheduleTimer(500);
+                    const replacement = replaceRequestArray.shift();
+
+                    if (fragmentController.isInitializationRequest(replacement)) {
+                        getInitRequest(replacement.quality);
+                    } else {
+                        const request = nextFragmentRequestRule.execute(streamProcessor, replacement);
+                        if (request) {
+                            fragmentModel.executeRequest(request);
+                        } else { //Use case - Playing at the bleeding live edge and frag is not available yet. Cycle back around.
+                            isFragmentProcessingInProgress = false;
+                            startScheduleTimer(500);
+                        }
                     }
                 }
             };
@@ -352,6 +358,8 @@ function ScheduleController(config) {
 
         if (e.error && e.serviceLocation && !isStopped) {
             replaceRequest(e.request);
+            isFragmentProcessingInProgress = false;
+            startScheduleTimer(0);
         }
     }
 


### PR DESCRIPTION
As discussed in #1702, the fast switch changes meant that alternate base urls were not failed to in the event of a download failure. This is fixed by kicking the scheduler once the replacement queue has been populated.

Additionally, extra checks are needed to ensure that if it was an initialisation segment that failed this can be rerequested since next fragment rule will not replace these.