### PR TITLE
old quality should be reported to droppedFrameHistory onQualityChangeRendered

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -152,7 +152,7 @@ function AbrController() {
 
     function onQualityChangeRendered(e) {
         if (e.mediaType === 'video') {
-            playbackIndex = e.newQuality;
+            playbackIndex = e.oldQuality;
             droppedFramesHistory.push(playbackIndex, videoModel.getPlaybackQuality());
         }
     }

--- a/src/streaming/rules/DroppedFramesHistory.js
+++ b/src/streaming/rules/DroppedFramesHistory.js
@@ -15,11 +15,13 @@ function DroppedFramesHistory() {
         let intervalTotalFrames = playbackQuality.totalVideoFrames - lastTotalFrames;
         lastTotalFrames = playbackQuality.totalVideoFrames;
 
-        if (!values[index]) {
-            values[index] = {droppedVideoFrames: intervalDroppedFrames, totalVideoFrames: intervalTotalFrames};
-        } else {
-            values[index].droppedVideoFrames += intervalDroppedFrames;
-            values[index].totalVideoFrames += intervalTotalFrames;
+        if (!isNaN(index)) {
+            if (!values[index]) {
+                values[index] = {droppedVideoFrames: intervalDroppedFrames, totalVideoFrames: intervalTotalFrames};
+            } else {
+                values[index].droppedVideoFrames += intervalDroppedFrames;
+                values[index].totalVideoFrames += intervalTotalFrames;
+            }
         }
     }
 


### PR DESCRIPTION
The outstanding dropped frames statistics in the VideoModel correspond to the old quality.