### PR TITLE
fix(TextBufferContoller): only export one default

### DIFF
--- a/src/streaming/text/TextBufferController.js
+++ b/src/streaming/text/TextBufferController.js
@@ -151,4 +151,3 @@ function TextBufferController(config) {
 
 TextBufferController.__dashjs_factory_name = 'TextBufferController';
 export default FactoryMaker.getClassFactory(TextBufferController);
-export default FactoryMaker.getClassFactory(TextBufferController);


### PR DESCRIPTION
https://github.com/Dash-Industry-Forum/dash.js/issues/1903

Caused by https://github.com/Dash-Industry-Forum/dash.js/commit/ed2005a31df7e227a295de8281a565c5604d41df#diff-d10a4783ead24da292fe133eb36db75bR154