### PR TITLE
add a SwitchHistoryRule  unit test

### DIFF
--- a/src/streaming/rules/abr/SwitchHistoryRule.js
+++ b/src/streaming/rules/abr/SwitchHistoryRule.js
@@ -16,8 +16,8 @@ function SwitchHistoryRule() {
 
 
     function getMaxIndex(rulesContext) {
-        const switchRequestHistory = rulesContext.getSwitchHistory();
-        let switchRequests = switchRequestHistory.getSwitchRequests();
+        const switchRequestHistory = rulesContext ? rulesContext.getSwitchHistory() : null;
+        let switchRequests = switchRequestHistory ? switchRequestHistory.getSwitchRequests() : [];
         let drops = 0;
         let noDrops = 0;
         let dropSize = 0;

--- a/test/unit/mocks/RulesContextMock.js
+++ b/test/unit/mocks/RulesContextMock.js
@@ -1,10 +1,18 @@
 import FragmentRequest from '../../../src/streaming/vo/FragmentRequest';
 
+function switchRequestHistoryMock() {
+    this.getSwitchRequests = function () {
+        return [{drops: 7,
+                noDrops: 0,
+                dropSize: 4}];
+    };
+}
+
 function RulesContextMock () {
-    this.getMediaInfo = function() {
+    this.getMediaInfo = function () {
 
     };
-    this.getMediaType = function() {
+    this.getMediaType = function () {
         return 'video';
     };
     this.getCurrentRequest = function() {
@@ -15,6 +23,9 @@ function RulesContextMock () {
     };    
     this.getTrackInfo = function() {};
     this.getAbrController = function() {};
+    this.getSwitchHistory = function() {
+        return new switchRequestHistoryMock();
+    };
 }
 
 export default RulesContextMock;

--- a/test/unit/streaming.rules.abr.SwitchHistoryRule.js
+++ b/test/unit/streaming.rules.abr.SwitchHistoryRule.js
@@ -1,0 +1,22 @@
+import SwitchHistoryRule from '../../src/streaming/rules/abr/SwitchHistoryRule';
+
+import RulesContextMock from './mocks/RulesContextMock';
+
+const expect = require('chai').expect;
+const context = {};
+const switchHistoryRule = SwitchHistoryRule(context).create();
+
+describe('SwitchHistoryRule', function () {
+    it("should return an empty switchRequest when getMaxIndex function is called with an empty parameter", function () {
+        const switchRequest = switchHistoryRule.getMaxIndex();
+
+        expect(switchRequest.quality).to.be.equal(-1);  // jshint ignore:line 
+    });
+
+    it("should return an switchRequest with quality equals 0 when one switchRequest equals to {drops: 7, noDrops: 0, dropSize: 4}, a division by zero occurs", function () {
+        let rulesContextMock = new RulesContextMock();
+        const switchRequest = switchHistoryRule.getMaxIndex(rulesContextMock);
+
+        expect(switchRequest.quality).to.be.equal(0);  // jshint ignore:line 
+    });
+});

--- a/test/unit/streaming.rules.abr.SwitchHistoryRule.js
+++ b/test/unit/streaming.rules.abr.SwitchHistoryRule.js
@@ -1,4 +1,5 @@
 import SwitchHistoryRule from '../../src/streaming/rules/abr/SwitchHistoryRule';
+import SwitchRequest from '../../src/streaming/rules/SwitchRequest';
 
 import RulesContextMock from './mocks/RulesContextMock';
 
@@ -10,7 +11,7 @@ describe('SwitchHistoryRule', function () {
     it("should return an empty switchRequest when getMaxIndex function is called with an empty parameter", function () {
         const switchRequest = switchHistoryRule.getMaxIndex();
 
-        expect(switchRequest.quality).to.be.equal(-1);  // jshint ignore:line 
+        expect(switchRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line 
     });
 
     it("should return an switchRequest with quality equals 0 when one switchRequest equals to {drops: 7, noDrops: 0, dropSize: 4}, a division by zero occurs", function () {


### PR DESCRIPTION
Hi,

in issue #2178, a division by zero has been detected, that is why a SwitchHistoryRule unit test is added. I don't know exactly what is expected because in javascript a division by zero returns INFINITY, not really an error.

Nico