### PR TITLE
set start 0 if availabilityWindow.start = null

### DIFF
--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -227,7 +227,7 @@ export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, 
     const minBufferTime = representation.adaptation.period.mpd.manifest.minBufferTime;
     const availabilityWindow = representation.segmentAvailabilityRange;
     let periodRelativeRange = {
-        start: timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, availabilityWindow.start),
+        start: timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, availabilityWindow.start || 0),
         end: timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, availabilityWindow.end)
     };
     const currentSegmentList = representation.segments;


### PR DESCRIPTION
fixes:
dash.all.debug.js:20787 Uncaught TypeError: Cannot read property 'start' of null
    at decideSegmentListRangeForTemplate (dash.all.debug.js:20787)
    at Object.getSegmentsFromTemplate [as getSegments] (dash.all.debug.js:20907)
    at Object.getSegments (dash.all.debug.js:20499)
    at updateSegments (dash.all.debug.js:16039)
    at updateSegmentList (dash.all.debug.js:16066)
    at Object.updateRepresentation (dash.all.debug.js:16077)
    at Object.updateData (dash.all.debug.js:18003)
    at Object.updateData (dash.all.debug.js:15662)
    at Object.updateMediaInfo (dash.all.debug.js:26537)
    at createStreamProcessor (dash.all.debug.js:26016)

start a player before start the stream (create the mpd file)