### PR TITLE
Fix #1749 - do not fail to build if not a git repo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,9 @@ module.exports = function (grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         githash: {
+            options: {
+                fail: false
+            },
             dist: {
             }
         },


### PR DESCRIPTION
Build was failing if code was grabbed as archive rather than cloned from git repo.

See https://www.npmjs.com/package/grunt-githash#optionsfail