### PR TITLE
update the use of streamProcessorDict in AbrController

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -290,6 +290,7 @@ function AbrController() {
             const streamId = streamInfo ? streamInfo.id : null;
             const oldQuality = getQualityFor(type);
             const rulesContext = RulesContext(context).create({
+                abrController: instance,
                 streamProcessor: streamProcessorDict[type],
                 currentValue: oldQuality,
                 playbackIndex: playbackIndex,
@@ -306,7 +307,7 @@ function AbrController() {
             if (getAutoSwitchBitrateFor(type)) {
                 const topQualityIdx = getTopQualityIndexFor(type, streamId);
                 const switchRequest = abrRulesCollection.getMaxQuality(rulesContext);
-                let newQuality = switchRequest.value;
+                let newQuality = switchRequest.quality;
                 if (newQuality > topQualityIdx) {
                     newQuality = topQualityIdx;
                 }

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -332,17 +332,21 @@ function AbrController() {
 
         const topQualityIdx = getTopQualityIndexFor(type, id);
         if (newQuality !== oldQuality && newQuality >= 0 && newQuality <= topQualityIdx) {
-            changeQuality(type, streamInfo, oldQuality, newQuality, topQualityIdx, reason);
+            changeQuality(type, oldQuality, newQuality, topQualityIdx, reason);
         }
     }
 
-    function changeQuality(type, streamInfo, oldQuality, newQuality, topQualityIdx, reason) {
-        if (debug.getLogToBrowserConsole()) {
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
-            log('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')\n' + JSON.stringify(reason));
+    function changeQuality(type, oldQuality, newQuality, topQualityIdx, reason) {
+        if (type  && streamProcessorDict[type]) {
+            var id = streamProcessorDict[type].id;
+            var streamInfo = streamProcessorDict[type].getStreamInfo();
+            if (debug.getLogToBrowserConsole()) {
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
+                log('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')\n' + JSON.stringify(reason));
+            }
+            setQualityFor(type, id, newQuality);
+            eventBus.trigger(Events.QUALITY_CHANGE_REQUESTED, {mediaType: type, streamInfo: streamInfo, oldQuality: oldQuality, newQuality: newQuality, reason: reason});
         }
-        setQualityFor(type, streamInfo.id, newQuality);
-        eventBus.trigger(Events.QUALITY_CHANGE_REQUESTED, {mediaType: type, streamInfo: streamInfo, oldQuality: oldQuality, newQuality: newQuality, reason: reason});
     }
 
     function setAbandonmentStateFor(type, state) {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -325,7 +325,7 @@ function AbrController() {
 
     function setPlaybackQuality(type, streamInfo, newQuality, reason) {
         const id = streamInfo.id;
-        const oldQuality = getQualityFor(type, streamInfo);
+        const oldQuality = getQualityFor(type);
         const isInt = newQuality !== null && !isNaN(newQuality) && (newQuality % 1 === 0);
 
         if (!isInt) throw new Error('argument is not an integer');
@@ -451,8 +451,8 @@ function AbrController() {
     function isPlayingAtTopQuality(streamInfo) {
         var isAtTop;
         var streamId = streamInfo.id;
-        var audioQuality = getQualityFor('audio', streamInfo);
-        var videoQuality = getQualityFor('video', streamInfo);
+        var audioQuality = getQualityFor('audio');
+        var videoQuality = getQualityFor('video');
 
         isAtTop = (audioQuality === getTopQualityIndexFor('audio', streamId)) &&
             (videoQuality === getTopQualityIndexFor('video', streamId));
@@ -460,8 +460,13 @@ function AbrController() {
         return isAtTop;
     }
 
-    function getQualityFor(type, streamInfo) {
-        var id = streamInfo.id;
+    function getQualityFor(type) {
+
+        if (!type || !streamProcessorDict[type]) {
+            return QUALITY_DEFAULT;
+        }
+
+        var id = streamProcessorDict[type].id;
         var quality;
 
         qualityDict[id] = qualityDict[id] || {};

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -227,7 +227,7 @@ function ScheduleController(config) {
             if (isReplacement) {
                 getNextFragment();
             } else {
-                abrController.checkPlaybackQuality(streamProcessor);
+                abrController.checkPlaybackQuality(type);
                 getNextFragment();
             }
 

--- a/test/unit/streaming.AbrControllerSpec.js
+++ b/test/unit/streaming.AbrControllerSpec.js
@@ -1,6 +1,7 @@
 import SpecHelper from './helpers/SpecHelper';
 import VoHelper from './helpers/VOHelper';
-import AbrController from '../../src/streaming/controllers/AbrController';
+import ObjectsHelper from './helpers/ObjectsHelper';
+import AbrController from '../src/streaming/controllers/AbrController';
 
 const expect = require('chai').expect;
 
@@ -8,10 +9,14 @@ describe("AbrController", function () {
     const context = {};
     const testType = 'video';
     const voHelper = new VoHelper();
+    const objectsHelper = new ObjectsHelper();
     const defaultQuality = AbrController.QUALITY_DEFAULT;
     const abrCtrl = AbrController(context).getInstance();
-    const dummyMediaInfo = voHelper.getDummyMediaInfo('video');
+    const dummyMediaInfo = voHelper.getDummyMediaInfo(testType);
     const representationCount = dummyMediaInfo.representationCount;
+    const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);
+
+    abrCtrl.initialize('video', streamProcessor);
 
     it("should update top quality index", function () {
         const expectedTopQuality = representationCount - 1;
@@ -27,7 +32,7 @@ describe("AbrController", function () {
         let newQuality;
 
         abrCtrl.setPlaybackQuality(testType, dummyMediaInfo.streamInfo, testQuality);
-        newQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        newQuality = abrCtrl.getQualityFor(testType);
         expect(newQuality).to.be.equal(testQuality);
     });
 
@@ -47,21 +52,21 @@ describe("AbrController", function () {
 
     it("should ignore an attempt to set a negative quality value", function () {
         const negativeQuality = -1;
-        const oldQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        const oldQuality = abrCtrl.getQualityFor(testType);
         let newQuality;
 
         abrCtrl.setPlaybackQuality(testType, dummyMediaInfo.streamInfo, negativeQuality);
-        newQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        newQuality = abrCtrl.getQualityFor(testType);
         expect(newQuality).to.be.equal(oldQuality);
     });
 
     it("should ignore an attempt to set a quality greater than top quality index", function () {
         const greaterThanTopQualityValue = representationCount;
-        const oldQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        const oldQuality = abrCtrl.getQualityFor(testType);
         let newQuality;
 
         abrCtrl.setPlaybackQuality(testType, dummyMediaInfo.streamInfo, greaterThanTopQualityValue);
-        newQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        newQuality = abrCtrl.getQualityFor(testType);
 
         expect(newQuality).to.be.equal(oldQuality);
     });
@@ -72,7 +77,7 @@ describe("AbrController", function () {
 
         abrCtrl.setPlaybackQuality(testType, dummyMediaInfo.streamInfo, testQuality);
         abrCtrl.reset();
-        newQuality = abrCtrl.getQualityFor(testType, dummyMediaInfo.streamInfo);
+        newQuality = abrCtrl.getQualityFor(testType);
         expect(newQuality).to.be.equal(defaultQuality);
     });
 

--- a/test/unit/streaming.AbrControllerSpec.js
+++ b/test/unit/streaming.AbrControllerSpec.js
@@ -1,7 +1,7 @@
 import SpecHelper from './helpers/SpecHelper';
 import VoHelper from './helpers/VOHelper';
 import ObjectsHelper from './helpers/ObjectsHelper';
-import AbrController from '../src/streaming/controllers/AbrController';
+import AbrController from '../../src/streaming/controllers/AbrController';
 
 const expect = require('chai').expect;
 


### PR DESCRIPTION
Hi,

this PR has to use,  actually, streamProcessorDict attribute. Each time a streamProcessor is created,it is stored in  streamProcessorDict array. So, the consequence is that the functions of AbrController just need type as parameter, not the streamProcessor reference.

Nicolas
