### PR TITLE
Use recent node versions in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
+  - "6"
 before_install: npm install -g grunt-cli
 install: npm install


### PR DESCRIPTION
As per https://github.com/nodejs/LTS/#lts-schedule:

- Node 0.12 is no longer supported after 31st Dec 2016
- Active LTS versions are 4 and 6.

Node 0.12 seems to be causing intermittent failures of our Travis builds for network-related reasons, which are not seen on the Node 4 job. Removing it should make our Travis badge more likely to remain green.