### PR TITLE
Fail properly when Base URL Resolution fails

### DIFF
--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -59,6 +59,16 @@ function BaseURLController() {
         eventBus.on(Events.SERVICE_LOCATION_BLACKLIST_CHANGED, onBlackListChanged, instance);
     }
 
+    function setConfig(config) {
+        if (config.baseURLTreeModel) {
+            baseURLTreeModel = config.baseURLTreeModel;
+        }
+
+        if (config.baseURLSelector) {
+            baseURLSelector = config.baseURLSelector;
+        }
+    }
+
     function update(manifest) {
         baseURLTreeModel.update(manifest);
         baseURLSelector.chooseSelectorFromManifest(manifest);
@@ -77,6 +87,8 @@ function BaseURLController() {
                 } else {
                     p.url = urlUtils.resolve(b.url, p.url);
                 }
+            } else {
+                return new BaseURL();
             }
 
             return p;
@@ -99,7 +111,8 @@ function BaseURLController() {
     instance = {
         reset: reset,
         initialize: initialize,
-        resolve: resolve
+        resolve: resolve,
+        setConfig: setConfig
     };
 
     setup();

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -69,6 +69,12 @@ function BaseURLSelector() {
         selector = basicSelector;
     }
 
+    function setConfig(config) {
+        if (config.selector) {
+            selector = config.selector;
+        }
+    }
+
     function chooseSelectorFromManifest(manifest) {
         if (dashManifestModel.getIsDVB(manifest)) {
             selector = dvbSelector;
@@ -116,7 +122,8 @@ function BaseURLSelector() {
     instance = {
         chooseSelectorFromManifest: chooseSelectorFromManifest,
         select: select,
-        reset: reset
+        reset: reset,
+        setConfig: setConfig
     };
 
     setup();

--- a/test/streaming.controllers.BaseURLController.js
+++ b/test/streaming.controllers.BaseURLController.js
@@ -1,0 +1,57 @@
+import BaseURLController from '../src/streaming/controllers/BaseURLController';
+import BasicSelector from '../src/streaming/rules/baseUrlResolution/BasicSelector';
+import BaseURLSelector from '../src/streaming/utils/BaseURLSelector';
+import BaseURL from '../src/dash/vo/BaseURL';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const context = {};
+
+const SERVICE_LOCATION_A = 'a';
+const SERVICE_LOCATION_B = 'b';
+
+const dummyBaseURLTreeModel = {
+    getForPath: () => {
+        return [{
+            baseUrls: [
+                new BaseURL('http://www.example.com/', SERVICE_LOCATION_A)
+            ],
+            selectedIdx: NaN
+        }, {
+            baseUrls: [
+                new BaseURL('http://www2.example.com/', SERVICE_LOCATION_B)
+            ],
+            selectedIdx: NaN
+        }];
+    }
+};
+
+const dummyBlacklistController = {
+    contains: sl => sl == SERVICE_LOCATION_B
+};
+
+describe('BaseURLController', function () {
+
+    it('should return undefined if resolution fails at any level', () => {
+
+        const basicSelector = BasicSelector(context).create({
+            blacklistController: dummyBlacklistController
+        });
+
+        const baseURLSelector = BaseURLSelector(context).create();
+        baseURLSelector.setConfig({
+            selector: basicSelector
+        });
+
+        const baseURLController = BaseURLController(context).getInstance();
+        baseURLController.setConfig({
+            baseURLTreeModel: dummyBaseURLTreeModel,
+            baseURLSelector: baseURLSelector
+        });
+
+        const selected = baseURLController.resolve();
+
+        expect(selected).to.be.undefined; // jshint ignore:line
+    });
+});


### PR DESCRIPTION
Debugging #1701 showed a bug that has always existed but was only exposed once the fast switch changes were added.

If URL resolution fails, an event is fired which stops the scheduler. If you subsequently try to resolve a Base URL after this (which in theory should never happen, but can in certain circumstances), the resolver can return unexpected results. This change ensures that no sensible result is returned once a failure has occurred.

This is a one line change (L91, BaseURLController) - all the other stuff is simply to get the test running to verify the fix.