### PR TITLE
Custom Abr Rules v2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,15 @@ module.exports = function (grunt) {
                 }
             },
 
+            build_factorymaker: {
+                options: {
+                    sourceMapIn: 'build/temp/dash.factorymaker.debug.js.map'
+                },
+                files: {
+                    'build/temp/dash.factorymaker.min.js': 'build/temp/dash.factorymaker.debug.js'
+                }
+            },
+
             build_reporting: {
                 options: {
                     sourceMapIn: 'build/temp/dash.reporting.debug.js.map'
@@ -103,6 +112,7 @@ module.exports = function (grunt) {
                     'dash.mss.min.js', 'dash.mss.min.js.map',
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
                     'dash.protection.debug.js', 'dash.protection.debug.js.map',
+                    'dash.factorymaker.debug.js', 'dash.factorymaker.debug.js.map',
                     'dash.reporting.debug.js', 'dash.reporting.debug.js.map',
                     'dash.mss.debug.js', 'dash.mss.debug.js.map'
                 ],
@@ -147,6 +157,12 @@ module.exports = function (grunt) {
                 options: {},
                 files: {
                     'build/temp/dash.reporting.debug.js.map': ['build/temp/dash.reporting.debug.js']
+                }
+            },
+            factorymaker: {
+                options: {},
+                files: {
+                    'build/temp/dash.factorymaker.debug.js.map': ['build/temp/dash.factorymaker.debug.js']
                 }
             },
             mss: {
@@ -209,6 +225,21 @@ module.exports = function (grunt) {
                     browserifyOptions: {
                         debug: true,
                         standalone: 'dashjs.MetricsReporting'
+                    },
+                    plugin: [
+                        'browserify-derequire', 'bundle-collapser/plugin'
+                    ],
+                    transform: ['babelify']
+                }
+            },
+            factorymaker: {
+                files: {
+                    'build/temp/dash.factorymaker.debug.js': ['src/core/FactoryMaker.js']
+                },
+                options: {
+                    browserifyOptions: {
+                        debug: true,
+                        standalone: 'dashjs.FactoryMaker'
                     },
                     plugin: [
                         'browserify-derequire', 'bundle-collapser/plugin'
@@ -299,7 +330,7 @@ module.exports = function (grunt) {
 
     require('load-grunt-tasks')(grunt);
     grunt.registerTask('default', ['dist', 'test']);
-    grunt.registerTask('dist', ['clean', 'jshint', 'jscs', 'browserify:mediaplayer', 'browserify:protection', 'browserify:reporting', 'browserify:mss', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
+    grunt.registerTask('dist', ['clean', 'jshint', 'jscs', 'browserify:mediaplayer', 'browserify:factorymaker', 'browserify:protection', 'browserify:reporting', 'browserify:mss', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
     grunt.registerTask('minimize', ['exorcise', 'githash', 'uglify']);
     grunt.registerTask('test', ['mocha_istanbul:test']);
     grunt.registerTask('watch', ['browserify:watch']);


### PR DESCRIPTION
Hi,

in the previous PR #1846, @jeremco has introduced the ability to overide abr rules outside of dash.js. It works well when the dash.all is used, it doesn't when the different modules are used.
So, I suggest that we add a factorymaker module in order to be able to overload the rules outside the dash.js.

Nicolas
