### PR TITLE
Set the seekable range on the mediaSource

### DIFF
--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -69,6 +69,13 @@ function MediaSourceController() {
         return source.duration;
     }
 
+    function setSeekable(source, start, end) {
+        if (typeof source.setLiveSeekableRange === 'function' && typeof source.clearLiveSeekableRange === 'function') {
+            source.clearLiveSeekableRange();
+            source.setLiveSeekableRange(start, end);
+        }
+    }
+
     function signalEndOfStream(source) {
 
         var buffers = source.sourceBuffers;
@@ -90,6 +97,7 @@ function MediaSourceController() {
         attachMediaSource: attachMediaSource,
         detachMediaSource: detachMediaSource,
         setDuration: setDuration,
+        setSeekable: setSeekable,
         signalEndOfStream: signalEndOfStream
     };
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -40,6 +40,7 @@ import FactoryMaker from '../../core/FactoryMaker';
 import {PlayList, PlayListTrace} from '../vo/metrics/PlayList';
 import Debug from '../../core/Debug';
 import InitCache from '../utils/InitCache';
+import MediaPlayerEvents from '../MediaPlayerEvents';
 
 function StreamController() {
 
@@ -132,6 +133,7 @@ function StreamController() {
         eventBus.on(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdated, this);
         eventBus.on(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
+        eventBus.on(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
     }
 
     /*
@@ -684,6 +686,7 @@ function StreamController() {
         eventBus.off(Events.PLAYBACK_ENDED, onEnded, this);
         eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdated, this);
         eventBus.off(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
+        eventBus.off(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
 
         baseURLController.reset();
         manifestUpdater.reset();
@@ -718,6 +721,16 @@ function StreamController() {
         }
 
         eventBus.trigger(Events.STREAM_TEARDOWN_COMPLETE);
+    }
+
+    function onMetricAdded(e) {
+        if (e.metric === 'DVRInfo') {
+            //Match media type? How can DVR window be different for media types?
+            //Should we normalize and union the two?
+            if (e.mediaType === 'audio') {
+                mediaSourceController.setSeekable(mediaSource, e.value.range.start, e.value.range.end);
+            }
+        }
     }
 
     instance = {


### PR DESCRIPTION
This continually sets the seekable attribute on the mediaSource to be the same as the current DVR window. It implements #1384 and is a fix for #1867