### PR TITLE
Enhanced debug

### DIFF
--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -43,11 +43,13 @@ function Debug() {
     let instance,
         logToBrowserConsole,
         showLogTimestamp,
+        showCalleeName,
         startTime;
 
     function setup() {
         logToBrowserConsole = true;
         showLogTimestamp = true;
+        showCalleeName = false;
         startTime = new Date().getTime();
     }
 
@@ -60,6 +62,16 @@ function Debug() {
      */
     function setLogTimestampVisible(value) {
         showLogTimestamp = value;
+    }
+    /**
+     * Prepends the callee object name, and media type if available, to each log message.
+     * @param {boolean} value Set to true if you want to see the callee object name and media type in each log message.
+     * @default false
+     * @memberof module:Debug
+     * @instance
+     */
+    function setCalleeNameVisible(value) {
+        showCalleeName = value;
     }
     /**
      * Toggles logging to the browser's javascript console.  If you set to false you will still receive a log event with the same message.
@@ -96,6 +108,13 @@ function Debug() {
             message += '[' + (logTime - startTime) + ']';
         }
 
+        if (showCalleeName && this && this.getClassName) {
+            message += '[' + this.getClassName() + ']';
+            if (this.getType) {
+                message += '[' + this.getType() + ']';
+            }
+        }
+
         if (message.length > 0) {
             message += ' ';
         }
@@ -114,6 +133,7 @@ function Debug() {
     instance = {
         log: log,
         setLogTimestampVisible: setLogTimestampVisible,
+        setCalleeNameVisible: setCalleeNameVisible,
         setLogToBrowserConsole: setLogToBrowserConsole,
         getLogToBrowserConsole: getLogToBrowserConsole
     };

--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -123,6 +123,9 @@ let FactoryMaker = (function () {
     }
 
     function merge(name, classConstructor, context, args) {
+        // Add getClassName function to class instance prototype (used by Debug)
+        classConstructor.getClassName = function () {return name;};
+
         let extensionContext = getExtensionContext(context);
         let extensionObject = extensionContext[name];
         if (extensionObject) {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -46,7 +46,6 @@ const SEGMENTS_UNAVAILABLE_ERROR_CODE = 1;
 function DashHandler(config) {
 
     let context = this.context;
-    let log = Debug(context).getInstance().log;
     let eventBus = EventBus(context).getInstance();
     const urlUtils = URLUtils(context).getInstance();
 
@@ -57,6 +56,7 @@ function DashHandler(config) {
     const baseURLController = config.baseURLController;
 
     let instance,
+        log,
         index,
         requestedTime,
         isDynamic,
@@ -67,6 +67,7 @@ function DashHandler(config) {
         segmentsGetter;
 
     function setup() {
+        log = Debug(context).getInstance().log.bind(instance);
         index = -1;
         currentTime = 0;
         earliestTime = NaN;

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -103,6 +103,10 @@ function DashHandler(config) {
         return earliestTime;
     }
 
+    function getType() {
+        return type;
+    }
+
     function reset() {
         segmentsGetter = null;
         currentTime = 0;
@@ -490,6 +494,7 @@ function DashHandler(config) {
         getInitRequest: getInitRequest,
         getSegmentRequestForTime: getSegmentRequestForTime,
         getNextSegmentRequest: getNextSegmentRequest,
+        getType: getType,
         generateSegmentRequestForTime: generateSegmentRequestForTime,
         updateRepresentation: updateRepresentation,
         setCurrentTime: setCurrentTime,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -58,10 +58,10 @@ function AbrController() {
 
     let context = this.context;
     let debug = Debug(context).getInstance();
-    const log = debug.log;
     let eventBus = EventBus(context).getInstance();
 
     let instance,
+        log,
         abrRulesCollection,
         streamController,
         autoSwitchBitrate,
@@ -91,6 +91,7 @@ function AbrController() {
         lastSwitchTime;
 
     function setup() {
+        log = debug.log.bind(instance);
         autoSwitchBitrate = {video: true, audio: true};
         topQualities = {};
         qualityDict = {};

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -49,7 +49,6 @@ const STALL_THRESHOLD = 0.5;
 function BufferController(config) {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
     const metricsModel = config.metricsModel;
     const manifestModel = config.manifestModel;
@@ -60,8 +59,8 @@ function BufferController(config) {
     const adapter = config.adapter;
     const textController = config.textController;
 
-
     let instance,
+        log,
         requiredQuality,
         isBufferingCompleted,
         bufferLevel,
@@ -86,6 +85,7 @@ function BufferController(config) {
         initCache;
 
     function setup() {
+        log = Debug(context).getInstance().log.bind(instance);
         requiredQuality = AbrController.QUALITY_DEFAULT;
         isBufferingCompleted = false;
         bufferLevel = 0;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -471,6 +471,10 @@ function ScheduleController(config) {
         return bufferLevelRule.getBufferTarget(streamProcessor, type, streamController.isVideoTrackPresent());
     }
 
+    function getType() {
+        return type;
+    }
+
     function setPlayList(playList) {
         playListMetrics = playList;
     }
@@ -536,6 +540,7 @@ function ScheduleController(config) {
 
     instance = {
         initialize: initialize,
+        getType: getType,
         getStreamProcessor: getStreamProcessor,
         getSeekTarget: getSeekTarget,
         setSeekTarget: setSeekTarget,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -49,7 +49,6 @@ import Debug from '../../core/Debug';
 function ScheduleController(config) {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
     const metricsModel = config.metricsModel;
     const manifestModel = config.manifestModel;
@@ -60,6 +59,7 @@ function ScheduleController(config) {
     const mediaPlayerModel = config.mediaPlayerModel;
 
     let instance,
+        log,
         type,
         fragmentModel,
         isDynamic,
@@ -89,6 +89,7 @@ function ScheduleController(config) {
         replaceRequestArray;
 
     function setup() {
+        log = Debug(context).getInstance().log.bind(instance);
         initialRequest = true;
         lastInitQuality = NaN;
         lastQualityIndex = NaN;


### PR DESCRIPTION
This PR enables to extend debug log messages with callee class name, and media type if available. 
This may facilitate debugging by filtering log messages in the browser console.

For example, if you filter log message related to DashHandler for video track, then you would get the following messages to displayed:

![debug](https://cloud.githubusercontent.com/assets/5312520/25739308/a5c43efc-3181-11e7-97d5-e8e0e2ec204e.jpg)

By the default, class names and types are not displayed.
This can be enabled by calling 

`player.getDebug().setCalleeNameVisible(true);
`