### PR TITLE
FactoryMaker exports

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,15 +61,6 @@ module.exports = function (grunt) {
                 }
             },
 
-            build_factorymaker: {
-                options: {
-                    sourceMapIn: 'build/temp/dash.factorymaker.debug.js.map'
-                },
-                files: {
-                    'build/temp/dash.factorymaker.min.js': 'build/temp/dash.factorymaker.debug.js'
-                }
-            },
-
             build_reporting: {
                 options: {
                     sourceMapIn: 'build/temp/dash.reporting.debug.js.map'
@@ -112,7 +103,6 @@ module.exports = function (grunt) {
                     'dash.mss.min.js', 'dash.mss.min.js.map',
                     'dash.mediaplayer.debug.js', 'dash.mediaplayer.debug.js.map',
                     'dash.protection.debug.js', 'dash.protection.debug.js.map',
-                    'dash.factorymaker.debug.js', 'dash.factorymaker.debug.js.map',
                     'dash.reporting.debug.js', 'dash.reporting.debug.js.map',
                     'dash.mss.debug.js', 'dash.mss.debug.js.map'
                 ],
@@ -159,12 +149,6 @@ module.exports = function (grunt) {
                     'build/temp/dash.reporting.debug.js.map': ['build/temp/dash.reporting.debug.js']
                 }
             },
-            factorymaker: {
-                options: {},
-                files: {
-                    'build/temp/dash.factorymaker.debug.js.map': ['build/temp/dash.factorymaker.debug.js']
-                }
-            },
             mss: {
                 options: {},
                 files: {
@@ -189,12 +173,11 @@ module.exports = function (grunt) {
         browserify: {
             mediaplayer: {
                 files: {
-                    'build/temp/dash.mediaplayer.debug.js': ['src/streaming/MediaPlayer.js']
+                    'build/temp/dash.mediaplayer.debug.js': ['index_mediaplayerOnly.js']
                 },
                 options: {
                     browserifyOptions: {
-                        debug: true,
-                        standalone: 'dashjs.MediaPlayer'
+                        debug: true
                     },
                     plugin: [
                         'browserify-derequire', 'bundle-collapser/plugin'
@@ -225,21 +208,6 @@ module.exports = function (grunt) {
                     browserifyOptions: {
                         debug: true,
                         standalone: 'dashjs.MetricsReporting'
-                    },
-                    plugin: [
-                        'browserify-derequire', 'bundle-collapser/plugin'
-                    ],
-                    transform: ['babelify']
-                }
-            },
-            factorymaker: {
-                files: {
-                    'build/temp/dash.factorymaker.debug.js': ['src/core/FactoryMaker.js']
-                },
-                options: {
-                    browserifyOptions: {
-                        debug: true,
-                        standalone: 'dashjs.FactoryMaker'
                     },
                     plugin: [
                         'browserify-derequire', 'bundle-collapser/plugin'
@@ -330,7 +298,7 @@ module.exports = function (grunt) {
 
     require('load-grunt-tasks')(grunt);
     grunt.registerTask('default', ['dist', 'test']);
-    grunt.registerTask('dist', ['clean', 'jshint', 'jscs', 'browserify:mediaplayer', 'browserify:factorymaker', 'browserify:protection', 'browserify:reporting', 'browserify:mss', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
+    grunt.registerTask('dist', ['clean', 'jshint', 'jscs', 'browserify:mediaplayer', 'browserify:protection', 'browserify:reporting', 'browserify:mss', 'browserify:all', 'babel:es5', 'minimize', 'copy:dist']);
     grunt.registerTask('minimize', ['exorcise', 'githash', 'uglify']);
     grunt.registerTask('test', ['mocha_istanbul:test']);
     grunt.registerTask('watch', ['browserify:watch']);

--- a/index_mediaplayerOnly.js
+++ b/index_mediaplayerOnly.js
@@ -1,0 +1,49 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import MediaPlayer from './src/streaming/MediaPlayer';
+import FactoryMaker from './src/core/FactoryMaker';
+import {getVersionString} from './src/core/Version';
+
+// Shove both of these into the global scope
+var context = (typeof window !== 'undefined' && window) || global;
+
+var dashjs = context.dashjs;
+if (!dashjs) {
+    dashjs = context.dashjs = {};
+}
+
+dashjs.MediaPlayer = MediaPlayer;
+dashjs.FactoryMaker = FactoryMaker;
+dashjs.Version = getVersionString();
+
+export default dashjs;
+export { MediaPlayer, FactoryMaker};

--- a/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
+++ b/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
@@ -31,7 +31,7 @@
 
 /*global dashjs*/
 
-var DownloadRatioRule;
+let DownloadRatioRule;
 
 function DownloadRatioRuleClass() {
 
@@ -40,6 +40,7 @@ function DownloadRatioRuleClass() {
     let MetricsModel = factory.getSingletonFactoryByName('MetricsModel');
     let DashMetrics = factory.getSingletonFactoryByName('DashMetrics');
     let DashManifestModel = factory.getSingletonFactoryByName('DashManifestModel');
+    let StreamController = factory.getSingletonFactoryByName('StreamController');
     let Debug = factory.getSingletonFactoryByName('Debug');
 
     let context = this.context;
@@ -51,15 +52,17 @@ function DownloadRatioRuleClass() {
 
     function getMaxIndex(rulesContext) {
 
-        var mediaType = rulesContext.getMediaInfo().type;
-        var current = rulesContext.getCurrentValue();
+        let mediaType = rulesContext.getMediaInfo().type;
 
         let metricsModel = MetricsModel(context).getInstance();
         let dashMetrics = DashMetrics(context).getInstance();
         let dashManifest = DashManifestModel(context).getInstance();
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        let metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        let streamController = StreamController(context).getInstance();
+        let abrController = rulesContext.getAbrController();
+        let current = abrController.getQualityFor(mediaType, streamController.getActiveStreamInfo());
 
-        var requests = dashMetrics.getHttpRequests(metrics),
+        let requests = dashMetrics.getHttpRequests(metrics),
             lastRequest = null,
             currentRequest = null,
             downloadTime,
@@ -125,8 +128,8 @@ function DownloadRatioRuleClass() {
 
             if (currentRequest.type !== 'MediaSegment' && currentRequest._tfinish && currentRequest.trequest && currentRequest.tresponse && currentRequest.trace && currentRequest.trace.length > 0) {
 
-                var _totalTime = (currentRequest._tfinish.getTime() - currentRequest.trequest.getTime()) / 1000;
-                var _downloadTime = (currentRequest._tfinish.getTime() - currentRequest.tresponse.getTime()) / 1000;
+                let _totalTime = (currentRequest._tfinish.getTime() - currentRequest.trequest.getTime()) / 1000;
+                let _downloadTime = (currentRequest._tfinish.getTime() - currentRequest.tresponse.getTime()) / 1000;
                 debug.log("[CustomRules][" + mediaType + "][DownloadRatioRule] DL: " + Number(_downloadTime.toFixed(3)) + "s, Total: " + Number(_totalTime.toFixed(3)) + "s, Length: " + getBytesLength(currentRequest));
 
                 totalTime += _totalTime;


### PR DESCRIPTION
HI 

PR #2057 was not sufficient to export FactoryMaker instance (using a module, 2 different instances were created). The idea here, is to export FactoryMaker directly in module mediaplayer, so that, there is only one instance of FactoryMaker.

This PR also updates sample custom ABR rules

Jérémie