### PR TITLE
Compact option of babel set to true

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,7 +159,8 @@ module.exports = function (grunt) {
 
         babel: {
             options: {
-                sourceMap: true
+                sourceMap: true,
+                compact: true
             },
             es5: {
                 files: [{

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -358,7 +358,7 @@ function DashAdapter() {
         return indexHandler ? indexHandler.getInitRequest(representation) : null;
     }
 
-    function getNextFragmentRequest(streamProcessor, trackInfo) {
+    function getNextFragmentRequest(streamProcessor, representationInfo) {
         let representationController,
             representation,
             indexHandler;
@@ -366,13 +366,13 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(representationInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.getNextSegmentRequest(representation) : null;
     }
 
-    function getFragmentRequestForTime(streamProcessor, trackInfo, time, options) {
+    function getFragmentRequestForTime(streamProcessor, representationInfo, time, options) {
         let representationController,
             representation,
             indexHandler;
@@ -380,13 +380,13 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(representationInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.getSegmentRequestForTime(representation, time, options) : null;
     }
 
-    function generateFragmentRequestForTime(streamProcessor, trackInfo, time) {
+    function generateFragmentRequestForTime(streamProcessor, representationInfo, time) {
         let representationController,
             representation,
             indexHandler;
@@ -394,7 +394,7 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         representationController = streamProcessor.getRepresentationController();
-        representation = getRepresentationForRepresentationInfo(trackInfo, representationController);
+        representation = getRepresentationForRepresentationInfo(representationInfo, representationController);
         indexHandler = streamProcessor.getIndexHandler();
 
         return indexHandler ? indexHandler.generateSegmentRequestForTime(representation, time) : null;

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -67,7 +67,7 @@ function AbandonRequestsRule(config) {
         const switchRequest = SwitchRequest(context).create(SwitchRequest.NO_CHANGE, {name: AbandonRequestsRule.__dashjs_factory_name});
 
         if (!rulesContext || !rulesContext.hasOwnProperty('getMediaInfo') || !rulesContext.hasOwnProperty('getMediaType') || !rulesContext.hasOwnProperty('getCurrentRequest') ||
-            !rulesContext.hasOwnProperty('getTrackInfo') || !rulesContext.hasOwnProperty('getAbrController')) {
+            !rulesContext.hasOwnProperty('getRepresentationInfo') || !rulesContext.hasOwnProperty('getAbrController')) {
             return switchRequest;
         }
 

--- a/test/unit/mocks/RulesContextMock.js
+++ b/test/unit/mocks/RulesContextMock.js
@@ -22,7 +22,7 @@ function RulesContextMock () {
 
         return fragRequest;
     };
-    this.getTrackInfo = function () {};
+    this.getRepresentationInfo = function () {};
     this.getAbrController = function () {};
     this.getSwitchHistory = function () {
         return new switchRequestHistoryMock();


### PR DESCRIPTION
Set [`compact`](https://babeljs.io/docs/usage/api/#options) option of babel to true explicitly to avoid the following warning message during compilation:

`[BABEL] Note: The code generator has deoptimised the styling of "D:/nginx/html/dash.js-2.0/src/streaming/MediaPlayer.js" as it exceeds the max of "100KB".`