### PR TITLE
Ensure ABR Rules are cleaned up correctly when player is reset

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1891,6 +1891,7 @@ function MediaPlayer() {
     function createControllers() {
 
         let abrRulesCollection = ABRRulesCollection(context).getInstance();
+        abrRulesCollection.reset();
         abrRulesCollection.initialize();
 
         let sourceBufferController = SourceBufferController(context).getInstance();

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -126,11 +126,20 @@ function ABRRulesCollection() {
         return shouldAbandon || SwitchRequest(context).create();
     }
 
+    function reset() {
+        [qualitySwitchRules, abandonFragmentRules].forEach(rules => {
+            if (rules && rules.length) {
+                rules.forEach(rule => rule.reset && rule.reset());
+            }
+        });
+    }
+
     instance = {
         initialize: initialize,
         getRules: getRules,
         getMaxQuality: getMaxQuality,
-        shouldAbandonFragment: shouldAbandonFragment
+        shouldAbandonFragment: shouldAbandonFragment,
+        reset: reset
     };
 
     return instance;


### PR DESCRIPTION
Whilst debugging another issue, I noticed that each time InsufficientBufferRule was created (once per session), it added a handler for the playback seeking event which was never released.

This PR ensures that rules which have a reset method have that method called at the start of each new session.