### PR TITLE
Fix MetricsReporting - pass correct config to ReportingFactory

### DIFF
--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -51,7 +51,8 @@ function MetricsController(config) {
             rangeController.initialize(metricsEntry.Range);
 
             reportingController = ReportingController(context).create({
-                log: config.log
+                log: config.log,
+                metricsConstants: config.metricsConstants
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);

--- a/src/streaming/metrics/controllers/ReportingController.js
+++ b/src/streaming/metrics/controllers/ReportingController.js
@@ -36,9 +36,7 @@ function ReportingController(config) {
     let reporters = [];
     let instance;
 
-    let reportingFactory = ReportingFactory(this.context).getInstance({
-        log: config.log
-    });
+    const reportingFactory = ReportingFactory(this.context).getInstance(config);
 
     function initialize(reporting, rangeController) {
         // "if multiple Reporting elements are present, it is expected that

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -33,19 +33,23 @@ import DVBReporting from './reporters/DVBReporting';
 
 function ReportingFactory(config) {
 
-    let knownReportingSchemeIdUris = {
+    const knownReportingSchemeIdUris = {
         'urn:dvb:dash:reporting:2014': DVBReporting
     };
 
-    let context = this.context;
-    let log = config.log;
+    const context = this.context;
+    const log = config.log;
+    const metricsConstants = config.metricsConstants;
+
     let instance;
 
     function create(entry, rangeController) {
         let reporting;
 
         try {
-            reporting = knownReportingSchemeIdUris[entry.schemeIdUri](context).create();
+            reporting = knownReportingSchemeIdUris[entry.schemeIdUri](context).create({
+                metricsConstants: metricsConstants
+            });
 
             reporting.initialize(entry, rangeController);
         } catch (e) {


### PR DESCRIPTION
https://github.com/Dash-Industry-Forum/dash.js/pull/2154 (specifically https://github.com/Dash-Industry-Forum/dash.js/commit/e6a1a4ffa6fd55f0f3e44bf74aaf3bed0c632c38) broke metric reporting because it did not pass MetricsConstants to all necessary modules - ReportingFactory and the modules it creates require this config.

I also changed some `let` to `const` whilst there.