### PR TITLE
Patch in xml2json to resolve xml syntax error in Firefox/IE/Edge

### DIFF
--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -535,19 +535,9 @@ function X2JS(config) {
         if (window.DOMParser) {
             var parser=new window.DOMParser();
             var parsererrorNS = null;
-            // IE9+ now is here
-            if(!isIEParser) {
-                try {
-                    parsererrorNS = parser.parseFromString("INVALID", "text/xml").getElementsByTagName("parsererror")[0].namespaceURI;
-                }
-                catch(err) {
-                    parsererrorNS = null;
-                }
-            }
             try {
                 xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
-                if( parsererrorNS!= null && xmlDoc.getElementsByTagNameNS(parsererrorNS, "parsererror").length > 0) {
-                    //throw new Error('Error parsing XML: '+xmlDocStr);
+                if(xmlDoc.getElementsByTagNameNS("*", "parseerror").length > 0) {
                     xmlDoc = null;
                 }
             }


### PR DESCRIPTION
Following @bbcrddave suggestion, patch (from @Stealthfox) to resolve an XML parse error: syntax error in Firefox/Edge/IE for MPD files.

Important: I don't see any possible caveat but before merging we have to test this in as many browsers as possible. I have already tested it successfully in many different browsers/versions (local env + browserStack) but four eyes see more than two.

This fixes #1665