### PR TITLE
Server certificate

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -34,6 +34,7 @@ import MediaCapability from '../vo/MediaCapability';
 import KeySystemConfiguration from '../vo/KeySystemConfiguration';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Protection from '../Protection';
+import BASE64 from '../../../../externals/base64';
 
 /**
  * @module ProtectionController
@@ -391,6 +392,11 @@ function ProtectionController(config) {
                 if (!event.error) {
                     keySystem = protectionModel.getKeySystem();
                     eventBus.trigger(Events.KEY_SYSTEM_SELECTED, {data: keySystemAccess});
+                    // Set server certificate from protData
+                    var protData = getProtData(keySystem);
+                    if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
+                        protectionModel.setServerCertificate(BASE64.decodeArray(protData.serverCertificate).buffer);
+                    }
                     for (var i = 0; i < pendingNeedKeyData.length; i++) {
                         for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
                             if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -128,9 +128,10 @@ function ProtectionModel_21Jan2015(config) {
             keySystem = keySystemAccess.keySystem;
             mediaKeys = mkeys;
             if (videoElement) {
-                videoElement.setMediaKeys(mediaKeys);
+                videoElement.setMediaKeys(mediaKeys).then(function () {
+                    eventBus.trigger(Events.INTERNAL_KEY_SYSTEM_SELECTED);
+                });
             }
-            eventBus.trigger(Events.INTERNAL_KEY_SYSTEM_SELECTED);
 
         }).catch(function () {
             eventBus.trigger(Events.INTERNAL_KEY_SYSTEM_SELECTED, {error: 'Error selecting keys system (' + keySystemAccess.keySystem.systemString + ')! Could not create MediaKeys -- TODO'});


### PR DESCRIPTION
This PR enables setting the server certificate which will be required from chrome 59, in order to avoid the server certificate request before each license request.

The server certificate has to be provided in base64 format in protectionData:

```
player.setProtectionData({
    "com.widevine.alpha": {
        "serverURL": "<licenser_url>",
        "serverCertificate": "<server_certificate_in_base64>",
        ...
});
```

Since the server certificate is specific to every license server, I am not able to provide any certificate for the test streams of sample webapp.
