### PR TITLE
fix handling of cached segments in ThroughputHistory

### DIFF
--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -84,8 +84,7 @@ function ThroughputHistory(config) {
                 // prevent cached fragment loads from skewing the average values
                 return;
             } else { // have no entries || have cached entries
-                // no uncached entries yet, rely on cached entries, set allowance for ABR rules
-                throughput /= 1000;
+                // no uncached entries yet, rely on cached entries because ABR rules need something to go by
                 throughputDict[mediaType].hasCachedEntries = true;
             }
         } else if (throughputDict[mediaType] && throughputDict[mediaType].hasCachedEntries) {

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -40,13 +40,6 @@ function ThroughputRule(config) {
     const log = Debug(context).getInstance().log;
     const metricsModel = config.metricsModel;
 
-    let throughputArray,
-        latencyArray;
-
-    function setup() {
-        reset();
-    }
-
     function checkConfig() {
         if (!metricsModel || !metricsModel.hasOwnProperty('getReadOnlyMetricsFor')) {
             throw new Error('Missing config parameter(s)');
@@ -68,11 +61,11 @@ function ThroughputRule(config) {
         const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
         const streamProcessor = rulesContext.getStreamProcessor();
         const abrController = rulesContext.getAbrController();
-        const throughputHistory = abrController.getThroughputHistory();
         const streamInfo = rulesContext.getStreamInfo();
         const isDynamic = streamInfo && streamInfo.manifestInfo ? streamInfo.manifestInfo.isDynamic : null;
-        let throughput = throughputHistory.getSafeAverageThroughput(mediaType, isDynamic);
-        let latency = throughputHistory.getAverageLatency(mediaType);
+        const throughputHistory = abrController.getThroughputHistory();
+        const throughput = throughputHistory.getSafeAverageThroughput(mediaType, isDynamic);
+        const latency = throughputHistory.getAverageLatency(mediaType);
         const bufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         const hasRichBuffer = rulesContext.hasRichBuffer();
 
@@ -94,8 +87,7 @@ function ThroughputRule(config) {
     }
 
     function reset() {
-        throughputArray = [];
-        latencyArray = [];
+        // no persistent information to reset
     }
 
     const instance = {
@@ -103,7 +95,6 @@ function ThroughputRule(config) {
         reset: reset
     };
 
-    setup();
     return instance;
 }
 


### PR DESCRIPTION
#2003 changed the behavior at startup when only cached segments are available to calculate throughput.  When no uncached segments are available, a throughput estimate is taken from cached segments.  This is not ideal, but ABR rules need something to go by.  As from #2003, the cached-fragment throughput is incorrectly divided by a factor of 1000.  This PR fixes that issue.