### PR TITLE
Added scanType field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare namespace dashjs {
         width?: number;
         height?: number;
         bandwidth?: number;
+        scanType?: string;
     }
 
     export interface MediaInfo {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -349,7 +349,8 @@ function DashManifestModel() {
             bitrateList.push({
                 bandwidth: reps[i].bandwidth,
                 width: reps[i].width || 0,
-                height: reps[i].height || 0
+                height: reps[i].height || 0,
+                scanType: reps[i].scanType || null
             });
         }
 
@@ -394,6 +395,9 @@ function DashManifestModel() {
             }
             if (r.hasOwnProperty('height')) {
                 representation.height = r.height;
+            }
+            if (r.hasOwnProperty('scanType')) {
+                representation.scanType = r.scanType;
             }
             if (r.hasOwnProperty('maxPlayoutRate')) {
                 representation.maxPlayoutRate = r.maxPlayoutRate;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -54,6 +54,7 @@ class Representation {
         this.bandwidth = NaN;
         this.width = NaN;
         this.height = NaN;
+        this.scanType = null;
         this.maxPlayoutRate = NaN;
     }
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -406,6 +406,7 @@ function AbrController() {
             bitrateInfo.bitrate = bitrateList[i].bandwidth;
             bitrateInfo.width = bitrateList[i].width;
             bitrateInfo.height = bitrateList[i].height;
+            bitrateInfo.scanType = bitrateList[i].scanType;
             infoList.push(bitrateInfo);
         }
 

--- a/src/streaming/vo/BitrateInfo.js
+++ b/src/streaming/vo/BitrateInfo.js
@@ -38,6 +38,7 @@ class BitrateInfo {
         this.bitrate = null;
         this.width = null;
         this.height = null;
+        this.scanType = null;
         this.qualityIndex = NaN;
     }
 }


### PR DESCRIPTION
In response to issue #1880 

The goal of this PR is to expose the scanType of a representation in order to allow implementations to show it to the user when selecting qualities, or even filter by scanType