### PR TITLE
Fix bug where EventBus handlers are removed before execution

### DIFF
--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -72,6 +72,7 @@ function EventBus() {
         if (!type || !listener || !handlers[type]) return;
         const idx = getHandlerIdx(type, listener, scope);
         if (idx < 0) return;
+        handlers[type] = handlers[type].slice(0);
         handlers[type].splice(idx, 1);
     }
 


### PR DESCRIPTION
Stop mutating `handlers[type]` in `EventBus#off`. Doing so prevents all handlers from being run if `off()` is called while executing a callback.

Fixes #1773 