### PR TITLE
bug fix on images CMAF subtitles

### DIFF
--- a/src/dash/utils/FragmentedTextBoxParser.js
+++ b/src/dash/utils/FragmentedTextBoxParser.js
@@ -115,7 +115,7 @@ function FragmentedTextBoxParser() {
                                     sampleData.subSizes = [];
                                     let entry = subsBox.entries[subsIndex];
                                     for (n = 0; n < entry.subsample_count; n++) {
-                                        sampleData.subSizes.push(entry.subsamples[j].subsample_size);
+                                        sampleData.subSizes.push(entry.subsamples[n].subsample_size);
                                     }
                                 }
                             }


### PR DESCRIPTION
Hi,

this PR has to fix a bug on  images CMAF subtitles. Images subtitles  were cut for this
[stream](http://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img.mpd).

it's a regression after PR 1954

Nicolas