### PR TITLE
Fix a pb if realPeriodId is "".

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -630,7 +630,7 @@ function DashManifestModel(config) {
 
         let id = Period.DEFAULT_ID + '_' + i;
 
-        if (realPeriod.hasOwnProperty(DashConstants.ID) && realPeriod.id !== '__proto__') {
+        if (realPeriod.hasOwnProperty(DashConstants.ID) && realPeriod.id.length > 0 && realPeriod.id !== '__proto__') {
             id = realPeriod.id;
         }
 


### PR DESCRIPTION
Using 4K stream (https://dash.akamaized.net/akamai/streamroot/050714/Spring_4Ktest.mpd)
In the manifest, period id value is "". Then the method DashAdapter::getAdaptationForMediaInfo returns null, because of the test (!mediaInfo.streamInfo.id).

This PR fixes the pb by checking length of id