### PR TITLE
[DRM] Ignore 'encrypted' event

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -558,6 +558,22 @@ function ProtectionController(config) {
             abInitData = abInitData.buffer;
         }
 
+        // If key system has already been selected and initData already seen, then do nothing
+        if (keySystem) {
+            let initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, abInitData);
+            if (initDataForKS) {
+
+                // Check for duplicate initData
+                let currentInitData = protectionModel.getAllInitData();
+                for (let i = 0; i < currentInitData.length; i++) {
+                    if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
+                        log('DRM: Ignoring initData because we have already seen it!');
+                        return;
+                    }
+                }
+            }
+        }
+
         log('DRM: initData:', String.fromCharCode.apply(null, new Uint8Array(abInitData)));
 
         let supportedKS = protectionKeyController.getSupportedKeySystems(abInitData, protDataSet);


### PR DESCRIPTION
Hi

This PR ignores 'encrypted' event in case the key system has already been selected and pssh already processed.

This avoids to call requestKeySystemAccess each time an init segment is pushed in sourcebuffer (each time bitrate is changed)
This may lead to a crash of CDM.

This can be the cause of issue #2159

Jeremie