### PR TITLE
Use latest version of dash.js package in webpack example

### DIFF
--- a/samples/modules/webpack/package.json
+++ b/samples/modules/webpack/package.json
@@ -6,7 +6,7 @@
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.2",
     "babel-preset-es2015": "^6.5.0",
-    "dashjs": "2.0.0",
+    "dashjs": "^2.0.0",
     "webpack": "^1.12.13"
   },
   "scripts": {


### PR DESCRIPTION
Use latest version of dash.js 2.x.x package in current webpack module example.