### PR TITLE
Check if fragmentDuration is defined in InsufficientBufferRule

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -53,9 +53,9 @@ const QUALITY_DEFAULT = 0;
 
 function AbrController() {
 
-    let context = this.context;
-    let debug = Debug(context).getInstance();
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const debug = Debug(context).getInstance();
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
         log,
@@ -229,16 +229,15 @@ function AbrController() {
      * @memberof AbrController#
      */
     function getInitialBitrateFor(type) {
-
-        let savedBitrate = domStorage.getSavedBitrateSettings(type);
+        const savedBitrate = domStorage.getSavedBitrateSettings(type);
 
         if (!bitrateDict.hasOwnProperty(type)) {
             if (ratioDict.hasOwnProperty(type)) {
-                let manifest = manifestModel.getValue();
-                let representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
+                const manifest = manifestModel.getValue();
+                const representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
 
                 if (Array.isArray(representation)) {
-                    let repIdx = Math.max(Math.round(representation.length * ratioDict[type]) - 1, 0);
+                    const repIdx = Math.max(Math.round(representation.length * ratioDict[type]) - 1, 0);
                     bitrateDict[type] = representation[repIdx].bandwidth;
                 } else {
                     bitrateDict[type] = 0;
@@ -362,7 +361,6 @@ function AbrController() {
                 droppedFramesHistory.push(playbackIndex, videoModel.getPlaybackQuality());
             }
 
-            //log("ABR enabled? (" + autoSwitchBitrate + ")");
             if (getAutoSwitchBitrateFor(type)) {
                 const topQualityIdx = getTopQualityIndexFor(type, streamId);
                 const switchRequest = abrRulesCollection.getMaxQuality(rulesContext);
@@ -399,8 +397,8 @@ function AbrController() {
 
     function changeQuality(type, oldQuality, newQuality, topQualityIdx, reason) {
         if (type  && streamProcessorDict[type]) {
-            var streamInfo = streamProcessorDict[type].getStreamInfo();
-            var id = streamInfo ? streamInfo.id : null;
+            const streamInfo = streamProcessorDict[type].getStreamInfo();
+            const id = streamInfo ? streamInfo.id : null;
             if (debug.getLogToBrowserConsole()) {
                 const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
                 log('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')\n' + JSON.stringify(reason));
@@ -428,11 +426,11 @@ function AbrController() {
     function getQualityForBitrate(mediaInfo, bitrate, latency) {
         if (useDeadTimeLatency && latency && streamProcessorDict[mediaInfo.type].getCurrentRepresentationInfo() && streamProcessorDict[mediaInfo.type].getCurrentRepresentationInfo().fragmentDuration) {
             latency = latency / 1000;
-            let fragmentDuration = streamProcessorDict[mediaInfo.type].getCurrentRepresentationInfo().fragmentDuration;
+            const fragmentDuration = streamProcessorDict[mediaInfo.type].getCurrentRepresentationInfo().fragmentDuration;
             if (latency > fragmentDuration) {
                 return 0;
             } else {
-                let deadTimeRatio = latency / fragmentDuration;
+                const deadTimeRatio = latency / fragmentDuration;
                 bitrate = bitrate * (1 - deadTimeRatio);
             }
         }
@@ -459,10 +457,10 @@ function AbrController() {
     function getBitrateList(mediaInfo) {
         if (!mediaInfo || !mediaInfo.bitrateList) return null;
 
-        let bitrateList = mediaInfo.bitrateList;
-        let type = mediaInfo.type;
+        const bitrateList = mediaInfo.bitrateList;
+        const type = mediaInfo.type;
 
-        let infoList = [];
+        const infoList = [];
         let bitrateInfo;
 
         for (let i = 0, ln = bitrateList.length; i < ln; i++) {
@@ -491,12 +489,12 @@ function AbrController() {
         }
         // else ABR_STRATEGY_DYNAMIC
 
-        let stableBufferTime = mediaPlayerModel.getStableBufferTime();
-        let switchOnThreshold = stableBufferTime;
-        let switchOffThreshold = 0.5 * stableBufferTime;
+        const stableBufferTime = mediaPlayerModel.getStableBufferTime();
+        const switchOnThreshold = stableBufferTime;
+        const switchOffThreshold = 0.5 * stableBufferTime;
 
-        let useBufferABR = isUsingBufferOccupancyABRDict[mediaType];
-        let newUseBufferABR = bufferLevel > (useBufferABR ? switchOffThreshold : switchOnThreshold); // use hysteresis to avoid oscillating rules
+        const useBufferABR = isUsingBufferOccupancyABRDict[mediaType];
+        const newUseBufferABR = bufferLevel > (useBufferABR ? switchOffThreshold : switchOnThreshold); // use hysteresis to avoid oscillating rules
         isUsingBufferOccupancyABRDict[mediaType] = newUseBufferABR;
 
         if (newUseBufferABR !== useBufferABR) {
@@ -517,9 +515,9 @@ function AbrController() {
     }
 
     function updateTopQualityIndex(mediaInfo) {
-        let type = mediaInfo.type;
-        let streamId = mediaInfo.streamInfo.id;
-        let max = mediaInfo.representationCount - 1;
+        const type = mediaInfo.type;
+        const streamId = mediaInfo.streamInfo.id;
+        const max = mediaInfo.representationCount - 1;
 
         setTopQualityIndex(type, streamId, max);
 
@@ -527,12 +525,11 @@ function AbrController() {
     }
 
     function isPlayingAtTopQuality(streamInfo) {
-        let isAtTop;
-        let streamId = streamInfo.id;
+        const streamId = streamInfo.id;
         const audioQuality = getQualityFor(Constants.AUDIO);
         const videoQuality = getQualityFor(Constants.VIDEO);
 
-        isAtTop = (audioQuality === getTopQualityIndexFor(Constants.AUDIO, streamId)) &&
+        const isAtTop = (audioQuality === getTopQualityIndexFor(Constants.AUDIO, streamId)) &&
             (videoQuality === getTopQualityIndexFor(Constants.VIDEO, streamId));
 
         return isAtTop;
@@ -540,7 +537,7 @@ function AbrController() {
 
     function getQualityFor(type) {
         if (type && streamProcessorDict[type]) {
-            let streamInfo = streamProcessorDict[type].getStreamInfo();
+            const streamInfo = streamProcessorDict[type].getStreamInfo();
             const id = streamInfo ? streamInfo.id : null;
             let quality;
 
@@ -575,15 +572,15 @@ function AbrController() {
             return newIdx;
         }
 
-        let minBitrate = getMinAllowedBitrateFor(type);
+        const minBitrate = getMinAllowedBitrateFor(type);
         if (minBitrate) {
-            let minIdx = getQualityForBitrate(streamProcessorDict[type].getMediaInfo(), minBitrate);
+            const minIdx = getQualityForBitrate(streamProcessorDict[type].getMediaInfo(), minBitrate);
             newIdx = Math.max (idx , minIdx);
         }
 
-        let maxBitrate = getMaxAllowedBitrateFor(type);
+        const maxBitrate = getMaxAllowedBitrateFor(type);
         if (maxBitrate) {
-            let maxIdx = getQualityForBitrate(streamProcessorDict[type].getMediaInfo(), maxBitrate);
+            const maxIdx = getQualityForBitrate(streamProcessorDict[type].getMediaInfo(), maxBitrate);
             newIdx = Math.min (newIdx , maxIdx);
         }
 
@@ -591,7 +588,7 @@ function AbrController() {
     }
 
     function checkMaxRepresentationRatio(idx, type, maxIdx) {
-        let maxRepresentationRatio = getMaxAllowedRepresentationRatioFor(type);
+        const maxRepresentationRatio = getMaxAllowedRepresentationRatioFor(type);
         if (isNaN(maxRepresentationRatio) || maxRepresentationRatio >= 1 || maxRepresentationRatio < 0) {
             return idx;
         }
@@ -603,8 +600,8 @@ function AbrController() {
     }
 
     function setElementSize() {
-        let hasPixelRatio = usePixelRatioInLimitBitrateByPortal && window.hasOwnProperty('devicePixelRatio');
-        let pixelRatio = hasPixelRatio ? window.devicePixelRatio : 1;
+        const hasPixelRatio = usePixelRatioInLimitBitrateByPortal && window.hasOwnProperty('devicePixelRatio');
+        const pixelRatio = hasPixelRatio ? window.devicePixelRatio : 1;
         elementWidth = videoModel.getClientWidth() * pixelRatio;
         elementHeight = videoModel.getClientHeight() * pixelRatio;
     }
@@ -618,8 +615,8 @@ function AbrController() {
             setElementSize();
         }
 
-        let manifest = manifestModel.getValue();
-        let representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
+        const manifest = manifestModel.getValue();
+        const representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
         let newIdx = idx;
 
         if (elementWidth > 0 && elementHeight > 0) {
@@ -646,17 +643,13 @@ function AbrController() {
             const streamProcessor = streamProcessorDict[type];
             if (!streamProcessor) return;// There may be a fragment load in progress when we switch periods and recreated some controllers.
 
-            let rulesContext = RulesContext(context).create({
+            const rulesContext = RulesContext(context).create({
                 abrController: instance,
                 streamProcessor: streamProcessor,
                 currentRequest: e.request,
                 useBufferOccupancyABR: useBufferOccupancyABR(type)
             });
-            let switchRequest = abrRulesCollection.shouldAbandonFragment(rulesContext);
-            //Removed overrideFunc
-            //    function (currentValue, newValue) {
-            //        return newValue;
-            //    });
+            const switchRequest = abrRulesCollection.shouldAbandonFragment(rulesContext);
 
             if (switchRequest.quality > SwitchRequest.NO_CHANGE) {
                 const fragmentModel = streamProcessor.getFragmentModel();
@@ -722,7 +715,7 @@ function AbrController() {
 }
 
 AbrController.__dashjs_factory_name = 'AbrController';
-let factory = FactoryMaker.getSingletonFactory(AbrController);
+const factory = FactoryMaker.getSingletonFactory(AbrController);
 factory.ABANDON_LOAD = ABANDON_LOAD;
 factory.QUALITY_DEFAULT = QUALITY_DEFAULT;
 FactoryMaker.updateSingletonFactory(AbrController.__dashjs_factory_name, factory);

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -42,7 +42,7 @@ const ABANDON_FRAGMENT_RULES = 'abandonFragmentRules';
 
 function ABRRulesCollection(config) {
 
-    let context = this.context;
+    const context = this.context;
 
     const mediaPlayerModel = config.mediaPlayerModel;
     const metricsModel = config.metricsModel;
@@ -57,7 +57,6 @@ function ABRRulesCollection(config) {
         abandonFragmentRules = [];
 
         if (mediaPlayerModel.getUseDefaultABRRules()) {
-
             // Only one of BolaRule and ThroughputRule will give a switchRequest.quality !== SwitchRequest.NO_CHANGE.
             // This is controlled by useBufferOccupancyABR mechanism in AbrController.
             qualitySwitchRules.push(
@@ -73,7 +72,6 @@ function ABRRulesCollection(config) {
                     dashMetrics: dashMetrics
                 })
             );
-
             qualitySwitchRules.push(
                 InsufficientBufferRule(context).create({
                     metricsModel: metricsModel,
@@ -86,7 +84,6 @@ function ABRRulesCollection(config) {
             qualitySwitchRules.push(
                 DroppedFramesRule(context).create()
             );
-
             abandonFragmentRules.push(
                 AbandonRequestsRule(context).create({
                     metricsModel: metricsModel,
@@ -97,7 +94,7 @@ function ABRRulesCollection(config) {
         }
 
         // add custom ABR rules if any
-        let customRules = mediaPlayerModel.getABRCustomRules();
+        const customRules = mediaPlayerModel.getABRCustomRules();
         customRules.forEach(function (rule) {
             if (rule.type === QUALITY_SWITCH_RULES) {
                 qualitySwitchRules.push(rule.rule(context).create());
@@ -114,8 +111,7 @@ function ABRRulesCollection(config) {
     }
 
     function getMinSwitchRequest(srArray) {
-
-        let values = {};
+        const values = {};
         let i,
             len,
             req,
@@ -157,17 +153,17 @@ function ABRRulesCollection(config) {
     }
 
     function getMaxQuality(rulesContext) {
-        let switchRequestArray = qualitySwitchRules.map(rule => rule.getMaxIndex(rulesContext));
-        let activeRules = getActiveRules(switchRequestArray);
-        let maxQuality = getMinSwitchRequest(activeRules);
+        const switchRequestArray = qualitySwitchRules.map(rule => rule.getMaxIndex(rulesContext));
+        const activeRules = getActiveRules(switchRequestArray);
+        const maxQuality = getMinSwitchRequest(activeRules);
 
         return maxQuality || SwitchRequest(context).create();
     }
 
     function shouldAbandonFragment(rulesContext) {
-        let abandonRequestArray = abandonFragmentRules.map(rule => rule.shouldAbandon(rulesContext));
-        let activeRules = getActiveRules(abandonRequestArray);
-        let shouldAbandon = getMinSwitchRequest(activeRules);
+        const abandonRequestArray = abandonFragmentRules.map(rule => rule.shouldAbandon(rulesContext));
+        const activeRules = getActiveRules(abandonRequestArray);
+        const shouldAbandon = getMinSwitchRequest(activeRules);
 
         return shouldAbandon || SwitchRequest(context).create();
     }
@@ -193,7 +189,7 @@ function ABRRulesCollection(config) {
 }
 
 ABRRulesCollection.__dashjs_factory_name = 'ABRRulesCollection';
-let factory = FactoryMaker.getClassFactory(ABRRulesCollection);
+const factory = FactoryMaker.getClassFactory(ABRRulesCollection);
 factory.QUALITY_SWITCH_RULES = QUALITY_SWITCH_RULES;
 factory.ABANDON_FRAGMENT_RULES = ABANDON_FRAGMENT_RULES;
 FactoryMaker.updateSingletonFactory(ABRRulesCollection.__dashjs_factory_name, factory);

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -76,7 +76,6 @@ function AbandonRequestsRule(config) {
         const req = rulesContext.getCurrentRequest();
 
         if (!isNaN(req.index)) {
-
             setFragmentRequestDict(mediaType, req.index);
 
             const stableBufferTime = mediaPlayerModel.getStableBufferTime();
@@ -112,7 +111,6 @@ function AbandonRequestsRule(config) {
                 const totalSampledValue = throughputArray[mediaType].reduce((a, b) => a + b, 0);
                 fragmentInfo.measuredBandwidthInKbps = Math.round(totalSampledValue / throughputArray[mediaType].length);
                 fragmentInfo.estimatedTimeOfDownload = +((fragmentInfo.bytesTotal * 8 / fragmentInfo.measuredBandwidthInKbps) / 1000).toFixed(2);
-                //log("id:",fragmentInfo.id, "kbps:", fragmentInfo.measuredBandwidthInKbps, "etd:",fragmentInfo.estimatedTimeOfDownload, fragmentInfo.bytesLoaded);
 
                 if (fragmentInfo.estimatedTimeOfDownload < fragmentInfo.segmentDuration * ABANDON_MULTIPLIER || rulesContext.getRepresentationInfo().quality === 0 ) {
                     return switchRequest;

--- a/src/streaming/rules/abr/DroppedFramesRule.js
+++ b/src/streaming/rules/abr/DroppedFramesRule.js
@@ -4,6 +4,7 @@ import SwitchRequest from '../SwitchRequest.js';
 import Debug from '../../../core/Debug';
 
 function DroppedFramesRule() {
+
     const context = this.context;
     const log = Debug(context).getInstance().log;
 
@@ -12,9 +13,9 @@ function DroppedFramesRule() {
 
 
     function getMaxIndex(rulesContext) {
-        let droppedFramesHistory = rulesContext.getDroppedFramesHistory();
+        const droppedFramesHistory = rulesContext.getDroppedFramesHistory();
         if (droppedFramesHistory) {
-            let dfh = droppedFramesHistory.getFrameHistory();
+            const dfh = droppedFramesHistory.getFrameHistory();
             let droppedFrames = 0;
             let totalFrames = 0;
             let maxIndex = SwitchRequest.NO_CHANGE;
@@ -42,6 +43,4 @@ function DroppedFramesRule() {
 }
 
 DroppedFramesRule.__dashjs_factory_name = 'DroppedFramesRule';
-let factory = FactoryMaker.getClassFactory(DroppedFramesRule);
-
-export default factory;
+export default FactoryMaker.getClassFactory(DroppedFramesRule);

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -39,12 +39,12 @@ function InsufficientBufferRule(config) {
 
     const INSUFFICIENT_BUFFER_SAFETY_FACTOR = 0.5;
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
 
-    let metricsModel = config.metricsModel;
-    let dashMetrics = config.dashMetrics;
+    const eventBus = EventBus(context).getInstance();
+    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
 
     let instance,
         bufferStateDict;
@@ -70,7 +70,7 @@ function InsufficientBufferRule(config) {
      * If the bufferLevel is high, then InsufficientBufferRule give a high MaxIndex allowing other rules to take over.
      */
     function getMaxIndex (rulesContext) {
-        let switchRequest = SwitchRequest(context).create();
+        const switchRequest = SwitchRequest(context).create();
 
         if (!rulesContext || !rulesContext.hasOwnProperty('getMediaType')) {
             return switchRequest;
@@ -78,11 +78,14 @@ function InsufficientBufferRule(config) {
 
         checkConfig();
 
-        let mediaType = rulesContext.getMediaType();
-        let metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
-        let lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
+        const mediaType = rulesContext.getMediaType();
+        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
+        const representationInfo = rulesContext.getRepresentationInfo();
+        const fragmentDuration = representationInfo.fragmentDuration;
 
-        if (!lastBufferStateVO || !wasFirstBufferLoadedEventTriggered(mediaType, lastBufferStateVO)) {
+        // Don't ask for a bitrate change if fragmentDuration is not defined
+        if (!lastBufferStateVO || !wasFirstBufferLoadedEventTriggered(mediaType, lastBufferStateVO) || !fragmentDuration) {
             return switchRequest;
         }
 
@@ -94,15 +97,11 @@ function InsufficientBufferRule(config) {
             const mediaInfo = rulesContext.getMediaInfo();
             const abrController = rulesContext.getAbrController();
             const throughputHistory = abrController.getThroughputHistory();
-            const representationInfo = rulesContext.getRepresentationInfo();
-            const fragmentDuration = representationInfo.fragmentDuration;
 
-            let bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
-
-            let throughput = throughputHistory.getAverageThroughput(mediaType);
-            let latency = throughputHistory.getAverageLatency(mediaType);
-
-            let bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+            const throughput = throughputHistory.getAverageThroughput(mediaType);
+            const latency = throughputHistory.getAverageLatency(mediaType);
+            const bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;
 
             switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, bitrate, latency);
             switchRequest.reason = 'InsufficientBufferRule: being conservative to avoid immediate rebuffering';

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -84,7 +84,7 @@ function InsufficientBufferRule(config) {
         const representationInfo = rulesContext.getRepresentationInfo();
         const fragmentDuration = representationInfo.fragmentDuration;
 
-        // Don't ask for a bitrate change if fragmentDuration is not defined
+        // Don't ask for a bitrate change if there is not info about buffer state or if fragmentDuration is not defined
         if (!lastBufferStateVO || !wasFirstBufferLoadedEventTriggered(mediaType, lastBufferStateVO) || !fragmentDuration) {
             return switchRequest;
         }

--- a/src/streaming/rules/abr/SwitchHistoryRule.js
+++ b/src/streaming/rules/abr/SwitchHistoryRule.js
@@ -4,6 +4,7 @@ import Debug from '../../../core/Debug';
 import SwitchRequest from '../SwitchRequest.js';
 
 function SwitchHistoryRule() {
+
     const context = this.context;
     const log = Debug(context).getInstance().log;
 
@@ -17,11 +18,11 @@ function SwitchHistoryRule() {
 
     function getMaxIndex(rulesContext) {
         const switchRequestHistory = rulesContext ? rulesContext.getSwitchHistory() : null;
-        let switchRequests = switchRequestHistory ? switchRequestHistory.getSwitchRequests() : [];
+        const switchRequests = switchRequestHistory ? switchRequestHistory.getSwitchRequests() : [];
         let drops = 0;
         let noDrops = 0;
         let dropSize = 0;
-        let switchRequest = SwitchRequest(context).create();
+        const switchRequest = SwitchRequest(context).create();
 
         for (let i = 0; i < switchRequests.length; i++) {
             if (switchRequests[i] !== undefined) {
@@ -48,6 +49,4 @@ function SwitchHistoryRule() {
 
 
 SwitchHistoryRule.__dashjs_factory_name = 'SwitchHistoryRule';
-let factory = FactoryMaker.getClassFactory(SwitchHistoryRule);
-
-export default factory;
+export default FactoryMaker.getClassFactory(SwitchHistoryRule);

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -38,6 +38,7 @@ function ThroughputRule(config) {
 
     const context = this.context;
     const log = Debug(context).getInstance().log;
+
     const metricsModel = config.metricsModel;
 
     function checkConfig() {
@@ -74,7 +75,6 @@ function ThroughputRule(config) {
         }
 
         if (abrController.getAbandonmentStateFor(mediaType) !== AbrController.ABANDON_LOAD) {
-
             if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
                 streamProcessor.getScheduleController().setTimeToLoadDelay(0);

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -1,14 +1,12 @@
-class DashMetricsMock {
-    constructor() {
-    }
+function DashMetricsMock () {
 
-    getCurrentDVRInfo() {
+    this.getCurrentDVRInfo = function () {
         return null;
-    }
+    };
 
-    getCurrentBufferLevel() {
+    this.getCurrentBufferLevel = function () {
         return 15;
-    }
+    };
 }
 
 export default DashMetricsMock;

--- a/test/unit/mocks/MetricsModelMock.js
+++ b/test/unit/mocks/MetricsModelMock.js
@@ -1,19 +1,21 @@
-class MetricsModelMock {
-    constructor() {
-        this.bufferState = 0;
-        this.bufferLevel = 0;
-    }
-    addBufferState(type, bufferState/*, bufferTarget*/) {
+function MetricsModelMock () {
+
+    this.bufferState = 0;
+    this.bufferLevel = 0;
+
+    this.addBufferState = function (type, bufferState/*, bufferTarget*/) {
         this.bufferState = bufferState;
-    }
+    };
 
-    addBufferLevel(type, date, bufferLevel ) {
+    this.addBufferLevel = function (type, date, bufferLevel) {
         this.bufferState = bufferLevel;
-    }
+    };
 
-    getReadOnlyMetricsFor() {
-        return null;
-    }
+    this.getReadOnlyMetricsFor = function () {
+        return {
+            BufferState: ['bufferStalled']
+        };
+    };
 }
 
 export default MetricsModelMock;

--- a/test/unit/mocks/RulesContextMock.js
+++ b/test/unit/mocks/RulesContextMock.js
@@ -27,6 +27,11 @@ function RulesContextMock () {
     this.getSwitchHistory = function () {
         return new switchRequestHistoryMock();
     };
+    this.getRepresentationInfo = function () {
+        return {
+            fragmentDuration: NaN
+        };
+    };
 }
 
 export default RulesContextMock;

--- a/test/unit/streaming.rules.abr.AbandonRequestsRule.js
+++ b/test/unit/streaming.rules.abr.AbandonRequestsRule.js
@@ -1,5 +1,5 @@
 import AbandonRequestsRule from '../../src/streaming/rules/abr/AbandonRequestsRule';
-
+import SwitchRequest from '../../src/streaming/rules/SwitchRequest';
 import MetricsModelMock from './mocks/MetricsModelMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
@@ -14,7 +14,7 @@ describe('AbandonRequestsRule', function () {
         const abandonRequestsRule = AbandonRequestsRule(context).create({});
         const abandonRequest = abandonRequestsRule.shouldAbandon();
 
-        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(abandonRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 
     it('should return an empty switchRequest when shouldAbandon function is called with a mock parameter', function () {
@@ -30,6 +30,6 @@ describe('AbandonRequestsRule', function () {
 
         const abandonRequest = abandonRequestsRule.shouldAbandon(rulesContextMock);
 
-        expect(abandonRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(abandonRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 });

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -1,24 +1,135 @@
 import InsufficientBufferRule from '../../src/streaming/rules/abr/InsufficientBufferRule';
+import SwitchRequest from '../../src/streaming/rules/SwitchRequest';
+import DashMetricsMock from './mocks/DashMetricsMock';
 
 const expect = require('chai').expect;
 
 const context = {};
-const insufficientBufferRule = InsufficientBufferRule(context).create({});
+let insufficientBufferRule;
 
 describe('InsufficientBufferRule', function () {
+    beforeEach(function () {
+        insufficientBufferRule = InsufficientBufferRule(context).create({});
+    });
+
     it('should return an empty switchRequest when getMaxIndex function is called with an empty parameter', function () {
         const maxIndexRequest = insufficientBufferRule.getMaxIndex();
 
-        expect(maxIndexRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 
     it('should return an empty switchRequest when getMaxIndex function is called with an malformed parameter', function () {
         const maxIndexRequest = insufficientBufferRule.getMaxIndex({});
 
-        expect(maxIndexRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 
     it('should throw an exception when attempting to call getMaxIndex While the config attribute has not been set properly', function () {
         expect(insufficientBufferRule.getMaxIndex.bind(insufficientBufferRule, {getMediaType: {}})).to.throw('Missing config parameter(s)');
+    });
+
+    it('should return an empty switch request when bufferState is empty', function () {
+        const dashMetricsMock = new DashMetricsMock();
+        const metricsModelMockWithEmptyBufferState = {
+            getReadOnlyMetricsFor: function () {
+                return {
+                    BufferState: []
+                };
+            }
+        };
+        const rulesContextMock = {
+            getMediaInfo: function () {},
+            getMediaType: function () { return 'video'; },
+            getAbrController: function () {},
+            getRepresentationInfo: function () { return { fragmentDuration: 4 };}
+        };
+        const rule = InsufficientBufferRule(context).create({
+            metricsModel: metricsModelMockWithEmptyBufferState,
+            dashMetrics: dashMetricsMock
+        });
+
+        const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
+    });
+
+    it('should return an empty switch request when first call is done with a buffer in state bufferStalled', function () {
+        const dashMetricsMock = new DashMetricsMock();
+        const metricsModelMockWithBufferState = {
+            getReadOnlyMetricsFor: function () {
+                return {
+                    BufferState: [{ state: 'bufferStalled' }]
+                };
+            }
+        };
+        const rulesContextMock = {
+            getMediaInfo: function () {},
+            getMediaType: function () { return 'video'; },
+            getAbrController: function () {},
+            getRepresentationInfo: function () { return { fragmentDuration: 4 };}
+        };
+        const rule = InsufficientBufferRule(context).create({
+            metricsModel: metricsModelMockWithBufferState,
+            dashMetrics: dashMetricsMock
+        });
+
+        let maxIndexRequest = rule.getMaxIndex(rulesContextMock);
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
+    });
+
+    it('should return an empty switch request when first call is done with a buffer in state bufferLoaded and fragmentDuration is NaN', function () {
+        const dashMetricsMock = new DashMetricsMock();
+        const metricsModelMockWithBufferState = {
+            getReadOnlyMetricsFor: function () {
+                return {
+                    BufferState: [{ state: 'bufferLoaded' }]
+                };
+            }
+        };
+        const rulesContextMock = {
+            getMediaInfo: function () {},
+            getMediaType: function () { return 'video'; },
+            getAbrController: function () {},
+            getRepresentationInfo: function () { return { fragmentDuration: NaN };}
+        };
+        const rule = InsufficientBufferRule(context).create({
+            metricsModel: metricsModelMockWithBufferState,
+            dashMetrics: dashMetricsMock
+        });
+
+        const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
+    });
+
+    it('should return index 0 when first call is done with a buffer in state bufferLoaded and fragmentDuration is NaN and then bufferStalled with fragmentDuration > 0', function () {
+        let bufferState = {
+            state: 'bufferLoaded'
+        };
+        let representationInfo = { fragmentDuration: NaN };
+        const dashMetricsMock = new DashMetricsMock();
+        const metricsModelMockBuffer = {
+            getReadOnlyMetricsFor: function () {
+                return {
+                    BufferState: [bufferState]
+                };
+            }
+        };
+        const rulesContextMock = {
+            getMediaInfo: function () {},
+            getMediaType: function () { return 'video'; },
+            getAbrController: function () {},
+            getRepresentationInfo: function () { return representationInfo;}
+        };
+
+        const rule = InsufficientBufferRule(context).create({
+            metricsModel: metricsModelMockBuffer,
+            dashMetrics: dashMetricsMock
+        });
+
+        rule.getMaxIndex(rulesContextMock);
+
+        bufferState.state = 'bufferStalled';
+        representationInfo.fragmentDuration = 4;
+        const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
+        expect(maxIndexRequest.quality).to.be.equal(0);
     });
 });

--- a/test/unit/streaming.rules.abr.ThroughputRule.js
+++ b/test/unit/streaming.rules.abr.ThroughputRule.js
@@ -1,4 +1,5 @@
 import ThroughputRule from '../../src/streaming/rules/abr/ThroughputRule';
+import SwitchRequest from '../../src/streaming/rules/SwitchRequest';
 
 const expect = require('chai').expect;
 
@@ -9,13 +10,13 @@ describe('ThroughputRule', function () {
     it('should return an empty switchRequest when getMaxIndex function is called with an empty parameter', function () {
         const maxIndexRequest = throughputRule.getMaxIndex();
 
-        expect(maxIndexRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 
     it('should return an empty switchRequest when getMaxIndex function is called with an malformed parameter', function () {
         const maxIndexRequest = throughputRule.getMaxIndex({});
 
-        expect(maxIndexRequest.quality).to.be.equal(-1);  // jshint ignore:line
+        expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);  // jshint ignore:line
     });
 
     it('should throw an exception when attempting to call getMaxIndex While the config attribute has not been set properly', function () {


### PR DESCRIPTION
In InsufficientBufferRule we are not checking if fragmentDuration is set. In live streams defined with SegmentTimeline and with short live delay time I have seen some cases in which fragmentDuration is NaN when evaluating this rule due to the fact that next segments list is empty. This makes the ABR algorithm to fluctuate a lot between the lowest bitrate and the right one according to Throughput/latency/buffer level values.

This PR avoid evaluating InsufficientBufferRule when there is no enough information to evaluate (it needs fragmentDuration). 

Alternatively we could not evaluate any rule when fragmentDuration is NaN (fragmentDuration is NaN when there are no segments and then, player won't request anything) but I preferred to patch just InsufficientBufferRule. Just thinking in cases or future rules that could take into account past situations for taking decisions (like SwitchHistoryRule). 

I took advantage of this PR to re-format ABR classes.

This fixes latest situation reported in #1977 