### PR TITLE
Code simplification : remove an unecessary reference.

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -60,7 +60,6 @@ function DashAdapter() {
         adaptations = {};
     }
 
-
     function getRepresentationForTrackInfo(trackInfo, representationController) {
         return representationController.getRepresentationForQuality(trackInfo.quality);
     }

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -92,11 +92,10 @@ function FragmentController(/*config*/) {
     function onFragmentLoadingCompleted(e) {
         if (fragmentModels[e.request.mediaType] !== e.sender) return;
 
-        const scheduleController = e.sender.getScheduleController();
         const request = e.request;
         const bytes = e.response;
         const isInit = isInitializationRequest(request);
-        const streamInfo = scheduleController.getStreamProcessor().getStreamInfo();
+        const streamInfo = request.mediaInfo.streamInfo;
 
         if (!bytes || !streamInfo) {
             log('No ' + request.mediaType + ' bytes to push or stream is inactive.');

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -116,7 +116,6 @@ function ScheduleController(config) {
         fragmentController = streamProcessor.getFragmentController();
         bufferController = streamProcessor.getBufferController();
         fragmentModel = fragmentController.getModel(type);
-        fragmentModel.setScheduleController(this);
         isDynamic = streamProcessor.isDynamic();
         scheduleWhilePaused = mediaPlayerModel.getScheduleWhilePaused();
 

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -66,14 +66,6 @@ function FragmentModel(config) {
         fragmentLoader = value;
     }
 
-    function setScheduleController(value) {
-        scheduleController = value;
-    }
-
-    function getScheduleController() {
-        return scheduleController;
-    }
-
     function isFragmentLoaded(request) {
         const isEqualComplete = function (req1, req2) {
             return ((req1.action === FragmentRequest.ACTION_COMPLETE) && (req1.action === req2.action));
@@ -255,8 +247,6 @@ function FragmentModel(config) {
 
     instance = {
         setLoader: setLoader,
-        setScheduleController: setScheduleController,
-        getScheduleController: getScheduleController,
         getRequests: getRequests,
         isFragmentLoaded: isFragmentLoaded,
         removeExecutedRequestsBeforeTime: removeExecutedRequestsBeforeTime,


### PR DESCRIPTION
fragmentModel is referenced in ScheduleController. ScheduleController was referenced in fragmentModel : removing this dual "dependence".
fragmentModel doesn't need ScheduleController, streamInfo is set in each request object