### PR TITLE
Update subtitles management

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -52,6 +52,8 @@ declare namespace dashjs {
         isSeeking(): boolean;
         isDynamic(): boolean;
         seek(value: number): void;
+        setPlaybackRate(value:number): void;
+        getPlaybackRate(): number;
         setMute(value: boolean): void;
         isMuted(): boolean;
         setVolume(value: number): void;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1687,25 +1687,12 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        //For external time text file,  the only action needed to change a track is marking the track mode to showing.
-        // Fragmented text tracks need the additional step of calling TextController.setTextTrack();
+
         if (textController === undefined) {
             textController = TextController(context).getInstance();
         }
 
-        let tracks = getVideoElement().textTracks;
-        const ln = tracks.length;
-
-        for (let i = 0; i < ln; i++) {
-            let track = tracks[i];
-            let mode = idx === i ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
-
-            if (track.mode !== mode) { //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
-                track.mode = mode;
-            }
-        }
-
-        textController.setTextTrack();
+        textController.setTextTrack(idx);
     }
 
     function getCurrentTextTrackIndex() {

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -337,7 +337,7 @@ function SourceBufferController(config) {
         try {
             if (mediaSource.readyState === 'open') {
                 buffer.abort();
-            } else if (buffer.setTextTrack && mediaSource.readyState === 'ended') {
+            } else if (buffer.resetEmbedded && mediaSource.readyState === 'ended') {
                 buffer.abort(); //The cues need to be removed from the TextSourceBuffer via a call to abort()
             }
         } catch (ex) {}

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -297,8 +297,19 @@ function VideoModel() {
         return element ? element.textTracks : [];
     }
 
-    function getTextTrack(idx) {
-        return element ? element.textTracks[idx] : null;
+    function getTextTrack(kind, label, lang) {
+        if (element) {
+            for (var i = 0; i < element.textTracks.length; i++) {
+                //label parameter could be a number (due to adaptationSet), but label, the attribute of textTrack, is a string => to modify...
+                //label could also be undefined (due to adaptationSet)
+                if (element.textTracks[i].kind === kind && (label ? element.textTracks[i].label == label : true) &&
+                   element.textTracks[i].language === lang) {
+                    return element.textTracks[i];
+                }
+            }
+        }
+
+        return null;
     }
 
     function addTextTrack(kind, label, lang) {

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -285,8 +285,39 @@ function VideoModel() {
         return element ? element.clientHeight : NaN;
     }
 
+    function getVideoWidth() {
+        return element ? element.videoWidth : NaN;
+    }
+
+    function getVideoHeight() {
+        return element ? element.videoHeight : NaN;
+    }
+
     function getTextTracks() {
         return element ? element.textTracks : [];
+    }
+
+    function getTextTrack(idx) {
+        return element ? element.textTracks[idx] : null;
+    }
+
+    function addTextTrack(kind, label, lang) {
+        if (element) {
+            return element.addTextTrack(kind, label, lang);
+        }
+        return null;
+    }
+
+    function appendChild(childElement) {
+        if (element) {
+            element.appendChild(childElement);
+        }
+    }
+
+    function removeChild(childElement) {
+        if (element) {
+            element.removeChild(childElement);
+        }
     }
 
     instance = {
@@ -316,7 +347,13 @@ function VideoModel() {
         getBufferRange: getBufferRange,
         getClientWidth: getClientWidth,
         getClientHeight: getClientHeight,
-        getTextTracks: getTextTracks
+        getTextTracks: getTextTracks,
+        getTextTrack: getTextTrack,
+        addTextTrack: addTextTrack,
+        appendChild: appendChild,
+        removeChild: removeChild,
+        getVideoWidth: getVideoWidth,
+        getVideoHeight: getVideoHeight
     };
 
     return instance;

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -146,7 +146,7 @@ function TextController() {
             }
             allTracksAreDisabled = track.mode !== Constants.TEXT_SHOWING;
             if (track.mode === Constants.TEXT_SHOWING) {
-                if (oldTrackIdx !== i) { // do not reset track if already the current track.  This happens when all captions get turned off via UI and then turned on again and with videojs.
+                if (oldTrackIdx !== i) { // do not reset track if already the current track. This happens when all captions get turned off via UI and then turned on again and with videojs.
                     textTracks.setCurrentTrackIdx(i);
                     textTracks.addCaptions(i, 0, null); // Make sure that previously queued captions are added as cues
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -128,15 +128,6 @@ function TextController() {
         let tracks = videoModel.getTextTracks();
         const ln = tracks.length;
 
-        for (let i = 0; i < ln; i++) {
-            let track = tracks[i];
-            let mode = idx === i ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
-
-            if (track.mode !== mode) { //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
-                track.mode = mode;
-            }
-        }
-
         let config = textSourceBuffer.getConfig();
         let fragmentModel = config.fragmentModel;
         let embeddedTracks = config.embeddedTracks;
@@ -148,6 +139,11 @@ function TextController() {
 
         for (let i = 0; i < ln; i++) {
             let track = tracks[i];
+            let mode = idx === i ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
+
+            if (track.mode !== mode) { //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
+                track.mode = mode;
+            }
             allTracksAreDisabled = track.mode !== Constants.TEXT_SHOWING;
             if (track.mode === Constants.TEXT_SHOWING) {
                 if (oldTrackIdx !== i) { // do not reset track if already the current track.  This happens when all captions get turned off via UI and then turned on again and with videojs.

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -122,7 +122,20 @@ function TextController() {
         textSourceBuffer.addEmbeddedTrack(mediaInfo);
     }
 
-    function setTextTrack() {
+    function setTextTrack(idx) {
+        //For external time text file,  the only action needed to change a track is marking the track mode to showing.
+        // Fragmented text tracks need the additional step of calling TextController.setTextTrack();
+        let tracks = videoModel.getTextTracks();
+        const ln = tracks.length;
+
+        for (let i = 0; i < ln; i++) {
+            let track = tracks[i];
+            let mode = idx === i ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
+
+            if (track.mode !== mode) { //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
+                track.mode = mode;
+            }
+        }
 
         let config = textSourceBuffer.getConfig();
         let fragmentModel = config.fragmentModel;
@@ -130,8 +143,6 @@ function TextController() {
         let isFragmented = config.isFragmented;
         let fragmentedTracks = config.fragmentedTracks;
 
-        let tracks = videoModel.getTextTracks();
-        const ln = tracks.length;
         let nrNonEmbeddedTracks = ln - embeddedTracks.length;
         let oldTrackIdx = textTracks.getCurrentTrackIdx();
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -125,50 +125,37 @@ function TextController() {
     function setTextTrack(idx) {
         //For external time text file,  the only action needed to change a track is marking the track mode to showing.
         // Fragmented text tracks need the additional step of calling TextController.setTextTrack();
-        let tracks = videoModel.getTextTracks();
-        const ln = tracks.length;
 
         let config = textSourceBuffer.getConfig();
         let fragmentModel = config.fragmentModel;
-        let embeddedTracks = config.embeddedTracks;
-        let isFragmented = config.isFragmented;
         let fragmentedTracks = config.fragmentedTracks;
 
-        let nrNonEmbeddedTracks = ln - embeddedTracks.length;
         let oldTrackIdx = textTracks.getCurrentTrackIdx();
+        if (oldTrackIdx !== idx) {
+            textTracks.setModeForTrackIdx(oldTrackIdx, Constants.TEXT_HIDDEN);
+            textTracks.setCurrentTrackIdx(idx);
+            textTracks.setModeForTrackIdx(idx, Constants.TEXT_SHOWING);
 
-        for (let i = 0; i < ln; i++) {
-            let track = tracks[i];
-            let mode = idx === i ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
+            let currentTrackInfo = textTracks.getCurrentTrackInfo();
 
-            if (track.mode !== mode) { //checking that mode is not already set by 3rd Party player frameworks that set mode to prevent event retrigger.
-                track.mode = mode;
-            }
-            allTracksAreDisabled = track.mode !== Constants.TEXT_SHOWING;
-            if (track.mode === Constants.TEXT_SHOWING) {
-                if (oldTrackIdx !== i) { // do not reset track if already the current track. This happens when all captions get turned off via UI and then turned on again and with videojs.
-                    textTracks.setCurrentTrackIdx(i);
-                    textTracks.addCaptions(i, 0, null); // Make sure that previously queued captions are added as cues
-
-                    // specific to fragmented text
-                    if (isFragmented && i < nrNonEmbeddedTracks) {
+            if (currentTrackInfo && currentTrackInfo.isFragmented && !currentTrackInfo.isEmbedded) {
+                for (let i = 0; i < fragmentedTracks.length; i++) {
+                    let mediaInfo = fragmentedTracks[i];
+                    if (currentTrackInfo.lang === mediaInfo.lang && currentTrackInfo.index === mediaInfo.index &&
+                        (currentTrackInfo.label ? currentTrackInfo.label === mediaInfo.id : true)) {
                         let currentFragTrack = mediaController.getCurrentTrackFor(Constants.FRAGMENTED_TEXT, streamController.getActiveStreamInfo());
-                        let newFragTrack = fragmentedTracks[i];
-                        if (newFragTrack !== currentFragTrack) {
+                        if (mediaInfo !== currentFragTrack) {
                             fragmentModel.abortRequests();
                             textTracks.deleteCuesFromTrackIdx(oldTrackIdx);
-                            mediaController.setTrack(newFragTrack);
+                            mediaController.setTrack(mediaInfo);
                             textSourceBuffer.setCurrentFragmentedTrackIdx(i);
                         }
                     }
                 }
-                break;
             }
         }
 
-        if (allTracksAreDisabled) {
-            textTracks.setCurrentTrackIdx(-1);
-        }
+        allTracksAreDisabled = idx === -1 ? true : false;
     }
 
     function getCurrentTrackIdx() {

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -286,7 +286,6 @@ function TextSourceBuffer() {
             textTrackInfo.label = mediaInfo.id; // AdaptationSet id (an unsigned int)
             textTrackInfo.index = mediaInfo.index; // AdaptationSet index in manifest
             textTrackInfo.isTTML = checkTTML();
-            textTrackInfo.video = videoModel.getElement();
             textTrackInfo.defaultTrack = getIsDefault(mediaInfo);
             textTrackInfo.isFragmented = isFragmented;
             textTrackInfo.isEmbedded = mediaInfo.isEmbedded ? true : false;

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -146,7 +146,6 @@ function TextSourceBuffer() {
     function initEmbedded() {
         embeddedTracks = [];
         mediaInfos = [];
-        // videoModel = VideoModel(context).getInstance();
         textTracks = TextTracks(context).getInstance();
         textTracks.setConfig({
             videoModel: videoModel

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -150,6 +150,9 @@ function TextTracks() {
 
                 let textTrack = videoModel.getTextTrack(textTrackQueue[i].kind, textTrackQueue[i].label, textTrackQueue[i].lang);
                 if (textTrack) {
+                    //each time a track is created, its mode should be showing by default
+                    //sometime, it's not on Chrome
+                    textTrack.mode = Constants.TEXT_SHOWING;
                     if (captionContainer && (textTrackQueue[i].isTTML || textTrackQueue[i].isEmbedded)) {
                         textTrack.renderingType = 'html';
                     } else {
@@ -229,8 +232,7 @@ function TextTracks() {
         }
     }
 
-    function checkVideoSize() {
-        let track = currentTrackIdx >= 0 && textTrackQueue[currentTrackIdx] ? videoModel.getTextTrack(textTrackQueue[currentTrackIdx].kind, textTrackQueue[currentTrackIdx].label, textTrackQueue[currentTrackIdx].lang) : null;
+    function checkVideoSize(track) {
         if (track && track.renderingType === 'html') {
             let clientWidth = videoModel.getClientWidth();
             let clientHeight = videoModel.getClientHeight();
@@ -367,7 +369,7 @@ function TextTracks() {
             track.isFromCEA608 = currentItem.isFromCEA608;
 
             if (!videoSizeCheckInterval && (currentItem.type === 'html' || currentItem.type === 'image')) {
-                videoSizeCheckInterval = setInterval(checkVideoSize.bind(this), 500);
+                videoSizeCheckInterval = setInterval(checkVideoSize.bind(self, track), 500);
             }
 
             if (currentItem.type === 'html') {

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -166,7 +166,9 @@ function TextTracks() {
             if (defaultIndex >= 0) {
                 for (let idx = 0; idx < textTrackQueue.length; idx++) {
                     let videoTextTrack = videoModel.getTextTrack(textTrackQueue[idx].kind, textTrackQueue[idx].label, textTrackQueue[idx].lang);
-                    videoTextTrack.mode = (idx === defaultIndex) ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
+                    if (videoTextTrack) {
+                        videoTextTrack.mode = (idx === defaultIndex) ? Constants.TEXT_SHOWING : Constants.TEXT_HIDDEN;
+                    }
                 }
             }
 

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -504,8 +504,6 @@ function TextTracks() {
             for (let r = lastIdx; r >= 0 ; r--) {
                 track.removeCue(cues[r]);
             }
-
-            track.mode = 'disabled';
         }
     }
 
@@ -526,6 +524,7 @@ function TextTracks() {
                 let track = getTextTrack.call(this, i);
                 track.nonAddedCues = [];
                 deleteTrackCues.call(this, track);
+                track.mode = 'disabled';
             }
 
         }

--- a/src/streaming/vo/TextTrackInfo.js
+++ b/src/streaming/vo/TextTrackInfo.js
@@ -34,7 +34,6 @@
  */
 class TextTrackInfo {
     constructor() {
-        this.video = null;
         this.captionData = null;
         this.label = null;
         this.lang = null;

--- a/test/unit/mocks/VideoElementMock.js
+++ b/test/unit/mocks/VideoElementMock.js
@@ -2,6 +2,7 @@ class TextTrackMock {
     constructor() {
         this.kind = null;
         this.label = null;
+        this.lang = null;
     }
 }
 
@@ -20,10 +21,11 @@ class VideoElementMock {
         this.setup();
     }   
 
-    addTextTrack(kind, label) {
+    addTextTrack(kind, label, lang) {
         let textTrack = new TextTrackMock();
         textTrack.kind = kind;
         textTrack.label = label;
+        textTrack.lang = lang;
         this.textTracks.push(textTrack);
 
         return textTrack;

--- a/test/unit/mocks/VideoModelMock.js
+++ b/test/unit/mocks/VideoModelMock.js
@@ -1,3 +1,5 @@
+import VideoElementMock from './VideoElementMock';
+
 class VideoModelMock {
     constructor() {
         this.isplaying = false;
@@ -10,6 +12,7 @@ class VideoModelMock {
         this.State = 'ready';
         this.tracks = [];
         this.source = null;
+        this.element = new VideoElementMock();
 
         this.events = {};
     }
@@ -96,6 +99,15 @@ class VideoModelMock {
 
     getTextTracks() {
         return this.tracks;
+    }
+
+    getTextTrack(idx) {
+        return this.element.textTracks[idx];
+    }
+
+
+    addTextTrack(kind, label, lang) {
+        return this.element.addTextTrack(kind, label, lang);
     }
 
     getTTMLRenderingDiv() {

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -6,7 +6,6 @@ import Events from '../../src/core/events/Events';
 import EventBus from '../../src/core/EventBus';
 
 import VideoModelMock from './mocks/VideoModelMock';
-import VideoElementMock from './mocks/VideoElementMock';
 
 const expect = require('chai').expect;
 const context = {};

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -75,7 +75,7 @@ describe('TextController', function () {
                 id: 'track2'
             }];
 
-            textController.setTextTrack();
+            textController.setTextTrack(-1);
             expect(textController.getAllTracksAreDisabled()).to.be.true;
 
         });
@@ -88,7 +88,7 @@ describe('TextController', function () {
                 id: 'track2'
             }];
 
-            textController.setTextTrack();
+            textController.setTextTrack(0);
             expect(textController.getAllTracksAreDisabled()).to.be.false;
 
         });

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -17,7 +17,6 @@ const objectUtils = ObjectUtils(context).getInstance();
 describe('TextController', function () {
 
     let videoModelMock = new VideoModelMock();
-    let videoMock;
     let textTracks;
     let textController;
 
@@ -47,14 +46,11 @@ describe('TextController', function () {
     describe('Method setTextTrack', function () {
 
         beforeEach( function() {
-            videoMock = new VideoElementMock();
-
             textTracks.addTextTrack({
                 index : 0,
                 kind : "subtitles",
                 label : 'eng',
                 defaultTrack : true,
-                video: videoMock,
                 isTTML : true
             }, 2);
 
@@ -63,7 +59,6 @@ describe('TextController', function () {
                 kind : "subtitles",
                 label : 'fr',
                 defaultTrack : false,
-                video: videoMock,
                 isTTML : true
             }, 2);
         });


### PR DESCRIPTION
Hi,

this PR has to fix the issue #2084 : the index of the subtitles track is a reference of textTrackInfo array. textTrack array of html5 video element has a different index.
In the same way, user can use the different subtitles with Firefox or Edge for instance. Indeed, before this PR, it was impossible to see subtitles in some specifc use cases (for instance, a first stream with one subtitles track, stop, load a second one, with two subtitles track).

Nicolas