### PR TITLE
Fix return-type annotation in index.d.ts for setRobustnessLevel

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare namespace dashjs {
     class VideoModel { }
 
     class ProtectionController {
-        setRobustnessLevel(level: string);
+        setRobustnessLevel(level: string): void;
     }
 
     export interface Bitrate {


### PR DESCRIPTION
Fix return-type annotation in index.d.ts for setRobustnessLevel to void as it has implicit 'any' return-type