### PR TITLE
Fix #1759 (regression) resume correctly after seek

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -352,8 +352,9 @@ function DashHandler(config) {
 
         updateSegments(representation);
         index = getIndexForSegments(time, representation, timeThreshold);
-        //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
+        //Index may be -1 if getSegments needs to update again.  So after getSegments is called and updated then try to get index again.
         if (index < 0) {
+            updateSegments(representation);
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 


### PR DESCRIPTION
Fixes #1759 caused by 930717e.

Original reason for 930717e was a problem were segment lists were updated out of order such that the previously fetched index was sometimes no longer valid. For instance, if a paused player drifted outside of the rewind window, when seeking back, the `getSegmentByIndex` and `getIndexForSegments` functions would be using different segment lists.

Moving `updateSegments` fixed the issue, but caused problems for other streams where the segment list needs to be updated on every `getSegmentRequestForTime` call.

6650178 now works, but the whole thing could probably do with refactoring and the first `updateSegments` should probably go somewhere else.