### PR TITLE
fix audio buffer target when videoTrackPresent

### DIFF
--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -57,7 +57,7 @@ function BufferLevelRule(config) {
             if (isNaN(representationInfo.fragmentDuration)) {
                 bufferTarget = videoBufferLevel;
             } else {
-                bufferTarget = Math.floor(Math.max(videoBufferLevel, representationInfo.fragmentDuration));
+                bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
             }
             // console.log('videoBufferLevel  - ' + videoBufferLevel + ' target : ' + bufferTarget);
         } else {


### PR DESCRIPTION
At the end of a stream, the videoBufferLevel is less than 1. If the fragmentDuration is less than 1, then floor(max(videoBufferLevel, fragmentDuration)) is 0 and the audio buffer target is set to 0. That causes the video to not play through to the end #1901.