### PR TITLE
Check startTime of cues is lower than endTime

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -120,15 +120,17 @@ function TTMLParser() {
                     startTime = (mediaTimeEvents[i] + offsetTime) < startTimeSegment ? startTimeSegment : (mediaTimeEvents[i] + offsetTime);
                     endTime = (mediaTimeEvents[i + 1] + offsetTime) > endTimeSegment ? endTimeSegment : (mediaTimeEvents[i + 1] + offsetTime);
 
-                    captionArray.push({
-                        start: startTime,
-                        end: endTime,
-                        type: 'html',
-                        cueID: getCueID(),
-                        isd: isd,
-                        images: images,
-                        embeddedImages: embeddedImages
-                    });
+                    if (startTime < endTime) {
+                        captionArray.push({
+                            start: startTime,
+                            end: endTime,
+                            type: 'html',
+                            cueID: getCueID(),
+                            isd: isd,
+                            images: images,
+                            embeddedImages: embeddedImages
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #2202 

In Edge browser, whenever a TextTrackCue object has an startTime greater than its endTime, an exception is raised avoiding all the other parsed cues to be shown.

Note: Although this issue is raising an issue within captions provided by the user (external or fragmented using wrong startTime/endTime values), we need to make dash.js resilience against this kind of situations. So, this PR.