### PR TITLE
[build] Set compact option to true explicitly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,7 +159,8 @@ module.exports = function (grunt) {
 
         babel: {
             options: {
-                sourceMap: true
+                sourceMap: true,
+                compact: true
             },
             es5: {
                 files: [{


### PR DESCRIPTION
Set [`compact`](https://babeljs.io/docs/usage/api/#options) option of babel to true explicitly to avoid the following warning message during compilation:

`[BABEL] Note: The code generator has deoptimised the styling of "D:/nginx/html/dash.js-2.0/src/streaming/MediaPlayer.js" as it exceeds the max of "100KB".`

Fix #2244 