### PR TITLE
Audio switch management update

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -164,7 +164,7 @@ function DashHandler(config) {
         request.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationStartTime + period.duration, period.mpd, isDynamic);
         request.quality = representation.index;
         request.mediaInfo = streamProcessor.getMediaInfo();
-        request.adaptationSetId = representation.adaptation.id;
+        request.representationId = representation.id;
 
         if (setRequestUrl(request, representation.initialization, representation)) {
             return request;

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -164,6 +164,7 @@ function DashHandler(config) {
         request.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationStartTime + period.duration, period.mpd, isDynamic);
         request.quality = representation.index;
         request.mediaInfo = streamProcessor.getMediaInfo();
+        request.adaptationSetId = representation.adaptation.id;
 
         if (setRequestUrl(request, representation.initialization, representation)) {
             return request;

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -69,6 +69,7 @@ function MssHandler(config) {
         //request.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationStartTime + period.duration, period.mpd, isDynamic);
         request.quality = representation.index;
         request.mediaInfo = streamProcessor.getMediaInfo();
+        request.adaptationSetId = representation.adaptation.id;
 
         const chunk = createDataChunk(request, streamProcessor.getStreamInfo().id);
 
@@ -92,6 +93,7 @@ function MssHandler(config) {
         chunk.end = chunk.start + chunk.duration;
         chunk.index = request.index;
         chunk.quality = request.quality;
+        chunk.adaptationSetId = request.adaptationSetId;
 
         return chunk;
     }

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -69,7 +69,7 @@ function MssHandler(config) {
         //request.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationStartTime + period.duration, period.mpd, isDynamic);
         request.quality = representation.index;
         request.mediaInfo = streamProcessor.getMediaInfo();
-        request.adaptationSetId = representation.adaptation.id;
+        request.representationId = representation.id;
 
         const chunk = createDataChunk(request, streamProcessor.getStreamInfo().id);
 
@@ -93,7 +93,7 @@ function MssHandler(config) {
         chunk.end = chunk.start + chunk.duration;
         chunk.index = request.index;
         chunk.quality = request.quality;
-        chunk.adaptationSetId = request.adaptationSetId;
+        chunk.representationId = request.representationId;
 
         return chunk;
     }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -157,8 +157,8 @@ function BufferController(config) {
         appendToBuffer(e.chunk);
     }
 
-    function switchInitData(streamId, adaptationSetId) {
-        const chunk = initCache.extract(streamId, adaptationSetId);
+    function switchInitData(streamId, representationId) {
+        const chunk = initCache.extract(streamId, representationId);
         if (chunk) {
             appendToBuffer(chunk);
         } else {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -157,8 +157,8 @@ function BufferController(config) {
         appendToBuffer(e.chunk);
     }
 
-    function switchInitData(streamId, quality, adaptationSetId) {
-        const chunk = initCache.extract(streamId, type, quality, adaptationSetId);
+    function switchInitData(streamId, adaptationSetId) {
+        const chunk = initCache.extract(streamId, adaptationSetId);
         if (chunk) {
             appendToBuffer(chunk);
         } else {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -217,7 +217,7 @@ function BufferController(config) {
                 return;
             }
 
-            if (!isNaN(appendedBytesInfo.index)) {
+            if (appendedBytesInfo && !isNaN(appendedBytesInfo.index)) {
                 maxAppendedIndex = Math.max(appendedBytesInfo.index, maxAppendedIndex);
                 checkIfBufferingCompleted();
             }
@@ -231,13 +231,15 @@ function BufferController(config) {
 
             onPlaybackProgression();
             isAppendingInProgress = false;
-            eventBus.trigger(Events.BYTES_APPENDED, {
-                sender: instance,
-                quality: appendedBytesInfo.quality,
-                startTime: appendedBytesInfo.start,
-                index: appendedBytesInfo.index,
-                bufferedRanges: ranges
-            });
+            if (appendedBytesInfo) {
+                eventBus.trigger(Events.BYTES_APPENDED, {
+                    sender: instance,
+                    quality: appendedBytesInfo.quality,
+                    startTime: appendedBytesInfo.start,
+                    index: appendedBytesInfo.index,
+                    bufferedRanges: ranges
+                });
+            }
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -381,13 +381,13 @@ function BufferController(config) {
         }
     }
 
-    function getClearRange() {
+    function getClearRange(threshold) {
 
         if (!buffer) return null;
 
         // we need to remove data that is more than one fragment before the video currentTime
         const currentTime = playbackController.getTime();
-        const req = streamProcessor.getFragmentModel().getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: currentTime })[0];
+        const req = streamProcessor.getFragmentModel().getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: currentTime, threshold: threshold})[0];
         const range = sourceBufferController.getBufferRange(buffer, currentTime);
 
         let removeEnd = (req && !isNaN(req.startTime)) ? req.startTime : Math.floor(currentTime);
@@ -437,7 +437,7 @@ function BufferController(config) {
     function onCurrentTrackChanged(e) {
         if (!buffer || (e.newMediaInfo.type !== type) || (e.newMediaInfo.streamInfo.id !== streamProcessor.getStreamInfo().id)) return;
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
-            clearBuffer(getClearRange());
+            clearBuffer(getClearRange(0));
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -157,8 +157,8 @@ function BufferController(config) {
         appendToBuffer(e.chunk);
     }
 
-    function switchInitData(streamId, quality) {
-        const chunk = initCache.extract(streamId, type, quality);
+    function switchInitData(streamId, quality, adaptationSetId) {
+        const chunk = initCache.extract(streamId, type, quality, adaptationSetId);
         if (chunk) {
             appendToBuffer(chunk);
         } else {

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -85,6 +85,7 @@ function FragmentController(/*config*/) {
         chunk.bytes = bytes;
         chunk.index = request.index;
         chunk.quality = request.quality;
+        chunk.adaptationSetId = request.adaptationSetId;
 
         return chunk;
     }

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -85,7 +85,7 @@ function FragmentController(/*config*/) {
         chunk.bytes = bytes;
         chunk.index = request.index;
         chunk.quality = request.quality;
-        chunk.adaptationSetId = request.adaptationSetId;
+        chunk.representationId = request.representationId;
 
         return chunk;
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -94,7 +94,7 @@ function ScheduleController(config) {
         lastQualityIndex = NaN;
         topQualityIndex = {};
         replaceRequestArray = [];
-        isStopped = false;
+        isStopped = true;
         playListMetrics = null;
         playListTraceMetrics = null;
         playListTraceMetricsClosed = true;
@@ -207,7 +207,8 @@ function ScheduleController(config) {
                     const replacement = replaceRequestArray.shift();
 
                     if (fragmentController.isInitializationRequest(replacement)) {
-                        getInitRequest(replacement.quality);
+                        //to be sure the specific init segment had not already been loaded.
+                        bufferController.switchInitData(replacement.mediaInfo.streamInfo.id, replacement.representationId);
                     } else {
                         const request = nextFragmentRequestRule.execute(streamProcessor, replacement);
                         if (request) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -202,7 +202,7 @@ function ScheduleController(config) {
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;
-                    bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality, adapter.getDataForMedia(currentRepresentationInfo.mediaInfo).id);
+                    bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.id);
                 } else {
                     const replacement = replaceRequestArray.shift();
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -202,7 +202,7 @@ function ScheduleController(config) {
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;
-                    bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality);
+                    bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality, adapter.getDataForMedia(currentRepresentationInfo.mediaInfo).id);
                 } else {
                     const replacement = replaceRequestArray.shift();
 

--- a/src/streaming/utils/InitCache.js
+++ b/src/streaming/utils/InitCache.js
@@ -41,19 +41,15 @@ function InitCache() {
 
     function save (chunk) {
         const id = chunk.streamId;
-        const type = chunk.mediaInfo.type;
-        const quality = chunk.quality;
-        const adaptationSetId = chunk.adaptationSetId;
+        const representationId = chunk.representationId;
 
         data[id] = data[id] || {};
-        data[id][type] = data[id][type] || {};
-        data[id][type][adaptationSetId] = data[id][type][adaptationSetId] || {};
-        data[id][type][adaptationSetId][quality] = chunk;
+        data[id][representationId] = chunk;
     }
 
-    function extract (streamId, mediaType, quality, adaptationSetId) {
-        if (data && data[streamId] && data[streamId][mediaType] && data[streamId][mediaType][adaptationSetId] && data[streamId][mediaType][adaptationSetId][quality]) {
-            return data[streamId][mediaType][adaptationSetId][quality];
+    function extract (streamId, representationId) {
+        if (data && data[streamId] && data[streamId][representationId]) {
+            return data[streamId][representationId];
         } else {
             return null;
         }

--- a/src/streaming/utils/InitCache.js
+++ b/src/streaming/utils/InitCache.js
@@ -43,15 +43,17 @@ function InitCache() {
         const id = chunk.streamId;
         const type = chunk.mediaInfo.type;
         const quality = chunk.quality;
+        const adaptationSetId = chunk.adaptationSetId;
 
         data[id] = data[id] || {};
         data[id][type] = data[id][type] || {};
-        data[id][type][quality] = chunk;
+        data[id][type][adaptationSetId] = data[id][type][adaptationSetId] || {};
+        data[id][type][adaptationSetId][quality] = chunk;
     }
 
-    function extract (streamId, mediaType, quality) {
-        if (data && data[streamId] && data[streamId][mediaType] && data[streamId][mediaType][quality]) {
-            return data[streamId][mediaType][quality];
+    function extract (streamId, mediaType, quality, adaptationSetId) {
+        if (data && data[streamId] && data[streamId][mediaType] && data[streamId][mediaType][adaptationSetId] && data[streamId][mediaType][adaptationSetId][quality]) {
+            return data[streamId][mediaType][adaptationSetId][quality];
         } else {
             return null;
         }

--- a/src/streaming/vo/DataChunk.js
+++ b/src/streaming/vo/DataChunk.js
@@ -45,7 +45,7 @@ class DataChunk {
         this.start = NaN;
         this.end = NaN;
         this.duration = NaN;
-        this.adaptationSetId = null;
+        this.representationId = null;
     }
 }
 

--- a/src/streaming/vo/DataChunk.js
+++ b/src/streaming/vo/DataChunk.js
@@ -45,6 +45,7 @@ class DataChunk {
         this.start = NaN;
         this.end = NaN;
         this.duration = NaN;
+        this.adaptationSetId = null;
     }
 }
 

--- a/src/streaming/vo/FragmentRequest.js
+++ b/src/streaming/vo/FragmentRequest.js
@@ -56,7 +56,7 @@ class FragmentRequest {
         this.bytesTotal = NaN;
         this.delayLoadingTime = NaN;
         this.responseType = 'arraybuffer';
-        this.adaptationSetId = null;
+        this.representationId = null;
     }
 }
 

--- a/src/streaming/vo/FragmentRequest.js
+++ b/src/streaming/vo/FragmentRequest.js
@@ -56,6 +56,7 @@ class FragmentRequest {
         this.bytesTotal = NaN;
         this.delayLoadingTime = NaN;
         this.responseType = 'arraybuffer';
+        this.adaptationSetId = null;
     }
 }
 


### PR DESCRIPTION
I used the sample http://wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvnumber.mpd in order to test audio switch management. I found the first downloaded init audio segment was always used for each language switch.
With this specific sample, it works maybe because the two audio configurations are very similar.
What I propose in this PR is to store init segment by adding the id of adaptationSet. Indeed, two audio languages could have the same quality in two different adaptationSet.