### PR TITLE
Don't use decodeURI when parsing cue text

### DIFF
--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -180,7 +180,7 @@ function VTTParser() {
             if (!lineData.match(regExToken))
                 subline = lineData;
         }
-        return decodeURI(subline);
+        return subline;
     }
 
     instance = {


### PR DESCRIPTION
Please see https://github.com/Dash-Industry-Forum/dash.js/issues/1825 for a description of the issue this resolves.