### PR TITLE
Fix #1884 - correctly apply manifest scheme to default time server request

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -34,7 +34,6 @@ import Stream from '../Stream';
 import ManifestUpdater from '../ManifestUpdater';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
-import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel';
 import MediaPlayerModel from '../models/MediaPlayerModel';
 import FactoryMaker from '../../core/FactoryMaker';
 import {
@@ -43,6 +42,7 @@ import {
 } from '../vo/metrics/PlayList';
 import Debug from '../../core/Debug';
 import InitCache from '../utils/InitCache';
+import URLUtils from '../utils/URLUtils';
 import MediaPlayerEvents from '../MediaPlayerEvents';
 import TimeSyncController from './TimeSyncController';
 import BaseURLController from './BaseURLController';
@@ -75,6 +75,7 @@ function StreamController() {
         textController,
         sourceBufferController,
         initCache,
+        urlUtils,
         errHandler,
         timelineConverter,
         streams,
@@ -101,6 +102,7 @@ function StreamController() {
         baseURLController = BaseURLController(context).getInstance();
         mediaSourceController = MediaSourceController(context).getInstance();
         initCache = InitCache(context).getInstance();
+        urlUtils = URLUtils(context).getInstance();
 
         resetInitialSettings();
     }
@@ -508,7 +510,7 @@ function StreamController() {
 
             let manifestUTCTimingSources = dashManifestModel.getUTCTimingSources(e.manifest);
             let allUTCTimingSources = (!dashManifestModel.getIsDynamic(manifest) || useCalculatedLiveEdgeTime) ? manifestUTCTimingSources : manifestUTCTimingSources.concat(mediaPlayerModel.getUTCTimingSources());
-            let isHTTPS = URIQueryAndFragmentModel(context).getInstance().isManifestHTTPS();
+            const isHTTPS = urlUtils.isHTTPS(e.manifest.url);
 
             //If https is detected on manifest then lets apply that protocol to only the default time source(s). In the future we may find the need to apply this to more then just default so left code at this level instead of in MediaPlayer.
             allUTCTimingSources.forEach(function (item) {

--- a/src/streaming/utils/URLUtils.js
+++ b/src/streaming/utils/URLUtils.js
@@ -44,6 +44,7 @@ function URLUtils() {
 
     const schemeRegex = /^[a-z][a-z0-9+\-.]*:/i;
     const httpUrlRegex = /^https?:\/\//i;
+    const httpsUrlRegex = /^https:\/\//i;
     const originRegex = /^([a-z][a-z0-9+\-.]*:\/\/[^\/]+)\/?/i;
 
     /**
@@ -226,6 +227,17 @@ function URLUtils() {
     }
 
     /**
+     * Determines whether the supplied url has https scheme
+     * @return {bool}
+     * @param {string} url
+     * @memberof module:URLUtils
+     * @instance
+     */
+    function isHTTPS(url) {
+        return httpsUrlRegex.test(url);
+    }
+
+    /**
      * Resolves a url given an optional base url
      * @return {string}
      * @param {string} url
@@ -247,6 +259,7 @@ function URLUtils() {
         isPathAbsolute:     isPathAbsolute,
         isSchemeRelative:   isSchemeRelative,
         isHTTPURL:          isHTTPURL,
+        isHTTPS:            isHTTPS,
         resolve:            resolve
     };
 

--- a/test/unit/streaming.utils.URLUtils.js
+++ b/test/unit/streaming.utils.URLUtils.js
@@ -346,4 +346,37 @@ describe('URLUtils', function () {
             expect(result).to.equal(expected); // jshint ignore:line
         });
     });
+
+    describe('isHTTPS', () => {
+        it('should return false for an url with http scheme', () => {
+            const httpUrl = 'http://www.example.com';
+
+            const result = urlUtils.isHTTPS(httpUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+
+        it('should return true for an url with https scheme', () => {
+            const httpsUrl = 'https://www.example.com';
+            const result = urlUtils.isHTTPS(httpsUrl);
+
+            expect(result).to.be.true; // jshint ignore:line
+        });
+
+        it('should return false for a non-HTTP-URL url', () => {
+            const ftpUrl = 'ftp://www.example.com';
+
+            const result = urlUtils.isHTTPS(ftpUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+
+        it('should return false for a relative url', () => {
+            const relativeUrl = '/path/to/some/file';
+
+            const result = urlUtils.isHTTPS(relativeUrl);
+
+            expect(result).to.be.false; // jshint ignore:line
+        });
+    });
 });


### PR DESCRIPTION
Ensure a fully resolved URL is used when deciding what the manifest scheme is. This failed when the supplied manifest URL was relative. `e.manifest.url` resolves fully at manifest load time.

See #1884 for discussion.