### PR TITLE
bug fix for segment timeline streams

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -124,7 +124,7 @@ function DashHandler(config) {
         index = -1;
         currentTime = 0;
         earliestTime = NaN;
-        requestedTime = NaN;
+        requestedTime = null;
         streamProcessor = null;
         segmentsGetter = null;
     }


### PR DESCRIPTION
Hi,

this PR has to fix a bug for live segment Timeline. Since PR #2030 , it was impossible to play live stream based on segment timeline.

Nicolas