### PR TITLE
split ThroughputHistory out of ThroughputRule, update InsufficientBufferRule

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -156,7 +156,7 @@ function RepresentationController() {
         availableRepresentations = updateRepresentations(adaptation);
 
         if (data === null && type !== 'fragmentedText') {
-            averageThroughput = abrController.getAverageThroughput(type);
+            averageThroughput = abrController.getThroughputHistory().getAverageThroughput(type);
             bitrate = averageThroughput || abrController.getInitialBitrateFor(type, streamInfo);
             quality = abrController.getQualityForBitrate(streamProcessor.getMediaInfo(), bitrate);
         } else {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -467,8 +467,7 @@ function AbrController() {
                 isDynamic = streamProcessorDict[mediaType].isDynamic();
             }
         }
-        let sampleSize = throughputHistory.getSampleSize(mediaType, isDynamic);
-        return throughputHistory.getAverageThroughput(mediaType, sampleSize);
+        return throughputHistory.getAverageThroughput(mediaType, isDynamic);
     }
 
     function getAverageLatency(mediaType) {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -130,7 +130,9 @@ function AbrController() {
             setElementSize();
         }
         eventBus.on(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
-        throughputHistory = ThroughputHistory().create();
+        throughputHistory = ThroughputHistory().create({
+            mediaPlayerModel: mediaPlayerModel
+        });
     }
 
     function createAbrRulesCollection() {
@@ -461,17 +463,8 @@ function AbrController() {
         return isBufferRich;
     }
 
-    function getAverageThroughput(mediaType, isDynamic) {
-        if (isDynamic === undefined) {
-            if (streamProcessorDict[mediaType]) {
-                isDynamic = streamProcessorDict[mediaType].isDynamic();
-            }
-        }
-        return throughputHistory.getAverageThroughput(mediaType, isDynamic);
-    }
-
-    function getAverageLatency(mediaType) {
-        return throughputHistory.getAverageLatency(mediaType);
+    function getThroughputHistory() {
+        return throughputHistory;
     }
 
     function updateTopQualityIndex(mediaInfo) {
@@ -642,8 +635,7 @@ function AbrController() {
     instance = {
         isPlayingAtTopQuality: isPlayingAtTopQuality,
         updateTopQualityIndex: updateTopQualityIndex,
-        getAverageThroughput: getAverageThroughput,
-        getAverageLatency: getAverageLatency,
+        getThroughputHistory: getThroughputHistory,
         getBitrateList: getBitrateList,
         getQualityForBitrate: getQualityForBitrate,
         getMaxAllowedBitrateFor: getMaxAllowedBitrateFor,

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -125,8 +125,8 @@ function ThroughputHistory(config) {
                 let ratio = arr[-i] / arr[-i - 1];
                 if (ratio >= THROUGHPUT_INCREASE_SCALE || ratio <= 1 / THROUGHPUT_DECREASE_SCALE) {
                     sampleSize += 1;
-                    if (sampleSize >= arr.length) {
-                        return arr.length;
+                    if (sampleSize === arr.length) { // cannot increase sampleSize beyond arr.length
+                        break;
                     }
                 }
             }
@@ -146,7 +146,7 @@ function ThroughputHistory(config) {
 
         arr = arr.slice(-sampleSize); // still works if sampleSize too large
         // arr.length >= 1
-        return arr.reduce((av, elem, i) => av + (elem - av) / (i + 1));
+        return arr.reduce((total, elem) => total + elem) / arr.length;
     }
 
     function getAverageThroughput(mediaType, isDynamic) {

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -1,0 +1,181 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2017, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import FactoryMaker from '../../core/FactoryMaker.js';
+
+function ThroughputHistory() {
+
+    const MAX_MEASUREMENTS_TO_KEEP = 20;
+    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE = 3;
+    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD = 4;
+    const AVERAGE_LATENCY_SAMPLE_AMOUNT = 4;
+    const CACHE_LOAD_THRESHOLD_VIDEO = 50;
+    const CACHE_LOAD_THRESHOLD_AUDIO = 5;
+    const THROUGHPUT_DECREASE_SCALE = 1.3;
+    const THROUGHPUT_INCREASE_SCALE = 1.3;
+
+    let throughputDict,
+        latencyDict;
+
+    function setup() {
+        throughputDict = {};
+        latencyDict = {};
+    }
+
+    function isCachedResponse(mediaType, latencyMs, downloadTimeMs) {
+        if (mediaType === 'video') {
+            return downloadTimeMs < CACHE_LOAD_THRESHOLD_VIDEO;
+        } else if (mediaType === 'audio') {
+            return downloadTimeMs < CACHE_LOAD_THRESHOLD_AUDIO;
+        }
+        // else return undefined;
+    }
+
+    function push(mediaType, lastHttpRequest) {
+        if (!lastHttpRequest.trace || !lastHttpRequest.trace.length) {
+            return;
+        }
+
+        const latencyTimeInMilliseconds = (lastHttpRequest.tresponse.getTime() - lastHttpRequest.trequest.getTime()) || 1;
+        const downloadTimeInMilliseconds = (lastHttpRequest._tfinish.getTime() - lastHttpRequest.tresponse.getTime()) || 1; //Make sure never 0 we divide by this value. Avoid infinity!
+        const downloadBytes = lastHttpRequest.trace.reduce((a, b) => a + b.b[0], 0);
+        const lastRequestThroughput = Math.round((downloadBytes * 8) / (downloadTimeInMilliseconds / 1000)); // bits per second
+        let throughput = lastRequestThroughput;
+
+        if (isCachedResponse(mediaType, latencyTimeInMilliseconds, downloadTimeInMilliseconds)) {
+            if (!(throughputDict[mediaType] && latencyDict[mediaType])) {
+                // prevent cached fragment loads from skewing the average values
+                return;
+            } else {
+                // allow first even if cached to set allowance for ABR rules
+                throughput /= 1000;
+            }
+        }
+
+        if (!throughputDict[mediaType]) {
+            throughputDict[mediaType] = [];
+        }
+        throughputDict[mediaType].push(throughput);
+        if (throughputDict[mediaType].length > MAX_MEASUREMENTS_TO_KEEP) {
+            throughputDict[mediaType].shift();
+        }
+
+        if (!latencyDict[mediaType]) {
+            latencyDict[mediaType] = [];
+        }
+        latencyDict[mediaType].push(latencyTimeInMilliseconds);
+        if (latencyDict[mediaType].length > MAX_MEASUREMENTS_TO_KEEP) {
+            latencyDict[mediaType].shift();
+        }
+    }
+
+    function getSampleSize(mediaType, isLive) {
+        if (mediaType === 'audio') {
+            let latencyArray = latencyDict[mediaType];
+            if (!latencyArray) {
+                return 0;
+            }
+
+            let sampleSize = AVERAGE_LATENCY_SAMPLE_AMOUNT;
+            if (sampleSize >= latencyArray.length) {
+                return latencyArray.length;
+            }
+
+            return sampleSize;
+        }
+
+        if (mediaType === 'video') {
+            let throughputArray = throughputDict[mediaType];
+            if (!throughputArray) {
+                return 0;
+            }
+
+            let sampleSize = isLive ? AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE : AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD;
+            if (sampleSize >= throughputArray.length) {
+                return throughputArray.length;
+            }
+
+            // if throughput samples vary a lot, average over a wider sample
+            for (let i = 1; i < sampleSize; ++i) {
+                let ratio = throughputArray[-i] / throughputArray[-i - 1];
+                if (ratio >= THROUGHPUT_INCREASE_SCALE || ratio <= 1 / THROUGHPUT_DECREASE_SCALE) {
+                    sampleSize += 1;
+                    if (sampleSize >= throughputArray.length) {
+                        return throughputArray.length;
+                    }
+                }
+            }
+
+            return sampleSize;
+        }
+    }
+
+    function getAverage(dict, mediaType, sampleSize) {
+        let arr = dict[mediaType];
+        if (isNaN(sampleSize)) {
+            sampleSize = getSampleSize(mediaType);
+        }
+
+        if (!arr || arr.length === 0 || sampleSize === 0) {
+            return NaN;
+        }
+
+        arr = arr.slice(-sampleSize); // still works if sampleSize too large
+        return arr.reduce((av, elem, i) => av + (elem / av) / (i + 1));
+    }
+
+    function getAverageThroughput(mediaType, sampleSize) {
+        return getAverage(throughputDict, mediaType, sampleSize);
+    }
+
+    function getAverageLatency(mediaType, sampleSize) {
+        return getAverage(latencyDict, mediaType, sampleSize);
+    }
+
+    function reset() {
+        setup();
+    }
+
+    const instance = {
+        push: push,
+        getSampleSize: getSampleSize,
+        getAverageThroughput: getAverageThroughput,
+        getAverageLatency: getAverageLatency,
+        reset: reset
+    };
+
+    setup();
+    return instance;
+}
+
+ThroughputHistory.__dashjs_factory_name = 'ThroughputHistory';
+let factory = FactoryMaker.getClassFactory(ThroughputHistory);
+export default factory;

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -77,8 +77,7 @@ function ABRRulesCollection(config) {
                 qualitySwitchRules.push(
                     ThroughputRule(context).create({
                         metricsModel: metricsModel,
-                        dashMetrics: dashMetrics,
-                        mediaPlayerModel: mediaPlayerModel
+                        dashMetrics: dashMetrics
                     })
                 );
                 qualitySwitchRules.push(

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -82,7 +82,8 @@ function ABRRulesCollection(config) {
                 );
                 qualitySwitchRules.push(
                     InsufficientBufferRule(context).create({
-                        metricsModel: metricsModel
+                        metricsModel: metricsModel,
+                        dashMetrics: dashMetrics
                     })
                 );
                 qualitySwitchRules.push(

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -55,7 +55,14 @@ function InsufficientBufferRule(config) {
     }
 
     /*
+     * InsufficientBufferRule does not kick in before the first BUFFER_LOADED event happens. This is reset at every seek.
      *
+     * If a BUFFER_EMPTY event happens, then InsufficientBufferRule returns switchRequest.quality=0 until BUFFER_LOADED happens.
+     *
+     * Otherwise InsufficientBufferRule gives a maximum bitrate depending on throughput and bufferLevel such that
+     * a whole fragment can be downloaded before the buffer runs out, subject to a conservative safety factor of 0.5.
+     * If the bufferLevel is low, then InsufficientBufferRule avoids rebuffering risk.
+     * If the bufferLevel is high, then InsufficientBufferRule give a high MaxIndex allowing other rules to take over.
      */
     function getMaxIndex (rulesContext) {
         const mediaType = rulesContext.getMediaType();

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -37,54 +37,72 @@ import SwitchRequest from '../SwitchRequest.js';
 
 function InsufficientBufferRule(config) {
 
+    const INSUFFICIENT_BUFFER_SAFETY_FACTOR = 0.5;
+
     let context = this.context;
     let log = Debug(context).getInstance().log;
     let eventBus = EventBus(context).getInstance();
 
     let metricsModel = config.metricsModel;
+    let dashMetrics = config.dashMetrics;
 
     let instance,
-        bufferStateDict,
-        lastSwitchTime,
-        waitToSwitchTime;
+        bufferStateDict;
 
     function setup() {
         bufferStateDict = {};
-        lastSwitchTime = 0;
-        waitToSwitchTime = 1000;
         eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
     }
 
+    /*
+     *
+     */
     function getMaxIndex (rulesContext) {
-        var now = new Date().getTime();
-        var mediaType = rulesContext.getMediaType();
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        var lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
+        const mediaType = rulesContext.getMediaType();
+        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         let switchRequest = SwitchRequest(context).create();
 
-        if (now - lastSwitchTime < waitToSwitchTime ||
-            lastBufferStateVO === null) {
+        if (!lastBufferStateVO || !wasFirstBufferLoadedEventTriggered(mediaType, lastBufferStateVO)) {
             return switchRequest;
         }
 
-        setBufferInfo(mediaType, lastBufferStateVO.state);
-        // After the sessions first buffer loaded event , if we ever have a buffer empty event we want to switch all the way down.
-        if (lastBufferStateVO.state === BufferController.BUFFER_EMPTY && bufferStateDict[mediaType].firstBufferLoadedEvent !== undefined) {
+        if (lastBufferStateVO.state === BufferController.BUFFER_EMPTY) {
             log('Switch to index 0; buffer is empty.');
             switchRequest.quality = 0;
             switchRequest.reason = 'InsufficientBufferRule: Buffer is empty';
+        } else {
+            const mediaInfo = rulesContext.getMediaInfo();
+            const abrController = rulesContext.getAbrController();
+            const throughputHistory = abrController.getThroughputHistory();
+            const trackInfo = rulesContext.getTrackInfo();
+            const fragmentDuration = trackInfo.fragmentDuration;
+
+            let bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+
+            let throughput = throughputHistory.getAverageThroughput(mediaType);
+            let latency = throughputHistory.getAverageLatency(mediaType);
+
+            let bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;
+
+            switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, bitrate, latency);
+            switchRequest.reason = 'InsufficientBufferRule: being conservative to avoid immediate rebuffering';
         }
 
-        lastSwitchTime = now;
         return switchRequest;
     }
 
-    function setBufferInfo(type, state) {
-        bufferStateDict[type] = bufferStateDict[type] || {};
-        bufferStateDict[type].state = state;
-        if (state === BufferController.BUFFER_LOADED && !bufferStateDict[type].firstBufferLoadedEvent) {
-            bufferStateDict[type].firstBufferLoadedEvent = true;
+    function wasFirstBufferLoadedEventTriggered(mediaType, currentBufferState) {
+        bufferStateDict[mediaType] = bufferStateDict[mediaType] || {};
+
+        let wasTriggered = false;
+        if (bufferStateDict[mediaType].firstBufferLoadedEvent) {
+            wasTriggered = true;
+        } else if (currentBufferState && currentBufferState.state === BufferController.BUFFER_LOADED) {
+            bufferStateDict[mediaType].firstBufferLoadedEvent = true;
+            wasTriggered = true;
         }
+        return wasTriggered;
     }
 
     function onPlaybackSeeking() {
@@ -94,7 +112,6 @@ function InsufficientBufferRule(config) {
     function reset() {
         eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
         bufferStateDict = {};
-        lastSwitchTime = 0;
     }
 
     instance = {

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -30,25 +30,14 @@
  */
 import BufferController from '../../controllers/BufferController';
 import AbrController from '../../controllers/AbrController';
-import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 import SwitchRequest from '../SwitchRequest.js';
 
 function ThroughputRule(config) {
 
-    const MAX_MEASUREMENTS_TO_KEEP = 20;
-    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE = 3;
-    const AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD = 4;
-    const AVERAGE_LATENCY_SAMPLES = AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD;
-    const CACHE_LOAD_THRESHOLD_VIDEO = 50;
-    const CACHE_LOAD_THRESHOLD_AUDIO = 5;
-    const THROUGHPUT_DECREASE_SCALE = 1.3;
-    const THROUGHPUT_INCREASE_SCALE = 1.3;
-
     const context = this.context;
     const log = Debug(context).getInstance().log;
-    const dashMetrics = config.dashMetrics;
     const metricsModel = config.metricsModel;
     const mediaPlayerModel = config.mediaPlayerModel;
 
@@ -60,76 +49,6 @@ function ThroughputRule(config) {
         latencyArray = [];
     }
 
-    function storeLastRequestThroughputByType(type, throughput) {
-        throughputArray[type] = throughputArray[type] || [];
-        throughputArray[type].push(throughput);
-    }
-
-    function storeLatency(mediaType, latency) {
-        if (!latencyArray[mediaType]) {
-            latencyArray[mediaType] = [];
-        }
-        latencyArray[mediaType].push(latency);
-
-        if (latencyArray[mediaType].length > AVERAGE_LATENCY_SAMPLES) {
-            return latencyArray[mediaType].shift();
-        }
-
-        return undefined;
-    }
-
-    function getAverageLatency(mediaType) {
-        let average;
-        if (latencyArray[mediaType] && latencyArray[mediaType].length > 0) {
-            average = latencyArray[mediaType].reduce((a, b) => { return a + b; }) / latencyArray[mediaType].length;
-        }
-
-        return average;
-    }
-
-    function getSample(type, isDynamic) {
-        let size = Math.min(throughputArray[type].length, isDynamic ? AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_LIVE : AVERAGE_THROUGHPUT_SAMPLE_AMOUNT_VOD);
-        const sampleArray = throughputArray[type].slice(size * -1, throughputArray[type].length);
-        if (sampleArray.length > 1) {
-            sampleArray.reduce((a, b) => {
-                if (a * THROUGHPUT_INCREASE_SCALE <= b || a >= b * THROUGHPUT_DECREASE_SCALE) {
-                    size++;
-                }
-                return b;
-            });
-        }
-        size = Math.min(throughputArray[type].length, size);
-        return throughputArray[type].slice(size * -1, throughputArray[type].length);
-    }
-
-    function getAverageThroughput(type, isDynamic) {
-        const sample = getSample(type, isDynamic);
-        let averageThroughput = 0;
-        if (sample.length > 0) {
-            const totalSampledValue = sample.reduce((a, b) => a + b, 0);
-            averageThroughput = totalSampledValue / sample.length;
-        }
-        if (throughputArray[type].length >= MAX_MEASUREMENTS_TO_KEEP) {
-            throughputArray[type].shift();
-        }
-        return (averageThroughput / 1000 ) * mediaPlayerModel.getBandwidthSafetyFactor();
-    }
-
-    function isCachedResponse(latency, downloadTime, mediaType) {
-        let ret = false;
-        switch (mediaType) {
-            case 'video':
-                ret = downloadTime < CACHE_LOAD_THRESHOLD_VIDEO;
-                break;
-            case 'audio':
-                ret = downloadTime < CACHE_LOAD_THRESHOLD_AUDIO;
-                break;
-            default:
-                break;
-        }
-        return ret;
-    }
-
     function getMaxIndex(rulesContext) {
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
@@ -137,57 +56,26 @@ function ThroughputRule(config) {
         const streamProcessor = rulesContext.getStreamProcessor();
         const abrController = rulesContext.getAbrController();
         const isDynamic = streamProcessor.isDynamic();
-        const lastRequest = dashMetrics.getCurrentHttpRequest(metrics);
         const bufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         const hasRichBuffer = rulesContext.hasRichBuffer();
         const switchRequest = SwitchRequest(context).create();
 
-        if (!metrics || !lastRequest || lastRequest.type !== HTTPRequest.MEDIA_SEGMENT_TYPE || !bufferStateVO || hasRichBuffer) {
+        if (!metrics || !bufferStateVO || hasRichBuffer) {
             return switchRequest;
         }
 
-        let downloadTimeInMilliseconds;
-        let latencyTimeInMilliseconds;
+        if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
 
-        if (lastRequest.trace && lastRequest.trace.length) {
-
-            latencyTimeInMilliseconds = (lastRequest.tresponse.getTime() - lastRequest.trequest.getTime()) || 1;
-            downloadTimeInMilliseconds = (lastRequest._tfinish.getTime() - lastRequest.tresponse.getTime()) || 1; //Make sure never 0 we divide by this value. Avoid infinity!
-
-            const bytes = lastRequest.trace.reduce((a, b) => a + b.b[0], 0);
-
-            const lastRequestThroughput = Math.round((bytes * 8) / (downloadTimeInMilliseconds / 1000));
-
-            let throughput;
-            let latency;
-            //Prevent cached fragment loads from skewing the average throughput value - allow first even if cached to set allowance for ABR rules..
-            if (isCachedResponse(latencyTimeInMilliseconds, downloadTimeInMilliseconds, mediaType)) {
-                if (!throughputArray[mediaType] || !latencyArray[mediaType]) {
-                    throughput = lastRequestThroughput / 1000;
-                    latency = latencyTimeInMilliseconds;
-                } else {
-                    throughput = getAverageThroughput(mediaType, isDynamic);
-                    latency = getAverageLatency(mediaType);
-                }
-            } else {
-                storeLastRequestThroughputByType(mediaType, lastRequestThroughput);
-                throughput = getAverageThroughput(mediaType, isDynamic);
-                storeLatency(mediaType, latencyTimeInMilliseconds);
-                latency = getAverageLatency(mediaType, isDynamic);
-            }
-
-            abrController.setAverageThroughput(mediaType, throughput);
-
-            if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
-
-                if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
-                    switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
-                    streamProcessor.getScheduleController().setTimeToLoadDelay(0);
-                    log('ThroughputRule requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
-                    switchRequest.reason = {throughput: throughput, latency: latency};
-                }
+            if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
+                let throughput = abrController.getAverageThroughput(mediaType, isDynamic) * mediaPlayerModel.getBandwidthSafetyFactor();
+                let latency = abrController.getAverageLatency(mediaType);
+                switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
+                streamProcessor.getScheduleController().setTimeToLoadDelay(0);
+                log('ThroughputRule requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
+                switchRequest.reason = {throughput: throughput, latency: latency};
             }
         }
+
         return switchRequest;
     }
 


### PR DESCRIPTION
Move the throughput/latency estimation from ThroughputRule to a separate ThroughputHistory.
Update the InsufficientBufferRule to also avoid downloading bitrates that are more prone to lead to rebuffering.