### PR TITLE
Control bar: allow multiple instances

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -40,24 +40,44 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         lastVolumeLevel = NaN,
         seeking = false,
         videoControllerVisibleTimeout = 0,
-        videoController = document.getElementById("videoController"),
-        playPauseBtn = document.getElementById("playPauseBtn"),
-        bitrateListBtn = document.getElementById("bitrateListBtn"),
-        captionBtn = document.getElementById("captionBtn"),
-        trackSwitchBtn = document.getElementById("trackSwitchBtn"),
-        seekbar = document.getElementById("seekbar"),
-        muteBtn = document.getElementById("muteBtn"),
-        volumebar = document.getElementById("volumebar"),
-        fullscreenBtn = document.getElementById("fullscreenBtn"),
-        timeDisplay = document.getElementById("videoTime"),
-        durationDisplay = document.getElementById("videoDuration"),
+        videoController,
+        playPauseBtn,
+        bitrateListBtn,
+        captionBtn,
+        trackSwitchBtn,
+        seekbar,
+        muteBtn,
+        volumebar,
+        fullscreenBtn,
+        timeDisplay,
+        durationDisplay,
+        idSuffix,
+
+        initControls = function (suffix) {
+            idSuffix = suffix;
+            videoController = document.getElementById(getControlId("videoController"));
+            playPauseBtn = document.getElementById(getControlId("playPauseBtn"));
+            bitrateListBtn = document.getElementById(getControlId("bitrateListBtn"));
+            captionBtn = document.getElementById(getControlId("captionBtn"));
+            trackSwitchBtn = document.getElementById(getControlId("trackSwitchBtn"));
+            seekbar = document.getElementById(getControlId("seekbar"));
+            muteBtn = document.getElementById(getControlId("muteBtn"));
+            volumebar = document.getElementById(getControlId("volumebar"));
+            fullscreenBtn = document.getElementById(getControlId("fullscreenBtn"));
+            timeDisplay = document.getElementById(getControlId("videoTime"));
+            durationDisplay = document.getElementById(getControlId("videoDuration"));
+        },
+
+        getControlId = function (id) {
+            return id + (idSuffix ? idSuffix : '');
+        },
 
 //************************************************************************************
 // PLAYBACK
 //************************************************************************************
 
         togglePlayPauseBtnState = function () {
-            var span = document.getElementById('iconPlayPause');
+            var span = document.getElementById(getControlId('iconPlayPause'));
             if(span !== null) {
                 if (player.isPaused()) {
                     span.classList.remove('icon-pause');
@@ -97,7 +117,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 //************************************************************************************
 
         toggleMuteBtnState = function () {
-            var span = document.getElementById('iconMute');
+            var span = document.getElementById(getControlId('iconMute'));
             if (player.isMuted()) {
                 span.classList.remove('icon-mute-off');
                 span.classList.add('icon-mute-on');
@@ -598,7 +618,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         setDuration: setDuration,
         setTime: setTime,
 
-        initialize: function () {
+        initialize: function (suffix) {
 
             if (!player) {
                 throw new Error("Please pass an instance of MediaPlayer.js when instantiating the ControlBar Object");
@@ -610,6 +630,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
             displayUTCTimeCodes = displayUTCTimeCodes === undefined ? false : displayUTCTimeCodes;
 
+            initControls(suffix);
             video.controls = false;
             videoContainer = player.getVideoContainer();
             captionBtn.classList.add("hide");

--- a/contrib/akamai/controlbar/README.md
+++ b/contrib/akamai/controlbar/README.md
@@ -7,7 +7,7 @@
 <script src="../../contrib/akamai/controlbar/ControlBar.js"></script>
 ```
 
-2. **Add HTML Snippit**
+2. **Add HTML Snippet**
 ```html
 <div id="videoController" class="video-controller unselectable">
     <div id="playPauseBtn" class="btn-play-pause" title="Play/Pause">
@@ -50,4 +50,42 @@ controlbar.show();
 controlbar.hide();
 controlbar.disable();
 controlbar.enable();
+```
+  
+  
+---
+#### Multiple instances
+To instantiate multiple players with control bars, set a suffix for every element id defined in the snippet and pass it in initialize method:
+
+```html
+<div id="videoController_1" class="video-controller unselectable">
+    <div id="playPauseBtn_1" class="btn-play-pause" title="Play/Pause">
+        <span id="iconPlayPause_1" class="icon-play"></span>
+    </div>
+    <span id="videoTime_1" class="time-display">00:00:00</span>
+    <div id="fullscreenBtn_1" class="btn-fullscreen control-icon-layout" title="Fullscreen">
+        <span class="icon-fullscreen-enter"></span>
+    </div>
+    <div id="bitrateListBtn_1" class="control-icon-layout" title="Bitrate List">
+        <span class="icon-bitrate"></span>
+    </div>
+    <input type="range" id="volumebar_1" class="volumebar" value="1" min="0" max="1" step=".01"/>
+    <div id="muteBtn_1" class="btn-mute control-icon-layout" title="Mute">
+        <span id="iconMute_1" class="icon-mute-off"></span>
+    </div>
+    <div id="trackSwitchBtn_1" class="control-icon-layout" title="A/V Tracks">
+        <span class="icon-tracks"></span>
+    </div>
+    <div id="captionBtn_1" class="btn-caption control-icon-layout" title="Closed Caption">
+        <span class="icon-caption"></span>
+    </div>
+    <span id="videoDuration_1" class="duration-display">00:00:00</span>
+    <div class="seekContainer">
+        <input type="range" id="seekbar_1" value="0" class="seekbar" min="0" step="0.01"/>
+    </div>
+</div>
+```
+
+```js
+controlbar.initialize('_1');
 ```


### PR DESCRIPTION
akamai/controlbar: support for multiple instances using a suffix to be set for existing controls in snippet, provided in initialize method. A better solution would autogenerate the snippet, but this is quick and backwards compatible.

Updated README.md.

Fixes #1890 