### PR TITLE
Playready custom data for IE 11

### DIFF
--- a/externals/base64.js
+++ b/externals/base64.js
@@ -157,4 +157,5 @@ if (undefined === atob) {
 if (typeof exports !== 'undefined') {
     exports.decode = BASE64.decode;
     exports.decodeArray = BASE64.decodeArray;
+    exports.encode = BASE64.encode;
 }

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -142,6 +142,7 @@ function ProtectionController(config) {
      * the MPD or from the PSSH box in the media
      *
      * @param {ArrayBuffer} initData the initialization data
+     * @param {Uint8Array} cdmData the custom data to provide to licenser
      * @memberof module:ProtectionController
      * @instance
      * @fires ProtectionController#KeySessionCreated
@@ -150,7 +151,7 @@ function ProtectionController(config) {
      * API will need to modified (and a new "generateRequest(keySession, initData)" API created)
      * to come up to speed with the latest EME standard
      */
-    function createKeySession(initData) {
+    function createKeySession(initData, cdmData) {
         const initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, initData);
         if (initDataForKS) {
 
@@ -163,7 +164,7 @@ function ProtectionController(config) {
                 }
             }
             try {
-                protectionModel.createKeySession(initDataForKS, sessionType);
+                protectionModel.createKeySession(initDataForKS, sessionType, cdmData);
             } catch (error) {
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Error creating key session! ' + error.message});
             }
@@ -367,7 +368,7 @@ function ProtectionController(config) {
                         } else {
                             log('DRM: KeySystem Access Granted');
                             eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: event.data});
-                            createKeySession(supportedKS[ksIdx].initData);
+                            createKeySession(supportedKS[ksIdx].initData, supportedKS[ksIdx].cdmData);
                         }
                     };
                     eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
@@ -416,7 +417,7 @@ function ProtectionController(config) {
                     for (let i = 0; i < pendingNeedKeyData.length; i++) {
                         for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
                             if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {
-                                createKeySession(pendingNeedKeyData[i][ksIdx].initData);
+                                createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
                                 break;
                             }
                         }

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -189,7 +189,8 @@ function ProtectionKeyController() {
                         if (!!initData) {
                             supportedKS.push({
                                 ks: keySystems[ksIdx],
-                                initData: initData
+                                initData: initData,
+                                cdmData: ks.getCDMData()
                             });
                         }
                     }

--- a/src/streaming/protection/drm/KeySystem.js
+++ b/src/streaming/protection/drm/KeySystem.js
@@ -115,3 +115,11 @@
  * from the PSSH box definition
  * @returns {?string} The license server URL or null if URL is not available in initData
  */
+
+ /**
+ * Returns specific CDM (custom) data.
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.KeySystem#getCDMData
+ * @returns {ArrayBuffer} the CDM (custom) data
+ */

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -88,6 +88,10 @@ function KeySystemClearKey(config) {
         return null;
     }
 
+    function getCDMData() {
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -96,6 +100,7 @@ function KeySystemClearKey(config) {
         getRequestHeadersFromMessage: getRequestHeadersFromMessage,
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
+        getCDMData: getCDMData,
         getClearKeysFromProtectionData: getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -213,6 +213,10 @@ function KeySystemPlayReady(config) {
         messageFormat = format;
     }
 
+    /**
+     * Initialize the Key system with protection data
+     * @param {Object} protectionData the protection data
+     */
     function init(protectionData) {
         if (protectionData) {
             protData = protectionData;

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -47,7 +47,13 @@ function KeySystemPlayReady(config) {
 
     let instance;
     let messageFormat = 'utf16';
-    let BASE64 = config.BASE64;
+    let BASE64 = config ? config.BASE64 : null;
+
+    function checkConfig() {
+        if (!BASE64 || !BASE64.hasOwnProperty('decodeArray') || !BASE64.hasOwnProperty('decodeArray') ) {
+            throw new Error('Missing config parameter(s)');
+        }
+    }
 
     function getRequestHeadersFromMessage(message) {
         let msg,
@@ -81,6 +87,7 @@ function KeySystemPlayReady(config) {
         let parser = new DOMParser();
         let dataview = (messageFormat === 'utf16') ? new Uint16Array(message) : new Uint8Array(message);
 
+        checkConfig();
         msg = String.fromCharCode.apply(null, dataview);
         xmlDoc = parser.parseFromString(msg, 'application/xml');
 
@@ -157,6 +164,7 @@ function KeySystemPlayReady(config) {
             PSSHBox,
             PSSHData;
 
+        checkConfig();
         // Handle common encryption PSSH
         if ('pssh' in cpData) {
             return CommonEncryption.parseInitDataFromContentProtection(cpData, BASE64);
@@ -233,6 +241,7 @@ function KeySystemPlayReady(config) {
             cdmDataBytes,
             i;
 
+        checkConfig();
         if (protData && protData.cdmData) {
 
             // Convert custom data into multibyte string

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -112,6 +112,10 @@ function KeySystemWidevine(config) {
         return null;
     }
 
+    function getCDMData() {
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -120,7 +124,8 @@ function KeySystemWidevine(config) {
         getInitData: getInitData,
         getRequestHeadersFromMessage: getRequestHeadersFromMessage,
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
-        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData
+        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
+        getCDMData: getCDMData
     };
 
     return instance;

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -191,7 +191,7 @@ function ProtectionModel_3Feb2014(config) {
         }
     }
 
-    function createKeySession(initData /*, keySystemType */) {
+    function createKeySession(initData, sessionType, cdmData) {
 
         if (!keySystem || !mediaKeys || !keySystemAccess) {
             throw new Error('Can not create sessions until you have selected a key system');
@@ -213,7 +213,7 @@ function ProtectionModel_3Feb2014(config) {
           throw new Error('Can not create sessions for unknown content types.');
 
         let contentType = capabilities.contentType;
-        let session = mediaKeys.createSession(contentType, new Uint8Array(initData));
+        let session = mediaKeys.createSession(contentType, new Uint8Array(initData), cdmData ? new Uint8Array(cdmData) : null);
         let sessionToken = createSessionToken(session, initData);
 
         // Add all event listeners

--- a/test/unit/streaming.protection.drm.KeySystemPlayReady.js
+++ b/test/unit/streaming.protection.drm.KeySystemPlayReady.js
@@ -1,20 +1,18 @@
 import KeySystemPlayReady from '../../src/streaming/protection/drm/KeySystemPlayReady.js';
 
 const expect = require('chai').expect;
-const fs = require('fs');
-const domParser = require('xmldom').DOMParser;
 
-describe('KeySystemPlayready', function(){
+describe('KeySystemPlayready', function () {
 
     let keySystem;
     let cdmData = null;
 
     const protData = {
         cdmData: '2lfuDn3JoEo0dM324cA5tSv1gNNw65mgysBqNJqtxGUk7ShUOE03N6LK0cryu2roCQtDghmF7cC6xyt1WTA86CmrUNFRjo1tcxQtTVEW9Xw68pH7/yU2GbtK4zbctx49sffi4fYy8fGEUB5079CesBONxoKli5j2ADM8CWz93a5mYegZWraOq3EH0nvwvRXZ'
-    }
+    };
 
     const expectedCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded"></CustomData></LicenseAcquisition></PlayReadyCDMData>';
-    
+
     const context = {};
 
     it('should exist', () => {
@@ -25,10 +23,10 @@ describe('KeySystemPlayready', function(){
     keySystem.init(protData);
     cdmData = keySystem.getCDMData();
 
-    it('should return the correct cdmData', function() {
-        expect(keySystem).to.be.not.undefined;
-        expect(cdmData).to.be.not.null;
+    it('should return the correct cdmData', function () {
+        expect(keySystem).to.be.defined; // jshint ignore:line
+        expect(cdmData).to.be.not.null; // jshint ignore:line
         expect(cdmData).to.equal(expectedCDMData);
     });
 
-})
+});

--- a/test/unit/streaming.protection.drm.KeySystemPlayReady.js
+++ b/test/unit/streaming.protection.drm.KeySystemPlayReady.js
@@ -1,9 +1,13 @@
+/* jshint expr: true */
+
 import KeySystemPlayReady from '../../src/streaming/protection/drm/KeySystemPlayReady.js';
+import BASE64 from '../../externals/base64';
 
 const expect = require('chai').expect;
 
 describe('KeySystemPlayready', function () {
 
+    let context;
     let keySystem;
     let cdmData = null;
 
@@ -13,19 +17,25 @@ describe('KeySystemPlayready', function () {
 
     const expectedCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded">MgBsAGYAdQBEAG4AMwBKAG8ARQBvADAAZABNADMAMgA0AGMAQQA1AHQAUwB2ADEAZwBOAE4AdwA2ADUAbQBnAHkAcwBCAHEATgBKAHEAdAB4AEcAVQBrADcAUwBoAFUATwBFADAAMwBOADYATABLADAAYwByAHkAdQAyAHIAbwBDAFEAdABEAGcAaABtAEYANwBjAEMANgB4AHkAdAAxAFcAVABBADgANgBDAG0AcgBVAE4ARgBSAGoAbwAxAHQAYwB4AFEAdABUAFYARQBXADkAWAB3ADYAOABwAEgANwAvAHkAVQAyAEcAYgB0AEsANAB6AGIAYwB0AHgANAA5AHMAZgBmAGkANABmAFkAeQA4AGYARwBFAFUAQgA1ADAANwA5AEMAZQBzAEIATwBOAHgAbwBLAGwAaQA1AGoAMgBBAEQATQA4AEMAVwB6ADkAMwBhADUAbQBZAGUAZwBaAFcAcgBhAE8AcQAzAEUASAAwAG4AdgB3AHYAUgBYAFoA</CustomData></LicenseAcquisition></PlayReadyCDMData>';
 
-    const context = {};
-
-    it('should exist', () => {
-        expect(KeySystemPlayReady).to.exist; // jshint ignore:line
+    beforeEach(function () {
+        context = {};
     });
 
-    keySystem = KeySystemPlayReady(context).getInstance();
-    keySystem.init(protData);
-    cdmData = keySystem.getCDMData();
+    it('should exist', () => {
+        expect(KeySystemPlayReady).to.exist;
+    });
+
+    it('should throw an exception when getting an instance while the config attribute has not been set properly', function () {
+        keySystem = KeySystemPlayReady(context).getInstance();
+        expect(keySystem.getCDMData.bind(keySystem)).to.throw('Missing config parameter(s)');
+    });
 
     it('should return the correct cdmData', function () {
-        expect(keySystem).to.be.defined; // jshint ignore:line
-        expect(cdmData).to.be.not.null; // jshint ignore:line
+        keySystem = KeySystemPlayReady(context).getInstance({BASE64: BASE64});
+        keySystem.init(protData);
+        cdmData = keySystem.getCDMData();
+        expect(keySystem).to.be.defined;
+        expect(cdmData).to.be.not.null;
         expect(cdmData).to.be.instanceOf(ArrayBuffer);
         var cdmDataString = String.fromCharCode.apply(null, new Uint16Array(cdmData));
         expect(cdmDataString).to.equal(expectedCDMData);

--- a/test/unit/streaming.protection.drm.KeySystemPlayReady.js
+++ b/test/unit/streaming.protection.drm.KeySystemPlayReady.js
@@ -11,7 +11,7 @@ describe('KeySystemPlayready', function () {
         cdmData: '2lfuDn3JoEo0dM324cA5tSv1gNNw65mgysBqNJqtxGUk7ShUOE03N6LK0cryu2roCQtDghmF7cC6xyt1WTA86CmrUNFRjo1tcxQtTVEW9Xw68pH7/yU2GbtK4zbctx49sffi4fYy8fGEUB5079CesBONxoKli5j2ADM8CWz93a5mYegZWraOq3EH0nvwvRXZ'
     };
 
-    const expectedCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded"></CustomData></LicenseAcquisition></PlayReadyCDMData>';
+    const expectedCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded">MgBsAGYAdQBEAG4AMwBKAG8ARQBvADAAZABNADMAMgA0AGMAQQA1AHQAUwB2ADEAZwBOAE4AdwA2ADUAbQBnAHkAcwBCAHEATgBKAHEAdAB4AEcAVQBrADcAUwBoAFUATwBFADAAMwBOADYATABLADAAYwByAHkAdQAyAHIAbwBDAFEAdABEAGcAaABtAEYANwBjAEMANgB4AHkAdAAxAFcAVABBADgANgBDAG0AcgBVAE4ARgBSAGoAbwAxAHQAYwB4AFEAdABUAFYARQBXADkAWAB3ADYAOABwAEgANwAvAHkAVQAyAEcAYgB0AEsANAB6AGIAYwB0AHgANAA5AHMAZgBmAGkANABmAFkAeQA4AGYARwBFAFUAQgA1ADAANwA5AEMAZQBzAEIATwBOAHgAbwBLAGwAaQA1AGoAMgBBAEQATQA4AEMAVwB6ADkAMwBhADUAbQBZAGUAZwBaAFcAcgBhAE8AcQAzAEUASAAwAG4AdgB3AHYAUgBYAFoA</CustomData></LicenseAcquisition></PlayReadyCDMData>';
 
     const context = {};
 
@@ -26,7 +26,9 @@ describe('KeySystemPlayready', function () {
     it('should return the correct cdmData', function () {
         expect(keySystem).to.be.defined; // jshint ignore:line
         expect(cdmData).to.be.not.null; // jshint ignore:line
-        expect(cdmData).to.equal(expectedCDMData);
+        expect(cdmData).to.be.instanceOf(ArrayBuffer);
+        var cdmDataString = String.fromCharCode.apply(null, new Uint16Array(cdmData));
+        expect(cdmDataString).to.equal(expectedCDMData);
     });
 
 });

--- a/test/unit/streaming.protection.drm.KeySystemPlayReady.js
+++ b/test/unit/streaming.protection.drm.KeySystemPlayReady.js
@@ -1,0 +1,34 @@
+import KeySystemPlayReady from '../../src/streaming/protection/drm/KeySystemPlayReady.js';
+
+const expect = require('chai').expect;
+const fs = require('fs');
+const domParser = require('xmldom').DOMParser;
+
+describe('KeySystemPlayready', function(){
+
+    let keySystem;
+    let cdmData = null;
+
+    const protData = {
+        cdmData: '2lfuDn3JoEo0dM324cA5tSv1gNNw65mgysBqNJqtxGUk7ShUOE03N6LK0cryu2roCQtDghmF7cC6xyt1WTA86CmrUNFRjo1tcxQtTVEW9Xw68pH7/yU2GbtK4zbctx49sffi4fYy8fGEUB5079CesBONxoKli5j2ADM8CWz93a5mYegZWraOq3EH0nvwvRXZ'
+    }
+
+    const expectedCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded"></CustomData></LicenseAcquisition></PlayReadyCDMData>';
+    
+    const context = {};
+
+    it('should exist', () => {
+        expect(KeySystemPlayReady).to.exist; // jshint ignore:line
+    });
+
+    keySystem = KeySystemPlayReady(context).getInstance();
+    keySystem.init(protData);
+    cdmData = keySystem.getCDMData();
+
+    it('should return the correct cdmData', function() {
+        expect(keySystem).to.be.not.undefined;
+        expect(cdmData).to.be.not.null;
+        expect(cdmData).to.equal(expectedCDMData);
+    });
+
+})


### PR DESCRIPTION
This PR to add Playready custom data support which is needed for IE11 with ProtectionModel_3Feb2014
It takes some custom data from the protection data object and add it (after an appropriate transformation) inside the SOAP request for the Playready licenser server
It has been tested successfully with Orange Playready licenser server
A unit test is provided