### PR TITLE
Bring back change from #2016 (Don't set initialized flag to false in MediaPlayer.reset() )

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -262,7 +262,6 @@ function MediaPlayer() {
             metricsReportingController.reset();
             metricsReportingController = null;
         }
-        mediaPlayerInitialized = false;
     }
 
     /**


### PR DESCRIPTION
This intended change from #2016 was reverted as part of a refactor https://github.com/Dash-Industry-Forum/dash.js/pull/2007 (https://github.com/Dash-Industry-Forum/dash.js/commit/3abca12a1eeb0df89224d4676d6089b4e64d9485)