### PR TITLE
Add reloading browser for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chai-spies": "^0.7.1",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
+    "grunt-browser-sync": "^2.2.0",
     "grunt-browserify": "^4.0.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel": "^5.3.1",
     "babelify": "^6.1.0",
     "browserify-derequire": "^0.9.4",
+    "bs-html-injector": "^3.0.3",
     "bundle-collapser": "^1.2.1",
     "chai": "^3.4.1",
     "chai-spies": "^0.7.1",


### PR DESCRIPTION
Improve build process of grunt for developers to make a change in the source code and automatically load the browser.

I add a web server to serve statics and Browsersync to reload the browser. The server includes a middleware to add the code necessary for Browsersync in html files. 

To launch the live reloading of the browser, execute 'grunt dev'.
To launch only a web server, execute 'grunt serve'.