### PR TITLE
Make quota_exceed reset isFragmentProcessingInProgress

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -205,7 +205,7 @@ function BufferController(config) {
 
     function onAppended(e) {
         if (buffer === e.buffer) {
-            if (e.error || !hasEnoughSpaceToAppend()) {
+            if (e.error) {
                 if (e.error.code === SourceBufferController.QUOTA_EXCEEDED_ERROR_CODE) {
                     criticalBufferLevel = sourceBufferController.getTotalBufferedTime(buffer) * 0.8;
                 }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -414,6 +414,7 @@ function ScheduleController(config) {
     function onQuotaExceeded(e) {
         if (e.sender.getStreamProcessor() !== streamProcessor) return;
         stop();
+        isFragmentProcessingInProgress = false;
     }
 
     function onURLResolutionFailed() {


### PR DESCRIPTION
When QUOTA_EXCEED is thrown when appending to the source buffer, the isFragmentProcessingInProgress flag isn't cleared, so no more scheduling occurs after this happens.