### PR TITLE
Fix minimum bitrate setting (setMinAllowedBitrateFor)

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -150,12 +150,13 @@ function RepresentationController() {
     }
 
     function updateData(newRealAdaptation, voAdaptation, type) {
+        const streamInfo = streamProcessor.getStreamInfo();
+        const maxQuality = abrController.getTopQualityIndexFor(type, streamInfo.id);
+        const minIdx = abrController.getMinAllowedIndexFor(type);
+
         let quality,
             averageThroughput;
-
         let bitrate = null;
-        let streamInfo = streamProcessor.getStreamInfo();
-        let maxQuality = abrController.getTopQualityIndexFor(type, streamInfo.id);
 
         updating = true;
         eventBus.trigger(Events.DATA_UPDATE_STARTED, {sender: this});
@@ -170,6 +171,9 @@ function RepresentationController() {
             quality = abrController.getQualityFor(type, streamInfo);
         }
 
+        if (minIdx !== undefined && quality < minIdx) {
+            quality = minIdx;
+        }
         if (quality > maxQuality) {
             quality = maxQuality;
         }

--- a/test/unit/helpers/ObjectsHelper.js
+++ b/test/unit/helpers/ObjectsHelper.js
@@ -10,7 +10,12 @@ class ObjectsHelper {
             getType: () => type,
             getCurrentTrack: () => {},
             getStreamInfo: () => { return { id: 'some_id', manifestInfo: {isDynamic: true} }; },
-            getMediaInfo: () => { return { bitrateList: [], mimeType:"video/mp4" }; },
+            getMediaInfo: () => { return { bitrateList: [
+                                                { bandwidth: 1000000 },
+                                                { bandwidth: 2000000 },
+                                                { bandwidth: 3000000 },
+                                           ], 
+                                           mimeType: "video/mp4" }},
             getIndexHandler: () => this.getDummyIndexHandler()
         };
     }

--- a/test/unit/streaming.controllers.AbrControllerSpec.js
+++ b/test/unit/streaming.controllers.AbrControllerSpec.js
@@ -33,12 +33,18 @@ describe('AbrController', function () {
     const representationCount = dummyMediaInfo.representationCount;
     const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);
 
-    abrCtrl.setConfig({
-        metricsModel: metricsModel,
-        dashMetrics: dashMetrics,
-        videoModel: videoModel
+    beforeEach(function () {
+        abrCtrl.setConfig({
+            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
+            videoModel: videoModel
+        });
+        abrCtrl.registerStreamType('video', streamProcessor);
     });
-    abrCtrl.registerStreamType('video', streamProcessor);
+
+    afterEach(function () {
+        abrCtrl.reset();
+    });
 
     it('should update top quality index', function () {
         const expectedTopQuality = representationCount - 1;
@@ -53,6 +59,7 @@ describe('AbrController', function () {
         const testQuality = 1;
         let newQuality;
 
+        abrCtrl.updateTopQualityIndex(dummyMediaInfo);
         abrCtrl.setPlaybackQuality(testType, dummyMediaInfo.streamInfo, testQuality);
         newQuality = abrCtrl.getQualityFor(testType);
         expect(newQuality).to.be.equal(testQuality);
@@ -115,5 +122,71 @@ describe('AbrController', function () {
         });
 
         expect(match.length).to.be.equal(expectedBitrates.length);
+    });
+
+    it('should return the appropriate max allowed index for the max allowed bitrate set', function () {
+        let maxAllowedIndex;
+
+        // Max allowed bitrate in kbps, bandwidth is in bps
+        abrCtrl.setMaxAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(0);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[1].bandwidth / 1000);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(1);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[2].bandwidth / 1000);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(2);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) + 1);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(0);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[1].bandwidth / 1000) + 1);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(1);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[2].bandwidth / 1000) + 1);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(2);
+
+        abrCtrl.setMaxAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) - 1);
+        maxAllowedIndex = abrCtrl.getMaxAllowedIndexFor(testType);
+        expect(maxAllowedIndex).to.be.equal(0);
+    });
+
+    it('should return the appropriate min allowed index for the min allowed bitrate set', function () {
+        let minAllowedIndex;
+
+        // Min allowed bitrate in kbps, bandwidth is in bps
+        abrCtrl.setMinAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(0);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[1].bandwidth / 1000);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(1);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, streamProcessor.getMediaInfo().bitrateList[2].bandwidth / 1000);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(2);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) + 1);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(1);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[1].bandwidth / 1000) + 1);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(2);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[2].bandwidth / 1000) + 1);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(2);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) - 1);
+        minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
+        expect(minAllowedIndex).to.be.equal(0);
     });
 });


### PR DESCRIPTION
Issue #2034 

Value set on setMinAllowedBitrateFor was not being applied.
Created two new methods in ABRController (getMaxAllowedIndexFor, getMinAllowedIndexFor).