### PR TITLE
[MSS] Fix a problem with MSS Fragment Info integration

### DIFF
--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -55,6 +55,8 @@ function MssFragmentInfoController(config) {
     const ISOBoxer = config.ISOBoxer;
     const log = config.log;
 
+    const controllerType = 'MssFragmentInfoController';
+
     function setup() {
     }
 
@@ -256,6 +258,7 @@ function MssFragmentInfoController(config) {
 
     instance = {
         initialize: initialize,
+        controllerType: controllerType,
         start: doStart,
         reset: reset
     };

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -58,8 +58,7 @@ function MssHandler(config) {
 
     let instance;
 
-    function setup() {
-    }
+    function setup() {}
 
     function onInitializationRequested(e) {
         let streamProcessor = e.sender.getStreamProcessor();
@@ -129,16 +128,29 @@ function MssHandler(config) {
                         processor.getType() === constants.AUDIO ||
                         processor.getType() === constants.FRAGMENTED_TEXT) {
 
-                        let fragmentInfoController = MssFragmentInfoController(context).create({
-                            streamProcessor: processor,
-                            eventBus: eventBus,
-                            metricsModel: metricsModel,
-                            playbackController: playbackController,
-                            ISOBoxer: config.ISOBoxer,
-                            log: config.log
-                        });
-                        fragmentInfoController.initialize();
-                        fragmentInfoController.start();
+                        // check taht there is no fragment info controller registered to processor
+                        let i;
+                        let alreadyRegistered = false;
+                        let externalControllers = processor.getExternalControllers();
+                        for (i = 0; i < externalControllers.length; i++) {
+                            if (externalControllers[i].controllerType &&
+                                externalControllers[i].controllerType === 'MssFragmentInfoController') {
+                                alreadyRegistered = true;
+                            }
+                        }
+
+                        if (!alreadyRegistered) {
+                            let fragmentInfoController = MssFragmentInfoController(context).create({
+                                streamProcessor: processor,
+                                eventBus: eventBus,
+                                metricsModel: metricsModel,
+                                playbackController: playbackController,
+                                ISOBoxer: config.ISOBoxer,
+                                log: config.log
+                            });
+                            fragmentInfoController.initialize();
+                            fragmentInfoController.start();
+                        }
                     }
                 });
             }

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -146,6 +146,10 @@ function StreamProcessor(config) {
         }
     }
 
+    function getExternalControllers() {
+        return spExternalControllers;
+    }
+
     function unregisterAllExternalController() {
         spExternalControllers = [];
     }
@@ -361,6 +365,7 @@ function StreamProcessor(config) {
         setBuffer: setBuffer,
         registerExternalController: registerExternalController,
         unregisterExternalController: unregisterExternalController,
+        getExternalControllers: getExternalControllers,
         unregisterAllExternalController: unregisterAllExternalController,
         reset: reset
     };


### PR DESCRIPTION
Hi,

This PR fixes a pb with MSS Fragment Info management

 - Each time stream was seeked, a new FramgentInfoController was created and registered in streamProcessor -> it leads to 412 errors because each FragmentInfoController asks next fragment in indexhandler to create the fragment info request. In this case, indexHandler will return request that are not yet available in server.

- Solution is to check that there is only one fragment info controller registered in stream processor.

Jérémie 