### PR TITLE
Sample player: add auto loaded stream as param url

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -657,25 +657,30 @@ app.controller('DashController', function($scope, sources, contributors) {
         }
 
         var vars = getUrlVars();
-        var paramUrl = null;
+        var item = {};
 
         if (vars && vars.hasOwnProperty("url")) {
-            paramUrl = vars.url;
+            item.url = vars.url;
         }
 
         if (vars && vars.hasOwnProperty("mpd")) {
-            paramUrl = vars.mpd;
+            item.url = vars.mpd;
         }
 
         if (vars && vars.hasOwnProperty("source")) {
-            paramUrl = vars.source;
+            item.url = vars.source;
         }
 
-        if (paramUrl !== null) {
+        if (vars && vars.hasOwnProperty("stream")) {
+            try {
+                item = JSON.parse(atob(vars.stream));
+            } catch (e) {}
+        }
+
+        if (item.url) {
             var startPlayback = false;
 
-            $scope.selectedItem = {};
-            $scope.selectedItem.url = paramUrl;
+            $scope.selectedItem = item;
 
             if (vars.hasOwnProperty("autoplay")) {
                 startPlayback = (vars.autoplay === 'true');


### PR DESCRIPTION
Add possibility to specify the auto loaded full stream object (url, protData, ...) as an url parameter (in base64 string) of the webapp.

This enables testing other streams not in sources.json for which you have to specify other parameters than only the manifest url.

Example usage:

```
var stream = {
          "name": "CableLabs Cenc PR/WV",
          "url": "http://html5.cablelabs.com:8100/cenc/prwv/dash.mpd",
          "protData": {
            "com.widevine.alpha": {
              "drmtoday": true,
              "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
              "httpRequestHeaders": {
                "dt-custom-data": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
              }
            },
            "com.microsoft.playready": {
              "drmtoday": true,
              "serverURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
              "httpRequestHeaders": {
                "http-header-CustomData": "eyJ1c2VySWQiOiIxMjM0NSIsInNlc3Npb25JZCI6ImV3b2dJQ0p3Y205bWFXeGxJaUE2SUhzS0lDQWdJQ0p3ZFhKamFHRnpaU0lnT2lCN0lIMEtJQ0I5TEFvZ0lDSnZkWFJ3ZFhSUWNtOTBaV04wYVc5dUlpQTZJSHNLSUNBZ0lDSmthV2RwZEdGc0lpQTZJR1poYkhObExBb2dJQ0FnSW1GdVlXeHZaM1ZsSWlBNklHWmhiSE5sTEFvZ0lDQWdJbVZ1Wm05eVkyVWlJRG9nWm1Gc2MyVUtJQ0I5TEFvZ0lDSnpkRzl5WlV4cFkyVnVjMlVpSURvZ1ptRnNjMlVLZlFvSyIsIm1lcmNoYW50IjoiY2FibGVsYWJzIn0K"
              }
            }
          }

window.open("http://.../dash-if-reference-player/index.html?autoplay=true&stream=" + btoa(JSON.stringify(stream)), "dash.js");
```
