### PR TITLE
Don't set initialized flag to false in MediaPlayer.reset()

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1985,7 +1985,6 @@ function MediaPlayer() {
             metricsReportingController.reset();
             metricsReportingController = null;
         }
-        mediaPlayerInitialized = false;
     }
 
     //***********************************


### PR DESCRIPTION
It's not true that the media player isn't initialised after calling reset() - it's in exactly the same state as calling initialize() with no arguments. It's still in a valid initialized state and possible to call attachView(), attachSource() and playback afterwards.