### PR TITLE
Fix to center subtitles in reference player [#1942]

### DIFF
--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -141,6 +141,10 @@ a:hover {
     width: 35%;
 }
 
+.videoContainer {
+    position: relative;
+}
+
 .video-controller {
     margin-top: -5px !important;
 }

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -195,7 +195,7 @@
         <!--VIDEO PLAYER / CONTROLS -->
         <div class="row">
             <div class="dash-video-player col-md-9">
-                <div id="videoContainer">
+                <div id="videoContainer" class="videoContainer">
                     <video></video>
                     <div id="video-caption"></div>
                     <div id="videoController" class="video-controller unselectable" ng-cloak>


### PR DESCRIPTION
Center the video-caption div on top of the videoContainer by setting videoContainer position.

Fixes #1942 