### PR TITLE
Removing hard-coded protocol on github buttons 

### DIFF
--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -70,11 +70,11 @@
             <!-- Using iframe to solve pre-flight request issue from GIT-->
             <div class="top-buttons">
                 <iframe id="star-button"
-                        src="http://ghbtns.com/github-btn.html?user=Dash-Industry-Forum&repo=dash.js&type=watch&count=true&size=large"
+                        src="//ghbtns.com/github-btn.html?user=Dash-Industry-Forum&repo=dash.js&type=watch&count=true&size=large"
                         height="30" width="150">
                 </iframe>
                 <iframe id="fork-button"
-                        src="http://ghbtns.com/github-btn.html?user=Dash-Industry-Forum&repo=dash.js&type=fork&count=true&size=large"
+                        src="//ghbtns.com/github-btn.html?user=Dash-Industry-Forum&repo=dash.js&type=fork&count=true&size=large"
                         height="30" width="150" >
                 </iframe>
             </div>


### PR DESCRIPTION
to suppress mixed content warnings when player is loaded under https