### PR TITLE
Metrics controller for all streams

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1982,7 +1982,7 @@ function MediaPlayer() {
 
     function detectMetricsReporting() {
         if (metricsReportingController) {
-            return metricsReportingController;
+            return;
         }
         // do not require MetricsReporting as dependencies as this is optional and intended to be loaded separately
         let MetricsReporting = dashjs.MetricsReporting; /* jshint ignore:line */
@@ -1996,16 +1996,12 @@ function MediaPlayer() {
                 dashManifestModel: dashManifestModel,
                 metricsModel: metricsModel
             });
-
-            return metricsReportingController;
         }
-
-        return null;
     }
 
     function detectMss() {
         if (mssHandler) {
-            return mssHandler;
+            return;
         }
         // do not require MssHandler as dependencies as this is optional and intended to be loaded separately
         let MssHandler = dashjs.MssHandler; /* jshint ignore:line */
@@ -2014,10 +2010,7 @@ function MediaPlayer() {
                 eventBus: eventBus,
                 mediaPlayerModel: mediaPlayerModel
             });
-            return mssHandler;
         }
-
-        return null;
     }
 
     function getDVRInfoMetric() {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1863,6 +1863,11 @@ function MediaPlayer() {
         attachView(null);
         protectionData = null;
         protectionController = null;
+        if (metricsReportingController) {
+            metricsReportingController.reset();
+            metricsReportingController = null;
+        }
+        mediaPlayerInitialized = false;
     }
 
     //***********************************
@@ -1879,7 +1884,6 @@ function MediaPlayer() {
             mediaController.reset();
             textController.reset();
             streamController = null;
-            metricsReportingController = null;
             if (isReady()) {
                 initializePlayback();
             }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1862,7 +1862,10 @@ function MediaPlayer() {
         attachSource(null);
         attachView(null);
         protectionData = null;
-        protectionController = null;
+        if (protectionController) {
+            protectionController.reset();
+            protectionController = null;
+        }
         if (metricsReportingController) {
             metricsReportingController.reset();
             metricsReportingController = null;

--- a/src/streaming/metrics/controllers/MetricsCollectionController.js
+++ b/src/streaming/metrics/controllers/MetricsCollectionController.js
@@ -82,7 +82,7 @@ function MetricsCollectionController(config) {
         );
     }
 
-    function reset() {
+    function resetMetricsControllers() {
         Object.keys(metricsControllers).forEach(key => {
             metricsControllers[key].reset();
         });
@@ -91,16 +91,21 @@ function MetricsCollectionController(config) {
     }
 
     function setup() {
-
-
         eventBus.on(Events.MANIFEST_UPDATED, update);
-        eventBus.on(Events.STREAM_TEARDOWN_COMPLETE, reset);
+        eventBus.on(Events.STREAM_TEARDOWN_COMPLETE, resetMetricsControllers);
+    }
+
+    function reset() {
+        eventBus.off(Events.MANIFEST_UPDATED, update);
+        eventBus.off(Events.STREAM_TEARDOWN_COMPLETE, resetMetricsControllers);
     }
 
     setup();
 
     // don't export any actual methods
-    return {};
+    return {
+        reset: reset
+    };
 }
 
 MetricsCollectionController.__dashjs_factory_name = 'MetricsCollectionController';

--- a/src/streaming/metrics/controllers/MetricsCollectionController.js
+++ b/src/streaming/metrics/controllers/MetricsCollectionController.js
@@ -102,7 +102,6 @@ function MetricsCollectionController(config) {
 
     setup();
 
-    // don't export any actual methods
     return {
         reset: reset
     };


### PR DESCRIPTION
Hi,

the aim of this PR is to manage properly metricsReportingController. Before thoses changes, the call to resetAndInitializePlayback set metricsReportingController to null, without doing any unregister events call. 
So, I suggest that a call to a reset function on metricsReportingController in reset function of MediaPlayer should be made. This reset function has to unregister events. After this step, metricsReportingController could be set to null.

Nicolas