### PR TITLE
ABR Rules Collection creation

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -46,7 +46,6 @@ import MediaPlayerModel from './models/MediaPlayerModel';
 import MetricsModel from './models/MetricsModel';
 import AbrController from './controllers/AbrController';
 import TimeSyncController from './controllers/TimeSyncController';
-import ABRRulesCollection from './rules/abr/ABRRulesCollection';
 import VideoModel from './models/VideoModel';
 import MediaSourceController from './controllers/MediaSourceController';
 import BaseURLController from './controllers/BaseURLController';
@@ -1965,10 +1964,6 @@ function MediaPlayer() {
 
     function createControllers() {
 
-        let abrRulesCollection = ABRRulesCollection(context).getInstance();
-        abrRulesCollection.reset();
-        abrRulesCollection.initialize();
-
         let sourceBufferController = SourceBufferController(context).getInstance();
         sourceBufferController.setConfig({
             dashManifestModel: dashManifestModel
@@ -1998,8 +1993,8 @@ function MediaPlayer() {
         });
         streamController.initialize(autoPlay, protectionData);
 
+        abrController.createAbrRulesCollection();
         abrController.setConfig({
-            abrRulesCollection: abrRulesCollection,
             streamController: streamController
         });
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+import ABRRulesCollection from '../rules/abr/ABRRulesCollection';
 import BitrateInfo from '../vo/BitrateInfo';
 import DOMStorage from '../utils/DOMStorage';
 import MediaPlayerModel from '../models/MediaPlayerModel';
@@ -129,6 +130,16 @@ function AbrController() {
         }
     }
 
+    function createAbrRulesCollection() {
+        abrRulesCollection = ABRRulesCollection(context).create({
+            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
+            mediaPlayerModel: mediaPlayerModel
+        });
+
+        abrRulesCollection.initialize();
+    }
+
     function reset() {
         eventBus.off(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
         eventBus.off(MediaPlayerEvents.QUALITY_CHANGE_RENDERED, onQualityChangeRendered, this);
@@ -136,6 +147,9 @@ function AbrController() {
         droppedFramesHistory = undefined;
         clearTimeout(abandonmentTimeout);
         abandonmentTimeout = null;
+        if (abrRulesCollection) {
+            abrRulesCollection.reset();
+        }
         setup();
     }
 
@@ -631,6 +645,7 @@ function AbrController() {
         setElementSize: setElementSize,
         setWindowResizeEventCalled: setWindowResizeEventCalled,
         initialize: initialize,
+        createAbrRulesCollection: createAbrRulesCollection,
         setConfig: setConfig,
         reset: reset
     };

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -35,16 +35,13 @@ import DroppedFramesRule from './DroppedFramesRule.js';
 import SwitchHistoryRule from './SwitchHistoryRule.js';
 import BolaRule from './BolaRule';
 import BolaAbandonRule from './BolaAbandonRule';
-import MediaPlayerModel from '../../models/MediaPlayerModel';
-import MetricsModel from '../../models/MetricsModel';
-import DashMetrics from '../../../dash/DashMetrics';
 import FactoryMaker from '../../../core/FactoryMaker';
 import SwitchRequest from '../SwitchRequest.js';
 
 const QUALITY_SWITCH_RULES = 'qualitySwitchRules';
 const ABANDON_FRAGMENT_RULES = 'abandonFragmentRules';
 
-function ABRRulesCollection() {
+function ABRRulesCollection(config) {
 
     let context = this.context;
 
@@ -52,13 +49,13 @@ function ABRRulesCollection() {
         qualitySwitchRules,
         abandonFragmentRules;
 
+    let metricsModel = config.metricsModel;
+    let dashMetrics = config.dashMetrics;
+    let mediaPlayerModel = config.mediaPlayerModel;
+
     function initialize() {
         qualitySwitchRules = [];
         abandonFragmentRules = [];
-
-        let metricsModel = MetricsModel(context).getInstance();
-        let dashMetrics = DashMetrics(context).getInstance();
-        let mediaPlayerModel = MediaPlayerModel(context).getInstance();
 
         if (mediaPlayerModel.getUseDefaultABRRules()) {
             if (mediaPlayerModel.getBufferOccupancyABREnabled()) {
@@ -104,7 +101,7 @@ function ABRRulesCollection() {
         });
     }
 
-    function getRules(type) {
+    function getRules (type) {
         switch (type) {
             case QUALITY_SWITCH_RULES:
                 return qualitySwitchRules;
@@ -184,21 +181,23 @@ function ABRRulesCollection() {
                 rules.forEach(rule => rule.reset && rule.reset());
             }
         });
+        qualitySwitchRules = [];
+        abandonFragmentRules = [];
     }
 
     instance = {
         initialize: initialize,
+        reset: reset,
         getRules: getRules,
         getMaxQuality: getMaxQuality,
-        shouldAbandonFragment: shouldAbandonFragment,
-        reset: reset
+        shouldAbandonFragment: shouldAbandonFragment
     };
 
     return instance;
 }
 
 ABRRulesCollection.__dashjs_factory_name = 'ABRRulesCollection';
-let factory = FactoryMaker.getSingletonFactory(ABRRulesCollection);
+let factory =  FactoryMaker.getClassFactory(ABRRulesCollection);
 factory.QUALITY_SWITCH_RULES = QUALITY_SWITCH_RULES;
 factory.ABANDON_FRAGMENT_RULES = ABANDON_FRAGMENT_RULES;
 FactoryMaker.updateSingletonFactory(ABRRulesCollection.__dashjs_factory_name, factory);

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -62,9 +62,11 @@ function ABRRulesCollection(config) {
                 qualitySwitchRules.push(
                     BolaRule(context).create({
                         metricsModel: metricsModel,
-                        dashMetrics: dashMetrics
+                        dashMetrics: dashMetrics,
+                        mediaPlayerModel: mediaPlayerModel
                     })
                 );
+
                 abandonFragmentRules.push(
                     BolaAbandonRule(context).create({
                         metricsModel: metricsModel,
@@ -75,16 +77,29 @@ function ABRRulesCollection(config) {
                 qualitySwitchRules.push(
                     ThroughputRule(context).create({
                         metricsModel: metricsModel,
-                        dashMetrics: dashMetrics
+                        dashMetrics: dashMetrics,
+                        mediaPlayerModel: mediaPlayerModel
                     })
                 );
+                qualitySwitchRules.push(
+                    InsufficientBufferRule(context).create({
+                        metricsModel: metricsModel
+                    })
+                );
+                qualitySwitchRules.push(
+                    SwitchHistoryRule(context).create()
+                );
+                qualitySwitchRules.push(
+                    DroppedFramesRule(context).create()
+                );
 
-                qualitySwitchRules.push(InsufficientBufferRule(context).create({
-                    metricsModel: metricsModel
-                }));
-                qualitySwitchRules.push(SwitchHistoryRule(context).create());
-                qualitySwitchRules.push(DroppedFramesRule(context).create());
-                abandonFragmentRules.push(AbandonRequestsRule(context).create());
+                abandonFragmentRules.push(
+                    AbandonRequestsRule(context).create({
+                        metricsModel: metricsModel,
+                        dashMetrics: dashMetrics,
+                        mediaPlayerModel: mediaPlayerModel
+                    })
+                );
             }
         }
 
@@ -101,7 +116,7 @@ function ABRRulesCollection(config) {
         });
     }
 
-    function getRules (type) {
+    function getRules(type) {
         switch (type) {
             case QUALITY_SWITCH_RULES:
                 return qualitySwitchRules;
@@ -197,7 +212,7 @@ function ABRRulesCollection(config) {
 }
 
 ABRRulesCollection.__dashjs_factory_name = 'ABRRulesCollection';
-let factory =  FactoryMaker.getClassFactory(ABRRulesCollection);
+let factory = FactoryMaker.getClassFactory(ABRRulesCollection);
 factory.QUALITY_SWITCH_RULES = QUALITY_SWITCH_RULES;
 factory.ABANDON_FRAGMENT_RULES = ABANDON_FRAGMENT_RULES;
 FactoryMaker.updateSingletonFactory(ABRRulesCollection.__dashjs_factory_name, factory);

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -29,13 +29,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import SwitchRequest from '../SwitchRequest';
-import MediaPlayerModel from '../../models/MediaPlayerModel';
-import DashMetrics from '../../../dash/DashMetrics';
-import MetricsModel from '../../models/MetricsModel';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 
-function AbandonRequestsRule() {
+function AbandonRequestsRule(config) {
 
     const ABANDON_MULTIPLIER = 1.8;
     const GRACE_TIME_THRESHOLD = 500;
@@ -44,20 +41,18 @@ function AbandonRequestsRule() {
     const context = this.context;
     const log = Debug(context).getInstance().log;
 
+    let mediaPlayerModel = config.mediaPlayerModel;
+    let dashMetrics = config.dashMetrics;
+    let metricsModel = config.metricsModel;
+
     let fragmentDict,
         abandonDict,
-        throughputArray,
-        mediaPlayerModel,
-        dashMetrics,
-        metricsModel;
+        throughputArray;
 
     function setup() {
         fragmentDict = {};
         abandonDict = {};
         throughputArray = [];
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
-        dashMetrics = DashMetrics(context).getInstance();
-        metricsModel = MetricsModel(context).getInstance();
     }
 
     function setFragmentRequestDict(type, id) {

--- a/src/streaming/rules/abr/BolaAbandonRule.js
+++ b/src/streaming/rules/abr/BolaAbandonRule.js
@@ -29,7 +29,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import SwitchRequest from '../SwitchRequest';
-import MediaPlayerModel from '../../models/MediaPlayerModel';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 import BolaRule from './BolaRule';
@@ -46,12 +45,10 @@ function BolaAbandonRule(config) {
     let metricsModel = config.metricsModel;
 
     let instance,
-        abandonDict,
-        mediaPlayerModel;
+        abandonDict;
 
     function setup() {
         abandonDict = {};
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
     }
 
     function rememberAbandon(mediaType, index, quality) {

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -33,7 +33,6 @@
 
 import SwitchRequest from '../SwitchRequest';
 import FactoryMaker from '../../../core/FactoryMaker';
-import MediaPlayerModel from '../../models/MediaPlayerModel';
 import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import DashAdapter from '../../../dash/DashAdapter';
 import EventBus from '../../../core/EventBus';
@@ -62,6 +61,7 @@ function BolaRule(config) {
     const log = Debug(context).getInstance().log;
     const dashMetrics = config.dashMetrics;
     const metricsModel = config.metricsModel;
+    const mediaPlayerModel = config.mediaPlayerModel;
     const eventBus = EventBus(context).getInstance();
 
     let instance,
@@ -69,7 +69,6 @@ function BolaRule(config) {
         lastFragmentLoadedDict,
         lastFragmentWasSwitchDict,
         eventMediaTypes,
-        mediaPlayerModel,
         adapter;
 
     function setup() {
@@ -77,7 +76,6 @@ function BolaRule(config) {
         lastFragmentLoadedDict = {};
         lastFragmentWasSwitchDict = {};
         eventMediaTypes = [];
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
         adapter = DashAdapter(context).getInstance();
         eventBus.on(Events.BUFFER_EMPTY, onBufferEmpty, instance);
         eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -30,7 +30,6 @@
  */
 import BufferController from '../../controllers/BufferController';
 import AbrController from '../../controllers/AbrController';
-import MediaPlayerModel from '../../models/MediaPlayerModel';
 import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
@@ -51,15 +50,14 @@ function ThroughputRule(config) {
     const log = Debug(context).getInstance().log;
     const dashMetrics = config.dashMetrics;
     const metricsModel = config.metricsModel;
+    const mediaPlayerModel = config.mediaPlayerModel;
 
     let throughputArray,
-        latencyArray,
-        mediaPlayerModel;
+        latencyArray;
 
     function setup() {
         throughputArray = [];
         latencyArray = [];
-        mediaPlayerModel = MediaPlayerModel(context).getInstance();
     }
 
     function storeLastRequestThroughputByType(type, throughput) {


### PR DESCRIPTION
Hi 

This PR proposes modifications about ABRRulesCollection creation :
- Now instanciated by AbrController (function createAbrRuleCollection), no more in mediaplayer (removes a link)
- Not a singleton anymore (used only in ABRController)
- metricsModel, dashMetrics, mediaPlayerModel are given in config at the creation 
- add a reset function called by ABRController::reset

Jérémie
