### PR TITLE
Fix a bug in ObjectUtils::areSimpleEquivalent method

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "codem-isoboxer": "^0.3.3",
     "imsc": "^1.0.0-beta.3",
-    "round10": "^1.0.3"
+    "round10": "^1.0.3",
+    "deep-equal": "^1.0.1"
   },
   "repository": {
     "type": "git",

--- a/src/streaming/models/BaseURLTreeModel.js
+++ b/src/streaming/models/BaseURLTreeModel.js
@@ -64,7 +64,7 @@ function BaseURLTreeModel() {
         if (!node[index]) {
             node[index] = new Node(baseUrls);
         } else {
-            if (!objectUtils.areSimpleEquivalent(baseUrls, node[index].data.baseUrls)) {
+            if (!objectUtils.areEqual(baseUrls, node[index].data.baseUrls)) {
                 node[index].data.baseUrls = baseUrls;
                 node[index].data.selectedIdx = DEFAULT_INDEX;
             }
@@ -74,7 +74,7 @@ function BaseURLTreeModel() {
     function getBaseURLCollectionsFromManifest(manifest) {
         let baseUrls = dashManifestModel.getBaseURLsFromElement(manifest);
 
-        if (!objectUtils.areSimpleEquivalent(baseUrls, root.data.baseUrls)) {
+        if (!objectUtils.areEqual(baseUrls, root.data.baseUrls)) {
             root.data.baseUrls = baseUrls;
             root.data.selectedIdx = DEFAULT_INDEX;
         }

--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -30,7 +30,7 @@
  */
 
 import FactoryMaker from '../../core/FactoryMaker';
-import equal from 'deep-equal';
+import deepEqual from 'deep-equal';
 
 /**
  * @module ObjectUtils
@@ -41,20 +41,19 @@ function ObjectUtils() {
     let instance;
 
     /**
-     * Returns true if objects resolve to the same string. Only really useful
-     * when the user controls the object generation
+     * Returns true if objects are equal
      * @return {boolean}
      * @param {object} obj1
      * @param {object} obj2
      * @memberof module:ObjectUtils
      * @instance
      */
-    function areSimpleEquivalent(obj1, obj2) {
-        return equal(obj1, obj2);
+    function areEqual(obj1, obj2) {
+        return deepEqual(obj1, obj2);
     }
 
     instance = {
-        areSimpleEquivalent: areSimpleEquivalent
+        areEqual: areEqual
     };
 
     return instance;

--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -30,6 +30,7 @@
  */
 
 import FactoryMaker from '../../core/FactoryMaker';
+import equal from 'deep-equal';
 
 /**
  * @module ObjectUtils
@@ -49,7 +50,7 @@ function ObjectUtils() {
      * @instance
      */
     function areSimpleEquivalent(obj1, obj2) {
-        return JSON.stringify(obj1) === JSON.stringify(obj2);
+        return equal(obj1, obj2);
     }
 
     instance = {

--- a/test/streaming.utils.ObjectUtils.js
+++ b/test/streaming.utils.ObjectUtils.js
@@ -7,7 +7,7 @@ const objectUtils = ObjectUtils(context).getInstance();
 
 describe('ObjectUtils', function () {
 
-    describe('areSimpleEquivalent', () => {
+    describe('equal', () => {
         it('should return true if object are equals - declared parameters in same order', () => {
             const obj1 = {
                 param1: 'param1',
@@ -19,7 +19,7 @@ describe('ObjectUtils', function () {
                 param2: 'param2'
             };
 
-            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+            const result = objectUtils.areEqual(obj1,obj2);
 
             expect(result).to.be.true; // jshint ignore:line
         });
@@ -35,7 +35,7 @@ describe('ObjectUtils', function () {
                 param1: 'param1'
             };
 
-            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+            const result = objectUtils.areEqual(obj1,obj2);
 
             expect(result).to.be.true; // jshint ignore:line
         });
@@ -51,7 +51,7 @@ describe('ObjectUtils', function () {
                 param2: 'param1'
             };
 
-            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+            const result = objectUtils.areEqual(obj1,obj2);
 
             expect(result).to.be.false; // jshint ignore:line
         });

--- a/test/streaming.utils.ObjectUtils.js
+++ b/test/streaming.utils.ObjectUtils.js
@@ -1,0 +1,59 @@
+import ObjectUtils from '../src/streaming/utils/ObjectUtils';
+
+const expect = require('chai').expect;
+
+const context = {};
+const objectUtils = ObjectUtils(context).getInstance();
+
+describe('ObjectUtils', function () {
+
+    describe('areSimpleEquivalent', () => {
+        it('should return true if object are equals - declared parameters in same order', () => {
+            const obj1 = {
+                param1: 'param1',
+                param2: 'param2'
+            };
+
+            const obj2 = {
+                param1: 'param1',
+                param2: 'param2'
+            };
+
+            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return true if object are equals - declared parameters in different order', () => {
+            const obj1 = {
+                param1: 'param1',
+                param2: 'param2'
+            };
+
+            const obj2 = {
+                param2: 'param2',
+                param1: 'param1'
+            };
+
+            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return false if object are different', () => {
+            const obj1 = {
+                param1: 'param1',
+                param2: 'param2'
+            };
+
+            const obj2 = {
+                param1: 'param2',
+                param2: 'param1'
+            };
+
+            const result = objectUtils.areSimpleEquivalent(obj1,obj2);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+    });
+});


### PR DESCRIPTION
If objects have same parameters but declared in a different order, string obtained using JSON.stringify() will be different and the method will return false, whereas it should return true.

The fix uses deep-equal module to avoid this bug.

I have although added a unit test to test the solution (in streaming.utils.ObjectUtils.js file) : using JSON.stringify(), the unit test fails, using deep-equal module, the test is in success