### PR TITLE
update AbandonRequestsRule - improved throughput estimation, now minds buffer level

### DIFF
--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -144,10 +144,11 @@ function AbandonRequestsRule(config) {
         }
 
         const bytesRemaining = fragmentInfo.bytesTotal - fragmentInfo.bytesLoaded;
-        fragmentInfo.estimatedTimeOfDownload = fragmentInfo.elapsedTime + 8 * bytesRemaining / fragmentInfo.throughput;
+        const estimatedTimeRemaining = 8 * bytesRemaining / fragmentInfo.throughput;
+        fragmentInfo.estimatedTimeOfDownload = fragmentInfo.elapsedTime + estimatedTimeRemaining;
 
         const bufferLevelMs = 1000 * bufferLevel;
-        if (fragmentInfo.estimatedTimeOfDownload < Math.min(fragmentInfo.segmentDurationMs * ABANDON_MULTIPLIER, bufferLevelMs)) {
+        if (fragmentInfo.estimatedTimeOfDownload < fragmentInfo.segmentDurationMs * ABANDON_MULTIPLIER  && estimatedTimeRemaining < bufferLevelMs) {
             // download is expected to finish in a reasonable time
             return switchRequest;
         }

--- a/test/unit/streaming.rules.abr.AbandonRequestsRule.js
+++ b/test/unit/streaming.rules.abr.AbandonRequestsRule.js
@@ -17,9 +17,16 @@ function RulesContextMock () {
         fragRequest.index = 1;
 
         return fragRequest;
-    };    
-    this.getTrackInfo = function() {};
-    this.getAbrController = function() {};
+    };
+    this.getAbrController = function() {
+        function getQualityFor() {
+            return 1;
+        }
+        let abrController = {
+            getQualityFor : getQualityFor
+        };
+        return abrController;
+    };
 }
 
 class MetricsModelMock {
@@ -49,13 +56,13 @@ class MediaPlayerModelMock {
     }
 
 }
-          
+
 describe('AbandonRequestsRule', function () {
     it("should return an empty switchRequest when shouldAbandon function is called with an empty parameter", function () {
         const abandonRequestsRule = AbandonRequestsRule(context).create({});
         const abandonRequest = abandonRequestsRule.shouldAbandon();
 
-        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line 
+        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line
     });
 
     it("should return an empty switchRequest when shouldAbandon function is called with a mock parameter", function () {
@@ -64,13 +71,13 @@ describe('AbandonRequestsRule', function () {
         let metricsModelMock = new MetricsModelMock();
         let mediaPlayerModelMock = new MediaPlayerModelMock();
 
-        const abandonRequestsRule = AbandonRequestsRule(context).create({metricsModel: metricsModelMock, 
+        const abandonRequestsRule = AbandonRequestsRule(context).create({metricsModel: metricsModelMock,
                                                                          dashMetrics: dashMetricsMock,
                                                                          mediaPlayerModel: mediaPlayerModelMock});
 
 
         const abandonRequest = abandonRequestsRule.shouldAbandon(rulesContextMock);
 
-        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line 
+        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line
     });
-}); 
+});


### PR DESCRIPTION
Improve throughput estimation:
AbandonRequestsRule was not reacting in time if there is a sudden drop in bandwidth, sometimes allowing avoidable rebuffering. The throughput estimate maintained by the rule was too slow to react. This update maintains a more accurate throughput estimate.

Introduce buffer level consideration:
This updated rule is more conservative (more likely to abandon) if the buffer level is very low. In addition to comparing estimateTimeOfDownload with the segmentDuration * 1.8, the updated rule now also compares it with bufferLevel.