### PR TITLE
Update reset functions

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -151,7 +151,6 @@ function MediaPlayer() {
 
         playbackController = PlaybackController(context).getInstance();
         mediaController = MediaController(context).getInstance();
-        mediaController.initialize();
         dashManifestModel = DashManifestModel(context).getInstance();
         dashMetrics = DashMetrics(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
@@ -1969,7 +1968,6 @@ function MediaPlayer() {
             dashManifestModel: dashManifestModel
         });
 
-        mediaController.initialize();
         mediaController.setConfig({
             errHandler: errHandler
         });

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -151,6 +151,11 @@ function MediaPlayer() {
 
         playbackController = PlaybackController(context).getInstance();
         mediaController = MediaController(context).getInstance();
+
+        mediaController.setConfig({
+            errHandler: errHandler
+        });
+
         dashManifestModel = DashManifestModel(context).getInstance();
         dashMetrics = DashMetrics(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
@@ -1966,10 +1971,6 @@ function MediaPlayer() {
         let sourceBufferController = SourceBufferController(context).getInstance();
         sourceBufferController.setConfig({
             dashManifestModel: dashManifestModel
-        });
-
-        mediaController.setConfig({
-            errHandler: errHandler
         });
 
         streamController = StreamController(context).getInstance();

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -88,8 +88,7 @@ function AbrController() {
         switchHistoryDict,
         droppedFramesHistory,
         metricsModel,
-        dashMetrics,
-        lastSwitchTime;
+        dashMetrics;
 
     function setup() {
         log = debug.log.bind(instance);
@@ -114,7 +113,6 @@ function AbrController() {
         videoModel = VideoModel(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
         dashMetrics = DashMetrics(context).getInstance();
-        lastSwitchTime = new Date().getTime() / 1000;
     }
 
     function initialize(type, streamProcessor) {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -91,21 +91,6 @@ function AbrController() {
         dashMetrics;
 
     function setup() {
-        log = debug.log.bind(instance);
-        autoSwitchBitrate = {video: true, audio: true};
-        topQualities = {};
-        qualityDict = {};
-        bitrateDict = {};
-        ratioDict = {};
-        averageThroughputDict = {};
-        abandonmentStateDict = {};
-        streamProcessorDict = {};
-        switchHistoryDict = {};
-        limitBitrateByPortal = false;
-        usePixelRatioInLimitBitrateByPortal = false;
-        if (windowResizeEventCalled === undefined) {
-            windowResizeEventCalled = false;
-        }
         domStorage = DOMStorage(context).getInstance();
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
@@ -113,6 +98,7 @@ function AbrController() {
         videoModel = VideoModel(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
         dashMetrics = DashMetrics(context).getInstance();
+        reset();
     }
 
     function initialize(type, streamProcessor) {
@@ -139,6 +125,21 @@ function AbrController() {
     }
 
     function reset() {
+        log = debug.log.bind(instance);
+        autoSwitchBitrate = {video: true, audio: true};
+        topQualities = {};
+        qualityDict = {};
+        bitrateDict = {};
+        ratioDict = {};
+        averageThroughputDict = {};
+        abandonmentStateDict = {};
+        streamProcessorDict = {};
+        switchHistoryDict = {};
+        limitBitrateByPortal = false;
+        usePixelRatioInLimitBitrateByPortal = false;
+        if (windowResizeEventCalled === undefined) {
+            windowResizeEventCalled = false;
+        }
         eventBus.off(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
         eventBus.off(MediaPlayerEvents.QUALITY_CHANGE_RENDERED, onQualityChangeRendered, this);
         playbackIndex = undefined;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -149,7 +149,6 @@ function AbrController() {
         if (abrRulesCollection) {
             abrRulesCollection.reset();
         }
-        setup();
     }
 
     function setConfig(config) {

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -66,10 +66,8 @@ function MediaController() {
         TRACK_SELECTION_MODE_WIDEST_RANGE
     ];
 
-    function initialize() {
-        tracks = {};
-        resetInitialSettings();
-        resetSwitchMode();
+    function setup() {
+        reset();
     }
 
     /**
@@ -322,7 +320,9 @@ function MediaController() {
      * @memberof MediaController#
      */
     function reset() {
-        initialize();
+        tracks = {};
+        resetInitialSettings();
+        resetSwitchMode();
         textController.reset();
     }
 
@@ -459,7 +459,6 @@ function MediaController() {
     }
 
     instance = {
-        initialize: initialize,
         checkInitialMediaSettingsForType: checkInitialMediaSettingsForType,
         addTrack: addTrack,
         getTracksFor: getTracksFor,
@@ -477,6 +476,8 @@ function MediaController() {
         setConfig: setConfig,
         reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -116,7 +116,6 @@ function MediaController() {
 
     /**
      * @param {MediaInfo} track
-     * @returns {boolean}
      * @memberof MediaController#
      */
     function addTrack(track) {
@@ -124,19 +123,17 @@ function MediaController() {
         var streamId = track ? track.streamInfo.id : null;
         var initSettings = getInitialSettings(mediaType);
 
-        if (!track || (!isMultiTrackSupportedByType(mediaType))) return false;
+        if (!track || (!isMultiTrackSupportedByType(mediaType))) return;
 
         tracks[streamId] = tracks[streamId] || createTrackInfo();
 
-        if (tracks[streamId][mediaType].list.indexOf(track) >= 0) return false;
+        if (tracks[streamId][mediaType].list.indexOf(track) >= 0) return;
 
         tracks[streamId][mediaType].list.push(track);
 
         if (initSettings && (matchSettings(initSettings, track)) && !getCurrentTrackFor(mediaType, track.streamInfo)) {
             setTrack(track);
         }
-
-        return true;
     }
 
     /**

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -195,7 +195,7 @@ function PlaybackController() {
         wallclockTimeIntervalId = null;
         playOnceInitialized = false;
         commonEarliestTime = {};
-        if (videoModel && element) {
+        if (videoModel) {
             eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
             eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
             eventBus.off(Events.BYTES_APPENDED, onBytesAppended, this);

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -61,13 +61,8 @@ function PlaybackController() {
         playOnceInitialized;
 
     function setup() {
-        currentTime = 0;
-        liveStartTime = NaN;
-        wallclockTimeIntervalId = null;
-        isDynamic = null;
-        playOnceInitialized = false;
-        commonEarliestTime = {};
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
+        reset();
     }
 
     function initialize(StreamInfo) {
@@ -195,7 +190,12 @@ function PlaybackController() {
     }
 
     function reset() {
-        if (videoModel) {
+        currentTime = 0;
+        liveStartTime = NaN;
+        wallclockTimeIntervalId = null;
+        playOnceInitialized = false;
+        commonEarliestTime = {};
+        if (videoModel && element) {
             eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
             eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
             eventBus.off(Events.BYTES_APPENDED, onBytesAppended, this);
@@ -205,7 +205,6 @@ function PlaybackController() {
         videoModel = null;
         streamInfo = null;
         isDynamic = null;
-        setup();
     }
 
     function setConfig(config) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -695,7 +695,6 @@ function StreamController() {
         manifestLoader.reset();
         timelineConverter.reset();
         liveEdgeFinder.reset();
-        adapter.reset();
         initCache.reset();
         isStreamSwitchingInProgress = false;
         isUpdating = false;

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -50,9 +50,10 @@ function AbandonRequestsRule(config) {
         throughputArray;
 
     function setup() {
-        fragmentDict = {};
-        abandonDict = {};
-        throughputArray = [];
+        mediaPlayerModel = MediaPlayerModel(context).getInstance();
+        dashMetrics = DashMetrics(context).getInstance();
+        metricsModel = MetricsModel(context).getInstance();
+        reset();
     }
 
     function setFragmentRequestDict(type, id) {
@@ -139,7 +140,9 @@ function AbandonRequestsRule(config) {
     }
 
     function reset() {
-        setup();
+        fragmentDict = {};
+        abandonDict = {};
+        throughputArray = [];
     }
 
     const instance = {

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -50,9 +50,6 @@ function AbandonRequestsRule(config) {
         throughputArray;
 
     function setup() {
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
-        dashMetrics = DashMetrics(context).getInstance();
-        metricsModel = MetricsModel(context).getInstance();
         reset();
     }
 

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -56,7 +56,6 @@ function ThroughputRule(config) {
         latencyArray;
 
     function setup() {
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
         reset();
     }
 

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -56,8 +56,8 @@ function ThroughputRule(config) {
         latencyArray;
 
     function setup() {
-        throughputArray = [];
-        latencyArray = [];
+        mediaPlayerModel = MediaPlayerModel(context).getInstance();
+        reset();
     }
 
     function storeLastRequestThroughputByType(type, throughput) {
@@ -192,7 +192,8 @@ function ThroughputRule(config) {
     }
 
     function reset() {
-        setup();
+        throughputArray = [];
+        latencyArray = [];
     }
 
     const instance = {

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -173,7 +173,7 @@ function TextSourceBuffer() {
 
     function resetEmbedded() {
         eventBus.off(Events.VIDEO_CHUNK_RECEIVED, onVideoChunkReceived, this);
-        if (textTracks !== null) {
+        if (textTracks) {
             textTracks.deleteAllTextTracks();
         }
         embeddedInitialized = false;


### PR DESCRIPTION
Hi,

in some files, the reset function was calling the setup function :

- AbrController.js
- PlaybackController.js
- AbandonRequestsRule.js
- ThroughputRule.js

The main consequence was an unnecessary call to getInstance function when the user changed the video stream. So, I propose to do the reverse : setup function calls the reset. The setup function only calls the different getInstance reference. The others attributes are initialized in the reset function.

Nicolas