### PR TITLE
fix initial textrack display mode loop

### DIFF
--- a/src/streaming/TextTracks.js
+++ b/src/streaming/TextTracks.js
@@ -155,7 +155,7 @@ function TextTracks() {
             }
             setCurrentTrackIdx.call(this, defaultIndex);
             if (defaultIndex >= 0) {
-                for (let idx = 0; i < video.textTracks.length; idx++) {
+                for (let idx = 0; idx < video.textTracks.length; idx++) {
                     video.textTracks[idx].mode = (idx === defaultIndex) ? 'showing' : 'hidden';
                 }
                 this.addCaptions(defaultIndex, 0, null);


### PR DESCRIPTION
The loop initializing the subtitles uses a variable undefined
So the subtitles are not visible at the start of the video