### PR TITLE
Fix trailing commas, update JSCS and JSHint configs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -6,6 +6,7 @@
     "validateQuoteMarks": "'",
     "disallowMixedSpacesAndTabs": true,
     "disallowTrailingWhitespace": true,
+    "disallowTrailingComma": true,
     "requireSpaceAfterKeywords": true,
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceAfterBinaryOperators": true,
@@ -21,6 +22,9 @@
     "validateParameterSeparator": ", ",
     "disallowMultipleVarDecl": {
         "allExcept": ["undefined"]
+    },
+    "disallowEmptyBlocks": {
+        "allExcept": ["comments"]
     },
     "jsDoc": {
         "checkTypes": "strictNativeCase",

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,12 +1,10 @@
 {
     "esnext": true,
     "noarg": true,
-    "noempty": true,
     "latedef": "nofunc",
     "undef": true,
     "unused": true,
     "strict": false,
-    "trailing": true,
     "node": true,
     "jquery" : true,
     "devel" : true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
                 files: {
                     'build/temp/dash.all.min.js': 'build/temp/dash.all.debug.js'
                 }
-            },
+            }
 
         },
         copy: {
@@ -103,7 +103,7 @@ module.exports = function (grunt) {
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
                     'dash.protection.debug.js', 'dash.protection.debug.js.map',
                     'dash.reporting.debug.js', 'dash.reporting.debug.js.map',
-                    'dash.mss.debug.js', 'dash.mss.debug.js.map',
+                    'dash.mss.debug.js', 'dash.mss.debug.js.map'
                 ],
                 dest: 'dist/',
                 filter: 'isFile'
@@ -113,7 +113,7 @@ module.exports = function (grunt) {
             mediaplayer: {
                 options: {},
                 files: {
-                    'build/temp/dash.mediaplayer.debug.js.map': ['build/temp/dash.mediaplayer.debug.js'],
+                    'build/temp/dash.mediaplayer.debug.js.map': ['build/temp/dash.mediaplayer.debug.js']
                 }
             },
             protection: {
@@ -150,7 +150,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     src: ['index.js', 'src/**/*.js', 'externals/**/*.js'],
-                    dest: 'build/es5/',
+                    dest: 'build/es5/'
                 }]
             }
         },

--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -115,7 +115,7 @@ function Debug() {
         log: log,
         setLogTimestampVisible: setLogTimestampVisible,
         setLogToBrowserConsole: setLogToBrowserConsole,
-        getLogToBrowserConsole: getLogToBrowserConsole,
+        getLogToBrowserConsole: getLogToBrowserConsole
     };
 
     setup();

--- a/src/dash/parser/matchers/StringMatcher.js
+++ b/src/dash/parser/matchers/StringMatcher.js
@@ -39,7 +39,7 @@ class StringMatcher extends BaseMatcher {
             (attr, nodeName) => {
                 const stringAttrsInElements = {
                     'MPD':                        [ 'id', 'profiles' ],
-                    'Period':                     [ 'id', ],
+                    'Period':                     [ 'id' ],
                     'BaseURL':                    [ 'serviceLocation', 'byteRange' ],
                     'SegmentBase':                [ 'indexRange' ],
                     'Initialization':             [ 'range' ],

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -588,7 +588,7 @@ function MssParser(config) {
     }
 
     instance = {
-        parse: internalParse,
+        parse: internalParse
     };
 
     setup();

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -97,7 +97,7 @@ function StreamProcessor(config) {
             dashMetrics: DashMetrics(context).getInstance(),
             dashManifestModel: DashManifestModel(context).getInstance(),
             timelineConverter: timelineConverter,
-            mediaPlayerModel: MediaPlayerModel(context).getInstance(),
+            mediaPlayerModel: MediaPlayerModel(context).getInstance()
         });
 
         bufferController.initialize(type, mediaSource, this);
@@ -264,7 +264,7 @@ function StreamProcessor(config) {
                 streamController: StreamController(context).getInstance(),
                 mediaController: MediaController(context).getInstance(),
                 adapter: adapter,
-                textSourceBuffer: TextSourceBuffer(context).getInstance(),
+                textSourceBuffer: TextSourceBuffer(context).getInstance()
             });
         }else {
             controller = TextController(context).create({

--- a/src/streaming/TextSourceBuffer.js
+++ b/src/streaming/TextSourceBuffer.js
@@ -699,7 +699,7 @@ function TextSourceBuffer() {
                                  videoWidth: videoElement.videoWidth,
                                  fontSize: fontSize,
                                  lineHeight: {},
-                                 linePadding: {},
+                                 linePadding: {}
                                });
         }
         return captionsArray;

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -385,7 +385,7 @@ function BufferController(config) {
 
         // we need to remove data that is more than one fragment before the video currentTime
         const currentTime = playbackController.getTime();
-        const req = streamProcessor.getFragmentModel().getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: currentTime, })[0];
+        const req = streamProcessor.getFragmentModel().getRequests({state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: currentTime })[0];
         const range = sourceBufferController.getBufferRange(buffer, currentTime);
 
         let removeEnd = (req && !isNaN(req.startTime)) ? req.startTime : Math.floor(currentTime);

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -51,7 +51,7 @@ function MetricsReporting() {
     function createMetricsReporting(config) {
         dvbErrorsTranslator = DVBErrorsTranslator(context).getInstance({
             eventBus: config.eventBus,
-            metricsModel: config.metricsModel,
+            metricsModel: config.metricsModel
         });
 
         return MetricsCollectionController(context).create(config);

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -59,7 +59,7 @@ function MetricsController(config) {
 
             metricsHandlersController = MetricsHandlersController(context).create({
                 log: config.log,
-                eventBus: config.eventBus,
+                eventBus: config.eventBus
             });
 
             metricsHandlersController.initialize(metricsEntry.metrics, reportingController);

--- a/src/streaming/metrics/utils/RNG.js
+++ b/src/streaming/metrics/utils/RNG.js
@@ -86,7 +86,7 @@ function RNG() {
     }
 
     instance = {
-        random: rand,
+        random: rand
     };
 
     initialise();

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -118,7 +118,7 @@ function Protection() {
         let controller = null;
 
         let protectionKeyController = ProtectionKeyController(context).getInstance();
-        protectionKeyController.setConfig({log: config.log,});
+        protectionKeyController.setConfig({log: config.log});
         protectionKeyController.initialize();
 
         let protectionModel =  getProtectionModel(config);

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -70,7 +70,7 @@ function KeySystemWidevine() {
         getInitData: getInitData,
         getRequestHeadersFromMessage: getRequestHeadersFromMessage,
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
-        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
+        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData
     };
 
     return instance;

--- a/src/streaming/protection/servers/ClearKey.js
+++ b/src/streaming/protection/servers/ClearKey.js
@@ -89,7 +89,7 @@ function ClearKey() {
         getHTTPMethod: getHTTPMethod,
         getResponseType: getResponseType,
         getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse,
+        getErrorResponse: getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -88,7 +88,7 @@ function DRMToday() {
         getHTTPMethod: getHTTPMethod,
         getResponseType: getResponseType,
         getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse,
+        getErrorResponse: getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -68,7 +68,7 @@ function PlayReady() {
         getHTTPMethod: getHTTPMethod,
         getResponseType: getResponseType,
         getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse,
+        getErrorResponse: getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/Widevine.js
+++ b/src/streaming/protection/servers/Widevine.js
@@ -59,7 +59,7 @@ function Widevine() {
         getHTTPMethod: getHTTPMethod,
         getResponseType: getResponseType,
         getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse,
+        getErrorResponse: getErrorResponse
     };
 
     return instance;


### PR DESCRIPTION
When I looked at CodeClimate I couldn't believe that we weren't seeing these flagged in the JSHint output. Turns out that test is, amongst others, long deprecated or removed.

I fixed the problem, then added the JSCS equivalents and removed the deprecated options in JSHint, so we shouldn't see these issues checked in anymore.