### PR TITLE
Fix #2149 - webkitAddKey argument mistmatch

### DIFF
--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -232,11 +232,11 @@ function ProtectionModel_01b(config) {
     }
 
     function updateKeySession(sessionToken, message) {
-        let sessionID = sessionToken.sessionID;
+        const sessionID = sessionToken.sessionID;
         if (!protectionKeyController.isClearKey(keySystem)) {
             // Send our request to the CDM
             videoElement[api.addKey](keySystem.systemString,
-                new Uint8Array(message), sessionToken.initData, sessionID);
+                new Uint8Array(message), new Uint8Array(sessionToken.initData), sessionID);
         } else {
             // For clearkey, message is a ClearKeyKeySet
             for (let i = 0; i < message.keyPairs.length; i++) {


### PR DESCRIPTION
Fix for reported issue #2149. Following specification, for Protection Model 01b, both Key and InitData parameters must be wrapped under Uint8Array.