### PR TITLE
expose manifest retry function

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1639,6 +1639,30 @@ function MediaPlayer() {
     }
 
     /**
+     * Total number of retry attempts that will occur on a manifest load before it fails.
+     *
+     * @default 4
+     * @param {int} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setManifestLoaderRetryAttempts(value) {
+        mediaPlayerModel.setManifestRetryAttempts(value);
+    }
+
+    /**
+     * Time in milliseconds of which to reload a failed manifest load attempt.
+     *
+     * @default 1000 milliseconds
+     * @param {int} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setManifestLoaderRetryInterval(value) {
+        mediaPlayerModel.setManifestRetryInterval(value);
+    }
+
+    /**
      * Sets whether withCredentials on all XHR requests is true or false
      *
      * @default false
@@ -2157,6 +2181,8 @@ function MediaPlayer() {
         setBufferTimeAtTopQuality: setBufferTimeAtTopQuality,
         setFragmentLoaderRetryAttempts: setFragmentLoaderRetryAttempts,
         setFragmentLoaderRetryInterval: setFragmentLoaderRetryInterval,
+        setManifestLoaderRetryAttempts: setManifestLoaderRetryAttempts,
+        setManifestLoaderRetryInterval: setManifestLoaderRetryInterval,
         setXHRWithCredentials: setXHRWithCredentials,
         setXHRWithCredentialsForType: setXHRWithCredentialsForType,
         getXHRWithCredentialsForType: getXHRWithCredentialsForType,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -243,12 +243,20 @@ function MediaPlayerModel() {
         retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE] = value;
     }
 
+    function setManifestRetryAttempts(value) {
+        retryAttempts[HTTPRequest.MPD_TYPE] = value;
+    }
+
     function setRetryAttemptsForType(type, value) {
         retryAttempts[type] = value;
     }
 
     function getFragmentRetryAttempts() {
         return retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE];
+    }
+
+    function getManifestRetryAttempts() {
+        return retryAttempts[HTTPRequest.MPD_TYPE];
     }
 
     function getRetryAttemptsForType(type) {
@@ -259,12 +267,20 @@ function MediaPlayerModel() {
         retryIntervals[HTTPRequest.MEDIA_SEGMENT_TYPE] = value;
     }
 
+    function setManifestRetryInterval(value) {
+        retryIntervals[HTTPRequest.MPD_TYPE] = value;
+    }
+
     function setRetryIntervalForType(type, value) {
         retryIntervals[type] = value;
     }
 
     function getFragmentRetryInterval() {
         return retryIntervals[HTTPRequest.MEDIA_SEGMENT_TYPE];
+    }
+
+    function getManifestRetryInterval() {
+        return retryIntervals[HTTPRequest.MPD_TYPE];
     }
 
     function getRetryIntervalForType(type) {
@@ -388,10 +404,14 @@ function MediaPlayerModel() {
         getBufferPruningInterval: getBufferPruningInterval,
         setFragmentRetryAttempts: setFragmentRetryAttempts,
         getFragmentRetryAttempts: getFragmentRetryAttempts,
+        setManifestRetryAttempts: setManifestRetryAttempts,
+        getManifestRetryAttempts: getManifestRetryAttempts,
         setRetryAttemptsForType: setRetryAttemptsForType,
         getRetryAttemptsForType: getRetryAttemptsForType,
         setFragmentRetryInterval: setFragmentRetryInterval,
         getFragmentRetryInterval: getFragmentRetryInterval,
+        setManifestRetryInterval: setManifestRetryInterval,
+        getManifestRetryInterval: getManifestRetryInterval,
         setRetryIntervalForType: setRetryIntervalForType,
         getRetryIntervalForType: getRetryIntervalForType,
         setWallclockTimeUpdateInterval: setWallclockTimeUpdateInterval,


### PR DESCRIPTION
Exposed manifest loader retry attempts function and retry interval functions as was listed in the the following issue - https://github.com/Dash-Industry-Forum/dash.js/issues/1939
