### PR TITLE
Mss package management

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,6 @@ import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
 import {getVersionString} from './src/core/Version';
 
-import MssHandler from './src/mss/MssHandler';
-
-
 // Shove both of these into the global scope
 var context = (typeof window !== 'undefined' && window) || global;
 
@@ -51,8 +48,6 @@ dashjs.Protection = Protection;
 dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
 dashjs.Version = getVersionString();
-dashjs.MssHandler = MssHandler;
-
 
 export default dashjs;
-export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, MssHandler};
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory};

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -26,6 +26,16 @@ app.controller('DashController', function($scope, sources, contributors) {
 
     sources.query(function (data) {
         $scope.availableStreams = data.items;
+        //if no mss package, remove mss samples.
+        let MssHandler = dashjs.MssHandler; /* jshint ignore:line */
+        if (typeof MssHandler !== 'function')
+        {
+            for(var i = $scope.availableStreams.length - 1; i >= 0; i--){
+                if($scope.availableStreams[i].name === 'Smooth Streaming'){
+                    $scope.availableStreams.splice(i,1);
+                }
+            }
+        }
     });
 
     contributors.query(function (data) {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -1,27 +1,6 @@
 {
   "items": [
     {
-      "name": "Smooth Streaming",
-      "submenu": [
-        {
-          "url": "http://2is7server2.rd.francetelecom.com/hasplayer/VOD_1/VOD_1.ism/manifest",
-          "name": "Prince Of Persia"
-        },
-        {
-          "url": "http://2is7server1.rd.francetelecom.com/VOD/BBB-SD/big_buck_bunny_1080p_stereo.ism/Manifest",
-          "name": "Big Buck Bunny"
-        },
-        {
-          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest",
-          "name": "Super Speedway"
-        },
-        {
-          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
-          "name": "Super Speedway + PlayReady DRM"
-        }
-      ]
-    },
-    {
       "name": "VOD (Static MPD)",
       "submenu": [
         {
@@ -1414,6 +1393,27 @@
         {
           "name": "Unified Streaming Live",
           "url": "http://live.unified-streaming.com/loop/loop.isml/loop.mpd?format=mp4&session_id=25020"
+        }
+      ]
+    },
+    {
+      "name": "Smooth Streaming",
+      "submenu": [
+        {
+          "url": "http://2is7server2.rd.francetelecom.com/hasplayer/VOD_1/VOD_1.ism/manifest",
+          "name": "Prince Of Persia"
+        },
+        {
+          "url": "http://2is7server1.rd.francetelecom.com/VOD/BBB-SD/big_buck_bunny_1080p_stereo.ism/Manifest",
+          "name": "Big Buck Bunny"
+        },
+        {
+          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest",
+          "name": "Super Speedway"
+        },
+        {
+          "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
+          "name": "Super Speedway + PlayReady DRM"
         }
       ]
     }


### PR DESCRIPTION
By default, smooth streaming management has not to be included in dash.all. In the 'dash-if-reference' web app, smooth streaming samples are stored at the end of the list.
Finally, in this webApp, smooth samples are showned to the user only if the mss package has been added in the index.html file.