### PR TITLE
Fix Destroy in ControlBar.js

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -58,12 +58,14 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
         togglePlayPauseBtnState = function () {
             var span = document.getElementById('iconPlayPause');
-            if (player.isPaused()) {
-                span.classList.remove('icon-pause')
-                span.classList.add('icon-play');
-            } else {
-                span.classList.remove('icon-play');
-                span.classList.add('icon-pause');
+            if(span !== null) {
+                if (player.isPaused()) {
+                    span.classList.remove('icon-pause');
+                    span.classList.add('icon-play');
+                } else {
+                    span.classList.remove('icon-play');
+                    span.classList.add('icon-pause');
+                }
             }
         },
 
@@ -679,7 +681,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
         destroy: function () {
 
-            reset();
+            this.reset();
 
             playPauseBtn.removeEventListener("click", onPlayPauseClick);
             muteBtn.removeEventListener("click", onMuteClick);


### PR DESCRIPTION
Added a null check so that `togglePlayPauseBtnState` will not explode if the button does not exist. In my particular context this was being fired after destroy was being called, so the button did not exist.

Also fixed what is presumably a typo. `reset` does not exist in that context, although `this.reset` should work.

Please do let me know if you'd like to change anything else!