### PR TITLE
fix for all live edge issues mentioned in  #1729

### DIFF
--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -30,7 +30,6 @@
  */
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
-
 import FactoryMaker from '../../core/FactoryMaker';
 
 function TimelineConverter() {
@@ -61,6 +60,10 @@ function TimelineConverter() {
 
     function getClientTimeOffset() {
         return clientServerTimeShift;
+    }
+
+    function setClientTimeOffset(value) {
+        clientServerTimeShift = value;
     }
 
     function getExpectedLiveEdge() {
@@ -168,10 +171,21 @@ function TimelineConverter() {
         return periodRelativeTime + periodStartTime;
     }
 
+    /*
+    * We need to figure out if we want to timesync for segmentTimeine where useCalculatedLiveEdge = true
+    * seems we figure out client offset based on logic in liveEdgeFinder getLiveEdge timelineConverter.setClientTimeOffset(liveEdge - representationInfo.DVRWindow.end);
+    * FYI StreamController's onManifestUpdated entry point to timeSync
+    * */
     function onTimeSyncComplete(e) {
-        if (e.error) return;
-        clientServerTimeShift = e.offset / 1000;
-        isClientServerTimeSyncCompleted = true;
+
+        if (isClientServerTimeSyncCompleted) return;
+
+        if (e.offset !== undefined) {
+
+            setClientTimeOffset(e.offset / 1000);
+            isClientServerTimeSyncCompleted = true;
+
+        }
     }
 
     function calcMSETimeOffset(representation) {
@@ -193,6 +207,7 @@ function TimelineConverter() {
         isTimeSyncCompleted: isTimeSyncCompleted,
         setTimeSyncCompleted: setTimeSyncCompleted,
         getClientTimeOffset: getClientTimeOffset,
+        setClientTimeOffset: setClientTimeOffset,
         getExpectedLiveEdge: getExpectedLiveEdge,
         setExpectedLiveEdge: setExpectedLiveEdge,
         calcAvailabilityStartTimeFromPresentationTime: calcAvailabilityStartTimeFromPresentationTime,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -314,6 +314,7 @@ function ScheduleController(config) {
         currentRepresentationInfo = streamProcessor.getCurrentRepresentationInfo();
 
         if (isDynamic && initialRequest) {
+            timelineConverter.setTimeSyncCompleted(true);
             setLiveEdgeSeekTarget();
         }
 
@@ -327,7 +328,6 @@ function ScheduleController(config) {
         const dvrWindowSize = currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo.DVRWindowSize / 2;
         const startTime = liveEdge - playbackController.computeLiveDelay(currentRepresentationInfo.fragmentDuration, dvrWindowSize);
         const request = adapter.getFragmentRequestForTime(streamProcessor, currentRepresentationInfo, startTime, {ignoreIsFinished: true});
-        timelineConverter.setTimeSyncCompleted(true);
         seekTarget = playbackController.getLiveStartTime();
         if (isNaN(seekTarget) || request.startTime > seekTarget) {
             playbackController.setLiveStartTime(request.startTime);

--- a/src/streaming/utils/LiveEdgeFinder.js
+++ b/src/streaming/utils/LiveEdgeFinder.js
@@ -48,7 +48,11 @@ function LiveEdgeFinder() {
 
     function getLiveEdge() {
         const representationInfo = streamProcessor.getCurrentRepresentationInfo();
-        const liveEdge = representationInfo.useCalculatedLiveEdgeTime ? timelineConverter.getExpectedLiveEdge() : representationInfo.DVRWindow.end;
+        let liveEdge = representationInfo.DVRWindow.end;
+        if (representationInfo.useCalculatedLiveEdgeTime) {
+            liveEdge = timelineConverter.getExpectedLiveEdge();
+            timelineConverter.setClientTimeOffset(liveEdge - representationInfo.DVRWindow.end);
+        }
         return liveEdge;
     }
 


### PR DESCRIPTION
This PR should solve all the issue raised in #1729 - This is a fix to restore but we need some work here so I am adding an issue about timesync refactor 

We need to figure out if we want to timesync for segmentTimeine where useCalculatedLiveEdge = true.   If not, we should bypass code in StreamController's onManifestUpdated entry point to timeSync and other places.  
