### PR TITLE
Format and minor changes of recently merged PRs

### DIFF
--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -34,13 +34,13 @@
 let FactoryMaker = (function () {
 
     let instance;
-    let extensions = [];
-    let singletonContexts = [];
-    let singletonFactories = [];
-    let classFactories = [];
+    const extensions = [];
+    const singletonContexts = [];
+    const singletonFactories = [];
+    const classFactories = [];
 
     function extend(name, childInstance, override, context) {
-        let extensionContext = getExtensionContext(context);
+        const extensionContext = getExtensionContext(context);
         if (!extensionContext[name] && childInstance) {
             extensionContext[name] = {
                 instance: childInstance,
@@ -62,8 +62,8 @@ let FactoryMaker = (function () {
      * @instance
      */
     function getSingletonInstance(context, className) {
-        for (let i in singletonContexts) {
-            let obj = singletonContexts[i];
+        for (const i in singletonContexts) {
+            const obj = singletonContexts[i];
             if (obj.context === context && obj.name === className) {
                 return obj.instance;
             }
@@ -81,8 +81,8 @@ let FactoryMaker = (function () {
      * @instance
      */
     function setSingletonInstance(context, className, instance) {
-        for (let i in singletonContexts) {
-            let obj = singletonContexts[i];
+        for (const i in singletonContexts) {
+            const obj = singletonContexts[i];
             if (obj.context === context && obj.name === className) {
                 singletonContexts[i].instance = instance;
                 return;
@@ -102,8 +102,8 @@ let FactoryMaker = (function () {
     /*------------------------------------------------------------------------------------------*/
 
     function registerFactory(name, factory, factoriesArray) {
-        for (let i in factoriesArray) {
-            let obj = factoriesArray[i];
+        for (const i in factoriesArray) {
+            const obj = factoriesArray[i];
             if (obj.name === name) {
                 factoriesArray[i].factory = factory;
                 return;
@@ -116,8 +116,8 @@ let FactoryMaker = (function () {
     }
 
     function getFactoryByName(name, factoriesArray) {
-        for (let i in factoriesArray) {
-            let obj = factoriesArray[i];
+        for (const i in factoriesArray) {
+            const obj = factoriesArray[i];
             if (obj.name === name) {
                 return factoriesArray[i].factory;
             }
@@ -126,8 +126,8 @@ let FactoryMaker = (function () {
     }
 
     function updateFactory(name, factory, factoriesArray) {
-        for (let i in factoriesArray) {
-            let obj = factoriesArray[i];
+        for (const i in factoriesArray) {
+            const obj = factoriesArray[i];
             if (obj.name === name) {
                 factoriesArray[i].factory = factory;
                 return;
@@ -224,8 +224,8 @@ let FactoryMaker = (function () {
         // Add getClassName function to class instance prototype (used by Debug)
         classConstructor.getClassName = function () {return name;};
 
-        let extensionContext = getExtensionContext(context);
-        let extensionObject = extensionContext[name];
+        const extensionContext = getExtensionContext(context);
+        const extensionObject = extensionContext[name];
         if (extensionObject) {
             let extension = extensionObject.instance;
             if (extensionObject.override) { //Override public methods in parent but keep parent.

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -45,7 +45,7 @@ import FactoryMaker from '../../core/FactoryMaker';
 function DashManifestModel(config) {
 
     let instance;
-    let context = this.context;
+    const context = this.context;
 
     const urlUtils = URLUtils(context).getInstance();
     const mediaController = config.mediaController;
@@ -196,7 +196,7 @@ function DashManifestModel(config) {
     }
 
     function getAdaptationForId(id, manifest, periodIndex) {
-        let realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
+        const realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
         let i,
             len;
 
@@ -210,7 +210,7 @@ function DashManifestModel(config) {
     }
 
     function getAdaptationForIndex(index, manifest, periodIndex) {
-        let realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : null : null;
+        const realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : null : null;
         if (realAdaptations && isInteger(index)) {
             return realAdaptations[index];
         } else {
@@ -219,8 +219,8 @@ function DashManifestModel(config) {
     }
 
     function getIndexForAdaptation(realAdaptation, manifest, periodIndex) {
-        let realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
-        let len = realAdaptations.length;
+        const realAdaptations = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
+        const len = realAdaptations.length;
 
         if (realAdaptation) {
             for (let i = 0; i < len; i++) {
@@ -235,10 +235,10 @@ function DashManifestModel(config) {
     }
 
     function getAdaptationsForType(manifest, periodIndex, type) {
-        let realAdaptationSet = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
+        const realAdaptationSet = manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
         let i,
             len;
-        let adaptations = [];
+        const adaptations = [];
 
         for (i = 0, len = realAdaptationSet.length; i < len; i++) {
             if (getIsTypeOf(realAdaptationSet[i], type)) {
@@ -250,14 +250,13 @@ function DashManifestModel(config) {
     }
 
     function getAdaptationForType(manifest, periodIndex, type, streamInfo) {
-
-        let adaptations = getAdaptationsForType(manifest, periodIndex, type);
+        const adaptations = getAdaptationsForType(manifest, periodIndex, type);
 
         if (!adaptations || adaptations.length === 0) return null;
 
         if (adaptations.length > 1 && streamInfo) {
-            let currentTrack = mediaController.getCurrentTrackFor(type, streamInfo);
-            let allMediaInfoForType = adapter.getAllMediaInfoForType(streamInfo, type);
+            const currentTrack = mediaController.getCurrentTrackFor(type, streamInfo);
+            const allMediaInfoForType = adapter.getAllMediaInfoForType(streamInfo, type);
             for (let i = 0, ln = adaptations.length; i < ln; i++) {
                 if (currentTrack && mediaController.isTracksEqual(currentTrack, allMediaInfoForType[i])) {
                     return adaptations[i];
@@ -275,7 +274,8 @@ function DashManifestModel(config) {
 
     function getCodec(adaptation, representationId) {
         if (adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0) {
-            let representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length ? adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
+            const representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length
+                ? adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
             return (representation.mimeType + ';codecs="' + representation.codecs + '"');
         }
 
@@ -309,7 +309,7 @@ function DashManifestModel(config) {
     }
 
     function hasProfile(manifest, profile) {
-        var has = false;
+        let has = false;
 
         if (manifest && manifest.profiles && manifest.profiles.length > 0) {
             has = (manifest.profiles.indexOf(profile) !== -1);
@@ -329,7 +329,7 @@ function DashManifestModel(config) {
         if (manifest && manifest.hasOwnProperty(DashConstants.MEDIA_PRESENTATION_DURATION)) {
             mpdDuration = manifest.mediaPresentationDuration;
         } else {
-            mpdDuration = Number.MAX_VALUE;
+            mpdDuration = Number.MAX_SAFE_INTEGER || Number.MAX_VALUE;
         }
 
         return mpdDuration;
@@ -354,10 +354,10 @@ function DashManifestModel(config) {
     function getBitrateListForAdaptation(realAdaptation) {
         if (!realAdaptation || !realAdaptation.Representation_asArray || !realAdaptation.Representation_asArray.length) return null;
 
-        let processedRealAdaptation = processAdaptation(realAdaptation);
-        let realRepresentations = processedRealAdaptation.Representation_asArray;
-        let ln = realRepresentations.length;
-        let bitrateList = [];
+        const processedRealAdaptation = processAdaptation(realAdaptation);
+        const realRepresentations = processedRealAdaptation.Representation_asArray;
+        const ln = realRepresentations.length;
+        const bitrateList = [];
         let i = 0;
 
         for (i = 0; i < ln; i++) {
@@ -373,11 +373,12 @@ function DashManifestModel(config) {
     }
 
     function getRepresentationFor(index, adaptation) {
-        return adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0 && isInteger(index) ? adaptation.Representation_asArray[index] : null;
+        return adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0 &&
+            isInteger(index) ? adaptation.Representation_asArray[index] : null;
     }
 
     function getRepresentationsForAdaptation(voAdaptation) {
-        let voRepresentations = [];
+        const voRepresentations = [];
         let voRepresentation,
             initialization,
             segmentInfo,
@@ -387,7 +388,7 @@ function DashManifestModel(config) {
             s;
 
         if (voAdaptation && voAdaptation.period && isInteger(voAdaptation.period.index)) {
-            var periodArray = voAdaptation.period.mpd.manifest.Period_asArray[voAdaptation.period.index];
+            const periodArray = voAdaptation.period.mpd.manifest.Period_asArray[voAdaptation.period.index];
             if (periodArray && periodArray.AdaptationSet_asArray && isInteger(voAdaptation.index)) {
                 processedRealAdaptation = processAdaptation(periodArray.AdaptationSet_asArray[voAdaptation.index]);
             }
@@ -402,14 +403,12 @@ function DashManifestModel(config) {
             if (realRepresentation.hasOwnProperty(DashConstants.ID)) {
                 voRepresentation.id = realRepresentation.id;
             }
-
             if (realRepresentation.hasOwnProperty(DashConstants.CODECS)) {
                 voRepresentation.codecs = realRepresentation.codecs;
             }
             if (realRepresentation.hasOwnProperty(DashConstants.CODEC_PRIVATE_DATA)) {
                 voRepresentation.codecPrivateData = realRepresentation.codecPrivateData;
             }
-
             if (realRepresentation.hasOwnProperty(DashConstants.BANDWITH)) {
                 voRepresentation.bandwidth = realRepresentation.bandwidth;
             }
@@ -500,9 +499,7 @@ function DashManifestModel(config) {
             }
 
             voRepresentation.MSETimeOffset = timelineConverter.calcMSETimeOffset(voRepresentation);
-
             voRepresentation.path = [voAdaptation.period.index, voAdaptation.index, i];
-
             voRepresentations.push(voRepresentation);
         }
 
@@ -510,8 +507,8 @@ function DashManifestModel(config) {
     }
 
     function getAdaptationsForPeriod(voPeriod) {
-        let realPeriod = voPeriod && isInteger(voPeriod.index) ? voPeriod.mpd.manifest.Period_asArray[voPeriod.index] : null;
-        let voAdaptations = [];
+        const realPeriod = voPeriod && isInteger(voPeriod.index) ? voPeriod.mpd.manifest.Period_asArray[voPeriod.index] : null;
+        const voAdaptations = [];
         let voAdaptationSet,
             realAdaptationSet,
             i;
@@ -545,15 +542,14 @@ function DashManifestModel(config) {
     }
 
     function getRegularPeriods(mpd) {
-        let isDynamic = mpd ? getIsDynamic(mpd.manifest) : false;
-        let voPeriods = [];
+        const isDynamic = mpd ? getIsDynamic(mpd.manifest) : false;
+        const voPeriods = [];
         let realPeriod1 = null;
         let realPeriod = null;
         let voPeriod1 = null;
         let voPeriod = null;
         let len,
             i;
-
 
         for (i = 0, len = mpd && mpd.manifest && mpd.manifest.Period_asArray ? mpd.manifest.Period_asArray.length : 0; i < len; i++) {
             realPeriod = mpd.manifest.Period_asArray[i];
@@ -640,7 +636,7 @@ function DashManifestModel(config) {
     }
 
     function getMpd(manifest) {
-        let mpd = new Mpd();
+        const mpd = new Mpd();
 
         if (manifest) {
             mpd.manifest = manifest;
@@ -698,16 +694,16 @@ function DashManifestModel(config) {
     }
 
     function getEventsForPeriod(period) {
-        let manifest = period && period.mpd && period.mpd.manifest ? period.mpd.manifest : null;
-        let periodArray = manifest ? manifest.Period_asArray : null;
-        let eventStreams = periodArray && period && isInteger(period.index) ? periodArray[period.index].EventStream_asArray : null;
-        let events = [];
+        const manifest = period && period.mpd && period.mpd.manifest ? period.mpd.manifest : null;
+        const periodArray = manifest ? manifest.Period_asArray : null;
+        const eventStreams = periodArray && period && isInteger(period.index) ? periodArray[period.index].EventStream_asArray : null;
+        const events = [];
         let i,
             j;
 
         if (eventStreams) {
             for (i = 0; i < eventStreams.length; i++) {
-                let eventStream = new EventStream();
+                const eventStream = new EventStream();
                 eventStream.period = period;
                 eventStream.timescale = 1;
 
@@ -723,7 +719,7 @@ function DashManifestModel(config) {
                     eventStream.value = eventStreams[i].value;
                 }
                 for (j = 0; j < eventStreams[i].Event_asArray.length; j++) {
-                    let event = new Event();
+                    const event = new Event();
                     event.presentationTime = 0;
                     event.eventStream = eventStream;
 
@@ -745,13 +741,13 @@ function DashManifestModel(config) {
     }
 
     function getEventStreams(inbandStreams, representation) {
-        let eventStreams = [];
+        const eventStreams = [];
         let i;
 
         if (!inbandStreams) return eventStreams;
 
         for (i = 0; i < inbandStreams.length; i++) {
-            let eventStream = new EventStream();
+            const eventStream = new EventStream();
             eventStream.timescale = 1;
             eventStream.representation = representation;
 
@@ -813,10 +809,10 @@ function DashManifestModel(config) {
     }
 
     function getUTCTimingSources(manifest) {
-        let isDynamic = getIsDynamic(manifest);
-        let hasAST = manifest ? manifest.hasOwnProperty(DashConstants.AVAILABILITY_START_TIME) : false;
-        let utcTimingsArray = manifest ? manifest.UTCTiming_asArray : null;
-        let utcTimingEntries = [];
+        const isDynamic = getIsDynamic(manifest);
+        const hasAST = manifest ? manifest.hasOwnProperty(DashConstants.AVAILABILITY_START_TIME) : false;
+        const utcTimingsArray = manifest ? manifest.UTCTiming_asArray : null;
+        const utcTimingEntries = [];
 
         // do not bother synchronizing the clock unless MPD is live,
         // or it is static and has availabilityStartTime attribute
@@ -826,7 +822,7 @@ function DashManifestModel(config) {
                 // in the manifest "indicates relative preference, first having
                 // the highest, and the last the lowest priority".
                 utcTimingsArray.forEach(function (utcTiming) {
-                    let entry = new UTCTiming();
+                    const entry = new UTCTiming();
 
                     if (utcTiming.hasOwnProperty(Constants.SCHEME_ID_URI)) {
                         entry.schemeIdUri = utcTiming.schemeIdUri;
@@ -859,10 +855,10 @@ function DashManifestModel(config) {
     }
 
     function getBaseURLsFromElement(node) {
-        let baseUrls = [];
+        const baseUrls = [];
         // if node.BaseURL_asArray and node.baseUri are undefined entries
         // will be [undefined] which entries.some will just skip
-        let entries = node.BaseURL_asArray || [node.baseUri];
+        const entries = node.BaseURL_asArray || [node.baseUri];
         let earlyReturn = false;
 
         entries.some(entry => {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -274,8 +274,8 @@ function DashManifestModel(config) {
 
     function getCodec(adaptation, representationId) {
         if (adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0) {
-            const representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length
-                ? adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
+            const representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length ?
+                adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
             return (representation.mimeType + ';codecs="' + representation.codecs + '"');
         }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -516,11 +516,12 @@ function MediaPlayer() {
     function getBufferLength(type) {
         const types = [Constants.VIDEO, Constants.AUDIO, Constants.FRAGMENTED_TEXT];
         if (!type) {
-            return types.map(
+            const buffer = types.map(
                 t => getTracksFor(t).length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor(t)) : Number.MAX_VALUE
             ).reduce(
                 (p, c) => Math.min(p, c)
             );
+            return buffer === Number.MAX_VALUE ? NaN : buffer;
         } else {
             if (types.indexOf(type) !== -1) {
                 const buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -38,9 +38,9 @@ import Debug from '../../core/Debug';
 
 function PlaybackController() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
         streamController,
@@ -163,7 +163,7 @@ function PlaybackController() {
      * @memberof PlaybackController#
      */
     function computeLiveDelay(fragmentDuration, dvrWindowSize) {
-        let mpd = dashManifestModel.getMpd(manifestModel.getValue());
+        const mpd = dashManifestModel.getMpd(manifestModel.getValue());
 
         let delay;
         const END_OF_PLAYLIST_PADDING = 10;
@@ -182,8 +182,7 @@ function PlaybackController() {
             // cap target latency to:
             // - dvrWindowSize / 2 for short playlists
             // - dvrWindowSize - END_OF_PLAYLIST_PADDING for longer playlists
-            let targetDelayCapping = Math.max(dvrWindowSize - END_OF_PLAYLIST_PADDING, dvrWindowSize / 2);
-
+            const targetDelayCapping = Math.max(dvrWindowSize - END_OF_PLAYLIST_PADDING, dvrWindowSize / 2);
             return Math.min(delay, targetDelayCapping);
         } else {
             return delay;
@@ -245,12 +244,12 @@ function PlaybackController() {
      */
     function getStreamStartTime(ignoreStartOffset) {
         let presentationStartTime;
-        let fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
+        const fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
         let startTimeOffset = NaN;
 
         if (fragData) {
-            let fragS = parseInt(fragData.s, 10);
-            let fragT = parseInt(fragData.t, 10);
+            const fragS = parseInt(fragData.s, 10);
+            const fragT = parseInt(fragData.t, 10);
             if (!ignoreStartOffset) {
                 startTimeOffset = !isNaN(fragS) ? fragS : fragT;
             }
@@ -261,7 +260,6 @@ function PlaybackController() {
 
         if (isDynamic) {
             if (!isNaN(startTimeOffset) && startTimeOffset > 1262304000) {
-
                 presentationStartTime = startTimeOffset - (streamInfo.manifestInfo.availableFrom.getTime() / 1000);
 
                 if (presentationStartTime > liveStartTime ||
@@ -287,9 +285,9 @@ function PlaybackController() {
     }
 
     function getActualPresentationTime(currentTime) {
-        let metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
-        let DVRMetrics = dashMetrics.getCurrentDVRInfo(metrics);
-        let DVRWindow = DVRMetrics ? DVRMetrics.range : null;
+        const metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
+        const DVRMetrics = dashMetrics.getCurrentDVRInfo(metrics);
+        const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
         let actualTime;
 
         if (!DVRWindow) return NaN;
@@ -320,11 +318,10 @@ function PlaybackController() {
     }
 
     function updateCurrentTime() {
-
         if (isPaused() || !isDynamic || videoModel.getReadyState() === 0) return;
-        let currentTime = getTime();
-        let actualTime = getActualPresentationTime(currentTime);
-        let timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
+        const currentTime = getTime();
+        const actualTime = getActualPresentationTime(currentTime);
+        const timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
         if (timeChanged) {
             seek(actualTime);
         }
@@ -334,7 +331,7 @@ function PlaybackController() {
         if (e.error) return;
 
         const representationInfo = adapter.convertDataToRepresentationInfo(e.currentRepresentation);
-        let info = representationInfo.mediaInfo.streamInfo;
+        const info = representationInfo.mediaInfo.streamInfo;
 
         if (streamInfo.id !== info.id) return;
         streamInfo = info;
@@ -370,7 +367,7 @@ function PlaybackController() {
     }
 
     function onPlaybackSeeking() {
-        let seekTime = getTime();
+        const seekTime = getTime();
         log('Seeking to: ' + seekTime);
         startUpdatingWallclockTime();
         eventBus.trigger(Events.PLAYBACK_SEEKING, {
@@ -384,8 +381,7 @@ function PlaybackController() {
     }
 
     function onPlaybackTimeUpdated() {
-        //log("Native video element event: timeupdate");
-        let time = getTime();
+        const time = getTime();
         if (time === currentTime) return;
         currentTime = time;
         eventBus.trigger(Events.PLAYBACK_TIME_UPDATED, {
@@ -395,12 +391,11 @@ function PlaybackController() {
     }
 
     function onPlaybackProgress() {
-        //log("Native video element event: progress");
         eventBus.trigger(Events.PLAYBACK_PROGRESS);
     }
 
     function onPlaybackRateChanged() {
-        let rate = getPlaybackRate();
+        const rate = getPlaybackRate();
         log('Native video element event: ratechange: ', rate);
         eventBus.trigger(Events.PLAYBACK_RATE_CHANGED, {
             playbackRate: rate
@@ -421,7 +416,7 @@ function PlaybackController() {
     }
 
     function onPlaybackError(event) {
-        let target = event.target || event.srcElement;
+        const target = event.target || event.srcElement;
         eventBus.trigger(Events.PLAYBACK_ERROR, {
             error: target.error
         });
@@ -444,6 +439,7 @@ function PlaybackController() {
         }
         return false;
     }
+
     function onBytesAppended(e) {
         let earliestTime,
             initialStartTime;
@@ -454,7 +450,7 @@ function PlaybackController() {
             return;
         }
 
-        let type = e.sender.getType();
+        const type = e.sender.getType();
 
         if (bufferedRange[streamInfo.id] === undefined) {
             bufferedRange[streamInfo.id] = [];

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -56,7 +56,7 @@ function ScheduleController(config) {
     const textController = config.textController;
     const sourceBufferController = config.sourceBufferController;
     const type = config.type;
-    let streamProcessor = config.streamProcessor;
+    const streamProcessor = config.streamProcessor;
 
     let instance,
         log,
@@ -160,7 +160,6 @@ function ScheduleController(config) {
     }
 
     function hasTopQualityChanged(type, id) {
-
         topQualityIndex[id] = topQualityIndex[id] || {};
         const newTopQualityIndex = abrController.getTopQualityIndexFor(type, id);
 
@@ -174,7 +173,6 @@ function ScheduleController(config) {
     }
 
     function schedule() {
-
         if (isStopped || isFragmentProcessingInProgress || !streamProcessor.getBufferController() || playbackController.isPaused() && !scheduleWhilePaused) {
             return;
         }
@@ -184,12 +182,11 @@ function ScheduleController(config) {
         const isReplacement = replaceRequestArray.length > 0;
         if (switchTrack || isReplacement ||
             hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id) ||
-            bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())
-        ) {
+            bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())) {
 
             const getNextFragment = function () {
                 log('ScheduleController - getNextFragment');
-                let fragmentController = streamProcessor.getFragmentController();
+                const fragmentController = streamProcessor.getFragmentController();
                 if (switchTrack) {
                     log('ScheduleController - switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
                     streamProcessor.switchInitData(currentRepresentationInfo.id);
@@ -354,7 +351,7 @@ function ScheduleController(config) {
     }
 
     function setLiveEdgeSeekTarget() {
-        let liveEdgeFinder = streamProcessor.getLiveEdgeFinder();
+        const liveEdgeFinder = streamProcessor.getLiveEdgeFinder();
         if (liveEdgeFinder) {
             const liveEdge = liveEdgeFinder.getLiveEdge();
             const dvrWindowSize = currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo.DVRWindowSize / 2;
@@ -490,7 +487,6 @@ function ScheduleController(config) {
     }
 
     function onPlaybackSeeking(e) {
-
         seekTarget = e.seekTime;
         setTimeToLoadDelay(0);
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -53,11 +53,11 @@ import BASE64 from '../../../../externals/base64';
 
 function ProtectionController(config) {
 
-    let protectionKeyController = config.protectionKeyController;
+    const protectionKeyController = config.protectionKeyController;
     let protectionModel = config.protectionModel;
-    let adapter = config.adapter;
-    let eventBus = config.eventBus;
-    let log = config.log;
+    const adapter = config.adapter;
+    const eventBus = config.eventBus;
+    const log = config.log;
 
     let instance,
         keySystems,
@@ -96,13 +96,11 @@ function ProtectionController(config) {
      * applications to create {@link StreamInfo} with the right information,
      */
     function initialize(manifest, aInfo, vInfo) {
-
         // TODO: We really need to do much more here... We need to be smarter about knowing
         // which adaptation sets for which we have initialized, including the default key ID
         // value from the ContentProtection elements so we know whether or not we still need to
         // select key systems and acquire keys.
         if (!initialized) {
-
             let streamInfo;
 
             if (!aInfo && !vInfo) {
@@ -113,11 +111,11 @@ function ProtectionController(config) {
 
             audioInfo = aInfo || (streamInfo ? adapter.getMediaInfoForType(streamInfo, Constants.AUDIO) : null);
             videoInfo = vInfo || (streamInfo ? adapter.getMediaInfoForType(streamInfo, Constants.VIDEO) : null);
-            let mediaInfo = (videoInfo) ? videoInfo : audioInfo; // We could have audio or video only
+            const mediaInfo = (videoInfo) ? videoInfo : audioInfo; // We could have audio or video only
 
             // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
             // and video will be the same.  Just use one valid MediaInfo object
-            let supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection);
+            const supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection);
             if (supportedKS && supportedKS.length > 0) {
                 selectKeySystem(supportedKS, true);
             }
@@ -140,11 +138,11 @@ function ProtectionController(config) {
      * to come up to speed with the latest EME standard
      */
     function createKeySession(initData) {
-        let initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, initData);
+        const initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, initData);
         if (initDataForKS) {
 
             // Check for duplicate initData
-            let currentInitData = protectionModel.getAllInitData();
+            const currentInitData = protectionModel.getAllInitData();
             for (let i = 0; i < currentInitData.length; i++) {
                 if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
                     log('DRM: Ignoring initData because we have already seen it!');
@@ -305,7 +303,7 @@ function ProtectionController(config) {
 
     function getProtData(keySystem) {
         let protData = null;
-        let keySystemString = keySystem.systemString;
+        const keySystemString = keySystem.systemString;
 
         if (protDataSet) {
             protData = (keySystemString in protDataSet) ? protDataSet[keySystemString] : null;
@@ -314,11 +312,11 @@ function ProtectionController(config) {
     }
 
     function getKeySystemConfiguration(keySystem) {
-        let protData = getProtData(keySystem);
-        let audioCapabilities = [];
-        let videoCapabilities = [];
-        let audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
-        let videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
+        const protData = getProtData(keySystem);
+        const audioCapabilities = [];
+        const videoCapabilities = [];
+        const audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
+        const videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
 
         if (audioInfo) {
             audioCapabilities.push(new MediaCapability(audioInfo.codec, audioRobustness));
@@ -334,9 +332,8 @@ function ProtectionController(config) {
     }
 
     function selectKeySystem(supportedKS, fromManifest) {
-
-        let self = this;
-        let requestedKeySystems = [];
+        const self = this;
+        const requestedKeySystems = [];
 
         let ksIdx;
         if (keySystem) {
@@ -348,7 +345,7 @@ function ProtectionController(config) {
 
                     // Ensure that we would be granted key system access using the key
                     // system and codec information
-                    let onKeySystemAccessComplete = function (event) {
+                    const onKeySystemAccessComplete = function (event) {
                         eventBus.off(Events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
                         if (event.error) {
                             if (!fromManifest) {
@@ -399,7 +396,7 @@ function ProtectionController(config) {
                     keySystem = protectionModel.getKeySystem();
                     eventBus.trigger(Events.KEY_SYSTEM_SELECTED, {data: keySystemAccess});
                     // Set server certificate from protData
-                    let protData = getProtData(keySystem);
+                    const protData = getProtData(keySystem);
                     if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
                         protectionModel.setServerCertificate(BASE64.decodeArray(protData.serverCertificate).buffer);
                     }
@@ -439,15 +436,15 @@ function ProtectionController(config) {
         }
 
         // Dispatch event to applications indicating we received a key message
-        let keyMessage = e.data;
+        const keyMessage = e.data;
         eventBus.trigger(Events.KEY_MESSAGE, {data: keyMessage});
-        let messageType = (keyMessage.messageType) ? keyMessage.messageType : 'license-request';
-        let message = keyMessage.message;
-        let sessionToken = keyMessage.sessionToken;
-        let protData = getProtData(keySystem);
-        let keySystemString = keySystem.systemString;
-        let licenseServerData = protectionKeyController.getLicenseServer(keySystem, protData, messageType);
-        let eventData = { sessionToken: sessionToken, messageType: messageType };
+        const messageType = (keyMessage.messageType) ? keyMessage.messageType : 'license-request';
+        const message = keyMessage.message;
+        const sessionToken = keyMessage.sessionToken;
+        const protData = getProtData(keySystem);
+        const keySystemString = keySystem.systemString;
+        const licenseServerData = protectionKeyController.getLicenseServer(keySystem, protData, messageType);
+        const eventData = { sessionToken: sessionToken, messageType: messageType };
 
         // Message not destined for license server
         if (!licenseServerData) {
@@ -458,7 +455,7 @@ function ProtectionController(config) {
 
         // Perform any special handling for ClearKey
         if (protectionKeyController.isClearKey(keySystem)) {
-            let clearkeys = protectionKeyController.processClearKeyLicenseRequest(protData, message);
+            const clearkeys = protectionKeyController.processClearKeyLicenseRequest(protData, message);
             if (clearkeys)  {
                 log('DRM: ClearKey license request handled by application!');
                 sendLicenseRequestCompleteEvent(eventData);
@@ -468,12 +465,12 @@ function ProtectionController(config) {
         }
 
         // All remaining key system scenarios require a request to a remote license server
-        let xhr = new XMLHttpRequest();
+        const xhr = new XMLHttpRequest();
 
         // Determine license server URL
         let url = null;
         if (protData && protData.serverURL) {
-            let serverURL = protData.serverURL;
+            const serverURL = protData.serverURL;
             if (typeof serverURL === 'string' && serverURL !== '') {
                 url = serverURL;
             } else if (typeof serverURL === 'object' && serverURL.hasOwnProperty(messageType)) {
@@ -498,7 +495,7 @@ function ProtectionController(config) {
         }
 
         const reportError = function (xhr, eventData, keySystemString, messageType) {
-            let errorMsg = ((xhr.response) ? licenseServerData.getErrorResponse(xhr.response, keySystemString, messageType) : 'NONE');
+            const errorMsg = ((xhr.response) ? licenseServerData.getErrorResponse(xhr.response, keySystemString, messageType) : 'NONE');
             sendLicenseRequestCompleteEvent(eventData, 'DRM: ' + keySystemString + ' update, XHR complete. status is "' + xhr.statusText + '" (' + xhr.status + '), readyState is ' + xhr.readyState + '.  Response is ' + errorMsg);
         };
 
@@ -506,7 +503,7 @@ function ProtectionController(config) {
         xhr.responseType = licenseServerData.getResponseType(keySystemString, messageType);
         xhr.onload = function () {
             if (this.status == 200) {
-                let licenseMessage = licenseServerData.getLicenseMessage(this.response, keySystemString, messageType);
+                const licenseMessage = licenseServerData.getLicenseMessage(this.response, keySystemString, messageType);
                 if (licenseMessage !== null) {
                     sendLicenseRequestCompleteEvent(eventData);
                     protectionModel.updateKeySession(sessionToken, licenseMessage);
@@ -526,9 +523,8 @@ function ProtectionController(config) {
 
         // Set optional XMLHttpRequest headers from protection data and message
         const updateHeaders = function (headers) {
-            let key;
             if (headers) {
-                for (key in headers) {
+                for (const key in headers) {
                     if ('authorization' === key.toLowerCase()) {
                         xhr.withCredentials = true;
                     }
@@ -566,11 +562,11 @@ function ProtectionController(config) {
 
         // If key system has already been selected and initData already seen, then do nothing
         if (keySystem) {
-            let initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, abInitData);
+            const initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, abInitData);
             if (initDataForKS) {
 
                 // Check for duplicate initData
-                let currentInitData = protectionModel.getAllInitData();
+                const currentInitData = protectionModel.getAllInitData();
                 for (let i = 0; i < currentInitData.length; i++) {
                     if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
                         log('DRM: Ignoring initData because we have already seen it!');
@@ -582,7 +578,7 @@ function ProtectionController(config) {
 
         log('DRM: initData:', String.fromCharCode.apply(null, new Uint8Array(abInitData)));
 
-        let supportedKS = protectionKeyController.getSupportedKeySystems(abInitData, protDataSet);
+        const supportedKS = protectionKeyController.getSupportedKeySystems(abInitData, protDataSet);
         if (supportedKS.length === 0) {
             log('DRM: Received needkey event with initData, but we don\'t support any of the key systems!');
             return;

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -48,19 +48,19 @@ function PlayReady() {
     const soap = 'http://schemas.xmlsoap.org/soap/envelope/';
 
     function uintToString(arrayBuffer) {
-        let encodedString = String.fromCharCode.apply(null, new Uint8Array(arrayBuffer));
-        let decodedString = decodeURIComponent(escape(encodedString));
+        const encodedString = String.fromCharCode.apply(null, new Uint8Array(arrayBuffer));
+        const decodedString = decodeURIComponent(escape(encodedString));
         return decodedString;
     }
 
     function parseServerResponse(serverResponse) {
         if (window.DOMParser) {
-            let stringResponse = uintToString(serverResponse);
-            let parser = new window.DOMParser();
-            let xmlDoc = parser.parseFromString(stringResponse, 'text/xml');
-            let envelope = xmlDoc ? xmlDoc.getElementsByTagNameNS(soap, 'Envelope')[0] : null;
-            let body = envelope ? envelope.getElementsByTagNameNS(soap, 'Body')[0] : null;
-            let fault = body ? body.getElementsByTagNameNS(soap, 'Fault')[0] : null;
+            const stringResponse = uintToString(serverResponse);
+            const parser = new window.DOMParser();
+            const xmlDoc = parser.parseFromString(stringResponse, 'text/xml');
+            const envelope = xmlDoc ? xmlDoc.getElementsByTagNameNS(soap, 'Envelope')[0] : null;
+            const body = envelope ? envelope.getElementsByTagNameNS(soap, 'Body')[0] : null;
+            const fault = body ? body.getElementsByTagNameNS(soap, 'Fault')[0] : null;
 
             if (fault) {
                 return null;
@@ -77,14 +77,14 @@ function PlayReady() {
         let idEnd = -1;
 
         if (window.DOMParser) {
-            let stringResponse = uintToString(serverResponse);
-            let parser = new window.DOMParser();
-            let xmlDoc = parser.parseFromString(stringResponse, 'text/xml');
-            let envelope = xmlDoc ? xmlDoc.getElementsByTagNameNS(soap, 'Envelope')[0] : null;
-            let body = envelope ? envelope.getElementsByTagNameNS(soap, 'Body')[0] : null;
-            let fault = body ? body.getElementsByTagNameNS(soap, 'Fault')[0] : null;
-            let detail = fault ? fault.getElementsByTagName('detail')[0] : null;
-            let exception = detail ? detail.getElementsByTagName('Exception')[0] : null;
+            const stringResponse = uintToString(serverResponse);
+            const parser = new window.DOMParser();
+            const xmlDoc = parser.parseFromString(stringResponse, 'text/xml');
+            const envelope = xmlDoc ? xmlDoc.getElementsByTagNameNS(soap, 'Envelope')[0] : null;
+            const body = envelope ? envelope.getElementsByTagNameNS(soap, 'Body')[0] : null;
+            const fault = body ? body.getElementsByTagNameNS(soap, 'Fault')[0] : null;
+            const detail = fault ? fault.getElementsByTagName('detail')[0] : null;
+            const exception = detail ? detail.getElementsByTagName('Exception')[0] : null;
             let node = null;
 
             if (fault === null) {

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -267,10 +267,10 @@ describe('DashManifestModel', function () {
         expect(isDynamic).to.be.false;    // jshint ignore:line
     });
 
-    it('should return Number.MAX_VALUE when getDuration is called and manifest is undefined', () => {
+    it('should return Number.MAX_SAFE_NUMBER (or Number.MAX_VALUE in case MAX_SAFE_NUMBER is not defined) when getDuration is called and manifest is undefined', () => {
         const duration = dashManifestModel.getDuration();
 
-        expect(duration).to.equal(Number.MAX_VALUE); // jshint ignore:line
+        expect(duration).to.equal(Number.MAX_SAFE_INTEGER || Number.MAX_VALUE); // jshint ignore:line
     });
 
     it('should return 0 when getRepresentationCount is called and adaptation is undefined', () => {

--- a/test/unit/streaming.controllers.BufferControllerSpec.js
+++ b/test/unit/streaming.controllers.BufferControllerSpec.js
@@ -29,21 +29,22 @@ const objectUtils = ObjectUtils(context).getInstance();
 const initCache = InitCache(context).getInstance();
 
 describe('BufferController', function () {
-
     // disable log
-
-    let debug = Debug(context).getInstance();
+    const debug = Debug(context).getInstance();
     debug.setLogToBrowserConsole(false);
-    let streamProcessor = new StreamProcessorMock(testType, streamInfo);
-    let sourceBufferMock = new SourceBufferControllerMock(testType);
-    let streamControllerMock = new StreamControllerMock();
-    let adapterMock = new AdapterMock();
-    let metricsModelMock = new MetricsModelMock();
-    let playbackControllerMock = new PlaybackControllerMock();
+    const streamProcessor = new StreamProcessorMock(testType, streamInfo);
+    const sourceBufferMock = new SourceBufferControllerMock(testType);
+    const streamControllerMock = new StreamControllerMock();
+    const adapterMock = new AdapterMock();
+    const metricsModelMock = new MetricsModelMock();
+    const playbackControllerMock = new PlaybackControllerMock();
 
     let bufferController;
 
     beforeEach(function () {
+        global.navigator = {
+            userAgent: 'node.js'
+        };
 
         bufferController = BufferController(context).create({
             metricsModel: metricsModelMock,
@@ -61,6 +62,7 @@ describe('BufferController', function () {
     });
 
     afterEach(function () {
+        delete global.navigator;
         bufferController = null;
         streamProcessor.reset();
         sourceBufferMock.reset(testType);
@@ -68,7 +70,6 @@ describe('BufferController', function () {
 
     describe('Method initialize', function () {
         it('should initialize the controller', function () {
-
             expect(bufferController.getType()).to.equal(testType);
             bufferController.initialize({});
 
@@ -77,20 +78,19 @@ describe('BufferController', function () {
 
     describe('Method createBuffer', function () {
         it('should not create a sourceBuffer if controller is not initialized', function () {
-
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.not.exist; // jshint ignore:line
         });
 
         it('should not create a sourceBuffer if controller is initialized with incorrect mediaSource', function () {
             bufferController.initialize(null);
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.not.exist; // jshint ignore:line
         });
 
         it('should create a sourceBuffer and initialize it', function () {
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
             expect(buffer.timestampOffset).to.equal(1);
         });
@@ -98,14 +98,14 @@ describe('BufferController', function () {
 
     describe('Method getStreamProcessor', function () {
         it('should return configured stream processor', function () {
-            let configuredSP = bufferController.getStreamProcessor();
+            const configuredSP = bufferController.getStreamProcessor();
             expect(objectUtils.areEqual(configuredSP, streamProcessor)).to.be.true; // jshint ignore:line
         });
     });
 
     describe('Methods get/set Buffer', function () {
         it('should update buffer', function () {
-            let buffer = 'testBuffer';
+            const buffer = 'testBuffer';
             bufferController.setBuffer(buffer);
             expect(bufferController.getBuffer()).to.equal(buffer);
         });
@@ -113,7 +113,7 @@ describe('BufferController', function () {
 
     describe('Methods get/set Media Source', function () {
         it('should update media source', function () {
-            let mediaSource = 'test';
+            const mediaSource = 'test';
             bufferController.setMediaSource(mediaSource);
             expect(bufferController.getMediaSource()).to.equal(mediaSource);
         });
@@ -121,7 +121,7 @@ describe('BufferController', function () {
 
     describe('Method switchInitData', function () {
         it('should append init data to source buffer if data have been cached', function () {
-            let chunk = {
+            const chunk = {
                 bytes: 'initData',
                 quality: 2,
                 mediaInfo: {
@@ -139,12 +139,11 @@ describe('BufferController', function () {
         });
 
         it('should trigger INIT_REQUESTED if no init data is cached', function (done) {
-
             // reset cache
             initCache.reset();
 
             bufferController.initialize({});
-            let onInitRequest = function () {
+            const onInitRequest = function () {
                 eventBus.off(Events.INIT_REQUESTED, onInitRequest);
                 done();
             };
@@ -156,7 +155,7 @@ describe('BufferController', function () {
 
     describe('Method reset', function () {
         it('should reset buffer controller', function () {
-            let buffer = 'testBuffer';
+            const buffer = 'testBuffer';
             bufferController.setBuffer(buffer);
             expect(bufferController.getBuffer()).to.equal(buffer);
 
@@ -169,8 +168,7 @@ describe('BufferController', function () {
 
     describe('Event INIT_FRAGMENT_LOADED handler', function () {
         it('should not append data to source buffer if wrong fragment model', function (done) {
-
-            let event = {
+            const event = {
                 fragmentModel: 'wrongFragmentModel',
                 chunk: {
                     bytes: 'initData',
@@ -182,7 +180,7 @@ describe('BufferController', function () {
                     representationId: 'representationId'
                 }
             };
-            let onInitDataLoaded = function () {
+            const onInitDataLoaded = function () {
                 eventBus.off(Events.INIT_FRAGMENT_LOADED, onInitDataLoaded);
                 expect(sourceBufferMock.buffer.bytes).to.be.undefined; // jshint ignore:line
                 done();
@@ -195,8 +193,7 @@ describe('BufferController', function () {
         });
 
         it('should append data to source buffer ', function (done) {
-
-            let event = {
+            const event = {
                 fragmentModel: streamProcessor.getFragmentModel(),
                 chunk: {
                     bytes: 'initData',
@@ -208,7 +205,7 @@ describe('BufferController', function () {
                     representationId: 'representationId'
                 }
             };
-            let onInitDataLoaded = function () {
+            const onInitDataLoaded = function () {
                 eventBus.off(Events.INIT_FRAGMENT_LOADED, onInitDataLoaded);
                 expect(sourceBufferMock.buffer.bytes).to.equal(event.chunk.bytes);
                 done();
@@ -221,8 +218,7 @@ describe('BufferController', function () {
         });
 
         it('should save init data into cache', function (done) {
-
-            let chunk = {
+            const chunk = {
                 bytes: 'initData',
                 quality: 2,
                 mediaInfo: {
@@ -231,14 +227,14 @@ describe('BufferController', function () {
                 streamId: 'streamId',
                 representationId: 'representationId'
             };
-            let event = {
+            const event = {
                 fragmentModel: streamProcessor.getFragmentModel(),
                 chunk: chunk
             };
 
             initCache.reset();
             let cache = initCache.extract(chunk.streamId, chunk.representationId);
-            let onInitDataLoaded = function () {
+            const onInitDataLoaded = function () {
                 eventBus.off(Events.INIT_FRAGMENT_LOADED, onInitDataLoaded);
 
                 // check initCache
@@ -255,8 +251,7 @@ describe('BufferController', function () {
     });
     describe('Event MEDIA_FRAGMENT_LOADED handler', function () {
         it('should not append data to source buffer if wrong fragment model', function (done) {
-
-            let event = {
+            const event = {
                 fragmentModel: 'wrongFragmentModel',
                 chunk: {
                     bytes: 'data',
@@ -268,7 +263,7 @@ describe('BufferController', function () {
                     representationId: 'representationId'
                 }
             };
-            let onMediaFragmentLoaded = function () {
+            const onMediaFragmentLoaded = function () {
                 eventBus.off(Events.MEDIA_FRAGMENT_LOADED, onMediaFragmentLoaded);
                 expect(sourceBufferMock.buffer.bytes).to.be.undefined; // jshint ignore:line
                 done();
@@ -281,8 +276,7 @@ describe('BufferController', function () {
         });
 
         it('should append data to source buffer ', function (done) {
-
-            let event = {
+            const event = {
                 fragmentModel: streamProcessor.getFragmentModel(),
                 chunk: {
                     bytes: 'data',
@@ -290,7 +284,7 @@ describe('BufferController', function () {
                     mediaInfo: 'video'
                 }
             };
-            let onMediaFragmentLoaded = function () {
+            const onMediaFragmentLoaded = function () {
                 eventBus.off(Events.MEDIA_FRAGMENT_LOADED, onMediaFragmentLoaded);
                 expect(sourceBufferMock.buffer.bytes).to.equal(event.chunk.bytes);
                 done();
@@ -303,8 +297,7 @@ describe('BufferController', function () {
         });
 
         it('should trigger VIDEO_CHUNK_RECEIVED if event is video', function (done) {
-
-            let event = {
+            const event = {
                 fragmentModel: streamProcessor.getFragmentModel(),
                 chunk: {
                     bytes: 'data',
@@ -314,7 +307,7 @@ describe('BufferController', function () {
                     }
                 }
             };
-            let onVideoChunk = function () {
+            const onVideoChunk = function () {
                 eventBus.off(Events.VIDEO_CHUNK_RECEIVED, onVideoChunk);
                 done();
             };
@@ -327,21 +320,20 @@ describe('BufferController', function () {
 
     describe('Event MEDIA_FRAGMENT_LOADED handler', function () {
         it('should not update buffer timestamp offset - wrong stream processor id', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
             expect(buffer.timestampOffset).to.equal(1);
 
-            let event = {
+            const event = {
                 newQuality: 2,
                 mediaType: testType,
                 streamInfo: {
                     id: 'wrongid'
                 }
             };
-            let onQualityChanged = function () {
+            const onQualityChanged = function () {
                 eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
 
                 expect(buffer.timestampOffset).to.equal(1);
@@ -354,21 +346,20 @@ describe('BufferController', function () {
         });
 
         it('should not update buffer timestamp offset - wrong media type', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
             expect(buffer.timestampOffset).to.equal(1);
 
-            let event = {
+            const event = {
                 newQuality: 2,
                 mediaType: 'wrongMediaType',
                 streamInfo: {
                     id: streamProcessor.getStreamInfo().id
                 }
             };
-            let onQualityChanged = function () {
+            const onQualityChanged = function () {
                 eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
 
                 expect(buffer.timestampOffset).to.equal(1);
@@ -383,18 +374,18 @@ describe('BufferController', function () {
         it('should not update buffer timestamp offset - wrong quality', function (done) {
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
             expect(buffer.timestampOffset).to.equal(1);
 
-            let event = {
+            const event = {
                 newQuality: 0,
                 mediaType: testType,
                 streamInfo: {
                     id: streamProcessor.getStreamInfo().id
                 }
             };
-            let onQualityChanged = function () {
+            const onQualityChanged = function () {
                 eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
 
                 expect(buffer.timestampOffset).to.equal(1);
@@ -407,21 +398,20 @@ describe('BufferController', function () {
         });
 
         it('should update buffer timestamp offset', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
             expect(buffer.timestampOffset).to.equal(1);
 
-            let event = {
+            const event = {
                 newQuality: 2,
                 mediaType: testType,
                 streamInfo: {
                     id: streamProcessor.getStreamInfo().id
                 }
             };
-            let onQualityChanged = function () {
+            const onQualityChanged = function () {
                 eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
 
                 expect(buffer.timestampOffset).to.equal(2);
@@ -436,13 +426,12 @@ describe('BufferController', function () {
 
     describe('Event PLAYBACK_SEEKING handler', function () {
         it('should trigger BUFFER_LEVEL_UPDATED event', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
 
-            let onBufferLevelUpdated = function (e) {
+            const onBufferLevelUpdated = function (e) {
                 eventBus.off(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, this);
                 expect(e.bufferLevel).to.equal(sourceBufferMock.getBufferLength());
 
@@ -455,13 +444,12 @@ describe('BufferController', function () {
         });
 
         it('should trigger BUFFER_LEVEL_STATE_CHANGED event', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
 
-            let onBufferStateChanged = function (e) {
+            const onBufferStateChanged = function (e) {
                 eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferStateChanged, this);
                 expect(e.state).to.equal('bufferLoaded');
 
@@ -474,13 +462,12 @@ describe('BufferController', function () {
         });
 
         it('should trigger BUFFER_LOADED event if enough buffer', function (done) {
-
             // init test
             bufferController.initialize({});
-            let buffer = bufferController.createBuffer('mediaInfos');
+            const buffer = bufferController.createBuffer('mediaInfos');
             expect(buffer).to.exist; // jshint ignore:line
 
-            let onBufferLoaded = function (/*e*/) {
+            const onBufferLoaded = function (/*e*/) {
                 eventBus.off(Events.BUFFER_LOADED, onBufferLoaded, this);
                 done();
             };
@@ -490,5 +477,4 @@ describe('BufferController', function () {
             eventBus.trigger(Events.PLAYBACK_SEEKING);
         });
     });
-
 });

--- a/test/unit/streaming.protection.servers.PlayReady.js
+++ b/test/unit/streaming.protection.servers.PlayReady.js
@@ -14,16 +14,19 @@ describe('PlayReady', function () {
     });
 
     describe('Response', function () {
-
         beforeEach(function () {
             if (typeof window === 'undefined') {
                 global.window = {
                     DOMParser: domParser
                 };
             }
+            licenseServerData = PlayReady(context).getInstance();
         });
 
-        licenseServerData = PlayReady(context).getInstance();
+        afterEach(function () {
+            delete global.window;
+            licenseServerData = null;
+        });
 
         it('should return the SOAP licenser response message', function (done) {
             fs.readFile(__dirname + '/data/licence/playreadySoapOKLicence.txt', function (err, buf) {


### PR DESCRIPTION
- Use MAX_SAFE_INTEGER in getDuration of MPD for live streams, as suggested by @devaublanc in PR #1678 (long time on hold because CLA was not accepted). @devaublanc, thanks for the change suggestion.
- Modify PlayReady test to get licenseServerData in beforeEach.
- Set OnSeekEnd listener in BufferController just for Safari on Mac. For other browser/OS combinations there is no need to listen for this event.
- Fix getBufferLength in MediaPlayer according to documentation. Buffer Length should be NaN when there are no tracks of valid media types.
- Some format changes of previously sent PRs