### PR TITLE
store throughput in localStorage, not bitrate of last quality

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -350,7 +350,10 @@ function RepresentationController() {
 
         if (e.oldQuality !== e.newQuality) {
             currentVoRepresentation = getRepresentationForQuality(e.newQuality);
-            domStorage.setSavedBitrateSettings(e.mediaType, currentVoRepresentation.bandwidth);
+            const bitrate = abrController.getThroughputHistory().getAverageThroughput(e.mediaType);
+            if (!isNaN(bitrate)) {
+                domStorage.setSavedBitrateSettings(e.mediaType, bitrate);
+            }
             addRepresentationSwitch();
         }
     }

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -161,7 +161,7 @@ function DOMStorage(config) {
             let key = LOCAL_STORAGE_BITRATE_KEY_TEMPLATE.replace(/\?/, type);
             let obj = JSON.parse(localStorage.getItem(key)) || {};
             let isExpired = (new Date().getTime() - parseInt(obj.timestamp, 10)) >= mediaPlayerModel.getLastBitrateCachingInfo().ttl || false;
-            let bitrate = parseInt(obj.bitrate, 10);
+            let bitrate = parseFloat(obj.bitrate);
 
             if (!isNaN(bitrate) && !isExpired) {
                 savedBitrate = bitrate;
@@ -188,7 +188,7 @@ function DOMStorage(config) {
         if (canStore(STORAGE_TYPE_LOCAL, LAST_BITRATE) && bitrate) {
             let key = LOCAL_STORAGE_BITRATE_KEY_TEMPLATE.replace(/\?/, type);
             try {
-                localStorage.setItem(key, JSON.stringify({bitrate: bitrate / 1000, timestamp: getTimestamp()}));
+                localStorage.setItem(key, JSON.stringify({bitrate: bitrate.toFixed(3), timestamp: getTimestamp()}));
             } catch (e) {
                 log(e.message);
             }


### PR DESCRIPTION
Storing the bitrate of one of the available representations can lead to excessive rounding down (#2124) when different video streams are available for the same origin.

Also some ABR rule other than ThroughputRule can cause a drop in quality. E.g. if a live streaming session has a very shorter buffer, then InsufficientBufferRule will be conservative and limit the quality to a bitrate lower than the throughput. In such a case we want the throughput and not the representation bitrate to be stored in localStorage.