### PR TITLE
fixed: Cannot read property 'Location as Array' of undefined

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -165,7 +165,7 @@ function ManifestLoader(config) {
                     // In the following, we only use the first Location entry even if many are available
                     // Compare with ManifestUpdater/DashManifestModel
                     if (manifest.hasOwnProperty(Constants.LOCATION)) {
-                        baseUri = urlUtils.parseBaseUrl(manifest.manifest.Location_asArray[0]);
+                        baseUri = urlUtils.parseBaseUrl(manifest.Location_asArray[0]);
                         log('BaseURI set by Location to: ' + baseUri);
                     }
 


### PR DESCRIPTION
I used a manifest with streams in multiple qualities from a Wowza server. I encountered an error "Cannot read property 'Location as Array' of undefined". In the Manifest loader I encountered the problem that manifest did not contain manifest. removing one of the manifest variables fixed the problem.
