### PR TITLE
Fix an exception on eventbus

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -198,7 +198,7 @@ function BufferController(config) {
         sourceBufferController.append(buffer, chunk);
 
         if (chunk.mediaInfo.type === 'video') {
-            eventBus.trigger(Events.VIDEO_CHUNK_RECEIVED, chunk);
+            eventBus.trigger(Events.VIDEO_CHUNK_RECEIVED, {chunk: chunk});
         }
     }
 

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -134,8 +134,8 @@ function TextSourceBuffer() {
         embeddedTracks = null;
     }
 
-
-    function onVideoChunkReceived(chunk) {
+    function onVideoChunkReceived(e) {
+        let chunk = e.chunk;
         if (chunk.mediaInfo.embeddedCaptions) {
             append(chunk.bytes, chunk);
         }


### PR DESCRIPTION
Hello 

The goal of this PR is to fix an exception on EventBus in the following scenario
When onInitFragmentLoaded is called, chunk is saved in initCache and appended to buffer, an event is then triggered (modifying chunk by adding type property).
If switchInitData is called, then chunk is extracted from initCache. Extracted chunk is appended to buffer and event is triggered -> exception because extracted chunk has already a 'type' property.

This commit fix the pb, because chunk is not modified by eventBus.

But maybe, would it be better if EventBus does not modify the paylod, but sends a event using format : 
event = {
eventType : type,
data : payload
}. 
All callback could access the payload using e.data. 

Jérémie