### PR TITLE
Fix #1722: Wait for dashjs before creating element(s) if loaded asynchronously

### DIFF
--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -94,17 +94,30 @@ function MediaPlayerFactory() {
 }
 
 let instance = MediaPlayerFactory();
+let loadInterval;
 
 function loadHandler() {
     window.removeEventListener('load', loadHandler);
     instance.createAll();
 }
 
+function loadIntervalHandler() {
+    if (window.dashjs) {
+        window.clearInterval(loadInterval);
+        instance.createAll();
+    }
+}
+
 let avoidAutoCreate = typeof window !== 'undefined' && window && window.dashjs && window.dashjs.skipAutoCreate;
 
-if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.dashjs && window.addEventListener) {
+if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.addEventListener) {
     if (window.document.readyState === 'complete') {
-        instance.createAll();
+        if (window.dashjs) {
+            instance.createAll();
+        } else {
+            // If loaded asynchronously, window.readyState may be 'complete' even if dashjs hasn't loaded yet
+            loadInterval = window.setInterval(loadIntervalHandler, 500);
+        }
     } else {
         window.addEventListener('load', loadHandler);
     }


### PR DESCRIPTION
Fixes #1722 caused by #1694, without re-breaking initial issue (#1680).

When MediaPlayerFactory tries to create elements:
- document is complete and dashjs loaded -> continue as normal
- document is not complete (#1722) -> add a load event listener
- document is complete but dashjs undefined (#1680) -> set an interval to wait for dashjs

There's probably a less icky way of achieving this without the need for the interval though?