### PR TITLE
Fix undefined fragData when using parsed manifest object

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -248,12 +248,13 @@ function PlaybackController() {
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
         let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
-        let fragS = parseInt(fragData.s, 10);
-        let fragT = parseInt(fragData.t, 10);
-        let startTimeOffset = NaN;
-
-        if (!ignoreStartOffset) {
+        var startTimeOffset = 0;
+        if(fragData) {
+          var fragS = parseInt(fragData.s, 10);
+          var fragT = parseInt(fragData.t, 10);
+          if (!ignoreStartOffset) {
             startTimeOffset = !isNaN(fragS) ? fragS : fragT;
+          }
         }
 
         if (isDynamic) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -251,11 +251,11 @@ function PlaybackController() {
         let startTimeOffset = 0;
 
         if (fragData) {
-          let fragS = parseInt(fragData.s, 10);
-          let fragT = parseInt(fragData.t, 10);
-          if (!ignoreStartOffset) {
-            startTimeOffset = !isNaN(fragS) ? fragS : fragT;
-          }
+            let fragS = parseInt(fragData.s, 10);
+            let fragT = parseInt(fragData.t, 10);
+            if (!ignoreStartOffset) {
+                startTimeOffset = !isNaN(fragS) ? fragS : fragT;
+            }
         }
 
         if (isDynamic) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -257,8 +257,8 @@ function PlaybackController() {
                 startTimeOffset = !isNaN(fragS) ? fragS : fragT;
             }
         } else {
-          // handle case where no media fragments are parsed from the manifest URL
-          startTimeOffset = 0;
+            // handle case where no media fragments are parsed from the manifest URL
+            startTimeOffset = 0;
         }
 
         if (isDynamic) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -248,10 +248,11 @@ function PlaybackController() {
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
         let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
-        var startTimeOffset = 0;
-        if(fragData) {
-          var fragS = parseInt(fragData.s, 10);
-          var fragT = parseInt(fragData.t, 10);
+        let startTimeOffset = 0;
+
+        if (fragData) {
+          let fragS = parseInt(fragData.s, 10);
+          let fragT = parseInt(fragData.t, 10);
           if (!ignoreStartOffset) {
             startTimeOffset = !isNaN(fragS) ? fragS : fragT;
           }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -248,7 +248,7 @@ function PlaybackController() {
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
         let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
-        let startTimeOffset = 0;
+        let startTimeOffset = NaN;
 
         if (fragData) {
             let fragS = parseInt(fragData.s, 10);
@@ -256,6 +256,9 @@ function PlaybackController() {
             if (!ignoreStartOffset) {
                 startTimeOffset = !isNaN(fragS) ? fragS : fragT;
             }
+        } else {
+          // handle case where no media fragments are parsed from the manifest URL
+          startTimeOffset = 0;
         }
 
         if (isDynamic) {


### PR DESCRIPTION
Fixes https://github.com/Dash-Industry-Forum/dash.js/issues/2088

When you initialize the stream with a parsed manifest object instead of the URL of a MPD, `getStreamStartTime` in `PlaybackController` tries to get the parsed media fragments but it's undefined since the parsing is never done for a parsed manifest object, it's only parsed from the URL of an MPD.

Example manifest that is passed in as a string to the parser: https://gist.github.com/CaliAlec/4ae753844344aab7da98e2418b22a624

In order to parse the manifest string, I'm using internal classes:

```
const manifest = MANIFEST_STRING;
const parser = DashParser().create();
const xlink = XLinkController().create({});
const mpd = parser.parse(manifest, xlink);
```