### PR TITLE
Add getter for average throughput on MediaPlayer's API

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1436,6 +1436,19 @@ function MediaPlayer() {
     }
 
     /**
+     * Returns the average throughput computed in the ABR logic
+     *
+     * @param {string} type
+     * @return {number} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getAverageThroughput(type) {
+        const throughputHistory = abrController.getThroughputHistory();
+        return throughputHistory ? throughputHistory.getAverageThroughput(type) : 0;
+    }
+
+    /**
      * A timeout value in seconds, which during the ABRController will block switch-up events.
      * This will only take effect after an abandoned fragment event occurs.
      *
@@ -2455,6 +2468,7 @@ function MediaPlayer() {
         removeAllABRCustomRule: removeAllABRCustomRule,
         setBandwidthSafetyFactor: setBandwidthSafetyFactor,
         getBandwidthSafetyFactor: getBandwidthSafetyFactor,
+        getAverageThroughput: getAverageThroughput,
         setAbandonLoadTimeout: setAbandonLoadTimeout,
         retrieveManifest: retrieveManifest,
         addUTCTimingSource: addUTCTimingSource,

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -32,7 +32,9 @@ class AbrControllerMock{
 
     createAbrRulesCollection() {}
 
-    reset() {}
+    reset() {
+        this.setup();
+    }
 
     setConfig() {}
 

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -26,6 +26,7 @@ class AbrControllerMock{
         this.limitBitrateByPortal = false;
         this.usePixelRatioInLimitBitrateByPortal = false;
         this.autoSwitchBitrate = {video: true, audio: true};
+        this.throughputHistory = undefined;
     }
 
     initialize() {}
@@ -162,6 +163,10 @@ class AbrControllerMock{
      */
     getBitrateList() {
 
+    }
+
+    getThroughputHistory() {
+        return this.throughputHistory;
     }
 
     updateTopQualityIndex() {}

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -162,10 +162,6 @@ class AbrControllerMock{
 
     }
 
-    setAverageThroughput() {}
-
-    getAverageThroughput() {}
-
     updateTopQualityIndex() {}
 
     isPlayingAtTopQuality() {}

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -327,7 +327,7 @@ describe("MediaPlayer", function () {
 
     });
 
-    describe("AutoBitrate Functions", function () {
+    describe("AbrController Functions", function () {
         afterEach(function () {
             abrControllerMock.reset();
         })
@@ -455,6 +455,22 @@ describe("MediaPlayer", function () {
 
             AutoSwitchBitrateFor = abrControllerMock.getAutoSwitchBitrateFor('video');
             expect(AutoSwitchBitrateFor).to.be.false;
+        });
+
+        it("Method getAverageThroughput should return 0 when throughputHistory is not set up", function() {
+            const averageThroughput = player.getAverageThroughput('video');
+            expect(averageThroughput).to.equal(0);
+        });
+
+        it("Method getAverageThroughput should value computed from ThroughputHistory", function() {
+            const AVERAGE_THROUGHPUT = 2000;
+            abrControllerMock.throughputHistory = {
+                getAverageThroughput: function() {
+                    return AVERAGE_THROUGHPUT;
+                }
+            };
+            const averageThroughput = player.getAverageThroughput('video');
+            expect(averageThroughput).to.equal(AVERAGE_THROUGHPUT);
         });
 
         describe("When it is not initialized", function () {

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -103,7 +103,7 @@ describe("MediaPlayer", function () {
             beforeEach(function () {
                 player.initialize(videoElementMock, dummyUrl, false);
             });
-            it("Method isReady should return false", function () {
+            it("Method isReady should return true", function () {
                 let isReady = player.isReady();
                 expect(isReady).to.be.true;
             });


### PR DESCRIPTION
This is really helpful to build debug graphs for the ABR logic