### PR TITLE
Robustness levels

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -432,7 +432,9 @@
               "serverURL": "https://drm-widevine-licensing.axtest.net/AcquireLicense",
               "httpRequestHeaders": {
                 "X-AxDRM-Message": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiNmU1YTFkMjYtMjc1Ny00N2Q3LTgwNDYtZWFhNWQxZDM0YjVhIn1dfX0.yF7PflOPv9qHnu3ZWJNZ12jgkqTabmwXbDWk_47tLNE"
-              }
+              },
+              "audioRobustness": "SW_SECURE_CRYPTO",
+              "videoRobustness": "SW_SECURE_DECODE"
             },
             "com.microsoft.playready": {
               "serverURL": "https://drm-playready-licensing.axtest.net/AcquireLicense",

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -313,24 +313,29 @@ function ProtectionController(config) {
         return protData;
     }
 
+    function getKeySystemConfiguration(keySystem) {
+        let protData = getProtData(keySystem);
+        let audioCapabilities = [];
+        let videoCapabilities = [];
+        let audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
+        let videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
+
+        if (audioInfo) {
+            audioCapabilities.push(new MediaCapability(audioInfo.codec, audioRobustness));
+        }
+        if (videoInfo) {
+            videoCapabilities.push(new MediaCapability(videoInfo.codec, videoRobustness));
+        }
+
+        return new KeySystemConfiguration(
+            audioCapabilities, videoCapabilities, 'optional',
+            (sessionType === 'temporary') ? 'optional' : 'required',
+            [sessionType]);
+    }
+
     function selectKeySystem(supportedKS, fromManifest) {
 
         let self = this;
-
-        // Build our request object for requestKeySystemAccess
-        let audioCapabilities = [];
-        let videoCapabilities = [];
-
-        if (videoInfo) {
-            videoCapabilities.push(new MediaCapability(videoInfo.codec, robustnessLevel));
-        }
-        if (audioInfo) {
-            audioCapabilities.push(new MediaCapability(audioInfo.codec, robustnessLevel));
-        }
-        let ksConfig = new KeySystemConfiguration(
-                audioCapabilities, videoCapabilities, 'optional',
-                (sessionType === 'temporary') ? 'optional' : 'required',
-                [sessionType]);
         let requestedKeySystems = [];
 
         let ksIdx;
@@ -339,7 +344,7 @@ function ProtectionController(config) {
             for (ksIdx = 0; ksIdx < supportedKS.length; ksIdx++) {
                 if (keySystem === supportedKS[ksIdx].ks) {
 
-                    requestedKeySystems.push({ks: supportedKS[ksIdx].ks, configs: [ksConfig]});
+                    requestedKeySystems.push({ks: supportedKS[ksIdx].ks, configs: [getKeySystemConfiguration(keySystem)]});
 
                     // Ensure that we would be granted key system access using the key
                     // system and codec information
@@ -368,7 +373,7 @@ function ProtectionController(config) {
 
             // Add all key systems to our request list since we have yet to select a key system
             for (let i = 0; i < supportedKS.length; i++) {
-                requestedKeySystems.push({ks: supportedKS[i].ks, configs: [ksConfig]});
+                requestedKeySystems.push({ks: supportedKS[i].ks, configs: [getKeySystemConfiguration(supportedKS[i].ks)]});
             }
 
             let keySystemAccess;

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -104,26 +104,6 @@ function KeySystemWidevine() {
         return pssh;
     }
 
-    function doGetKeySystemConfigurations(videoCodec, audioCodec, sessionType) {
-        var ksConfigurations = MediaPlayer.dependencies.protection.CommonEncryption.getKeySystemConfigurations(videoCodec, audioCodec, sessionType);
-        if (protData) {
-            if (protData.audioRobustness) {
-                ksConfigurations[0].audioCapabilities[0].robustness = protData.audioRobustness;
-            }
-            if (protData.videoRobustness) {
-                ksConfigurations[0].videoCapabilities[0].robustness = protData.videoRobustness;
-            }
-        }
-        return ksConfigurations;
-    }
-
-    function doGetServerCertificate() {
-        if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
-            return BASE64.decodeArray(protData.serverCertificate).buffer;
-        }
-        return null;
-    }
-
     function getRequestHeadersFromMessage( /*message*/ ) {
         return null;
     }
@@ -142,8 +122,6 @@ function KeySystemWidevine() {
         systemString: systemString,
         init: init,
         getInitData: getInitData,
-        getKeySystemConfigurations: doGetKeySystemConfigurations,
-        getServerCertificate: doGetServerCertificate,
         getRequestHeadersFromMessage: getRequestHeadersFromMessage,
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -52,9 +52,6 @@ function KeySystemWidevine() {
     function init(protectionData) {
         if (protectionData) {
             protData = protectionData;
-            if (protData.sessionType) {
-                this.sessionType = protData.sessionType;
-            }
         }
     }
 


### PR DESCRIPTION
This PR enables setting the audio/video robustness levels in protData, in order to avoid warning on chrome ("It is recommended that a robustness level be specified...")
An exemple of robustness level values is provided for sample stream "Axinom Test Content (conservative/legacy) / 1080p with PlayReady and Widevine DRM, single key"