### PR TITLE
Fix #1731 - ensure BaseURLs are resolved properly for SegmentBase

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -36,6 +36,7 @@ import EventBus from '../core/EventBus';
 import FactoryMaker from '../core/FactoryMaker';
 import Debug from '../core/Debug';
 import URLUtils from '../streaming/utils/URLUtils';
+import Representation from './vo/Representation';
 
 import {replaceTokenForTemplate, getTimeBasedSegment, getSegmentByIndex} from './utils/SegmentsUtils';
 import SegmentsGetter from './utils/SegmentsGetter';
@@ -115,11 +116,11 @@ function DashHandler(config) {
     }
 
     function unescapeDollarsInTemplate(url) {
-        return url.split('$$').join('$');
+        return url ? url.split('$$').join('$') : url;
     }
 
     function replaceIDForTemplate(url, value) {
-        if (value === null || url.indexOf('$RepresentationID$') === -1) { return url; }
+        if (value === null || url === null || url.indexOf('$RepresentationID$') === -1) { return url; }
         var v = value.toString();
         return url.split('$RepresentationID$').join(v);
     }
@@ -230,8 +231,8 @@ function DashHandler(config) {
     }
 
     function updateRepresentation(representation, keepIdx) {
-        var hasInitialization = representation.initialization;
-        var hasSegments = representation.segmentInfoType !== 'BaseURL' && representation.segmentInfoType !== 'SegmentBase' && !representation.indexRange;
+        var hasInitialization = Representation.hasInitialization(representation);
+        var hasSegments = Representation.hasSegments(representation);
         var error;
 
         if (!representation.segmentDuration && !representation.segments) {
@@ -475,7 +476,7 @@ function DashHandler(config) {
 
         onSegmentListUpdated(representation, segments);
 
-        if (!representation.initialization) return;
+        if (!Representation.hasInitialization(representation)) return;
 
         eventBus.trigger(Events.REPRESENTATION_UPDATED, {sender: this, representation: representation});
     }

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -93,7 +93,8 @@ function SegmentBaseLoader() {
 
             if (initRange) {
                 representation.range = initRange;
-                representation.initialization = info.url;
+                // note that we don't explicitly set rep.initialization as this
+                // will be computed when all BaseURLs are resolved later
                 eventBus.trigger(Events.INITIALIZATION_LOADED, {representation: representation});
             } else {
                 info.range.end = info.bytesLoaded + info.bytesToLoad;
@@ -249,8 +250,9 @@ function SegmentBaseLoader() {
             size = refs[i].referenced_size;
 
             segment = new Segment();
+            // note that we don't explicitly set segment.media as this will be
+            // computed when all BaseURLs are resolved later
             segment.duration = duration;
-            segment.media = info.url;
             segment.startTime = time;
             segment.timescale = timescale;
             end = start + size - 1;

--- a/src/dash/WebmSegmentBaseLoader.js
+++ b/src/dash/WebmSegmentBaseLoader.js
@@ -171,7 +171,7 @@ function WebmSegmentBaseLoader() {
         return cues;
     }
 
-    function parseSegments(data, media, segmentStart, segmentEnd, segmentDuration) {
+    function parseSegments(data, segmentStart, segmentEnd, segmentDuration) {
         let duration;
         let parsed;
         let segments;
@@ -197,8 +197,9 @@ function WebmSegmentBaseLoader() {
                 duration = segmentDuration - parsed[i].CueTime;
             }
 
+            // note that we don't explicitly set segment.media as this will be
+            // computed when all BaseURLs are resolved later
             segment.duration = duration;
-            segment.media = media;
             segment.startTime = parsed[i].CueTime;
             segment.timescale = 1000; // hardcoded for ms
             start = parsed[i].CueTracks[0].ClusterPosition + segmentStart;
@@ -278,7 +279,7 @@ function WebmSegmentBaseLoader() {
         request = getFragmentRequest(info);
 
         const onload = function (response) {
-            segments = parseSegments(response, info.url, segmentStart, segmentEnd, duration);
+            segments = parseSegments(response, segmentStart, segmentEnd, duration);
             callback(segments);
         };
 
@@ -312,7 +313,8 @@ function WebmSegmentBaseLoader() {
         request = getFragmentRequest(info);
 
         const onload = function () {
-            representation.initialization = info.url;
+            // note that we don't explicitly set rep.initialization as this
+            // will be computed when all BaseURLs are resolved later
             eventBus.trigger(Events.INITIALIZATION_LOADED, {representation: representation});
         };
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -43,6 +43,7 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import MediaPlayerEvents from '../../streaming/MediaPlayerEvents';
 import FactoryMaker from '../../core/FactoryMaker';
+import Representation from '../vo/Representation';
 
 function RepresentationController() {
 
@@ -214,7 +215,7 @@ function RepresentationController() {
     function isAllRepresentationsUpdated() {
         for (var i = 0, ln = availableRepresentations.length; i < ln; i++) {
             var segmentInfoType = availableRepresentations[i].segmentInfoType;
-            if (availableRepresentations[i].segmentAvailabilityRange === null || availableRepresentations[i].initialization === null ||
+            if (availableRepresentations[i].segmentAvailabilityRange === null || !Representation.hasInitialization(availableRepresentations[i]) ||
                     ((segmentInfoType === 'SegmentBase' || segmentInfoType === 'BaseURL') && !availableRepresentations[i].segments)
             ) {
                 return false;

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -421,41 +421,43 @@ function DashManifestModel() {
                         .join(r.bandwidth).split('$RepresentationID$').join(r.id);
                 }
             } else {
-                segmentInfo = r.BaseURL;
                 representation.segmentInfoType = 'BaseURL';
             }
 
-            if (segmentInfo.hasOwnProperty('Initialization')) {
-                initialization = segmentInfo.Initialization;
-                if (initialization.hasOwnProperty('sourceURL')) {
-                    representation.initialization = initialization.sourceURL;
-                } else if (initialization.hasOwnProperty('range')) {
-                    representation.range = initialization.range;
-                    representation.initialization = r.BaseURL;
+            if (segmentInfo) {
+                if (segmentInfo.hasOwnProperty('Initialization')) {
+                    initialization = segmentInfo.Initialization;
+                    if (initialization.hasOwnProperty('sourceURL')) {
+                        representation.initialization = initialization.sourceURL;
+                    } else if (initialization.hasOwnProperty('range')) {
+                        representation.range = initialization.range;
+                        // initialization source url will be determined from
+                        // BaseURL when resolved at load time.
+                    }
+                } else if (r.hasOwnProperty('mimeType') && getIsTextTrack(r.mimeType)) {
+                    representation.range = 0;
                 }
-            } else if (r.hasOwnProperty('mimeType') && getIsTextTrack(r.mimeType)) {
-                representation.range = 0;
-            }
 
-            if (segmentInfo.hasOwnProperty('timescale')) {
-                representation.timescale = segmentInfo.timescale;
-            }
-            if (segmentInfo.hasOwnProperty('duration')) {
-                // TODO according to the spec @maxSegmentDuration specifies the maximum duration of any Segment in any Representation in the Media Presentation
-                // It is also said that for a SegmentTimeline any @d value shall not exceed the value of MPD@maxSegmentDuration, but nothing is said about
-                // SegmentTemplate @duration attribute. We need to find out if @maxSegmentDuration should be used instead of calculated duration if the the duration
-                // exceeds @maxSegmentDuration
-                //representation.segmentDuration = Math.min(segmentInfo.duration / representation.timescale, adaptation.period.mpd.maxSegmentDuration);
-                representation.segmentDuration = segmentInfo.duration / representation.timescale;
-            }
-            if (segmentInfo.hasOwnProperty('startNumber')) {
-                representation.startNumber = segmentInfo.startNumber;
-            }
-            if (segmentInfo.hasOwnProperty('indexRange')) {
-                representation.indexRange = segmentInfo.indexRange;
-            }
-            if (segmentInfo.hasOwnProperty('presentationTimeOffset')) {
-                representation.presentationTimeOffset = segmentInfo.presentationTimeOffset / representation.timescale;
+                if (segmentInfo.hasOwnProperty('timescale')) {
+                    representation.timescale = segmentInfo.timescale;
+                }
+                if (segmentInfo.hasOwnProperty('duration')) {
+                    // TODO according to the spec @maxSegmentDuration specifies the maximum duration of any Segment in any Representation in the Media Presentation
+                    // It is also said that for a SegmentTimeline any @d value shall not exceed the value of MPD@maxSegmentDuration, but nothing is said about
+                    // SegmentTemplate @duration attribute. We need to find out if @maxSegmentDuration should be used instead of calculated duration if the the duration
+                    // exceeds @maxSegmentDuration
+                    //representation.segmentDuration = Math.min(segmentInfo.duration / representation.timescale, adaptation.period.mpd.maxSegmentDuration);
+                    representation.segmentDuration = segmentInfo.duration / representation.timescale;
+                }
+                if (segmentInfo.hasOwnProperty('startNumber')) {
+                    representation.startNumber = segmentInfo.startNumber;
+                }
+                if (segmentInfo.hasOwnProperty('indexRange')) {
+                    representation.indexRange = segmentInfo.indexRange;
+                }
+                if (segmentInfo.hasOwnProperty('presentationTimeOffset')) {
+                    representation.presentationTimeOffset = segmentInfo.presentationTimeOffset / representation.timescale;
+                }
             }
 
             representation.MSETimeOffset = timelineConverter.calcMSETimeOffset(representation);

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -55,6 +55,10 @@ export function replaceTokenForTemplate(url, token, value) {
     var tokenLen = token.length;
     var formatTagLen = formatTag.length;
 
+    if (!url) {
+        return url;
+    }
+
     // keep looping round until all instances of <token> have been
     // replaced. once that has happened, startPos below will be -1
     // and the completed url will be returned.

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -52,6 +52,17 @@ class Representation {
         this.bandwidth = NaN;
         this.maxPlayoutRate = NaN;
     }
+
+    static hasInitialization(r) {
+        return r.initialization ||
+            ((r.segmentInfoType !== 'BaseURL' || r.segmentInfoType !== 'SegmentBase') && r.range);
+    }
+
+    static hasSegments(r) {
+        return r.segmentInfoType !== 'BaseURL' &&
+            r.segmentInfoType !== 'SegmentBase' &&
+            !r.indexRange;
+    }
 }
 
 export default Representation;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -54,8 +54,8 @@ class Representation {
     }
 
     static hasInitialization(r) {
-        return r.initialization ||
-            ((r.segmentInfoType !== 'BaseURL' || r.segmentInfoType !== 'SegmentBase') && r.range);
+        return !!r.initialization ||
+            ((r.segmentInfoType !== 'BaseURL' || r.segmentInfoType !== 'SegmentBase') && !!r.range);
     }
 
     static hasSegments(r) {

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -54,8 +54,8 @@ class Representation {
     }
 
     static hasInitialization(r) {
-        return !!r.initialization ||
-            ((r.segmentInfoType !== 'BaseURL' || r.segmentInfoType !== 'SegmentBase') && !!r.range);
+        return (r.initialization !== null) ||
+            ((r.segmentInfoType !== 'BaseURL' || r.segmentInfoType !== 'SegmentBase') && (r.range !== null));
     }
 
     static hasSegments(r) {


### PR DESCRIPTION
The manifest in #1731 showed up an issue where `BaseURLs` were not resolved properly for `SegmentBase` elements if they had a path in them because the path element appeared to be resolved twice. The reason for this was that `SegmentBase` and `BaseURL` manifest types were copying the `BaseURL` element to `initialization`, but still resolving the BaseURLs anyway, leading to the behaviour seen.

Further, once the BaseURL resolution had been performed at startup time for these manifest types it could not be redone so they would not be able to benefit from BaseURL redundancy (although this is probably less of an issue since they are for on-demand use).

I tested these specific changes using:
- http://timcin-wedding.s3-eu-west-1.amazonaws.com/videotest-album/hls/a5b3f3f0d4d711e6b653affe68f4ebc2/playlist.mpd (from #1731)
- http://dash.edgesuite.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd (BaseURL test vector)

... as well as the usual suspects from the sample list.

Also tested Webm with:
- http://downloads.webmproject.org/demos/adaptive/webm_dash_mevq-ver2-vid6-aud1.mpd
- http://yt-dash-mse-test.commondatastorage.googleapis.com/media/feelings_vp9-20130806-manifest.mpd

and these work great but we do not have enough test material for webm IMO.