### PR TITLE
Fix bad merge when PR #1979 and PR #1956 have been merged in development

### DIFF
--- a/test/unit/streaming.utils.ObjectUtils.js
+++ b/test/unit/streaming.utils.ObjectUtils.js
@@ -1,4 +1,4 @@
-import ObjectUtils from '../src/streaming/utils/ObjectUtils';
+import ObjectUtils from '../../src/streaming/utils/ObjectUtils';
 
 const expect = require('chai').expect;
 


### PR DESCRIPTION
In PR #1956 unit tests have been moved to test/unit folder.
PR #1979 adds a new unit test. When merging in development version, the new unit test have not been moved to test/unit.

This PR merge the pb. 

Jérémie