### PR TITLE
fix for segmenttimeline live start #1729

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -327,7 +327,7 @@ function ScheduleController(config) {
         const dvrWindowSize = currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo.DVRWindowSize / 2;
         const startTime = liveEdge - playbackController.computeLiveDelay(currentRepresentationInfo.fragmentDuration, dvrWindowSize);
         const request = adapter.getFragmentRequestForTime(streamProcessor, currentRepresentationInfo, startTime, {ignoreIsFinished: true});
-
+        timelineConverter.setTimeSyncCompleted(true);
         seekTarget = playbackController.getLiveStartTime();
         if (isNaN(seekTarget) || request.startTime > seekTarget) {
             playbackController.setLiveStartTime(request.startTime);


### PR DESCRIPTION
So when I refactored for Dynamic multiperiod I noticed a "way too complex" system used for liveedge search as a rule.  I removed a ton of code to simplify this and that was successful except I missed one line that was critical for segmentTimeline since it does not use Timesync. 

timelineConverter.setTimeSyncCompleted(true);

So for SegmentTimeline the seekAtStart was not called properly. 

I believe setting this from a single point,  at live edge search complete handler in schedule controller is the best place in the code.  Other option is,  we can add back in the handler into timelineConverter just to set this locally but I think that actually makes it more confusing .  IMHO. 

I tested with some URLS in the issues as well as all of the live streams in the live section in the player. 
All is working as expected. 