### PR TITLE
XlinkController matchers set in ManifestLoader

### DIFF
--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -81,7 +81,15 @@ function DashParser(config) {
         }
     }
 
-    function parse(data, xlinkController) {
+    function getMatchers() {
+        return matchers;
+    }
+
+    function getIron() {
+        return objectIron;
+    }
+
+    function parse(data) {
         let manifest;
 
         checkConfig();
@@ -101,9 +109,6 @@ function DashParser(config) {
 
             const ironedTime = window.performance.now();
 
-            xlinkController.setMatchers(matchers);
-            xlinkController.setIron(objectIron);
-
             log('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
         } catch (err) {
             errorHandler.manifestError('parsing the manifest failed', 'parse', data, err);
@@ -114,7 +119,9 @@ function DashParser(config) {
     }
 
     instance = {
-        parse: parse
+        parse: parse,
+        getMatchers: getMatchers,
+        getIron: getIron
     };
 
     setup();

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -635,6 +635,13 @@ function MssParser(config) {
         return xmlDoc;
     }
 
+    function getMatchers() {
+        return null;
+    }
+
+    function getIron() {
+        return null;
+    }
 
     function internalParse(data) {
         let xmlDoc = null;
@@ -662,7 +669,9 @@ function MssParser(config) {
     }
 
     instance = {
-        parse: internalParse
+        parse: internalParse,
+        getMatchers: getMatchers,
+        getIron: getIron
     };
 
     setup();

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -152,7 +152,11 @@ function ManifestLoader(config) {
                     return;
                 }
 
-                const manifest = parser.parse(data, xlinkController);
+                // init xlinkcontroller with matchers and iron object from created parser
+                xlinkController.setMatchers(parser.getMatchers());
+                xlinkController.setIron(parser.getIron());
+
+                const manifest = parser.parse(data);
 
                 if (manifest) {
                     manifest.url = actualUrl || url;

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -67,11 +67,15 @@ function XlinkController(config) {
     }
 
     function setMatchers(value) {
-        matchers = value;
+        if (value) {
+            matchers = value;
+        }
     }
 
     function setIron(value) {
-        iron = value;
+        if (value) {
+            iron = value;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi
This PR changes the way matchers and iron parameters are given to XLinkControllers, to uniformize API of parsers 

Jérémie