### PR TITLE
Move STREAM_TEARDOWN_COMPLETE to MediaPlayerEvents

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -67,7 +67,6 @@ class CoreEvents extends EventsBase {
         this.STREAMS_COMPOSED = 'streamsComposed';
         this.STREAM_BUFFERING_COMPLETED = 'streamBufferingCompleted';
         this.STREAM_COMPLETED = 'streamCompleted';
-        this.STREAM_TEARDOWN_COMPLETE = 'streamTeardownComplete';
         this.TIMED_TEXT_REQUESTED = 'timedTextRequested';
         this.TIME_SYNCHRONIZATION_COMPLETED = 'timeSynchronizationComplete';
         this.URL_RESOLUTION_FAILED = 'urlResolutionFailed';

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -145,6 +145,13 @@ class MediaPlayerEvents extends EventsBase {
          * @event MediaPlayerEvents#STREAM_INITIALIZED
          */
         this.STREAM_INITIALIZED = 'streamInitialized';
+
+        /**
+         * Triggered when the player has been reset.
+         * @event MediaPlayerEvents#STREAM_TEARDOWN_COMPLETE
+         */
+        this.STREAM_TEARDOWN_COMPLETE = 'streamTeardownComplete';
+
         /**
          * Triggered once all text tracks detected in the MPD are added to the video element.
          * @event MediaPlayerEvents#TEXT_TRACKS_ADDED


### PR DESCRIPTION
Fix https://github.com/Dash-Industry-Forum/dash.js/issues/2005

I could also rename this event to something more explicit like `PLAYER_RESET` if necessary