### PR TITLE
Add  unsupported codecs detection

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -38,9 +38,6 @@ import FactoryMaker from '../core/FactoryMaker';
 import cea608parser from '../../externals/cea608-parser';
 
 function DashAdapter() {
-
-    //let context = this.context;
-
     let instance,
         dashManifestModel,
         voPeriods,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -273,9 +273,9 @@ function DashManifestModel(config) {
         return adaptations[0];
     }
 
-    function getCodec(adaptation) {
+    function getCodec(adaptation, representationId) {
         if (adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0) {
-            let representation = adaptation.Representation_asArray[0];
+            let representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length ? adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
             return (representation.mimeType + ';codecs="' + representation.codecs + '"');
         }
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -32,7 +32,6 @@ import Constants from './constants/Constants';
 import StreamProcessor from './StreamProcessor';
 import EventController from './controllers/EventController';
 import FragmentController from './controllers/FragmentController';
-import VideoModel from './models/VideoModel';
 import EventBus from '../core/EventBus';
 import Events from '../core/events/Events';
 import Debug from '../core/Debug';
@@ -252,7 +251,7 @@ function Stream(config) {
 
         if (!!mediaInfo.contentProtection && !capabilities.supportsEncryptedMedia()) {
             errHandler.capabilityError('encryptedmedia');
-        } else if (!capabilities.supportsCodec(VideoModel(context).getInstance().getElement(), codec)) {
+        } else if (!capabilities.supportsCodec(codec)) {
             msg = type + 'Codec (' + codec + ') is not supported.';
             errHandler.manifestError(msg, 'codec', manifestModel.getValue());
             log(msg);
@@ -445,7 +444,7 @@ function Stream(config) {
             if (i === 0) return true;
 
             const codec = dashManifestModel.getCodec(realAdaptation, i);
-            if (codec && !capabilities.supportsCodec(VideoModel(context).getInstance().getElement(), codec)) {
+            if (!capabilities.supportsCodec(codec)) {
                 log('[Stream] codec not supported: ' + codec);
                 return false;
             }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -435,26 +435,23 @@ function Stream(config) {
     }
 
     function filterCodecs(type) {
-        let realAdaptation = dashManifestModel.getAdaptationForType(manifestModel.getValue(), streamInfo.index, type, streamInfo);
-        let codec,
-                i;
+        const realAdaptation = dashManifestModel.getAdaptationForType(manifestModel.getValue(), streamInfo.index, type, streamInfo);
+        let codec;
 
         if (!realAdaptation || !Array.isArray(realAdaptation.Representation_asArray)) return null;
 
         // Filter codecs that are not supported
-        // But keep at least codec from lowest representation
-        i = 1;
-        while (i < realAdaptation.Representation_asArray.length) {
+        realAdaptation.Representation_asArray.filter((_, i) => {
+            // keep at least codec from lowest representation
+            if (i === 0) return true;
+
             codec = dashManifestModel.getCodec(realAdaptation, i);
-            if (codec) {
-                if (!capabilities.supportsCodec(VideoModel(context).getInstance().getElement(), codec)) {
-                    log('[Stream] codec not supported: ' + codec);
-                    realAdaptation.Representation_asArray.splice(i, 1);
-                    i--;
-                }
+            if (codec && !capabilities.supportsCodec(VideoModel(context).getInstance().getElement(), codec)) {
+                log('[Stream] codec not supported: ' + codec);
+                return false;
             }
-            i++;
-        }
+            return true;
+        });
     }
 
     function checkIfInitializationCompleted() {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -436,7 +436,6 @@ function Stream(config) {
 
     function filterCodecs(type) {
         const realAdaptation = dashManifestModel.getAdaptationForType(manifestModel.getValue(), streamInfo.index, type, streamInfo);
-        let codec;
 
         if (!realAdaptation || !Array.isArray(realAdaptation.Representation_asArray)) return null;
 
@@ -445,7 +444,7 @@ function Stream(config) {
             // keep at least codec from lowest representation
             if (i === 0) return true;
 
-            codec = dashManifestModel.getCodec(realAdaptation, i);
+            const codec = dashManifestModel.getCodec(realAdaptation, i);
             if (codec && !capabilities.supportsCodec(VideoModel(context).getInstance().getElement(), codec)) {
                 log('[Stream] codec not supported: ' + codec);
                 return false;

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -60,9 +60,16 @@ function Capabilities() {
         encryptedMediaSupported = value;
     }
 
-    function supportsCodec(element, codec) {
-        let canPlay = element.canPlayType(codec);
-        return (canPlay === 'probably' || canPlay === 'maybe');
+    function supportsCodec(codec) {
+        if ('MediaSource' in window && MediaSource.isTypeSupported(codec)) {
+            return true;
+        }
+
+        if ('WebKitMediaSource' in window && WebKitMediaSource.isTypeSupported(codec)) {
+            return true;
+        }
+
+        return false;
     }
 
     instance = {


### PR DESCRIPTION
Hi,

as explained in issue #1643, only codec of the first representation is verified by dash.js. Unfortunately, the others codec are not tested. In this PR, when an unsupported codec is detected, the representation is deleted from the adaptation.

Nicolas