### PR TITLE
Do not add SwitchRequests with NO_CHANGE to SwitchRequestHistory

### DIFF
--- a/src/streaming/rules/SwitchRequestHistory.js
+++ b/src/streaming/rules/SwitchRequestHistory.js
@@ -1,5 +1,6 @@
 
 import FactoryMaker from '../../core/FactoryMaker.js';
+import SwitchRequest from './SwitchRequest.js';
 
 const SWITCH_REQUEST_HISTORY_DEPTH = 8; // must be > SwitchHistoryRule SAMPLE_SIZE to enable rule
 
@@ -8,6 +9,9 @@ function SwitchRequestHistory() {
     let srHistory = []; // history of each switch
 
     function push(switchRequest) {
+        if (switchRequest.newValue === SwitchRequest.NO_CHANGE) {
+              switchRequest.newValue = switchRequest.oldValue;
+        }
         if (!switchRequests[switchRequest.oldValue]) {
             switchRequests[switchRequest.oldValue] = {noDrops: 0, drops: 0, dropSize: 0};
         }

--- a/src/streaming/rules/SwitchRequestHistory.js
+++ b/src/streaming/rules/SwitchRequestHistory.js
@@ -10,7 +10,7 @@ function SwitchRequestHistory() {
 
     function push(switchRequest) {
         if (switchRequest.newValue === SwitchRequest.NO_CHANGE) {
-              switchRequest.newValue = switchRequest.oldValue;
+            switchRequest.newValue = switchRequest.oldValue;
         }
         if (!switchRequests[switchRequest.oldValue]) {
             switchRequests[switchRequest.oldValue] = {noDrops: 0, drops: 0, dropSize: 0};


### PR DESCRIPTION
Adding those requests breaks the SwitchHistoryRule
Fix  #1892


(New PR due to some merge issues)