### PR TITLE
PLAYBACK_TIME_UPDATED is now fired on paused live streams

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -57,15 +57,26 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 //************************************************************************************
 
         togglePlayPauseBtnState = function () {
+            if (player.isPaused()) {
+                setPlayBtn();
+            } else {
+                setPauseBtn();
+            }
+        },
+        
+        setPlayBtn = function () {
             var span = document.getElementById('iconPlayPause');
-            if(span !== null) {
-                if (player.isPaused()) {
-                    span.classList.remove('icon-pause');
-                    span.classList.add('icon-play');
-                } else {
-                    span.classList.remove('icon-play');
-                    span.classList.add('icon-pause');
-                }
+            if (span !== null) {
+                span.classList.remove('icon-pause');
+                span.classList.add('icon-play');
+            }
+        },
+
+        setPauseBtn = function () {
+            var span = document.getElementById('iconPlayPause');
+            if (span !== null) {
+                span.classList.remove('icon-play');
+                span.classList.add('icon-pause');
             }
         },
 
@@ -281,6 +292,8 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
         onStreamInitialized = function (e) {
 
+            updateDuration();
+
             var contentFunc;
             //Bitrate Menu
             if (bitrateListBtn) {
@@ -328,6 +341,12 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
                 }
             }
 
+        },
+
+        onStreamTeardownComplete = function (e) {
+            setPlayBtn();
+            timeDisplay.textContent = '00:00';
+            seekbar.value = 0;
         },
 
         createMenu = function (info, contentFunc) {
@@ -623,6 +642,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             player.on(dashjs.MediaPlayer.events.PLAYBACK_SEEKED, onSeeked, this);
             player.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded, this);
             player.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, onStreamInitialized, this);
+            player.on(dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, onStreamTeardownComplete, this);
 
             playPauseBtn.addEventListener("click", onPlayPauseClick);
             muteBtn.addEventListener("click", onMuteClick);
@@ -696,6 +716,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             player.off(dashjs.MediaPlayer.events.PLAYBACK_SEEKED, onSeeked, this);
             player.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, onTracksAdded, this);
             player.off(dashjs.MediaPlayer.events.STREAM_INITIALIZED, onStreamInitialized, this);
+            player.off(dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, onStreamTeardownComplete, this);
 
             document.removeEventListener("fullscreenchange", onFullScreenChange);
             document.removeEventListener("MSFullscreenChange", onFullScreenChange);


### PR DESCRIPTION
Issue #2175 

This allows the player to update the playhead position.

akamai/controlbar: updates duration label on STREAM_INITIALIZED event, resets time/seekbar/play button on STREAM_TEARDOWN_COMPLETE event.

