### PR TITLE
Update audio track switch

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -279,10 +279,10 @@ function Stream(config) {
             trackChangedEvent = e;
             manifestUpdater.refreshManifest();
         } else {
-            if (mediaInfo.type !== Constants.FRAGMENTED_TEXT) {
-                trackChangedEvent = e;
-            }
             processor.updateMediaInfo(mediaInfo);
+            if (mediaInfo.type !== Constants.FRAGMENTED_TEXT) {
+                processor.switchTrackAsked();
+            }
         }
     }
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -270,11 +270,8 @@ function Stream(config) {
 
         let currentTime = playbackController.getTime();
         log('Stream -  Process track changed at current time ' + currentTime);
-        let buffer = processor.getBuffer();
         let mediaInfo = e.newMediaInfo;
         let manifest = manifestModel.getValue();
-        let idx = streamProcessors.indexOf(processor);
-        let mediaSource = processor.getMediaSource();
 
         log('Stream -  Update stream controller');
         if (manifest.refreshManifestOnSwitchTrack) {
@@ -283,17 +280,9 @@ function Stream(config) {
             manifestUpdater.refreshManifest();
         } else {
             if (mediaInfo.type !== Constants.FRAGMENTED_TEXT) {
-
-                processor.reset(true);
-                createStreamProcessor(mediaInfo, mediaSource, {
-                    buffer: buffer,
-                    replaceIdx: idx,
-                    currentTime: currentTime
-                });
-                playbackController.seek(playbackController.getTime());
-            } else {
-                processor.updateMediaInfo( mediaInfo);
+                trackChangedEvent = e;
             }
+            processor.updateMediaInfo(mediaInfo);
         }
     }
 
@@ -562,6 +551,7 @@ function Stream(config) {
                 let processor = getProcessorForMediaInfo(trackChangedEvent.oldMediaInfo);
                 if (!processor) return;
                 processor.switchTrackAsked();
+                trackChangedEvent = undefined;
             }
         }
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -110,7 +110,6 @@ function StreamProcessor(config) {
             mediaPlayerModel: mediaPlayerModel,
             abrController: abrController,
             playbackController: playbackController,
-            mediaController: mediaController,
             streamController: streamController,
             textController: textController,
             sourceBufferController: sourceBufferController,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -193,7 +193,7 @@ function ScheduleController(config) {
                 log('ScheduleController - getNextFragment');
                 let fragmentController = streamProcessor.getFragmentController();
                 if (switchTrack) {
-                    log('ScheduleController - switch track has been asked, get init request');
+                    log('ScheduleController - switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
                     streamProcessor.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.id);
                     switchTrack = false;
                 } else if (currentRepresentationInfo.quality !== lastInitQuality) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -148,8 +148,6 @@ function ScheduleController(config) {
 
         startScheduleTimer(0);
 
-        switchTrack = true;
-
         log('Schedule controller starting for ' + type);
     }
 
@@ -614,6 +612,7 @@ function ScheduleController(config) {
         topQualityIndex = {};
         replaceRequestArray = [];
         isStopped = true;
+        switchTrack = true;
     }
 
     instance = {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -148,6 +148,8 @@ function ScheduleController(config) {
 
         startScheduleTimer(0);
 
+        switchTrack = true;
+
         log('Schedule controller starting for ' + type);
     }
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -52,7 +52,6 @@ function ScheduleController(config) {
     const mediaPlayerModel = config.mediaPlayerModel;
     const abrController = config.abrController;
     const playbackController = config.playbackController;
-    const mediaController = config.mediaController;
     const streamController = config.streamController;
     const textController = config.textController;
     const sourceBufferController = config.sourceBufferController;
@@ -245,13 +244,11 @@ function ScheduleController(config) {
         })[0];
 
         if (request && replaceRequestArray.indexOf(request) === -1 && !dashManifestModel.getIsTextTrack(type)) {
-            const isCurrentTrack = mediaController.isCurrentTrack(request.mediaInfo);
             const fastSwitchModeEnabled = mediaPlayerModel.getFastSwitchEnabled();
             const bufferLevel = streamProcessor.getBufferLevel();
             const abandonmentState = abrController.getAbandonmentStateFor(type);
 
-            if (!isCurrentTrack ||
-                fastSwitchModeEnabled && request.quality < currentRepresentationInfo.quality && bufferLevel >= safeBufferLevel && abandonmentState !== AbrController.ABANDON_LOAD) {
+            if (fastSwitchModeEnabled && request.quality < currentRepresentationInfo.quality && bufferLevel >= safeBufferLevel && abandonmentState !== AbrController.ABANDON_LOAD) {
                 replaceRequest(request);
                 log('Reloading outdated fragment at index: ', request.index);
             } else if (request.quality > currentRepresentationInfo.quality) {


### PR DESCRIPTION
Hi,
as explained in the issue #1928, the audio track switch is broken for segmentTimeLine dash manifest.  I think that it's unnecessary to destroy audio stream processor when an audio switch occurs. What dash.js player has to do is to restart scheduleController, load the new init segment and continue .... :-)

In order to this PR has to work properly, PR #2144 needs to be merged. I also would like to do more tests with dash streams with many audio tracks, if you have some.....thanks! ;-)

Nicolas

