### PR TITLE
[MS Edge bug] Response header string starts with \n

### DIFF
--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -309,8 +309,8 @@ function DashMetrics() {
         if (!headerStr) {
             return headers;
         }
-        
-        // Trim headerStr to fix a MS Edge bug with xhr.getAllResponseHeaders method 
+
+        // Trim headerStr to fix a MS Edge bug with xhr.getAllResponseHeaders method
         // which send a string starting with a "\n" character
         var headerPairs = headerStr.trim().split('\u000d\u000a');
         for (var i = 0, ilen = headerPairs.length; i < ilen; i++) {

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -309,7 +309,10 @@ function DashMetrics() {
         if (!headerStr) {
             return headers;
         }
-        var headerPairs = headerStr.split('\u000d\u000a');
+        
+        // Trim headerStr to fix a MS Edge bug with xhr.getAllResponseHeaders method 
+        // which send a string starting with a "\n" character
+        var headerPairs = headerStr.trim().split('\u000d\u000a');
         for (var i = 0, ilen = headerPairs.length; i < ilen; i++) {
             var headerPair = headerPairs[i];
             var index = headerPair.indexOf('\u003a\u0020');


### PR DESCRIPTION
Trim headerStr to fix a MS Edge bug with xhr.getAllResponseHeaders method which send a string starting with a "\n" character

Sources :
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5403401/
- https://connect.microsoft.com/IE/feedbackdetail/view/1929694/ie-edge-incorrectly-return-the-header-with-a-leading-new-line-character
- https://github.com/exceptionless/Exceptionless.JavaScript/issues/23