### PR TITLE
Fix issue # 1938 - MSS with dvrWindowsSize = 0

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -281,7 +281,7 @@ function RepresentationController(config) {
             err,
             repSwitch;
 
-        if (r.adaptation.period.mpd.manifest.type === DashConstants.DYNAMIC)
+        if (r.adaptation.period.mpd.manifest.type === DashConstants.DYNAMIC && !r.adaptation.period.mpd.manifest.ignorePostponeTimePeriod)
         {
             let segmentAvailabilityTimePeriod = r.segmentAvailabilityRange.end - r.segmentAvailabilityRange.start;
             // We must put things to sleep unless till e.g. the startTime calculation in ScheduleController.onLiveEdgeSearchCompleted fall after the segmentAvailabilityRange.start

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -476,6 +476,7 @@ function MssParser(config) {
             manifest.availabilityStartTime = new Date(manifestLoadedTime.getTime() - (manifest.timeShiftBufferDepth * 1000));
             manifest.refreshManifestOnSwitchTrack = true;
             manifest.doNotUpdateDVRWindowOnBufferUpdated = true; // done by Mss fragment processor
+            manifest.ignorePostponeTimePeriod = true; // in Mss, manifest is never updated
         }
 
         // Map period node to manifest root node
@@ -526,6 +527,12 @@ function MssParser(config) {
                 }
             } else {
                 adaptations[i].SegmentTemplate.initialization = '$Bandwidth$';
+                // Match timeShiftBufferDepth to video segment timeline duration
+                if (manifest.timeShiftBufferDepth > 0 &&
+                    adaptations[i].contentType === 'video' &&
+                    manifest.timeShiftBufferDepth > adaptations[i].SegmentTemplate.SegmentTimeline.duration) {
+                    manifest.timeShiftBufferDepth = adaptations[i].SegmentTemplate.SegmentTimeline.duration;
+                }
             }
 
             // Propagate content protection information into each adaptation

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -177,12 +177,17 @@ function PlaybackController() {
             delay = streamInfo.manifestInfo.minBufferTime * 2;
         }
 
-        // cap target latency to:
-        // - dvrWindowSize / 2 for short playlists
-        // - dvrWindowSize - END_OF_PLAYLIST_PADDING for longer playlists
-        let targetDelayCapping = Math.max(dvrWindowSize - END_OF_PLAYLIST_PADDING, dvrWindowSize / 2);
+        if ( dvrWindowSize > 0 ) {
+            // cap target latency to:
+            // - dvrWindowSize / 2 for short playlists
+            // - dvrWindowSize - END_OF_PLAYLIST_PADDING for longer playlists
+            let targetDelayCapping = Math.max(dvrWindowSize - END_OF_PLAYLIST_PADDING, dvrWindowSize / 2);
 
-        return Math.min(delay, targetDelayCapping);
+            return Math.min(delay, targetDelayCapping);
+        }
+        else {
+            return delay;
+        }
     }
 
     function reset() {

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -83,7 +83,8 @@ function NextFragmentRequestRule(config) {
             request = adapter.getFragmentRequestForTime(streamProcessor, representationInfo, time, {
                 keepIdx: !hasSeekTarget
             });
-            if (streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
+            while ( streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
+                // loop until we found not loaded fragment, or no fragment
                 request = adapter.getNextFragmentRequest(streamProcessor, representationInfo);
             }
             if (request) {


### PR DESCRIPTION
Hi 

This PR solves a pb encountered by @qchroman (cf Issue #1938) , when playing streams
https://djkxw9frc3oss.cloudfront.net/live/live.isml/Manifest
https://djkxw9frc3oss.cloudfront.net/live/Sintel_0500.isml/Manifest

It has to be noticed that using these streams, some fragments are quite long (10s) and sometimes getFragmentRequestForTime doesn't return the right fragment corresponding to time, but the previous one, because of threshold in FragmentModel:getRequestForTime. That's why there is a loop in nextFragmentRuel, to get the first next not loaded fragment.

Another point is buffer parameters are :
            "liveDelay": 18,
            "stableBufferTime": 16,
            "bufferTimeAtTopQuality": 16,
            "bufferTimeAtTopQualityLongForm": 16