### PR TITLE
Don't let crazy rewind window be applied to mediaSource seekable range

### DIFF
--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -70,7 +70,8 @@ function MediaSourceController() {
     }
 
     function setSeekable(source, start, end) {
-        if (typeof source.setLiveSeekableRange === 'function' && typeof source.clearLiveSeekableRange === 'function') {
+        if (typeof source.setLiveSeekableRange === 'function' && typeof source.clearLiveSeekableRange === 'function' &&
+                source.readyState === 'open' && start >= 0 && start < end) {
             source.clearLiveSeekableRange();
             source.setLiveSeekableRange(start, end);
         }


### PR DESCRIPTION
Fix for issue #2089, implementing the preconditions, start is positive and less than end, and the mediaSource has readyState open. I didn't do much investigation here into the underlying question of why we would have such a strange availability window, so that remains a mystery.