### PR TITLE
Rename TrackInfo VO to RepresentationInfo VO 

### DIFF
--- a/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
+++ b/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
@@ -152,7 +152,7 @@ function DownloadRatioRuleClass() {
         }
 
         count = rulesContext.getMediaInfo().representationCount;
-        currentRepresentation = rulesContext.getTrackInfo();
+        currentRepresentation = rulesContext.getRepresentationInfo();
         currentBandwidth = dashManifest.getBandwidth(currentRepresentation);
         for (i = 0; i < count; i += 1) {
             bandwidths.push(rulesContext.getMediaInfo().bitrateList[i].bandwidth);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -28,8 +28,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
 import Constants from '../streaming/constants/Constants';
-import TrackInfo from '../streaming/vo/TrackInfo';
+import RepresentationInfo from '../streaming/vo/RepresentationInfo';
 import MediaInfo from '../streaming/vo/MediaInfo';
 import StreamInfo from '../streaming/vo/StreamInfo';
 import ManifestInfo from '../streaming/vo/ManifestInfo';
@@ -58,8 +59,9 @@ function DashAdapter() {
         }
     }
 
-    function getRepresentationForTrackInfo(trackInfo, representationController) {
-        return representationController && trackInfo ? representationController.getRepresentationForQuality(trackInfo.quality) : null;
+
+    function getRepresentationForRepresentationInfo(representationInfo, representationController) {
+        return representationController && representationInfo ? representationController.getRepresentationForQuality(representationInfo.quality): null;
     }
 
     function getAdaptationForMediaInfo(mediaInfo) {
@@ -80,21 +82,21 @@ function DashAdapter() {
         return null;
     }
 
-    function convertRepresentationToTrackInfo(voRepresentation) {
-        let trackInfo = new TrackInfo();
+    function convertRepresentationToRepresentationInfo(voRepresentation) {
+        let representationInfo = new RepresentationInfo();
         const realAdaptation = voRepresentation.adaptation.period.mpd.manifest.Period_asArray[voRepresentation.adaptation.period.index].AdaptationSet_asArray[voRepresentation.adaptation.index];
         const realRepresentation = dashManifestModel.getRepresentationFor(voRepresentation.index, realAdaptation);
 
-        trackInfo.id = voRepresentation.id;
-        trackInfo.quality = voRepresentation.index;
-        trackInfo.bandwidth = dashManifestModel.getBandwidth(realRepresentation);
-        trackInfo.DVRWindow = voRepresentation.segmentAvailabilityRange;
-        trackInfo.fragmentDuration = voRepresentation.segmentDuration || (voRepresentation.segments && voRepresentation.segments.length > 0 ? voRepresentation.segments[0].duration : NaN);
-        trackInfo.MSETimeOffset = voRepresentation.MSETimeOffset;
-        trackInfo.useCalculatedLiveEdgeTime = voRepresentation.useCalculatedLiveEdgeTime;
-        trackInfo.mediaInfo = convertAdaptationToMediaInfo(voRepresentation.adaptation);
+        representationInfo.id = voRepresentation.id;
+        representationInfo.quality = voRepresentation.index;
+        representationInfo.bandwidth = dashManifestModel.getBandwidth(realRepresentation);
+        representationInfo.DVRWindow = voRepresentation.segmentAvailabilityRange;
+        representationInfo.fragmentDuration = voRepresentation.segmentDuration || (voRepresentation.segments && voRepresentation.segments.length > 0 ? voRepresentation.segments[0].duration : NaN);
+        representationInfo.MSETimeOffset = voRepresentation.MSETimeOffset;
+        representationInfo.useCalculatedLiveEdgeTime = voRepresentation.useCalculatedLiveEdgeTime;
+        representationInfo.mediaInfo = convertAdaptationToMediaInfo(voRepresentation.adaptation);
 
-        return trackInfo;
+        return representationInfo;
     }
 
     function convertAdaptationToMediaInfo(adaptation) {
@@ -367,7 +369,7 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForTrackInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.getNextSegmentRequest(representation) : null;
@@ -381,7 +383,7 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForTrackInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.getSegmentRequestForTime(representation, time, options) : null;
@@ -395,7 +397,7 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForTrackInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.generateSegmentRequestForTime(representation, time) : null;
@@ -444,13 +446,13 @@ function DashAdapter() {
         checkQuality(quality);
 
         let voRepresentation = representationController.getRepresentationForQuality(quality);
-        return voRepresentation ? convertRepresentationToTrackInfo(voRepresentation) : null;
+        return voRepresentation ? convertRepresentationToRepresentationInfo(voRepresentation) : null;
     }
 
     function getCurrentRepresentationInfo(representationController) {
         checkRepresentationController(representationController);
         let voRepresentation = representationController.getCurrentRepresentation();
-        return voRepresentation ? convertRepresentationToTrackInfo(voRepresentation) : null;
+        return voRepresentation ? convertRepresentationToRepresentationInfo(voRepresentation) : null;
     }
 
     function getEvent(eventBox, eventStreams, startTime) {
@@ -495,8 +497,8 @@ function DashAdapter() {
             events = dashManifestModel.getEventsForPeriod(getPeriodForStreamInfo(info, voPeriods));
         } else if (info instanceof MediaInfo) {
             events = dashManifestModel.getEventStreamForAdaptationSet(manifest, getAdaptationForMediaInfo(info));
-        } else if (info instanceof TrackInfo) {
-            events = dashManifestModel.getEventStreamForRepresentation(manifest, getRepresentationForTrackInfo(info, streamProcessor.getRepresentationController()));
+        } else if (info instanceof RepresentationInfo) {
+            events = dashManifestModel.getEventStreamForRepresentation(manifest, getRepresentationForRepresentationInfo(info, streamProcessor.getRepresentationController()));
         }
 
         return events;
@@ -508,7 +510,7 @@ function DashAdapter() {
     }
 
     instance = {
-        convertDataToTrack: convertRepresentationToTrackInfo,
+        convertDataToRepresentationInfo: convertRepresentationToRepresentationInfo,
         getDataForMedia: getAdaptationForMediaInfo,
         getStreamsInfo: getStreamsInfo,
         getMediaInfoForType: getMediaInfoForType,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -61,7 +61,7 @@ function DashAdapter() {
 
 
     function getRepresentationForRepresentationInfo(representationInfo, representationController) {
-        return representationController && representationInfo ? representationController.getRepresentationForQuality(representationInfo.quality): null;
+        return representationController && representationInfo ? representationController.getRepresentationForQuality(representationInfo.quality) : null;
     }
 
     function getAdaptationForMediaInfo(mediaInfo) {

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -302,8 +302,8 @@ function RepresentationController() {
         }
 
         if (manifestUpdateInfo) {
-            for (let i = 0; i < manifestUpdateInfo.trackInfo.length; i++) {
-                repInfo = manifestUpdateInfo.trackInfo[i];
+            for (let i = 0; i < manifestUpdateInfo.representationInfo.length; i++) {
+                repInfo = manifestUpdateInfo.representationInfo[i];
                 if (repInfo.index === r.index && repInfo.mediaType === streamProcessor.getType()) {
                     alreadyAdded = true;
                     break;

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -121,7 +121,7 @@ function MediaController() {
 
         if (!track || (!isMultiTrackSupportedByType(mediaType))) return;
 
-        tracks[streamId] = tracks[streamId] || createTrackInfo();
+        tracks[streamId] = tracks[streamId] || createRepresentationInfo();
 
         if (tracks[streamId][mediaType].list.indexOf(track) >= 0) return;
 
@@ -434,7 +434,7 @@ function MediaController() {
         return tmpArr[0];
     }
 
-    function createTrackInfo() {
+    function createRepresentationInfo() {
         return {
             audio: {
                 list: [],

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -121,7 +121,7 @@ function MediaController() {
 
         if (!track || (!isMultiTrackSupportedByType(mediaType))) return;
 
-        tracks[streamId] = tracks[streamId] || createRepresentationInfo();
+        tracks[streamId] = tracks[streamId] || createTrackInfo();
 
         if (tracks[streamId][mediaType].list.indexOf(track) >= 0) return;
 
@@ -434,7 +434,7 @@ function MediaController() {
         return tmpArr[0];
     }
 
-    function createRepresentationInfo() {
+    function createTrackInfo() {
         return {
             audio: {
                 list: [],

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -332,7 +332,7 @@ function PlaybackController() {
     function onDataUpdateCompleted(e) {
         if (e.error) return;
 
-        let representationInfo = adapter.convertDataToTrack(e.currentRepresentation);
+        let representationInfo = adapter.convertDataToRepresentationInfo(e.currentRepresentation);
         let info = representationInfo.mediaInfo.streamInfo;
 
         if (streamInfo.id !== info.id) return;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -332,7 +332,7 @@ function PlaybackController() {
     function onDataUpdateCompleted(e) {
         if (e.error) return;
 
-        let representationInfo = adapter.convertDataToRepresentationInfo(e.currentRepresentation);
+        const representationInfo = adapter.convertDataToRepresentationInfo(e.currentRepresentation);
         let info = representationInfo.mediaInfo.streamInfo;
 
         if (streamInfo.id !== info.id) return;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -332,7 +332,7 @@ function ScheduleController(config) {
             return;
         }
 
-        currentRepresentationInfo = adapter.convertDataToTrack(e.currentRepresentation);
+        currentRepresentationInfo = adapter.convertDataToRepresentationInfo(e.currentRepresentation);
     }
 
     function onStreamInitialized(e) {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -369,7 +369,7 @@ function MetricsModel() {
     function addManifestUpdateRepresentationInfo(manifestUpdate, id, index, streamIndex, mediaType, presentationTimeOffset, startNumber, fragmentInfoType) {
         if (manifestUpdate) {
 
-            let vo = new ManifestUpdateRepresentationInfo();
+            const vo = new ManifestUpdateRepresentationInfo();
             vo.id = id;
             vo.index = index;
             vo.streamIndex = streamIndex;

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -38,7 +38,7 @@ import BufferLevel from '../vo/metrics/BufferLevel';
 import BufferState from '../vo/metrics/BufferState';
 import DVRInfo from '../vo/metrics/DVRInfo';
 import DroppedFrames from '../vo/metrics/DroppedFrames';
-import {ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateTrackInfo} from '../vo/metrics/ManifestUpdate';
+import {ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateRepresentationInfo} from '../vo/metrics/ManifestUpdate';
 import SchedulingInfo from '../vo/metrics/SchedulingInfo';
 import EventBus from '../../core/EventBus';
 import RequestsQueue from '../vo/metrics/RequestsQueue';
@@ -368,8 +368,8 @@ function MetricsModel() {
 
     function addManifestUpdateRepresentationInfo(manifestUpdate, id, index, streamIndex, mediaType, presentationTimeOffset, startNumber, fragmentInfoType) {
         if (manifestUpdate) {
-            let vo = new ManifestUpdateTrackInfo();
 
+            let vo = new ManifestUpdateRepresentationInfo();
             vo.id = id;
             vo.index = index;
             vo.streamIndex = streamIndex;
@@ -378,7 +378,7 @@ function MetricsModel() {
             vo.fragmentInfoType = fragmentInfoType;
             vo.presentationTimeOffset = presentationTimeOffset;
 
-            manifestUpdate.trackInfo.push(vo);
+            manifestUpdate.representationInfo.push(vo);
             metricUpdated(manifestUpdate.mediaType, MetricsConstants.MANIFEST_UPDATE_TRACK_INFO, manifestUpdate);
 
             return vo;

--- a/src/streaming/rules/RulesContext.js
+++ b/src/streaming/rules/RulesContext.js
@@ -35,7 +35,7 @@ function RulesContext(config) {
 
     let instance;
     let abrController = config.abrController;
-    let sp = config.streamProcessor;
+    let streamProcessor = config.streamProcessor;
     let representationInfo = config.streamProcessor.getCurrentRepresentationInfo();
     let switchHistory = config.switchHistory;
     let droppedFramesHistory = config.droppedFramesHistory;
@@ -54,12 +54,12 @@ function RulesContext(config) {
         return representationInfo.mediaInfo;
     }
 
-    function getTrackInfo() {
+    function getRepresentationInfo() {
         return representationInfo;
     }
 
     function getStreamProcessor() {
-        return sp;
+        return streamProcessor;
     }
 
     function getAbrController() {
@@ -91,7 +91,7 @@ function RulesContext(config) {
         getStreamInfo: getStreamInfo,
         getStreamProcessor: getStreamProcessor,
         getAbrController: getAbrController,
-        getTrackInfo: getTrackInfo,
+        getRepresentationInfo: getRepresentationInfo,
         useBufferOccupancyABR: useBufferOccupancyABR
     };
 

--- a/src/streaming/rules/RulesContext.js
+++ b/src/streaming/rules/RulesContext.js
@@ -34,13 +34,13 @@ import FactoryMaker from '../../core/FactoryMaker';
 function RulesContext(config) {
 
     let instance;
-    let abrController = config.abrController;
-    let streamProcessor = config.streamProcessor;
-    let representationInfo = config.streamProcessor.getCurrentRepresentationInfo();
-    let switchHistory = config.switchHistory;
-    let droppedFramesHistory = config.droppedFramesHistory;
-    let currentRequest = config.currentRequest;
-    let bufferOccupancyABR = config.useBufferOccupancyABR;
+    const abrController = config.abrController;
+    const streamProcessor = config.streamProcessor;
+    const representationInfo = config.streamProcessor.getCurrentRepresentationInfo();
+    const switchHistory = config.switchHistory;
+    const droppedFramesHistory = config.droppedFramesHistory;
+    const currentRequest = config.currentRequest;
+    const bufferOccupancyABR = config.useBufferOccupancyABR;
 
     function getMediaType() {
         return representationInfo.mediaInfo.type;

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -114,7 +114,7 @@ function AbandonRequestsRule(config) {
                 fragmentInfo.estimatedTimeOfDownload = +((fragmentInfo.bytesTotal * 8 / fragmentInfo.measuredBandwidthInKbps) / 1000).toFixed(2);
                 //log("id:",fragmentInfo.id, "kbps:", fragmentInfo.measuredBandwidthInKbps, "etd:",fragmentInfo.estimatedTimeOfDownload, fragmentInfo.bytesLoaded);
 
-                if (fragmentInfo.estimatedTimeOfDownload < fragmentInfo.segmentDuration * ABANDON_MULTIPLIER || rulesContext.getTrackInfo().quality === 0 ) {
+                if (fragmentInfo.estimatedTimeOfDownload < fragmentInfo.segmentDuration * ABANDON_MULTIPLIER || rulesContext.getRepresentationInfo().quality === 0 ) {
                     return switchRequest;
                 } else if (!abandonDict.hasOwnProperty(fragmentInfo.id)) {
 

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -94,7 +94,7 @@ function InsufficientBufferRule(config) {
             const mediaInfo = rulesContext.getMediaInfo();
             const abrController = rulesContext.getAbrController();
             const throughputHistory = abrController.getThroughputHistory();
-            const trackInfo = rulesContext.getTrackInfo();
+            const trackInfo = rulesContext.getRepresentationInfo();
             const fragmentDuration = trackInfo.fragmentDuration;
 
             let bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -94,8 +94,8 @@ function InsufficientBufferRule(config) {
             const mediaInfo = rulesContext.getMediaInfo();
             const abrController = rulesContext.getAbrController();
             const throughputHistory = abrController.getThroughputHistory();
-            const trackInfo = rulesContext.getRepresentationInfo();
-            const fragmentDuration = trackInfo.fragmentDuration;
+            const representationInfo = rulesContext.getRepresentationInfo();
+            const fragmentDuration = representationInfo.fragmentDuration;
 
             let bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
 

--- a/src/streaming/vo/RepresentationInfo.js
+++ b/src/streaming/vo/RepresentationInfo.js
@@ -32,7 +32,7 @@
  * @class
  * @ignore
  */
-class TrackInfo {
+class RepresentationInfo {
     constructor() {
         this.id = null;
         this.quality = null;
@@ -43,4 +43,4 @@ class TrackInfo {
     }
 }
 
-export default TrackInfo;
+export default RepresentationInfo;

--- a/src/streaming/vo/metrics/ManifestUpdate.js
+++ b/src/streaming/vo/metrics/ManifestUpdate.js
@@ -93,10 +93,10 @@ class ManifestUpdate {
          */
         this.streamInfo = [];
         /**
-         * Array holding list of TrackInfo VO Objects
+         * Array holding list of RepresentationInfo VO Objects
          * @public
          */
-        this.trackInfo = [];
+        this.representationInfo = [];
 
     }
 }
@@ -135,7 +135,7 @@ class ManifestUpdateStreamInfo {
 /**
  * @classdesc This Object holds reference to the current representation's info when the manifest was updated.
  */
-class ManifestUpdateTrackInfo {
+class ManifestUpdateRepresentationInfo {
     /**
      * @class
      */
@@ -156,7 +156,7 @@ class ManifestUpdateTrackInfo {
          */
         this.mediaType = null;
         /**
-         * Which reprenset
+         * Which representation
          * @public
          */
         this.streamIndex = null;
@@ -178,4 +178,4 @@ class ManifestUpdateTrackInfo {
     }
 }
 
-export { ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateTrackInfo };
+export { ManifestUpdate, ManifestUpdateStreamInfo, ManifestUpdateRepresentationInfo };


### PR DESCRIPTION
Hello

The goal of this pull-request is to rename TrackInfo to RepresentationInfo. 
The name TrackInfo was not comprehensive and was confusing.
In RulesContext, the method getTrackInfo was returning the parameter representationInfo, which was initialized using config.streamProcessor.getCurrentRepresentationInfo(); 
getCurrentRepresentationInfo was creating an object of type TrackInfo.

It's a little bit confusing.