### PR TITLE
feat(TextTrackInfo) Passthrough roles even if dash can't parse them

### DIFF
--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -176,6 +176,7 @@ function TextSourceBuffer() {
             textTrackInfo.isFragmented = isFragmented;
             textTrackInfo.isEmbedded = mediaInfo.isEmbedded ? true : false;
             textTrackInfo.kind = getKind();
+            textTrackInfo.roles = mediaInfo.roles;
             var totalNrTracks = (mediaInfos ? mediaInfos.length : 0) + embeddedTracks.length;
             textTracks.addTextTrack(textTrackInfo, totalNrTracks);
         }


### PR DESCRIPTION
Assuming an AdaptionSet has roles defined, the only way to access them is via [`MediaPlayer#getTracksFor('text')`](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html#getTracksFor__anchor). If the manifest is using fragmented text, then `MediaPlayer#getTracksFor('text')` will return `[]` and the only way to get the text track list is to listen for `TEXT_TRACKS_ADDED`. However, the `tracks` in the `TEXT_TRACKS_ADDED` event is `TextTrackInfo[]`, which does not include the original `roles`.

This will pass through whatever `roles` are parsed, allowing them to be accessed for all text track types.

Possibly a workaround for #1236