### PR TITLE
Smooth Streaming support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,6 +70,15 @@ module.exports = function (grunt) {
                 }
             },
 
+            build_mss: {
+                options: {
+                    sourceMapIn: 'build/temp/dash.mss.debug.js.map'
+                },
+                files: {
+                    'build/temp/dash.mss.min.js': 'build/temp/dash.mss.debug.js'
+                }
+            },
+
             build_all: {
                 options: {
                     sourceMapIn: 'build/temp/dash.all.debug.js.map'
@@ -90,9 +99,11 @@ module.exports = function (grunt) {
                     'dash.protection.min.js', 'dash.protection.min.js.map',
                     'dash.all.debug.js', 'dash.all.debug.js.map',
                     'dash.reporting.min.js', 'dash.reporting.min.js.map',
+                    'dash.mss.min.js', 'dash.mss.min.js.map',
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
                     'dash.protection.debug.js', 'dash.protection.debug.js.map',
-                    'dash.reporting.debug.js', 'dash.reporting.debug.js.map'
+                    'dash.reporting.debug.js', 'dash.reporting.debug.js.map',
+                    'dash.mss.debug.js', 'dash.mss.debug.js.map',
                 ],
                 dest: 'dist/',
                 filter: 'isFile'
@@ -121,6 +132,12 @@ module.exports = function (grunt) {
                 options: {},
                 files: {
                     'build/temp/dash.reporting.debug.js.map': ['build/temp/dash.reporting.debug.js']
+                }
+            },
+            mss: {
+                options: {},
+                files: {
+                    'build/temp/dash.mss.debug.js.map': ['build/temp/dash.mss.debug.js']
                 }
             }
         },
@@ -184,6 +201,21 @@ module.exports = function (grunt) {
                     transform: ['babelify']
                 }
             },
+            mss: {
+                files: {
+                    'build/temp/dash.mss.debug.js': ['src/mss/MssHandler.js']
+                },
+                options: {
+                    browserifyOptions: {
+                        debug: true,
+                        standalone: 'dashjs.MssHandler'
+                    },
+                    plugin: [
+                        'browserify-derequire', 'bundle-collapser/plugin'
+                    ],
+                    transform: ['babelify']
+                }
+            },
             all: {
                 files: {
                     'build/temp/dash.all.debug.js': ['index.js']
@@ -210,7 +242,7 @@ module.exports = function (grunt) {
                         debug: true
                     },
                     plugin: [
-                      ['browserify-derequire']
+                        ['browserify-derequire']
                     ],
                     transform: ['babelify']
                 }
@@ -250,13 +282,13 @@ module.exports = function (grunt) {
     });
 
     require('load-grunt-tasks')(grunt);
-    grunt.registerTask('default',   ['dist', 'test']);
-    grunt.registerTask('dist',      ['clean', 'jshint', 'jscs', 'browserify:mediaplayer' , 'browserify:protection', 'browserify:reporting', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
-    grunt.registerTask('minimize',  ['exorcise', 'githash', 'uglify']);
-    grunt.registerTask('test',      ['mocha_istanbul:test']);
-    grunt.registerTask('watch',     ['browserify:watch']);
-    grunt.registerTask('release',   ['default', 'jsdoc']);
-    grunt.registerTask('debug',     ['clean', 'browserify:all', 'exorcise:all', 'copy:dist']);
-    grunt.registerTask('lint',      ['jshint', 'jscs']);
+    grunt.registerTask('default', ['dist', 'test']);
+    grunt.registerTask('dist', ['clean', 'jshint', 'jscs', 'browserify:mediaplayer', 'browserify:protection', 'browserify:reporting', 'browserify:mss', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
+    grunt.registerTask('minimize', ['exorcise', 'githash', 'uglify']);
+    grunt.registerTask('test', ['mocha_istanbul:test']);
+    grunt.registerTask('watch', ['browserify:watch']);
+    grunt.registerTask('release', ['default', 'jsdoc']);
+    grunt.registerTask('debug', ['clean', 'browserify:all', 'exorcise:all', 'copy:dist']);
+    grunt.registerTask('lint', ['jshint', 'jscs']);
     grunt.registerTask('prepublish', ['githooks', 'dist']);
 };

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
 import {getVersionString} from './src/core/Version';
 
+import MssHandler from './src/mss/MssHandler';
+
 
 // Shove both of these into the global scope
 var context = (typeof window !== 'undefined' && window) || global;
@@ -49,7 +51,8 @@ dashjs.Protection = Protection;
 dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
 dashjs.Version = getVersionString();
+dashjs.MssHandler = MssHandler;
 
 
 export default dashjs;
-export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory};
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, MssHandler};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uglify-js": "^2.4.21"
   },
   "dependencies": {
-    "codem-isoboxer": "^0.3.0",
+    "codem-isoboxer": "^0.3.2",
     "round10": "^1.0.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uglify-js": "^2.4.21"
   },
   "dependencies": {
-    "codem-isoboxer": "0.2.7",
+    "codem-isoboxer": "^0.3.0",
     "round10": "^1.0.3"
   },
   "repository": {

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -185,7 +185,7 @@ app.controller('DashController', function($scope, sources, contributors) {
     $scope.controlbar.disable();
     $scope.version = $scope.player.getVersion();
 
-    $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) {}, $scope);
+    $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) { console.error(e.error + ' : ' + e.event.message);}, $scope);
 
     $scope.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, function (e) {
         $scope[e.mediaType + "Index"] = e.oldQuality + 1 ;

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -1,6 +1,27 @@
 {
   "items": [
     {
+      "name": "Smooth Streaming",
+      "submenu": [
+        {
+          "url": "http://2is7server2.rd.francetelecom.com/hasplayer/VOD_1/VOD_1.ism/manifest",
+          "name": "Prince Of Persia"
+        },
+        {
+          "url": "http://2is7server1.rd.francetelecom.com/VOD/BBB-SD/big_buck_bunny_1080p_stereo.ism/Manifest",
+          "name": "Big Buck Bunny"
+        },
+        {
+          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest",
+          "name": "Super Speedway"
+        },
+        {
+          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
+          "name": "Super Speedway + PlayReady DRM"
+        }
+      ]
+    },
+    {
       "name": "VOD (Static MPD)",
       "submenu": [
         {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -379,8 +379,21 @@ function DashManifestModel() {
                 representation.id = r.id;
             }
 
+            if (r.hasOwnProperty('codecs')) {
+                representation.codecs = r.codecs;
+            }
+            if (r.hasOwnProperty('codecPrivateData')) {
+                representation.codecPrivateData = r.codecPrivateData;
+            }
+
             if (r.hasOwnProperty('bandwidth')) {
                 representation.bandwidth = r.bandwidth;
+            }
+            if (r.hasOwnProperty('width')) {
+                representation.width = r.width;
+            }
+            if (r.hasOwnProperty('height')) {
+                representation.height = r.height;
             }
             if (r.hasOwnProperty('maxPlayoutRate')) {
                 representation.maxPlayoutRate = r.maxPlayoutRate;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -39,6 +39,8 @@ class Representation {
         this.adaptation = null;
         this.segmentInfoType = null;
         this.initialization = null;
+        this.codecs = null;
+        this.codecPrivateData = null;
         this.segmentDuration = NaN;
         this.timescale = 1;
         this.startNumber = 1;
@@ -50,6 +52,8 @@ class Representation {
         this.segmentAvailabilityRange = null;
         this.availableSegmentsNumber = 0;
         this.bandwidth = NaN;
+        this.width = NaN;
+        this.height = NaN;
         this.maxPlayoutRate = NaN;
     }
 

--- a/src/mss/MssFragmentProcessor.js
+++ b/src/mss/MssFragmentProcessor.js
@@ -735,7 +735,7 @@ function MssFragmentProcessor() {
         let tfdt = isoFile.fetch('tfdt');
         let traf = isoFile.fetch('traf');
         if (tfdt === null) {
-            tfdt = ISOBoxer.createBox('tfdt', traf, tfhd);
+            tfdt = ISOBoxer.createFullBox('tfdt', traf, tfhd);
             tfdt.version = 1;
             tfdt.flags = 0;
             tfdt.baseMediaDecodeTime = Math.floor(e.request.startTime * e.request.timescale);

--- a/src/mss/MssFragmentProcessor.js
+++ b/src/mss/MssFragmentProcessor.js
@@ -1,0 +1,833 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../core/FactoryMaker';
+// import Debug from '../core/Debug';
+// import ErrorHandler from '../streaming/utils/ErrorHandler';
+// import BASE64 from '../../../externals/base64';
+import ISOBoxer from 'codem-isoboxer';
+import ProtectionKeyController from '../streaming/protection/controllers/ProtectionKeyController';
+
+
+// Add specific box processors not provided by codem-isoboxer library
+
+function arrayEqual(arr1, arr2) {
+    return (arr1.length === arr2.length) && arr1.every(function (element, index) {
+        return element === arr2[index];
+    });
+}
+
+function saioProcessor() {
+    this._procFullBox();
+    if (this.flags & 1) {
+        this._procField('aux_info_type', 'uint', 32);
+        this._procField('aux_info_type_parameter', 'uint', 32);
+    }
+    this._procField('entry_count', 'uint', 32);
+    this._procFieldArray('offset', this.entry_count, 'uint', (this.version === 1) ? 64 : 32);
+}
+
+function saizProcessor() {
+    this._procFullBox();
+    if (this.flags & 1) {
+        this._procField('aux_info_type', 'uint', 32);
+        this._procField('aux_info_type_parameter', 'uint', 32);
+    }
+    this._procField('default_sample_info_size', 'uint', 8);
+    this._procField('sample_count', 'uint', 32);
+    if (this.default_sample_info_size === 0) {
+        this._procFieldArray('sample_info_size', this.sample_count, 'uint', 8);
+    }
+}
+
+function sencProcessor() {
+    this._procFullBox();
+    this._procField('sample_count', 'uint', 32);
+    if (this.flags & 1) {
+        this._procField('IV_size', 'uint', 8);
+    }
+    this._procEntries('entry', this.sample_count, function (entry) {
+        this._procEntryField(entry, 'InitializationVector', 'data', 8);
+        if (this.flags & 2) {
+            this._procEntryField(entry, 'NumberOfEntries', 'uint', 16);
+            this._procSubEntries(entry, 'clearAndCryptedData', entry.NumberOfEntries, function (clearAndCryptedData) {
+                this._procEntryField(clearAndCryptedData, 'BytesOfClearData', 'uint', 16);
+                this._procEntryField(clearAndCryptedData, 'BytesOfEncryptedData', 'uint', 32);
+            });
+        }
+    });
+}
+
+function uuidProcessor() {
+    let tfxdUserType =   [0x6D, 0x1D, 0x9B, 0x05, 0x42, 0xD5, 0x44, 0xE6, 0x80, 0xE2, 0x14, 0x1D, 0xAF, 0xF7, 0x57, 0xB2];
+    let tfrfUserType =   [0xD4, 0x80, 0x7E, 0xF2, 0xCA, 0x39, 0x46, 0x95, 0x8E, 0x54, 0x26, 0xCB, 0x9E, 0x46, 0xA7, 0x9F];
+    let sepiffUserType = [0xA2, 0x39, 0x4F, 0x52, 0x5A, 0x9B, 0x4f, 0x14, 0xA2, 0x44, 0x6C, 0x42, 0x7C, 0x64, 0x8D, 0xF4];
+
+    if (arrayEqual(this.usertype, tfxdUserType)) {
+        this._procFullBox();
+        if (this._parsing) {
+            this.type = 'tfxd';
+        }
+        this._procField('fragment_absolute_time', 'uint', (this.version === 1) ? 64 : 32);
+        this._procField('fragment_duration', 'uint', (this.version === 1) ? 64 : 32);
+    }
+
+    if (arrayEqual(this.usertype, tfrfUserType)) {
+        this._procFullBox();
+        if (this._parsing) {
+            this.type = 'tfrf';
+        }
+        this._procField('fragment_count', 'uint', 8);
+        this._procEntries('entry', this.fragment_count, function (entry) {
+            this._procEntryField(entry, 'fragment_absolute_time', 'uint', (this.version === 1) ? 64 : 32);
+            this._procEntryField(entry, 'fragment_duration', 'uint', (this.version === 1) ? 64 : 32);
+        });
+    }
+
+    if (arrayEqual(this.usertype, sepiffUserType)) {
+        if (this._parsing) {
+            this.type = 'sepiff';
+        }
+        sencProcessor.call(this);
+    }
+}
+
+ISOBoxer.addBoxProcessor('uuid', uuidProcessor);
+ISOBoxer.addBoxProcessor('saio', saioProcessor);
+ISOBoxer.addBoxProcessor('saiz', saizProcessor);
+ISOBoxer.addBoxProcessor('senc', sencProcessor);
+
+
+
+function MssFragmentProcessor() {
+
+    let context = this.context;
+    let protectionKeyController = ProtectionKeyController(context).getInstance();
+    // const log = Debug(context).getInstance().log;
+    // const errorHandler = ErrorHandler(context).getInstance();
+
+    const TIME_SCALE = 10000000;
+    const NALUTYPE_SPS = 7;
+    const NALUTYPE_PPS = 8;
+
+    let instance,
+        period,
+        adaptationSet,
+        representation,
+        contentProtection,
+        trackId;
+
+    function setup() {}
+
+    function createFtypBox(isoFile) {
+        let ftyp = ISOBoxer.createBox('ftyp', isoFile);
+        ftyp.major_brand = 'iso6';
+        ftyp.minor_version = 1; // is an informative integer for the minor version of the major brand
+        ftyp.compatible_brands = []; //is a list, to the end of the box, of brands isom, iso6 and msdh
+        ftyp.compatible_brands[0] = 'isom'; // => decimal ASCII value for isom
+        ftyp.compatible_brands[1] = 'iso6'; // => decimal ASCII value for iso6
+        ftyp.compatible_brands[2] = 'msdh'; // => decimal ASCII value for msdh
+
+        return ftyp;
+    }
+
+    function createMoovBox(isoFile) {
+
+        // moov box
+        let moov = ISOBoxer.createBox('moov', isoFile);
+
+        // moov/mvhd
+        createMvhdBox(moov);
+
+        // moov/trak
+        let trak = ISOBoxer.createBox('trak', moov);
+
+        // moov/trak/tkhd
+        createTkhdBox(trak);
+
+        // moov/trak/mdia
+        let mdia = ISOBoxer.createBox('mdia', trak);
+
+        // moov/trak/mdia/mdhd
+        createMdhdBox(mdia);
+
+        // moov/trak/mdia/hdlr
+        createHdlrBox(mdia);
+
+        // moov/trak/mdia/minf
+        let minf = ISOBoxer.createBox('minf', mdia);
+
+        switch (adaptationSet.type) {
+            case 'video':
+                // moov/trak/mdia/minf/vmhd
+                createVmhdBox(minf);
+                break;
+            case 'audio':
+                // moov/trak/mdia/minf/smhd
+                createSmhdBox(minf);
+                break;
+            default:
+                break;
+        }
+
+        // moov/trak/mdia/minf/dinf
+        let dinf = ISOBoxer.createBox('dinf', minf);
+
+        // moov/trak/mdia/minf/dinf/dref
+        createDrefBox(dinf);
+
+        // moov/trak/mdia/minf/stbl
+        let stbl = ISOBoxer.createBox('stbl', minf);
+
+        // Create empty stts, stsc, stco and stsz boxes
+        // Use data field as for codem-isoboxer unknown boxes for setting fields value
+
+        // moov/trak/mdia/minf/stbl/stts
+        let stts = ISOBoxer.createFullBox('stts', stbl);
+        stts._data = [0, 0, 0, 0, 0, 0, 0, 0]; // version = 0, flags = 0, entry_count = 0
+
+        // moov/trak/mdia/minf/stbl/stsc
+        let stsc = ISOBoxer.createFullBox('stsc', stbl);
+        stsc._data = [0, 0, 0, 0, 0, 0, 0, 0]; // version = 0, flags = 0, entry_count = 0
+
+        // moov/trak/mdia/minf/stbl/stco
+        let stco = ISOBoxer.createFullBox('stco', stbl);
+        stco._data = [0, 0, 0, 0, 0, 0, 0, 0]; // version = 0, flags = 0, entry_count = 0
+
+        // moov/trak/mdia/minf/stbl/stsz
+        let stsz = ISOBoxer.createFullBox('stsz', stbl);
+        stsz._data = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // version = 0, flags = 0, sample_size = 0, sample_count = 0
+
+        // moov/trak/mdia/minf/stbl/stsd
+        createStsdBox(stbl);
+
+        // moov/mvex
+        let mvex = ISOBoxer.createBox('mvex', moov);
+
+        // moov/mvex/trex
+        createTrexBox(mvex);
+
+        if (contentProtection) {
+            let supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(contentProtection);
+            createProtectionSystemSpecificHeaderBox(moov, supportedKS);
+        }
+    }
+
+    function createMvhdBox(moov) {
+
+        let mvhd = ISOBoxer.createFullBox('mvhd', moov);
+
+        mvhd.version = 1; // version = 1  in order to have 64bits duration value
+
+        mvhd.creation_time = 0; // the creation time of the presentation => ignore (set to 0)
+        mvhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
+        mvhd.timescale = TIME_SCALE; // the time-scale for the entire presentation => 10000000 for MSS
+        mvhd.duration = Math.round(period.duration * TIME_SCALE); // the length of the presentation (in the indicated timescale) =>  take duration of period
+        mvhd.rate = 1.0; // 16.16 number, '1.0' = normal playback
+        mvhd.volume = 1.0; // 8.8 number, '1.0' = full volume
+        mvhd.reserved1 = 0;
+        mvhd.reserved2 = [0x0, 0x0];
+        mvhd.matrix = [
+            1, 0, 0, // provides a transformation matrix for the video;
+            0, 1, 0, // (u,v,w) are restricted here to (0,0,1)
+            0, 0, 16384
+        ];
+        mvhd.pre_defined = [0, 0, 0, 0, 0, 0];
+        mvhd.next_track_ID = trackId + 1; // indicates a value to use for the track ID of the next track to be added to this presentation
+
+        return mvhd;
+    }
+
+    function createTkhdBox(trak) {
+
+        let tkhd = ISOBoxer.createFullBox('tkhd', trak);
+
+        tkhd.version = 1; // version = 1  in order to have 64bits duration value
+        tkhd.flags = 0x1 | // Track_enabled (0x000001): Indicates that the track is enabled
+            0x2 | // Track_in_movie (0x000002):  Indicates that the track is used in the presentation
+            0x4; // Track_in_preview (0x000004):  Indicates that the track is used when previewing the presentation
+
+        tkhd.creation_time = 0; // the creation time of the presentation => ignore (set to 0)
+        tkhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
+        tkhd.track_ID = trackId; // uniquely identifies this track over the entire life-time of this presentation
+        tkhd.reserved1 = 0;
+        tkhd.duration = Math.round(period.duration * TIME_SCALE); // the duration of this track (in the timescale indicated in the Movie Header Box) =>  take duration of period
+        tkhd.reserved2 = [0x0, 0x0];
+        tkhd.layer = 0; // specifies the front-to-back ordering of video tracks; tracks with lower numbers are closer to the viewer => 0 since only one video track
+        tkhd.alternate_group = 0; // specifies a group or collection of tracks => ignore
+        tkhd.volume = 1.0; // '1.0' = full volume
+        tkhd.reserved3 = 0;
+        tkhd.matrix = [
+            1, 0, 0, // provides a transformation matrix for the video;
+            0, 1, 0, // (u,v,w) are restricted here to (0,0,1)
+            0, 0, 16384
+        ];
+        tkhd.width = representation.width; // visual presentation width
+        tkhd.height = representation.height; // visual presentation height
+
+        return tkhd;
+    }
+
+    function createMdhdBox(mdia) {
+
+        let mdhd = ISOBoxer.createFullBox('mdhd', mdia);
+
+        mdhd.version = 1; // version = 1  in order to have 64bits duration value
+
+        mdhd.creation_time = 0; // the creation time of the presentation => ignore (set to 0)
+        mdhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
+        mdhd.timescale = TIME_SCALE; // the time-scale for the entire presentation
+        mdhd.duration = Math.round(period.duration * TIME_SCALE); // the duration of this media (in the scale of the timescale). If the duration cannot be determined then duration is set to all 1s.
+        mdhd.language = adaptationSet.lang || 'und'; // declares the language code for this media (see getLanguageCode())
+        mdhd.pre_defined = 0;
+
+        return mdhd;
+    }
+
+    function createHdlrBox(mdia) {
+
+        let hdlr = ISOBoxer.createFullBox('hdlr', mdia);
+
+        hdlr.pre_defined = 0;
+        switch (adaptationSet.type) {
+            case 'video':
+                hdlr.handler_type = 'vide';
+                break;
+            case 'audio':
+                hdlr.handler_type = 'soun';
+                break;
+            default:
+                hdlr.handler_type = 'meta';
+                break;
+        }
+        hdlr.name = representation.id;
+        hdlr.reserved = [0, 0, 0];
+
+        return hdlr;
+    }
+
+    function createVmhdBox(minf) {
+
+        let vmhd = ISOBoxer.createFullBox('vmhd', minf);
+
+        vmhd.flags = 1;
+
+        vmhd.graphicsmode = 0; // specifies a composition mode for this video track, from the following enumerated set, which may be extended by derived specifications: copy = 0 copy over the existing image
+        vmhd.opcolor = [0, 0, 0]; // is a set of 3 colour values (red, green, blue) available for use by graphics modes
+
+        return vmhd;
+    }
+
+    function createSmhdBox(minf) {
+
+        let smhd = ISOBoxer.createFullBox('smhd', minf);
+
+        smhd.flags = 1;
+
+        smhd.balance = 0; // is a fixed-point 8.8 number that places mono audio tracks in a stereo space; 0 is centre (the normal value); full left is -1.0 and full right is 1.0.
+        smhd.reserved = 0;
+
+        return smhd;
+    }
+
+    function createDrefBox(dinf) {
+
+        let dref = ISOBoxer.createFullBox('dref', dinf);
+
+        dref.entry_count = 1;
+        dref.entries = [];
+
+        let url = ISOBoxer.createFullBox('url ', dref, false);
+        url.location = '';
+        url.flags = 1;
+
+        dref.entries.push(url);
+
+        return dref;
+    }
+
+    function createStsdBox(stbl) {
+
+        let stsd = ISOBoxer.createFullBox('stsd', stbl);
+
+        stsd.entries = [];
+        switch (adaptationSet.type) {
+            case 'video':
+            case 'audio':
+                stsd.entries.push(createSampleEntry(stsd));
+                break;
+            default:
+                break;
+        }
+
+        stsd.entry_count = stsd.entries.length; // is an integer that counts the actual entries
+        return stsd;
+    }
+
+    function createSampleEntry(stsd) {
+        let codec = representation.codecs.substring(0, representation.codecs.indexOf('.'));
+
+        switch (codec) {
+            case 'avc1':
+                return createAVCVisualSampleEntry(stsd, codec);
+            case 'mp4a':
+                return createMP4AudioSampleEntry(stsd, codec);
+            default:
+                throw {
+                    name: 'Unsupported codec',
+                    message: 'Unsupported codec',
+                    data: {
+                        codec: codec
+                    }
+                };
+        }
+    }
+
+    function createAVCVisualSampleEntry(stsd, codec) {
+        let avc1;
+
+        if (contentProtection) {
+            avc1 = ISOBoxer.createBox('encv', stsd, false);
+        } else {
+            avc1 = ISOBoxer.createBox('avc1', stsd, false);
+        }
+
+        // SampleEntry fields
+        avc1.reserved1 = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
+        avc1.data_reference_index = 1;
+
+        // VisualSampleEntry fields
+        avc1.pre_defined1 = 0;
+        avc1.reserved2 = 0;
+        avc1.pre_defined2 = [0, 0, 0];
+        avc1.height = representation.height;
+        avc1.width = representation.width;
+        avc1.horizresolution = 72; // 72 dpi
+        avc1.vertresolution = 72; // 72 dpi
+        avc1.reserved3 = 0;
+        avc1.frame_count = 1; // 1 compressed video frame per sample
+        avc1.compressorname = [
+            0x0A, 0x41, 0x56, 0x43, 0x20, 0x43, 0x6F, 0x64, // = 'AVC Coding';
+            0x69, 0x6E, 0x67, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ];
+        avc1.depth = 0x0018; // 0x0018 – images are in colour with no alpha.
+        avc1.pre_defined3 = 65535;
+        avc1.config = createAVC1ConfigurationRecord();
+        if (contentProtection) {
+            // Create and add Protection Scheme Info Box
+            let sinf = ISOBoxer.createBox('sinf', avc1);
+
+            // Create and add Original Format Box => indicate codec type of the encrypted content
+            createOriginalFormatBox(sinf, codec);
+
+            // Create and add Scheme Type box
+            createSchemeTypeBox(sinf);
+
+            // Create and add Scheme Information Box
+            createSchemeInformationBox(sinf);
+        }
+
+        return avc1;
+    }
+
+    function createAVC1ConfigurationRecord() {
+
+        let avcC = null;
+        let avcCLength = 15; // length = 15 by default (0 SPS and 0 PPS)
+
+        // First get all SPS and PPS from codecPrivateData
+        let sps = [];
+        let pps = [];
+        let AVCProfileIndication = 0;
+        let AVCLevelIndication = 0;
+        let profile_compatibility = 0;
+
+
+        let nalus = representation.codecPrivateData.split('00000001').slice(1);
+        let naluBytes, naluType;
+
+        for (let i = 0; i < nalus.length; i++) {
+            naluBytes = hexStringtoBuffer(nalus[i]);
+
+            naluType = naluBytes[0] & 0x1F;
+
+            switch (naluType) {
+                case NALUTYPE_SPS:
+                    sps.push(naluBytes);
+                    avcCLength += naluBytes.length + 2; // 2 = sequenceParameterSetLength field length
+                    break;
+                case NALUTYPE_PPS:
+                    pps.push(naluBytes);
+                    avcCLength += naluBytes.length + 2; // 2 = pictureParameterSetLength field length
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Get profile and level from SPS
+        if (sps.length > 0) {
+            AVCProfileIndication = sps[0][1];
+            profile_compatibility = sps[0][2];
+            AVCLevelIndication = sps[0][3];
+        }
+
+        // Generate avcC buffer
+        avcC = new Uint8Array(avcCLength);
+
+        let i = 0;
+        // length
+        avcC[i++] = (avcCLength & 0xFF000000) >> 24;
+        avcC[i++] = (avcCLength & 0x00FF0000) >> 16;
+        avcC[i++] = (avcCLength & 0x0000F000) >> 8;
+        avcC[i++] = (avcCLength & 0x000000FF);
+        avcC.set([0x61, 0x76, 0x63, 0x43], i); // type = 'avcC'
+        i += 4;
+        avcC[i++] = 1; // configurationVersion = 1
+        avcC[i++] = AVCProfileIndication;
+        avcC[i++] = profile_compatibility;
+        avcC[i++] = AVCLevelIndication;
+        avcC[i++] = 0xFF; // '11111' + lengthSizeMinusOne = 3
+        avcC[i++] = 0xE0 | sps.length; // '111' + numOfSequenceParameterSets
+        for (let n = 0; n < sps.length; n++) {
+            avcC[i++] = (sps[n].length & 0xFF00) >> 8;
+            avcC[i++] = (sps[n].length & 0x00FF);
+            avcC.set(sps[n], i);
+            i += sps[n].length;
+        }
+        avcC[i++] = pps.length; // numOfPictureParameterSets
+        for (let n = 0; n < pps.length; n++) {
+            avcC[i++] = (pps[n].length & 0xFF00) >> 8;
+            avcC[i++] = (pps[n].length & 0x00FF);
+            avcC.set(pps[n], i);
+            i += pps[n].length;
+        }
+
+        return avcC;
+    }
+
+    function createMP4AudioSampleEntry(stsd, codec) {
+        let mp4a;
+
+        if (contentProtection) {
+            mp4a = ISOBoxer.createBox('enca', stsd, false);
+        } else {
+            mp4a = ISOBoxer.createBox('mp4a', stsd, false);
+        }
+
+        // SampleEntry fields
+        mp4a.reserved1 = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
+        mp4a.data_reference_index = 1;
+
+        // AudioSampleEntry fields
+        mp4a.reserved2 = [0x0, 0x0];
+        mp4a.channelcount = representation.audioChannels;
+        mp4a.samplesize = 16;
+        mp4a.pre_defined = 0;
+        mp4a.reserved_3 = 0;
+        mp4a.samplerate = representation.audioSamplingRate << 16;
+
+        mp4a.esds = createMPEG4AACESDescriptor();
+
+        if (contentProtection) {
+            // Create and add Protection Scheme Info Box
+            let sinf = ISOBoxer.createBox('sinf', mp4a);
+
+            // Create and add Original Format Box => indicate codec type of the encrypted content
+            createOriginalFormatBox(sinf, codec);
+
+            // Create and add Scheme Type box
+            createSchemeTypeBox(sinf);
+
+            // Create and add Scheme Information Box
+            createSchemeInformationBox(sinf);
+        }
+
+        return mp4a;
+    }
+
+    function createMPEG4AACESDescriptor() {
+
+        // AudioSpecificConfig (see ISO/IEC 14496-3, subpart 1) => corresponds to hex bytes contained in 'codecPrivateData' field
+        let audioSpecificConfig = hexStringtoBuffer(representation.codecPrivateData);
+
+        // ESDS length = esds box header length (= 12) +
+        //               ES_Descriptor header length (= 5) +
+        //               DecoderConfigDescriptor header length (= 15) +
+        //               decoderSpecificInfo header length (= 2) +
+        //               AudioSpecificConfig length (= codecPrivateData length)
+        let esdsLength = 34 + audioSpecificConfig.length;
+        let esds = new Uint8Array(esdsLength);
+
+        let i = 0;
+        // esds box
+        esds[i++] = (esdsLength & 0xFF000000) >> 24; // esds box length
+        esds[i++] = (esdsLength & 0x00FF0000) >> 16; // ''
+        esds[i++] = (esdsLength & 0x0000F000) >> 8; // ''
+        esds[i++] = (esdsLength & 0x000000FF); // ''
+        esds.set([0x65, 0x73, 0x64, 0x73], i); // type = 'esds'
+        i += 4;
+        esds.set([0, 0, 0, 0], i); // version = 0, flags = 0
+        i += 4;
+        // ES_Descriptor (see ISO/IEC 14496-1 (Systems))
+        esds[i++] = 0x03; // tag = 0x03 (ES_DescrTag)
+        esds[i++] = 20 + audioSpecificConfig.length; // size
+        esds[i++] = (trackId & 0xFF00) >> 8; // ES_ID = track_id
+        esds[i++] = (trackId & 0x00FF); // ''
+        esds[i++] = 0; // flags and streamPriority
+
+        // DecoderConfigDescriptor (see ISO/IEC 14496-1 (Systems))
+        esds[i++] = 0x04; // tag = 0x04 (DecoderConfigDescrTag)
+        esds[i++] = 15 + audioSpecificConfig.length; // size
+        esds[i++] = 0x40; // objectTypeIndication = 0x40 (MPEG-4 AAC)
+        esds[i] = 0x05 << 2; // streamType = 0x05 (Audiostream)
+        esds[i] |= 0 << 1; // upStream = 0
+        esds[i++] |= 1; // reserved = 1
+        esds[i++] = 0xFF; // buffersizeDB = undefined
+        esds[i++] = 0xFF; // ''
+        esds[i++] = 0xFF; // ''
+        esds[i++] = (representation.bandwidth & 0xFF000000) >> 24; // maxBitrate
+        esds[i++] = (representation.bandwidth & 0x00FF0000) >> 16; // ''
+        esds[i++] = (representation.bandwidth & 0x0000FF00) >> 8; // ''
+        esds[i++] = (representation.bandwidth & 0x000000FF); // ''
+        esds[i++] = (representation.bandwidth & 0xFF000000) >> 24; // avgbitrate
+        esds[i++] = (representation.bandwidth & 0x00FF0000) >> 16; // ''
+        esds[i++] = (representation.bandwidth & 0x0000FF00) >> 8; // ''
+        esds[i++] = (representation.bandwidth & 0x000000FF); // ''
+
+        // DecoderSpecificInfo (see ISO/IEC 14496-1 (Systems))
+        esds[i++] = 0x05; // tag = 0x05 (DecSpecificInfoTag)
+        esds[i++] = audioSpecificConfig.length; // size
+        esds.set(audioSpecificConfig, i); // AudioSpecificConfig bytes
+
+        return esds;
+    }
+
+    function createOriginalFormatBox(sinf, codec) {
+        let frma = ISOBoxer.createBox('frma', sinf);
+        frma.data_format = stringToCharCode(codec);
+    }
+
+    function createSchemeTypeBox(sinf) {
+        let schm = ISOBoxer.createFullBox('schm', sinf);
+
+        schm.flags = 0;
+        schm.version = 0;
+        schm.scheme_type = 0x63656E63; // 'cenc' => common encryption
+        schm.scheme_version = 0x00010000; // version set to 0x00010000 (Major version 1, Minor version 0)
+    }
+
+    function createSchemeInformationBox(sinf) {
+        let schi = ISOBoxer.createBox('schi', sinf);
+
+        // Create and add Track Encryption Box
+        createTrackEncryptionBox(schi);
+    }
+
+    function createProtectionSystemSpecificHeaderBox(moov, keySystems) {
+        let pssh_bytes,
+            pssh,
+            i;
+
+        for (i = 0; i < keySystems.length; i += 1) {
+            pssh_bytes = new Uint8Array(keySystems[i].initData);
+            pssh = ISOBoxer.parseBuffer(keySystems[i].initData).boxes[0];
+            moov.append(pssh);
+        }
+    }
+
+    function createTrackEncryptionBox(schi) {
+        var tenc = ISOBoxer.createFullBox('tenc', schi);
+
+        tenc.flags = 0;
+        tenc.version = 0;
+
+        tenc.default_IsEncrypted = 0x1;
+        tenc.default_IV_size = 8;
+        tenc.default_KID = (contentProtection && (contentProtection.length) > 0 && contentProtection[0]['cenc:default_KID']) ?
+            contentProtection[0]['cenc:default_KID'] :
+            [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
+
+    }
+
+    function createTrexBox(moov) {
+
+        let trex = ISOBoxer.createFullBox('trex', moov);
+
+        trex.track_ID = trackId;
+        trex.default_sample_description_index = 1;
+        trex.default_sample_duration = 0;
+        trex.default_sample_size = 0;
+        trex.default_sample_flags = 0;
+
+        return trex;
+    }
+
+    function hexStringtoBuffer(str) {
+        let buf = new Uint8Array(str.length / 2);
+        let i;
+
+        for (i = 0; i < str.length / 2; i += 1) {
+            buf[i] = parseInt('' + str[i * 2] + str[i * 2 + 1], 16);
+        }
+        return buf;
+    }
+
+    function stringToCharCode(str) {
+        let code = 0;
+        let i;
+
+        for (i = 0; i < str.length; i += 1) {
+            code |= str.charCodeAt(i) << ((str.length - i - 1) * 8);
+        }
+        return code;
+    }
+
+    function generateMoov(rep) {
+
+        let isoFile,
+            arrayBuffer;
+
+        representation = rep;
+        adaptationSet = representation.adaptation;
+
+        period = adaptationSet.period;
+        trackId = adaptationSet.index + 1;
+        contentProtection = period.mpd.manifest.Period_asArray[period.index].AdaptationSet_asArray[adaptationSet.index].ContentProtection;
+
+        isoFile = ISOBoxer.createFile();
+        createFtypBox(isoFile);
+        createMoovBox(isoFile);
+
+        arrayBuffer = isoFile.write();
+
+        return arrayBuffer;
+    }
+
+    function processMoof(e) {
+        let i;
+        // e.request contains request description object
+        // e.response contains fragment bytes
+        let isoFile = ISOBoxer.parseBuffer(e.response);
+        // Update track_Id in tfhd box
+        let tfhd = isoFile.fetch('tfhd');
+        tfhd.track_ID = e.request.mediaInfo.index + 1;
+
+        // Add tfdt box
+        let tfdt = isoFile.fetch('tfdt');
+        let traf = isoFile.fetch('traf');
+        if (tfdt === null) {
+            tfdt = ISOBoxer.createBox('tfdt', traf, tfhd);
+            tfdt.version = 1;
+            tfdt.flags = 0;
+            tfdt.baseMediaDecodeTime = Math.floor(e.request.startTime * e.request.timescale);
+        }
+
+        let trun = isoFile.fetch('trun');
+
+        // Process tfxd boxes
+        // This box provide absolute timestamp but we take the segment start time for tfdt
+        let tfxd = isoFile.fetch('tfxd');
+        if (tfxd) {
+            tfxd._parent.boxes.splice(tfxd._parent.boxes.indexOf(tfxd), 1);
+            tfxd = null;
+        }
+        let tfrf = isoFile.fetch('tfrf');
+        if (tfrf) {
+            tfrf._parent.boxes.splice(tfrf._parent.boxes.indexOf(tfrf), 1);
+            tfrf = null;
+        }
+
+        // If protected content in PIFF1.1 format (sepiff box = Sample Encryption PIFF)
+        // => convert sepiff box it into a senc box
+        // => create saio and saiz boxes (if not already present)
+        let sepiff = isoFile.fetch('sepiff');
+        if (sepiff !== null) {
+            sepiff.type = 'senc';
+            sepiff.usertype = undefined;
+
+            let saio = isoFile.fetch('saio');
+            if (saio === null) {
+                // Create Sample Auxiliary Information Offsets Box box (saio)
+                saio = ISOBoxer.createFullBox('saio', traf);
+                saio.version = 0;
+                saio.flags = 0;
+                saio.entry_count = 1;
+                saio.offset = [];
+
+                let saiz = ISOBoxer.createFullBox('saiz', traf);
+                saiz.version = 0;
+                saiz.flags = 0;
+                saiz.sample_count = sepiff.sample_count;
+                saiz.default_sample_info_size = 0;
+                saiz.sample_info_size = [];
+
+                if (sepiff.flags & 0x02) {
+                    // Sub-sample encryption => set sample_info_size for each sample
+                    for (i = 0; i < sepiff.sample_count; i += 1) {
+                        // 10 = 8 (InitializationVector field size) + 2 (subsample_count field size)
+                        // 6 = 2 (BytesOfClearData field size) + 4 (BytesOfEncryptedData field size)
+                        saiz.sample_info_size[i] = 10 + (6 * sepiff.entry[i].NumberOfEntries);
+                    }
+                } else {
+                    // No sub-sample encryption => set default sample_info_size = InitializationVector field size (8)
+                    saiz.default_sample_info_size = 8;
+                }
+            }
+        }
+
+        tfhd.flags &= 16777214; // set tfhd.base-data-offset-present to false
+        tfhd.flags |= 131072; // set tfhd.default-base-is-moof to true
+        trun.flags |= 1; // set trun.data-offset-present to true
+
+        let moof = isoFile.fetch('moof');
+
+        let length = moof.getLength();
+        //offset is equal to length of the moof box + size and type definition for mdat box.
+        trun.data_offset = length + 8;
+
+        e.response = isoFile.write();
+    }
+
+    instance = {
+        generateMoov: generateMoov,
+        processMoof: processMoof
+    };
+
+    setup();
+
+    return instance;
+}
+
+MssFragmentProcessor.__dashjs_factory_name = 'MssFragmentProcessor';
+export default FactoryMaker.getClassFactory(MssFragmentProcessor);

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -30,6 +30,7 @@
  */
 
 import Events from '../core/events/Events';
+import MediaPlayerEvents from '../streaming/MediaPlayerEvents';
 import EventBus from '../core/EventBus';
 import FactoryMaker from '../core/FactoryMaker';
 //import Debug from '../core/Debug';
@@ -37,19 +38,21 @@ import DataChunk from '../streaming/vo/DataChunk';
 import FragmentRequest from '../streaming/vo/FragmentRequest';
 import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import MssFragmentProcessor from './MssFragmentProcessor';
+import MssParser from './parser/MssParser';
 
-function MssHandler() {
+function MssHandler(config) {
 
     let context = this.context;
     //let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    let eventBus = config.eventBus;
     let mssFragmentProcessor = MssFragmentProcessor(context).create();
+    let mssParser;
 
     let instance;
 
     function setup() {
         eventBus.on(Events.INIT_REQUESTED, onInitializationRequested, instance, EventBus.EVENT_PRIORITY_HIGH);
-        eventBus.on(Events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, EventBus.EVENT_PRIORITY_HIGH);
+        eventBus.on(MediaPlayerEvents.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, EventBus.EVENT_PRIORITY_HIGH);
     }
 
     function onInitializationRequested(e) {
@@ -108,8 +111,14 @@ function MssHandler() {
         eventBus.off(Events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, this);
     }
 
+    function createMssParser() {
+        mssParser = MssParser(context).create(config);
+        return mssParser;
+    }
+
     instance = {
-        reset: reset
+        reset: reset,
+        createMssParser: createMssParser
     };
 
     setup();

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -1,0 +1,122 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Events from '../core/events/Events';
+import EventBus from '../core/EventBus';
+import FactoryMaker from '../core/FactoryMaker';
+//import Debug from '../core/Debug';
+import DataChunk from '../streaming/vo/DataChunk';
+import FragmentRequest from '../streaming/vo/FragmentRequest';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
+import MssFragmentProcessor from './MssFragmentProcessor';
+
+function MssHandler() {
+
+    let context = this.context;
+    //let log = Debug(context).getInstance().log;
+    let eventBus = EventBus(context).getInstance();
+    let mssFragmentProcessor = MssFragmentProcessor(context).create();
+
+    let instance;
+
+    function setup() {
+        eventBus.on(Events.INIT_REQUESTED, onInitializationRequested, instance, EventBus.EVENT_PRIORITY_HIGH);
+        eventBus.on(Events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, EventBus.EVENT_PRIORITY_HIGH);
+    }
+
+    function onInitializationRequested(e) {
+        let streamProcessor = e.sender.getStreamProcessor();
+        let request = new FragmentRequest();
+        let representationController = streamProcessor.getRepresentationController();
+        let representation = representationController.getCurrentRepresentation();
+        let period,
+            presentationStartTime;
+
+        period = representation.adaptation.period;
+
+        request.mediaType = representation.adaptation.type;
+        request.type = HTTPRequest.INIT_SEGMENT_TYPE;
+        request.range = representation.range;
+        presentationStartTime = period.start;
+        //request.availabilityStartTime = timelineConverter.calcAvailabilityStartTimeFromPresentationTime(presentationStartTime, representation.adaptation.period.mpd, isDynamic);
+        //request.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationStartTime + period.duration, period.mpd, isDynamic);
+        request.quality = representation.index;
+        request.mediaInfo = streamProcessor.getMediaInfo();
+
+        const chunk = createDataChunk(request, streamProcessor.getStreamInfo().id);
+
+        // Generate initialization segment (moov)
+        chunk.bytes = mssFragmentProcessor.generateMoov(representation);
+
+        eventBus.trigger(Events.INIT_FRAGMENT_LOADED, {chunk: chunk, fragmentModel: streamProcessor.getFragmentModel()});
+
+        // Change the sender value to stop event to be propagated
+        e.sender = null;
+    }
+
+    function createDataChunk(request, streamId) {
+        const chunk = new DataChunk();
+
+        chunk.streamId = streamId;
+        chunk.mediaInfo = request.mediaInfo;
+        chunk.segmentType = request.type;
+        chunk.start = request.startTime;
+        chunk.duration = request.duration;
+        chunk.end = chunk.start + chunk.duration;
+        chunk.index = request.index;
+        chunk.quality = request.quality;
+
+        return chunk;
+    }
+
+
+    function onSegmentMediaLoaded(e) {
+        // Process moof to transcode it from MSS to DASH
+        mssFragmentProcessor.processMoof(e);
+    }
+
+    function reset() {
+        eventBus.off(Events.INIT_REQUESTED, onInitializationRequested, this);
+        eventBus.off(Events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, this);
+    }
+
+    instance = {
+        reset: reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+MssHandler.__dashjs_factory_name = 'MssHandler';
+let factory = FactoryMaker.getClassFactory(MssHandler);
+export default factory;

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -51,8 +51,6 @@ function MssHandler(config) {
     let instance;
 
     function setup() {
-        eventBus.on(Events.INIT_REQUESTED, onInitializationRequested, instance, EventBus.EVENT_PRIORITY_HIGH);
-        eventBus.on(MediaPlayerEvents.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, EventBus.EVENT_PRIORITY_HIGH);
     }
 
     function onInitializationRequested(e) {
@@ -106,9 +104,14 @@ function MssHandler(config) {
         mssFragmentProcessor.processMoof(e);
     }
 
+    function registerEvents() {
+        eventBus.on(Events.INIT_REQUESTED, onInitializationRequested, instance, EventBus.EVENT_PRIORITY_HIGH);
+        eventBus.on(MediaPlayerEvents.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, EventBus.EVENT_PRIORITY_HIGH);
+    }
+
     function reset() {
         eventBus.off(Events.INIT_REQUESTED, onInitializationRequested, this);
-        eventBus.off(Events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, this);
+        eventBus.off(MediaPlayerEvents.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, this);
     }
 
     function createMssParser() {
@@ -118,7 +121,8 @@ function MssHandler(config) {
 
     instance = {
         reset: reset,
-        createMssParser: createMssParser
+        createMssParser: createMssParser,
+        registerEvents: registerEvents
     };
 
     setup();

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -1,0 +1,625 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../../core/FactoryMaker';
+import MediaPlayerModel from '../../streaming/models/MediaPlayerModel';
+import MetricsModel from '../../streaming/models/MetricsModel';
+import Debug from '../../core/Debug';
+import ErrorHandler from '../../streaming/utils/ErrorHandler';
+import BASE64 from '../../../externals/base64';
+import KeySystemPlayReady from './../../streaming/protection/drm/KeySystemPlayReady';
+import KeySystemWidevine from './../../streaming/protection/drm/KeySystemWidevine';
+
+function MssParser() {
+
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
+    const errorHandler = ErrorHandler(context).getInstance();
+
+    const TIME_SCALE_100_NANOSECOND_UNIT = 10000000.0;
+    const SUPPORTED_CODECS = ['AAC', 'AACL', 'AVC1', 'H264', 'TTML', 'DFXP'];
+    const samplingFrequencyIndex = {
+            96000: 0x0,
+            88200: 0x1,
+            64000: 0x2,
+            48000: 0x3,
+            44100: 0x4,
+            32000: 0x5,
+            24000: 0x6,
+            22050: 0x7,
+            16000: 0x8,
+            12000: 0x9,
+            11025: 0xA,
+            8000: 0xB,
+            7350: 0xC
+        };
+    const mimeTypeMap = {
+            'video': 'video/mp4',
+            'audio': 'audio/mp4',
+            'text': 'application/mp4'
+        };
+
+    let instance,
+        mediaPlayerModel,
+        metricsModel;
+
+
+    function setup() {
+        mediaPlayerModel = MediaPlayerModel(context).getInstance();
+        metricsModel = MetricsModel(context).getInstance();
+    }
+
+    function mapPeriod(smoothStreamingMedia) {
+        let period = {};
+        let streams,
+            adaptation;
+
+        period.duration = (parseFloat(smoothStreamingMedia.getAttribute('Duration')) === 0) ? Infinity : parseFloat(smoothStreamingMedia.getAttribute('Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
+
+        // For each StreamIndex node, create an AdaptationSet element
+        period.AdaptationSet_asArray = [];
+        streams = smoothStreamingMedia.getElementsByTagName('StreamIndex');
+        for (let i = 0; i < streams.length; i++) {
+            adaptation = mapAdaptationSet(streams[i]);
+            if (adaptation !== null) {
+                period.AdaptationSet_asArray.push(adaptation);
+            }
+        }
+
+        if (period.AdaptationSet_asArray.length > 0) {
+            period.AdaptationSet = (period.AdaptationSet_asArray.length > 1) ? period.AdaptationSet_asArray : period.AdaptationSet_asArray[0];
+        }
+
+        return period;
+    }
+
+    function mapAdaptationSet(streamIndex) {
+
+        let adaptationSet = {};
+        let representations = [];
+        let segmentTemplate = {};
+        let qualityLevels,
+            representation,
+            segments,
+            range,
+            i;
+
+        adaptationSet.id = streamIndex.getAttribute('Name');
+        adaptationSet.contentType = streamIndex.getAttribute('Type');
+        adaptationSet.lang = streamIndex.getAttribute('Language') || 'und';
+        adaptationSet.mimeType = mimeTypeMap[adaptationSet.contentType];
+        adaptationSet.subType = streamIndex.getAttribute('Subtype');
+        adaptationSet.maxWidth = streamIndex.getAttribute('MaxWidth');
+        adaptationSet.maxHeight = streamIndex.getAttribute('MaxHeight');
+
+        // Create a SegmentTemplate with a SegmentTimeline
+        segmentTemplate = mapSegmentTemplate(streamIndex);
+
+        qualityLevels = streamIndex.getElementsByTagName('QualityLevel');
+        // For each QualityLevel node, create a Representation element
+        for (i = 0; i < qualityLevels.length; i++) {
+            // Propagate BaseURL and mimeType
+            qualityLevels[i].BaseURL = adaptationSet.BaseURL;
+            qualityLevels[i].mimeType = adaptationSet.mimeType;
+
+            // Set quality level id
+            qualityLevels[i].Id = adaptationSet.id + '_' + qualityLevels[i].getAttribute('Index');
+
+            // Map Representation to QualityLevel
+            representation = mapRepresentation(qualityLevels[i], streamIndex);
+
+            if (representation !== null) {
+                // Copy SegmentTemplate into Representation
+                representation.SegmentTemplate = segmentTemplate;
+
+                representations.push(representation);
+            }
+        }
+
+        if (representations.length === 0) {
+            return null;
+        }
+
+        adaptationSet.Representation = (representations.length > 1) ? representations : representations[0];
+        adaptationSet.Representation_asArray = representations;
+
+        // Set SegmentTemplate
+        adaptationSet.SegmentTemplate = segmentTemplate;
+
+        segments = segmentTemplate.SegmentTimeline.S_asArray;
+
+        range = {
+            start: segments[0].t / segmentTemplate.timescale,
+            end: (segments[segments.length - 1].t + segments[segments.length - 1].d) / segmentTemplate.timescale
+        };
+
+        //metricsModel.addDVRInfo(adaptationSet.contentType, new Date(), null, range);
+
+        return adaptationSet;
+    }
+
+    function mapRepresentation(qualityLevel, streamIndex) {
+
+        let representation = {};
+        let fourCCValue = null;
+
+        representation.id = qualityLevel.Id;
+        representation.bandwidth = parseInt(qualityLevel.getAttribute('Bitrate'), 10);
+        representation.mimeType = qualityLevel.mimeType;
+        representation.width = parseInt(qualityLevel.getAttribute('MaxWidth'), 10);
+        representation.height = parseInt(qualityLevel.getAttribute('MaxHeight'), 10);
+
+        fourCCValue = qualityLevel.getAttribute('FourCC');
+
+        // If FourCC not defined at QualityLevel level, then get it from StreamIndex level
+        if (fourCCValue === null) {
+            fourCCValue = streamIndex.getAttribute('FourCC');
+        }
+
+        // If still not defined (optionnal for audio stream, see https://msdn.microsoft.com/en-us/library/ff728116%28v=vs.95%29.aspx),
+        // then we consider the stream is an audio AAC stream
+        if (fourCCValue === null) {
+            fourCCValue = 'AAC';
+        }
+
+        // Check if codec is supported
+        if (SUPPORTED_CODECS.indexOf(fourCCValue.toUpperCase()) === -1) {
+            // Do not send warning
+            //this.errHandler.sendWarning(MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_CODEC_UNSUPPORTED, "Codec not supported", {codec: fourCCValue});
+            log('[MssParser] Codec not supported: ' + fourCCValue);
+            return null;
+        }
+
+        // Get codecs value according to FourCC field
+        if (fourCCValue === 'H264' || fourCCValue === 'AVC1') {
+            representation.codecs = getH264Codec(qualityLevel);
+        } else if (fourCCValue.indexOf('AAC') >= 0) {
+            representation.codecs = getAACCodec(qualityLevel, fourCCValue);
+            representation.audioSamplingRate = parseInt(qualityLevel.getAttribute('SamplingRate'), 10);
+            representation.audioChannels = parseInt(qualityLevel.getAttribute('Channels'), 10);
+        } else if (fourCCValue.indexOf('TTML') || fourCCValue.indexOf('DFXP')) {
+            representation.codecs = 'stpp';
+        }
+
+        representation.codecPrivateData = '' + qualityLevel.getAttribute('CodecPrivateData');
+        representation.BaseURL = qualityLevel.BaseURL;
+
+        return representation;
+    }
+
+    function getH264Codec(qualityLevel) {
+        let codecPrivateData = qualityLevel.getAttribute('CodecPrivateData').toString();
+        let nalHeader,
+            avcoti;
+
+
+        // Extract from the CodecPrivateData field the hexadecimal representation of the following
+        // three bytes in the sequence parameter set NAL unit.
+        // => Find the SPS nal header
+        nalHeader = /00000001[0-9]7/.exec(codecPrivateData);
+        // => Find the 6 characters after the SPS nalHeader (if it exists)
+        avcoti = nalHeader && nalHeader[0] ? (codecPrivateData.substr(codecPrivateData.indexOf(nalHeader[0]) + 10, 6)) : undefined;
+
+        return 'avc1.' + avcoti;
+    }
+
+    function getAACCodec(qualityLevel, fourCCValue) {
+        let objectType = 0;
+        let codecPrivateData = qualityLevel.getAttribute('CodecPrivateData').toString();
+        let samplingRate = parseInt(qualityLevel.getAttribute('SamplingRate'), 10);
+        let codecPrivateDataHex,
+            arr16,
+            indexFreq,
+            extensionSamplingFrequencyIndex;
+
+        //chrome problem, in implicit AAC HE definition, so when AACH is detected in FourCC
+        //set objectType to 5 => strange, it should be 2
+        if (fourCCValue === 'AACH') {
+            objectType = 0x05;
+        }
+        //if codecPrivateData is empty, build it :
+        if (codecPrivateData === undefined || codecPrivateData === '') {
+            objectType = 0x02; //AAC Main Low Complexity => object Type = 2
+            indexFreq = samplingFrequencyIndex[samplingRate];
+            if (fourCCValue === 'AACH') {
+                // 4 bytes :     XXXXX         XXXX          XXXX             XXXX                  XXXXX      XXX   XXXXXXX
+                //           ' ObjectType' 'Freq Index' 'Channels value'   'Extens Sampl Freq'  'ObjectType'  'GAS' 'alignment = 0'
+                objectType = 0x05; // High Efficiency AAC Profile = object Type = 5 SBR
+                codecPrivateData = new Uint8Array(4);
+                extensionSamplingFrequencyIndex = samplingFrequencyIndex[samplingRate * 2]; // in HE AAC Extension Sampling frequence
+                // equals to SamplingRate*2
+                //Freq Index is present for 3 bits in the first byte, last bit is in the second
+                codecPrivateData[0] = (objectType << 3) | (indexFreq >> 1);
+                codecPrivateData[1] = (indexFreq << 7) | (qualityLevel.Channels << 3) | (extensionSamplingFrequencyIndex >> 1);
+                codecPrivateData[2] = (extensionSamplingFrequencyIndex << 7) | (0x02 << 2); // origin object type equals to 2 => AAC Main Low Complexity
+                codecPrivateData[3] = 0x0; //alignment bits
+
+                arr16 = new Uint16Array(2);
+                arr16[0] = (codecPrivateData[0] << 8) + codecPrivateData[1];
+                arr16[1] = (codecPrivateData[2] << 8) + codecPrivateData[3];
+                //convert decimal to hex value
+                codecPrivateDataHex = arr16[0].toString(16);
+                codecPrivateDataHex = arr16[0].toString(16) + arr16[1].toString(16);
+
+            } else {
+                // 2 bytes :     XXXXX         XXXX          XXXX              XXX
+                //           ' ObjectType' 'Freq Index' 'Channels value'   'GAS = 000'
+                codecPrivateData = new Uint8Array(2);
+                //Freq Index is present for 3 bits in the first byte, last bit is in the second
+                codecPrivateData[0] = (objectType << 3) | (indexFreq >> 1);
+                codecPrivateData[1] = (indexFreq << 7) | (parseInt(qualityLevel.getAttribute('Channels'), 10) << 3);
+                // put the 2 bytes in an 16 bits array
+                arr16 = new Uint16Array(1);
+                arr16[0] = (codecPrivateData[0] << 8) + codecPrivateData[1];
+                //convert decimal to hex value
+                codecPrivateDataHex = arr16[0].toString(16);
+            }
+
+            codecPrivateData = '' + codecPrivateDataHex;
+            codecPrivateData = codecPrivateData.toUpperCase();
+            qualityLevel.setAttribute('CodecPrivateData', codecPrivateData);
+        } else if (objectType === 0) {
+            objectType = (parseInt(codecPrivateData.substr(0, 2), 16) & 0xF8) >> 3;
+        }
+
+        return 'mp4a.40.' + objectType;
+    }
+
+    function mapSegmentTemplate(streamIndex) {
+
+        let segmentTemplate = {};
+        let mediaUrl;
+
+        mediaUrl = streamIndex.getAttribute('Url').replace('{bitrate}', '$Bandwidth$');
+        mediaUrl = mediaUrl.replace('{start time}', '$Time$');
+
+        segmentTemplate.media = mediaUrl;
+        segmentTemplate.timescale = TIME_SCALE_100_NANOSECOND_UNIT;
+
+        segmentTemplate.SegmentTimeline = mapSegmentTimeline(streamIndex);
+
+        return segmentTemplate;
+    }
+
+    function mapSegmentTimeline(streamIndex) {
+
+        let segmentTimeline = {};
+        let chunks = streamIndex.getElementsByTagName('c');
+        let segments = [];
+        let i,
+            t, d;
+
+        for (i = 0; i < chunks.length; i++) {
+            // Get time and duration attributes
+            t = parseFloat(chunks[i].getAttribute('t'));
+            d = parseFloat(chunks[i].getAttribute('d'));
+
+            if ((i === 0) && !t) {
+                t = 0;
+            }
+
+            if (i > 0) {
+                // Update previous segment duration if not defined
+                if (!segments[segments.length - 1].d) {
+                    segments[segments.length - 1].d = t - segments[segments.length - 1].t;
+                }
+                // Set segment absolute timestamp if not set
+                if (!t) {
+                    t = segments[segments.length - 1].t + segments[segments.length - 1].d;
+                }
+            }
+
+            // Create new segment
+            segments.push({
+                d: d,
+                t: t
+            });
+
+        }
+
+        segmentTimeline.S = segments;
+        segmentTimeline.S_asArray = segments;
+
+        return segmentTimeline;
+    }
+
+    function getKIDFromProtectionHeader(protectionHeader) {
+        let prHeader,
+            wrmHeader,
+            xmlReader,
+            KID;
+
+        // Get PlayReady header as byte array (base64 decoded)
+        prHeader = BASE64.decodeArray(protectionHeader.firstChild.data);
+
+        // Get Right Management header (WRMHEADER) from PlayReady header
+        wrmHeader = getWRMHeaderFromPRHeader(prHeader);
+
+        // Convert from multi-byte to unicode
+        wrmHeader = new Uint16Array(wrmHeader.buffer);
+
+        // Convert to string
+        wrmHeader = String.fromCharCode.apply(null, wrmHeader);
+
+        // Parse <WRMHeader> to get KID field value
+        xmlReader = (new DOMParser()).parseFromString(wrmHeader, 'application/xml');
+        KID = xmlReader.querySelector('KID').textContent;
+
+        // Get KID (base64 decoded) as byte array
+        KID = BASE64.decodeArray(KID);
+
+        // Convert UUID from little-endian to big-endian
+        convertUuidEndianness(KID);
+
+        return KID;
+    }
+
+    function getWRMHeaderFromPRHeader(prHeader) {
+        let length,
+            recordCount,
+            recordType,
+            recordLength,
+            recordValue;
+        let i = 0;
+
+        // Parse PlayReady header
+
+        // Length - 32 bits (LE format)
+        length = (prHeader[i + 3] << 24) + (prHeader[i + 2] << 16) + (prHeader[i + 1] << 8) + prHeader[i];
+        i += 4;
+
+        // Record count - 16 bits (LE format)
+        recordCount = (prHeader[i + 1] << 8) + prHeader[i];
+        i += 2;
+
+        // Parse records
+        while (i < prHeader.length) {
+            // Record type - 16 bits (LE format)
+            recordType = (prHeader[i + 1] << 8) + prHeader[i];
+            i += 2;
+
+            // Check if Rights Management header (record type = 0x01)
+            if (recordType === 0x01) {
+
+                // Record length - 16 bits (LE format)
+                recordLength = (prHeader[i + 1] << 8) + prHeader[i];
+                i += 2;
+
+                // Record value => contains <WRMHEADER>
+                recordValue = new Uint8Array(recordLength);
+                recordValue.set(prHeader.subarray(i, i + recordLength));
+                return recordValue;
+            }
+        }
+
+        return null;
+    }
+
+    function convertUuidEndianness(uuid) {
+        swapBytes(uuid, 0, 3);
+        swapBytes(uuid, 1, 2);
+        swapBytes(uuid, 4, 5);
+        swapBytes(uuid, 6, 7);
+    }
+
+    function swapBytes(bytes, pos1, pos2) {
+        let temp = bytes[pos1];
+        bytes[pos1] = bytes[pos2];
+        bytes[pos2] = temp;
+    }
+
+
+    function createPRContentProtection(protectionHeader) {
+
+        let contentProtection = {};
+        let keySystem = KeySystemPlayReady(context).getInstance();
+        let pro;
+
+        pro = {
+            __text: protectionHeader.firstChild.data,
+            __prefix: 'mspr'
+        };
+
+        contentProtection.schemeIdUri = keySystem.schemeIdURI;
+        contentProtection.value = keySystem.systemString;
+        contentProtection.pro = pro;
+        contentProtection.pro_asArray = pro;
+
+        return contentProtection;
+    }
+
+    function createWidevineContentProtection( /*protectionHeader*/ ) {
+
+        let contentProtection = {};
+        let keySystem = KeySystemWidevine(context).getInstance();
+
+        contentProtection.schemeIdUri = keySystem.schemeIdURI;
+        contentProtection.value = keySystem.systemString;
+
+        return contentProtection;
+    }
+
+    function processManifest(xmlDoc, manifestLoadedTime) {
+        let manifest = {};
+        let contentProtections = [];
+        let smoothStreamingMedia = xmlDoc.getElementsByTagName('SmoothStreamingMedia')[0];
+        let protection = xmlDoc.getElementsByTagName('Protection')[0];
+        let protectionHeader = null;
+        let period,
+            adaptations,
+            contentProtection,
+            KID,
+            realDuration,
+            firstSegment,
+            lastSegment,
+            adaptationTimeOffset,
+            i;
+
+        // Set manifest node properties
+        manifest.protocol = 'MSS';
+        manifest.profiles = 'urn:mpeg:dash:profile:isoff-live:2011';
+        manifest.type = smoothStreamingMedia.getAttribute('IsLive') === 'TRUE' ? 'dynamic' : 'static';
+        manifest.timeShiftBufferDepth = parseFloat(smoothStreamingMedia.getAttribute('DVRWindowLength')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        manifest.mediaPresentationDuration = (parseFloat(smoothStreamingMedia.getAttribute('Duration')) === 0) ? Infinity : parseFloat(smoothStreamingMedia.getAttribute('Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        manifest.minBufferTime = mediaPlayerModel.getStableBufferTime();
+
+        // In case of live streams, set availabilityStartTime property according to DVRWindowLength
+        if (manifest.type === 'dynamic') {
+            manifest.availabilityStartTime = new Date(manifestLoadedTime.getTime() - (manifest.timeShiftBufferDepth * 1000));
+        }
+
+        // Map period node to manifest root node
+        manifest.Period = mapPeriod(smoothStreamingMedia);
+        manifest.Period_asArray = [manifest.Period];
+
+        // Initialize period start time
+        period = manifest.Period;
+        period.start = 0;
+
+        // ContentProtection node
+        if (protection !== undefined) {
+            protectionHeader = xmlDoc.getElementsByTagName('ProtectionHeader')[0];
+
+            // Some packagers put newlines into the ProtectionHeader base64 string, which is not good
+            // because this cannot be correctly parsed. Let's just filter out any newlines found in there.
+            protectionHeader.firstChild.data = protectionHeader.firstChild.data.replace(/\n|\r/g, '');
+
+            // Get KID (in CENC format) from protection header
+            KID = getKIDFromProtectionHeader(protectionHeader);
+
+            // Create ContentProtection for PlayReady
+            contentProtection = createPRContentProtection(protectionHeader);
+            contentProtection['cenc:default_KID'] = KID;
+            contentProtections.push(contentProtection);
+
+            // Create ContentProtection for Widevine (as a CENC protection)
+            contentProtection = createWidevineContentProtection(protectionHeader);
+            contentProtection['cenc:default_KID'] = KID;
+            contentProtections.push(contentProtection);
+
+            manifest.ContentProtection = (contentProtections.length > 1) ? contentProtections : contentProtections[0];
+            manifest.ContentProtection_asArray = contentProtections;
+        }
+
+        adaptations = period.AdaptationSet_asArray;
+        for (i = 0; i < adaptations.length; i += 1) {
+            // In case of VOD streams, check if start time is greater than 0.
+            // Therefore, set period start time to the higher adaptation start time
+            if (manifest.type === 'static' && adaptations[i].contentType !== 'text') {
+                firstSegment = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray[0];
+                lastSegment = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray[adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray.length - 1];
+                adaptations[i].SegmentTemplate.initialization = '$Bandwidth$';
+                adaptationTimeOffset = parseFloat(firstSegment.t) / TIME_SCALE_100_NANOSECOND_UNIT;
+                period.start = (period.start === 0) ? adaptationTimeOffset : Math.max(period.start, adaptationTimeOffset);
+                //get last segment start time, add the duration of this last segment
+                realDuration = parseFloat(((lastSegment.t + lastSegment.d) / TIME_SCALE_100_NANOSECOND_UNIT).toFixed(3));
+                //detect difference between announced duration (in MSS manifest) and real duration => in any case, we want that the video element sends the ended event.
+                //set the smallest value between all the adaptations
+                if (!isNaN(realDuration) && realDuration < manifest.mediaPresentationDuration) {
+                    manifest.mediaPresentationDuration = realDuration;
+                    period.duration = realDuration;
+                }
+            } else {
+                adaptations[i].SegmentTemplate.initialization = '$Bandwidth$';
+            }
+
+            // Propagate content protection information into each adaptation
+            if (manifest.ContentProtection !== undefined) {
+                adaptations[i].ContentProtection = manifest.ContentProtection;
+                adaptations[i].ContentProtection_asArray = manifest.ContentProtection_asArray;
+            }
+        }
+
+        // Delete Content Protection under root manifest node
+        delete manifest.ContentProtection;
+        delete manifest.ContentProtection_asArray;
+
+        return manifest;
+    }
+
+    function parseDOM(data) {
+
+        let xmlDoc = null;
+
+        if (window.DOMParser) {
+            try {
+                let parser = new window.DOMParser();
+
+                xmlDoc = parser.parseFromString(data, 'text/xml');
+                if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
+                    throw new Error('Error parsing XML');
+                }
+            } catch (e) {
+                errorHandler.manifestError('parsing the manifest failed', 'parse', data, e);
+                xmlDoc = null;
+            }
+        }
+
+        return xmlDoc;
+    }
+
+
+    function internalParse(data) {
+        let xmlDoc = null;
+        let manifest = null;
+
+        const startTime = window.performance.now();
+
+        // Parse the MSS XML manifest
+        xmlDoc = parseDOM(data);
+
+        const xmlParseTime = window.performance.now();
+
+        if (xmlDoc === null) {
+            return null;
+        }
+
+        // Convert MSS manifest into DASH manifest
+        manifest = processManifest(xmlDoc, new Date());
+
+        const mss2dashTime = window.performance.now();
+
+        log('Parsing complete: (xmlParsing: ' + (xmlParseTime - startTime).toPrecision(3) + 'ms, mss2dash: ' + (mss2dashTime - xmlParseTime).toPrecision(3) + 'ms, total: ' + ((mss2dashTime - startTime) / 1000).toPrecision(3) + 's)');
+
+        return manifest;
+    }
+
+    instance = {
+        parse: internalParse,
+    };
+
+    setup();
+
+    return instance;
+}
+
+MssParser.__dashjs_factory_name = 'MssParser';
+export default FactoryMaker.getClassFactory(MssParser);

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -37,6 +37,9 @@ import {HTTPRequest} from './vo/metrics/HTTPRequest';
 import EventBus from '../core/EventBus';
 import Events from '../core/events/Events';
 import FactoryMaker from '../core/FactoryMaker';
+import DashParser from '../dash/parser/DashParser';
+import MssParser from '../mss/parser/MssParser';
+import MssHandler from '../mss/MssHandler';
 
 const MANIFEST_LOADER_ERROR_PARSING_FAILURE = 1;
 const MANIFEST_LOADER_ERROR_LOADING_FAILURE = 2;
@@ -47,11 +50,12 @@ function ManifestLoader(config) {
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
     const urlUtils = URLUtils(context).getInstance();
-    const parser = config.parser;
 
     let instance,
         xhrLoader,
-        xlinkController;
+        xlinkController,
+        mssHandler,
+        parser;
 
     function setup() {
         eventBus.on(Events.XLINK_READY, onXlinkReady, instance);
@@ -67,6 +71,8 @@ function ManifestLoader(config) {
             metricsModel: config.metricsModel,
             requestModifier: config.requestModifier
         });
+
+        parser = null;
     }
 
     function onXlinkReady(event) {
@@ -75,6 +81,21 @@ function ManifestLoader(config) {
                 manifest: event.manifest
             }
         );
+    }
+
+    function createParser(data) {
+
+        // Analyze manifest content to detect protocol and select appropriate parser
+        if (data.indexOf('SmoothStreamingMedia') > -1) {
+            //do some business to transform it into a Dash Manifest
+            mssHandler = MssHandler(context).create();
+            return MssParser(context).create();
+        }
+        else if (data.indexOf('MPD') > -1) {
+            return DashParser(context).create();
+        } else {
+            return null;
+        }
     }
 
     function load (url) {
@@ -100,6 +121,24 @@ function ManifestLoader(config) {
                     }
 
                     baseUri = urlUtils.parseBaseUrl(url);
+                }
+
+                // Create parser according to manifest type
+                if (parser === null) {
+                    parser = createParser(data);
+                }
+
+                if (parser === null) {
+                    eventBus.trigger(
+                        Events.INTERNAL_MANIFEST_LOADED, {
+                            manifest: null,
+                            error: new Error(
+                                MANIFEST_LOADER_ERROR_PARSING_FAILURE,
+                                `Failed detecting manifest type: ${url}`
+                            )
+                        }
+                    );
+                    return;
                 }
 
                 const manifest = parser.parse(data, xlinkController);
@@ -152,6 +191,10 @@ function ManifestLoader(config) {
         if (xhrLoader) {
             xhrLoader.abort();
             xhrLoader = null;
+        }
+
+        if (mssHandler) {
+            mssHandler.reset();
         }
     }
 

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -90,6 +90,7 @@ function ManifestLoader(config) {
             //do some business to transform it into a Dash Manifest
             if (mssHandler) {
                 parser = mssHandler.createMssParser();
+                mssHandler.registerEvents();
             }else {
                 errorHandler.manifestError('manifest type unsupported', 'createParser');
             }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -60,7 +60,6 @@ import {getVersionString} from './../core/Version';
 
 //Dash
 import DashAdapter from '../dash/DashAdapter';
-import DashParser from '../dash/parser/DashParser';
 import DashManifestModel from '../dash/models/DashManifestModel';
 import DashMetrics from '../dash/DashMetrics';
 import TimelineConverter from '../dash/utils/TimelineConverter';
@@ -1896,15 +1895,9 @@ function MediaPlayer() {
     function createManifestLoader() {
         return ManifestLoader(context).create({
             errHandler: errHandler,
-            parser: createManifestParser(),
             metricsModel: metricsModel,
             requestModifier: RequestModifier(context).getInstance()
         });
-    }
-
-    function createManifestParser() {
-        //TODO-Refactor Need to be able to switch this create out so will need API to set which parser to use?
-        return DashParser(context).create();
     }
 
     function createAdaptor() {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -92,6 +92,7 @@ function MediaPlayer() {
         mediaController,
         protectionController,
         metricsReportingController,
+        mssHandler,
         adapter,
         metricsModel,
         mediaPlayerModel,
@@ -1741,6 +1742,7 @@ function MediaPlayer() {
             videoModel.setElement(element);
             detectProtection();
             detectMetricsReporting();
+            detectMss();
         }
         resetAndInitializePlayback();
     }
@@ -1896,7 +1898,8 @@ function MediaPlayer() {
         return ManifestLoader(context).create({
             errHandler: errHandler,
             metricsModel: metricsModel,
-            requestModifier: RequestModifier(context).getInstance()
+            requestModifier: RequestModifier(context).getInstance(),
+            mssHandler: mssHandler
         });
     }
 
@@ -1949,6 +1952,22 @@ function MediaPlayer() {
             });
 
             return metricsReportingController;
+        }
+
+        return null;
+    }
+
+    function detectMss() {
+        if (mssHandler) {
+            return mssHandler;
+        }
+        // do not require MssHandler as dependencies as this is optional and intended to be loaded separately
+        let MssHandler = dashjs.MssHandler; /* jshint ignore:line */
+        if (typeof MssHandler === 'function') {//TODO need a better way to register/detect plugin components
+            mssHandler = MssHandler(context).create({
+                eventBus: eventBus,
+                mediaPlayerModel: mediaPlayerModel});
+            return mssHandler;
         }
 
         return null;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -164,10 +164,10 @@ function ScheduleController(config) {
 
         if (initialRequest) {
             initialRequest = false;
-            getInitRequest(currentRepresentationInfo.quality);
-        } else {
-            startScheduleTimer(0);
         }
+
+        startScheduleTimer(0);
+
         log('Schedule controller starting for ' + type);
     }
 
@@ -262,7 +262,7 @@ function ScheduleController(config) {
     }
 
     function onInitRequested(e) {
-        if (e.sender.getStreamProcessor() !== streamProcessor) return;
+        if (!e.sender || e.sender.getStreamProcessor() !== streamProcessor) return;
         getInitRequest(currentRepresentationInfo.quality);
     }
 
@@ -340,6 +340,8 @@ function ScheduleController(config) {
             latency: liveEdge - seekTarget,
             clientTimeOffset: timelineConverter.getClientTimeOffset()
         });
+
+        timelineConverter.setTimeSyncCompleted(true);
     }
 
     function onStreamCompleted(e) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -340,8 +340,6 @@ function ScheduleController(config) {
             latency: liveEdge - seekTarget,
             clientTimeOffset: timelineConverter.getClientTimeOffset()
         });
-
-        timelineConverter.setTimeSyncCompleted(true);
     }
 
     function onStreamCompleted(e) {

--- a/src/streaming/controllers/TextController.js
+++ b/src/streaming/controllers/TextController.js
@@ -31,6 +31,7 @@
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
+import InitCache from '../utils/InitCache';
 
 function TextController(config) {
 
@@ -47,7 +48,8 @@ function TextController(config) {
         buffer,
         type,
         streamProcessor,
-        representationController;
+        representationController,
+        initCache;
 
     function setup() {
 
@@ -68,6 +70,7 @@ function TextController(config) {
         setMediaSource(source);
         streamProcessor = StreamProcessor;
         representationController = streamProcessor.getRepresentationController();
+        initCache = InitCache(context).getInstance();
     }
 
     /**
@@ -133,6 +136,15 @@ function TextController(config) {
         return isBufferingCompleted;
     }
 
+    function switchInitData(streamId, quality) {
+        const chunk = initCache.extract(streamId, type, quality);
+        if (chunk) {
+            sourceBufferController.append(chunk);
+        } else {
+            eventBus.trigger(Events.INIT_REQUESTED, {sender: instance});
+        }
+    }
+
     instance = {
         initialize: initialize,
         createBuffer: createBuffer,
@@ -141,6 +153,7 @@ function TextController(config) {
         getStreamProcessor: getStreamProcessor,
         getIsBufferingCompleted: getIsBufferingCompleted,
         setMediaSource: setMediaSource,
+        switchInitData: switchInitData,
         reset: reset
     };
 

--- a/src/streaming/utils/InitCache.js
+++ b/src/streaming/utils/InitCache.js
@@ -50,7 +50,11 @@ function InitCache() {
     }
 
     function extract (streamId, mediaType, quality) {
-        return data[streamId][mediaType][quality];
+        if (data && data[streamId] && data[streamId][mediaType] && data[streamId][mediaType][quality]) {
+            return data[streamId][mediaType][quality];
+        } else {
+            return null;
+        }
     }
 
 


### PR DESCRIPTION
We, at Orange Labs (me and my colleague @nicosang), started integration of smooth streaming support into dash.js, as we proposed last year during dash.js f2f meeting.
For the time being, we have achieved to extend dash.js in order to support smooth streaming static streams, clear and encrypted (with PlayReady).

What we have done:
-	Add of ‘src/mss’ source package. 
-	Add of smooth streaming parser MssParser, that parses smooth streaming manifest and converts it into dash manifest object: mapping from smooth streaming nodes to dash nodes including creation of SegmentTimelines
-	Add of MssHandler that hands processing of initialization and media segments. This class is registered on INIT_REQUESTED and FRAGMENT_LOADING_COMPLETED in order to trigger these segments processing. We took benefit of events priority and propagation system in order to generate initialization segments without sending http requests, and to process media segments before being appended into the buffers
-	Integration of protocol detection and appropriate parser instantiation in the ManifestLoader
-	Integration of the MssFragmentProcessor that is used to generate initialization segments (based on manifest information) and  process media segments in order to convert them into MSE compliant media segments (for example transform tfxd box into tfdt box)
-	Add of some more attributes (codecs, codecPrivateData) to Dash manifest model’s Representation object that are required to generate initialization segments
-	Integration of a new version if codem-isoboxer library which is now capable of generating/writing mp4 files. We have contributed to this library to add these new functionalities with reduced overhead. The version used is the 0.3.0.

All these additional stuff have no impact on dash contents processing.
Also the mss package is not included by default in the core MediaPlayer build file since we have integrated the mss package as it has been done for protection and metrics packages.

Finally, we had to modify some part of the core streaming as we already proposed in #1669.
This is required for smooth streaming use case so that an event for generating initialization segment is also sent at startup, which is actually not the case.
This PR has not been accepted because it was introducing some regression with some streams, but by reading the last comments this is not the reason.

