### PR TITLE
allow multiple moofs per segment

### DIFF
--- a/src/streaming/utils/IsoFile.js
+++ b/src/streaming/utils/IsoFile.js
@@ -35,18 +35,7 @@ import FactoryMaker from '../../core/FactoryMaker';
 function IsoFile() {
 
     let instance,
-        parsedIsoFile,
-        commonProps,
-        sidxProps,
-        sidxRefProps,
-        emsgProps,
-        mdhdProps,
-        mfhdProps,
-        subsProps,
-        tfhdProps,
-        tfdtProps,
-        trunProps,
-        trunSampleProps;
+        parsedIsoFile;
 
     /**
     * @param {string} type
@@ -109,133 +98,13 @@ function IsoFile() {
         return parsedIsoFile._cursor.offset;
     }
 
-    function setup() {
-        commonProps = {
-            offset: '_offset',
-            size: 'size',
-            type: 'type'
-        };
-
-        sidxProps = {
-            references: 'references',
-            timescale: 'timescale',
-            earliest_presentation_time: 'earliest_presentation_time',
-            first_offset: 'first_offset'
-        };
-
-        sidxRefProps = {
-            reference_type: 'reference_type',
-            referenced_size: 'referenced_size',
-            subsegment_duration: 'subsegment_duration'
-        };
-
-        emsgProps = {
-            id: 'id',
-            value: 'value',
-            timescale: 'timescale',
-            scheme_id_uri: 'scheme_id_uri',
-            presentation_time_delta: 'presentation_time_delta',
-            event_duration: 'event_duration',
-            message_data: 'message_data'
-        };
-
-        mdhdProps = {
-            timescale: 'timescale'
-        };
-
-        mfhdProps = {
-            sequence_number: 'sequence_number'
-        };
-
-        subsProps = {
-            entry_count: 'entry_count',
-            entries: 'entries'
-        };
-
-        tfhdProps = {
-            base_data_offset: 'base_data_offset',
-            sample_description_index: 'sample_description_index',
-            default_sample_duration: 'default_sample_duration',
-            default_sample_size: 'default_sample_size',
-            default_sample_flags: 'default_sample_flags',
-            flags: 'flags'
-        };
-
-        tfdtProps = {
-            version: 'version',
-            baseMediaDecodeTime: 'baseMediaDecodeTime',
-            flags: 'flags'
-        };
-
-        trunProps = {
-            sample_count: 'sample_count',
-            first_sample_flags: 'first_sample_flags',
-            data_offset: 'data_offset',
-            flags: 'flags',
-            samples: 'samples'
-        };
-
-        trunSampleProps = {
-            sample_size: 'sample_size',
-            sample_duration: 'sample_duration',
-            sample_composition_time_offset: 'sample_composition_time_offset'
-        };
-    }
-
-    function copyProps(from, to, props) {
-        for (var prop in props) {
-            to[prop] = from[props[prop]];
-        }
-    }
-
     function convertToDashIsoBox(boxData) {
         if (!boxData) return null;
 
-        var box = new IsoBox();
-        var i,
-            ln;
-
-        copyProps(boxData, box, commonProps);
+        var box = new IsoBox(boxData);
 
         if (boxData.hasOwnProperty('_incomplete')) {
             box.isComplete = !boxData._incomplete;
-        }
-
-        switch (box.type) {
-            case 'sidx':
-                copyProps(boxData, box, sidxProps);
-                if (box.references) {
-                    for (i = 0, ln = box.references.length; i < ln; i++) {
-                        copyProps(boxData.references[i], box.references[i], sidxRefProps);
-                    }
-                }
-                break;
-            case 'emsg':
-                copyProps(boxData, box, emsgProps);
-                break;
-            case 'mdhd':
-                copyProps(boxData, box, mdhdProps);
-                break;
-            case 'mfhd':
-                copyProps(boxData, box, mfhdProps);
-                break;
-            case 'subs':
-                copyProps(boxData, box, subsProps);
-                break;
-            case 'tfhd':
-                copyProps(boxData, box, tfhdProps);
-                break;
-            case 'tfdt':
-                copyProps(boxData, box, tfdtProps);
-                break;
-            case 'trun':
-                copyProps(boxData, box, trunProps);
-                if (box.samples) {
-                    for (i = 0, ln = box.samples.length; i < ln; i++) {
-                        copyProps(boxData.samples[i], box.samples[i], trunSampleProps);
-                    }
-                }
-                break;
         }
 
         return box;
@@ -248,8 +117,6 @@ function IsoFile() {
         getLastBox: getLastBox,
         getOffset: getOffset
     };
-
-    setup();
 
     return instance;
 }

--- a/src/streaming/vo/IsoBox.js
+++ b/src/streaming/vo/IsoBox.js
@@ -33,12 +33,108 @@
  * @ignore
  */
 class IsoBox {
-    constructor() {
-        this.offset = NaN;
-        this.type = null;
-        this.size = NaN;
+    constructor(boxData) {
+        this.offset = boxData._offset;
+        this.type = boxData.type;
+        this.size = boxData.size;
+        this.boxes = [];
+        if (boxData.boxes) {
+            for (let i = 0; i < boxData.boxes.length; i++) {
+                this.boxes.push(new IsoBox(boxData.boxes[i]));
+            }
+        }
         this.isComplete = true;
+
+        switch (boxData.type) {
+            case 'sidx':
+                this.timescale = boxData.timescale;
+                this.earliest_presentation_time = boxData.earliest_presentation_time;
+                this.first_offset = boxData.first_offset;
+                this.references = boxData.references;
+                if (boxData.references) {
+                    this.references = [];
+                    for (let i = 0; i < boxData.references.length; i++) {
+                        let reference = {
+                            reference_type: boxData.references[i].reference_type,
+                            referenced_size: boxData.references[i].referenced_size,
+                            subsegment_duration: boxData.references[i].subsegment_duration
+                        };
+                        this.references.push(reference);
+                    }
+                }
+                break;
+            case 'emsg':
+                this.id = boxData.id;
+                this.value = boxData.value;
+                this.timescale = boxData.timescale;
+                this.scheme_id_uri = boxData.scheme_id_uri;
+                this.presentation_time_delta = boxData.presentation_time_delta;
+                this.event_duration = boxData.event_duration;
+                this.message_data = boxData.message_data;
+                break;
+            case 'mdhd':
+                this.timescale = boxData.timescale;
+                break;
+            case 'mfhd':
+                this.sequence_number = boxData.sequence_number;
+                break;
+            case 'subs':
+                this.entry_count = boxData.entry_count;
+                this.entries = boxData.entries;
+                break;
+            case 'tfhd':
+                this.base_data_offset = boxData.base_data_offset;
+                this.sample_description_index = boxData.sample_description_index;
+                this.default_sample_duration = boxData.default_sample_duration;
+                this.default_sample_size = boxData.default_sample_size;
+                this.default_sample_flags = boxData.default_sample_flags;
+                this.flags = boxData.flags;
+                break;
+            case 'tfdt':
+                this.version = boxData.version;
+                this.baseMediaDecodeTime = boxData.baseMediaDecodeTime;
+                this.flags = boxData.flags;
+                break;
+            case 'trun':
+                this.sample_count = boxData.sample_count;
+                this.first_sample_flags = boxData.first_sample_flags;
+                this.data_offset = boxData.data_offset;
+                this.flags = boxData.flags;
+                this.samples = boxData.samples;
+                if (boxData.samples) {
+                    this.samples = [];
+                    for (let i = 0, ln = boxData.samples.length; i < ln; i++) {
+                        let sample = {
+                            sample_size: boxData.samples[i].sample_size,
+                            sample_duration: boxData.samples[i].sample_duration,
+                            sample_composition_time_offset: boxData.samples[i].sample_composition_time_offset
+                        };
+                        this.samples.push(sample);
+                    }
+                }
+                break;
+        }
+
     }
+
+    getChildBox(type) {
+        for (let i = 0; i < this.boxes.length; i++) {
+            if (this.boxes[i].type === type) {
+                return this.boxes[i];
+            }
+        }
+    }
+
+    getChildBoxes(type) {
+        let boxes = [];
+        for (let i = 0; i < this.boxes.length; i++) {
+            if (this.boxes[i].type === type) {
+                boxes.push(this.boxes[i]);
+            }
+        }
+        return boxes;
+    }
+
 }
 
 export default IsoBox;


### PR DESCRIPTION
I don't expect this PR as it currently is to get accepted, but it's a good place to discuss.

Right now, dash.js only parses out the text information from the first `moof` in a segment. It would be nice if the text data could be pulled out of _all_ the `moof`s in a segment.

This PR patches in support for multiple `moof`s per segment for CEA608 captions.

Is there anywhere else in the code where multiple `moof`s per segment are rejected, or is it only the text stuff?