### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.js]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+insert_final_newline = true


### PR DESCRIPTION
It's better to have [.editorconfig](http://editorconfig.org/) in the project so that every contributor shares the same consistent coding styles (e.g. indent by 4 spaces, line end is LF, character encoding is UTF-8).