### PR TITLE
fix: ordering of cea606 data

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -363,25 +363,6 @@ function TextSourceBuffer() {
     */
     function extractCea608Data(data) {
 
-        /* Insert [time, data] pairs in order into array. */
-        var insertInOrder = function (arr, time, data) {
-            var len = arr.length;
-            if (len > 0) {
-                if (time >= arr[len - 1][0]) {
-                    arr.push([time, data]);
-                } else {
-                    for (var pos = len - 1; pos >= 0; pos--) {
-                        if (time < arr[pos][0]) {
-                            arr.splice(pos, 0, [time, data]);
-                            break;
-                        }
-                    }
-                }
-            } else {
-                arr.push([time, data]);
-            }
-        };
-
         var isoFile = boxParser.parse(data);
         var moof = isoFile.getBox('moof');
         var tfdt = isoFile.getBox('tfdt');
@@ -424,7 +405,7 @@ function TextSourceBuffer() {
                 var ccData = cea608parser.extractCea608DataFromRange(raw, cea608Ranges[j]);
                 for (var k = 0; k < 2; k++) {
                     if (ccData[k].length > 0) {
-                        insertInOrder(allCcData.fields[k], sampleTime, ccData[k]);
+                        allCcData.fields[k].push([sampleTime, ccData[k]]);
                     }
                 }
             }
@@ -432,6 +413,11 @@ function TextSourceBuffer() {
             accDuration += sample.sample_duration;
             startPos += sample.sample_size;
         }
+
+        // Sort by sampleTime ascending order
+        allCcData.fields[0].sort(function (a, b) { return a[0] - b[0]; });
+        allCcData.fields[1].sort(function (a, b) { return a[0] - b[0]; });
+
         var endSampleTime = baseSampleTime + accDuration;
         allCcData.startTime = baseSampleTime;
         allCcData.endTime = endSampleTime;


### PR DESCRIPTION
The `insertInOrder` method fails to insert the CC packets in order and causes issue with CEA-608 caption dispaly. A simpler sort method can be used after the data is found to sort the data.

```
var a = []

insertInOrder(a, 1, [1]);
insertInOrder(a, 2, [2]);
insertInOrder(a, 3, [3]);
insertInOrder(a, 2.5, [2.5]);
insertInOrder(a, 2, [2]);

console.log(a);
```

the following quick test exposes the issues with `insertInOrder`.