### PR TITLE
fix switch track audio with different number of representations

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -163,7 +163,7 @@ function RepresentationController() {
 
         voAvailableRepresentations = updateRepresentations(voAdaptation);
 
-        if (realAdaptation === null && type !== Constants.FRAGMENTED_TEXT) {
+        if ((realAdaptation === null || (realAdaptation.id != newRealAdaptation.id)) && type !== Constants.FRAGMENTED_TEXT) {
             averageThroughput = abrController.getThroughputHistory().getAverageThroughput(type);
             bitrate = averageThroughput || abrController.getInitialBitrateFor(type, streamInfo);
             quality = abrController.getQualityForBitrate(streamProcessor.getMediaInfo(), bitrate);

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -273,6 +273,7 @@ function Stream(config) {
         } else {
             processor.updateMediaInfo(mediaInfo);
             if (mediaInfo.type !== Constants.FRAGMENTED_TEXT) {
+                abrController.updateTopQualityIndex(mediaInfo);
                 processor.switchTrackAsked();
             }
         }


### PR DESCRIPTION
When we switch from an audio track with one representation to another track with 2 or more, currently we don't change of quality (stuck to quality 0) due to #2151 and the fact we do not recreate audio stream processor anymore.
This PR fixes this problem 