### PR TITLE
Add support for SMPTE-TT base64-encoded  subtitles images.

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -451,6 +451,7 @@ function TextTracks() {
                 cue.cueHTMLElement = currentItem.cueHTMLElement;
                 cue.isd = currentItem.isd;
                 cue.images = currentItem.images;
+                cue.embeddedImages = currentItem.embeddedImages;
                 cue.cueID = currentItem.cueID;
                 cue.scaleCue = scaleCue.bind(self);
                 captionContainer.style.left = actualVideoLeft + 'px';
@@ -465,14 +466,20 @@ function TextTracks() {
                         captionContainer.appendChild(finalCue);
                         if (this.isd) {
                             renderHTML(this.isd, finalCue,  function (uri) {
-                                let urnTester = /^(urn:)(mpeg:[a-z0-9][a-z0-9-]{0,31}:)(subs:)([0-9])$/ ;
-                                if (urnTester.test(uri)) {
-                                    let match = urnTester.exec(uri);
+                                let imsc1ImgUrnTester = /^(urn:)(mpeg:[a-z0-9][a-z0-9-]{0,31}:)(subs:)([0-9])$/;
+                                let smpteImgUrnTester = /^#(.*)$/;
+                                if (imsc1ImgUrnTester.test(uri)) {
+                                    let match = imsc1ImgUrnTester.exec(uri);
                                     let imageId = parseInt(match[4],10) - 1;
                                     let imageData = btoa(cue.images[imageId]);
                                     let dataUrl = 'data:image/png;base64,' + imageData;
                                     return dataUrl;
-                                }else {
+                                } else if (smpteImgUrnTester.test(uri)) {
+                                    let match = smpteImgUrnTester.exec(uri);
+                                    let imageId = match[1];
+                                    let dataUrl = 'data:image/png;base64,' + cue.embeddedImages[imageId];
+                                    return dataUrl;
+                                } else {
                                     return null;
                                 }
                             }, captionContainer.clientHeight, captionContainer.clientWidth);


### PR DESCRIPTION
Added support for embedded base64-encoded SMPTE-TT image element.

Tested with http://vm2.dashif.org/dash/vod/testpic_2s/img_subs.mpd

Compared to before imscJS integration, I saw the following differences:

The name space `xmlns:tts="http://www.w3.org/ns/ttml#styling"` needed to be corrected (was `#style#`).

Of the three variants on using `tts:extent` and `tts:origin`:
http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_px.xml
http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_percent.xml
http://vm2.dashif.org/dash/vod/testpic_2s/img_subs_div.xml
the two first still work, but the third does not since it specifies `tts:extent` and `tts:origin` in the `div`element, and this is not allowed by TTML.




