### PR TITLE
Move check video presence call.

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -356,8 +356,6 @@ function Stream(config) {
         }else {
             streamProcessor.updateMediaInfo(manifest, mediaInfo);
         }
-
-        return streamProcessor;
     }
 
     function initializeMediaForType(type, mediaSource) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -298,7 +298,6 @@ function StreamController() {
         if (oldStream) oldStream.deactivate();
         activeStream = newStream;
         playbackController.initialize(activeStream.getStreamInfo());
-        videoTrackDetected = checkVideoPresence();
 
         //TODO detect if we should close and repose or jump to activateStream.
         openMediaSource(seekTime);
@@ -343,6 +342,8 @@ function StreamController() {
                 });
                 playbackController.seek(startTime); //seek to period start time
             }
+        }else {
+            videoTrackDetected = checkVideoPresence();
         }
 
         activeStream.startEventController();


### PR DESCRIPTION
the call to checkVideoPresence was made in the first call to SwitchStream, done from composeStreams. The problem is, at this specific time, no StreamProcessor has been built. The return value of this function is always false.
I suggest to call this function in activateStream, the first time.