### PR TITLE
Fix up getting-started samples so they work on more platforms

### DIFF
--- a/samples/getting-started-basic-embed/auto-load-multi-video.html
+++ b/samples/getting-started-basic-embed/auto-load-multi-video.html
@@ -15,7 +15,7 @@
             height: 180px;
         }
     </style>
-
+    </head>
     <body>
         <div>
             <video autoplay controls>

--- a/samples/getting-started-basic-embed/auto-load-single-video-src.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-src.html
@@ -15,7 +15,7 @@
             height: 360px;
         }
     </style>
-
+    </head>
     <body>
         <div>
             <video data-dashjs-player autoplay src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" controls="true"/>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
@@ -47,7 +47,7 @@
             height: 180px;
         }
     </style>
-
+    </head>
     <body onload="init()">
         <div>
             <video id="video1" autoplay controls="true">

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-context-and-source.html
@@ -48,7 +48,7 @@
         }
     </style>
     </head>
-    <body onload="init()">
+    <body>
         <div>
             <video id="video1" autoplay controls="true">
                 <source src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" type="application/dash+xml"/>
@@ -62,5 +62,10 @@
             <video id="video4" autoplay controls="true">
             </video>
         </div>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>

--- a/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video-with-reference.html
@@ -30,7 +30,7 @@
         }
     </style>
     </head>
-    <body onload="init()">
+    <body>
         <div>
             <video class="dashjs-player" autoplay controls>
                 <source src="http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd" type="application/dash+xml"/>
@@ -40,5 +40,10 @@
             <span id="stats"/>
         </div>
 
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>

--- a/samples/getting-started-basic-embed/auto-load-single-video.html
+++ b/samples/getting-started-basic-embed/auto-load-single-video.html
@@ -15,7 +15,7 @@
             height: 360px;
         }
     </style>
-
+    </head>
     <body>
         <div>
             <video autoplay preload="none" controls="true">

--- a/samples/getting-started-basic-embed/listening-to-events.html
+++ b/samples/getting-started-basic-embed/listening-to-events.html
@@ -97,7 +97,7 @@
             background-color: orange;
         }
     </style>
-
+    </head>
     <body onload="init()">
         <div>
         This sample allows you to explore the various external events that are accessible from MediaPlayer. Events can be dynamically added and removed. <br/>

--- a/samples/getting-started-basic-embed/listening-to-events.html
+++ b/samples/getting-started-basic-embed/listening-to-events.html
@@ -98,7 +98,7 @@
         }
     </style>
     </head>
-    <body onload="init()">
+    <body>
         <div>
         This sample allows you to explore the various external events that are accessible from MediaPlayer. Events can be dynamically added and removed. <br/>
         Choose the events you would like to monitor before starting playback:
@@ -142,5 +142,10 @@
             <p/>
             <span id="eventHolder">Events actively being listened to are shown below. Remove the listener by clicking on the event button.<br/></span>
         </div>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>

--- a/samples/getting-started-basic-embed/manual-load-single-video.html
+++ b/samples/getting-started-basic-embed/manual-load-single-video.html
@@ -27,7 +27,7 @@
             height: 360px;
         }
     </style>
-
+    </head>
     <body onload="init()">
         <div>
             <video controls="true">

--- a/samples/getting-started-basic-embed/manual-load-single-video.html
+++ b/samples/getting-started-basic-embed/manual-load-single-video.html
@@ -28,10 +28,15 @@
         }
     </style>
     </head>
-    <body onload="init()">
+    <body>
         <div>
             <video controls="true">
             </video>
         </div>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>

--- a/samples/live-streaming/live-delay-comparison-custom-manifest.html
+++ b/samples/live-streaming/live-delay-comparison-custom-manifest.html
@@ -88,7 +88,7 @@
             width:50px;
         }
     </style>
-
+    </head>
 <body onload="init()">
 
 This sample allows you to explore the two MediaPlayer APIS which control live delay - setLiveDelay and setLiveDelayFragmentCount.<br/>

--- a/samples/live-streaming/live-delay-comparison-custom-manifest.html
+++ b/samples/live-streaming/live-delay-comparison-custom-manifest.html
@@ -89,7 +89,7 @@
         }
     </style>
     </head>
-<body onload="init()">
+<body>
 
 This sample allows you to explore the two MediaPlayer APIS which control live delay - setLiveDelay and setLiveDelayFragmentCount.<br/>
 The first takes the desired delay in seconds. The second takes the delay in terms of fragment count.
@@ -127,5 +127,10 @@ Enter the URL to a live (dynamic) stream manifest :
         </div>
     </div>
 </div>
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        init();
+    });
+</script>
 </body>
 </html>

--- a/samples/live-streaming/live-delay-comparison-using-fragmentCount.html
+++ b/samples/live-streaming/live-delay-comparison-using-fragmentCount.html
@@ -79,7 +79,7 @@ Debug files are not compressed or obfuscated making the file size much larger co
         </style>
     </head>
 
-    <body onload="init()">
+    <body>
     This sample illustrates the combined effects of segment duration and the "<strong>setLiveDelayFragmentCount</strong>" MediaPlayer method on the latency of live stream playback.
         The upper layer of videos are all playing a live stream with 2s segment duration. The lower layer use 6s segment duration. For each stream, the playback position
         behind live is varied between 0, 2 and 4 segments. Note that the default value for dash.js is 4 segments, which is a trade off between stability and latency.
@@ -129,6 +129,11 @@ Debug files are not compressed or obfuscated making the file size much larger co
                 Buffer length: <span id="video6buffer"></span>
                 </td></tr>
         </table>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>
 

--- a/samples/live-streaming/live-delay-comparison-using-setLiveDelay.html
+++ b/samples/live-streaming/live-delay-comparison-using-setLiveDelay.html
@@ -79,7 +79,7 @@ Debug files are not compressed or obfuscated making the file size much larger co
         </style>
     </head>
 
-    <body onload="init()">
+    <body>
     This sample illustrates the combined effects of segment duration and the "<strong>setLiveDelay</strong>" MediaPlayer method on the latency of live stream playback.
     The upper layer of videos are all playing a live stream with 2s segment duration, with setLiveDelay values of 2s, 4s, and 8s. The lower layer use 6s segment duration,
     with setLiveDelay values of 6s, 12s, and 24s. Lowest latency is achieved with shorter segments and with a lower live delay value. Higher stability/robustness is achieved with a higher live delay which allows a larger forward buffer.
@@ -128,6 +128,11 @@ Debug files are not compressed or obfuscated making the file size much larger co
                 Buffer length: <span id="video6buffer"></span>
                 </td></tr>
         </table>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
     </body>
 </html>
 


### PR DESCRIPTION
This week I have been looking at Google's [cobalt](http://cobalt.foo/), and I thought I'd see if I could get dash.js to run on it.

The manual-load-single-video sample works great, but `<body onload>` doesn't work to get the application running, so I needed to change it to using an event listener. This should be a harmless on other platforms - I have verified all examples still work in Chrome.

I also noticed that most samples did not have a closing head tag, so I fixed that up.