### PR TITLE
Update multi period management

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -119,6 +119,8 @@ function Stream(config) {
     function deactivate() {
         let ln = streamProcessors ? streamProcessors.length : 0;
         for (let i = 0; i < ln; i++) {
+            let fragmentModel = streamProcessors[i].getFragmentModel();
+            fragmentModel.removeExecutedRequestsBeforeTime(this.getStartTime() + this.getDuration());
             streamProcessors[i].reset();
         }
         streamProcessors = [];

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -123,6 +123,10 @@ function Stream(config) {
             fragmentModel.removeExecutedRequestsBeforeTime(this.getStartTime() + this.getDuration());
             streamProcessors[i].reset();
         }
+        //all stream processors have been destroyed, stream has to reset abrController which has reference on stream processors.
+        if (abrController) {
+            abrController.reset();
+        }
         streamProcessors = [];
         isStreamActivated = false;
         isMediaInitialized = false;

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -120,7 +120,7 @@ function Stream(config) {
         let ln = streamProcessors ? streamProcessors.length : 0;
         for (let i = 0; i < ln; i++) {
             let fragmentModel = streamProcessors[i].getFragmentModel();
-            fragmentModel.removeExecutedRequestsBeforeTime(this.getStartTime() + this.getDuration());
+            fragmentModel.removeExecutedRequestsBeforeTime(getStartTime() + getDuration());
             streamProcessors[i].reset();
         }
         //all stream processors have been destroyed, stream has to reset abrController which has reference on stream processors.


### PR DESCRIPTION
Hi,

the goal of this PR is to update management of multi period streams. 

First, when a switch stream occurs, streamProcessors array is destroyed. It's the reason why abrController don't have to keep references on those streamProcessors.

Then, after a stream switch, executedRequests array (in FragmentModel) was not cleaned. That's why if we seek back to the initial stream at an already played time, the getNextRequestTime returns a request at the time of the end of the last executed Request...not the wanted time. A test can be done with the stream https://dash.akamaized.net/dash264/TestCases/5a/1/manifest.mpd : play the initial stream (about 10 seconds), seek in the second stream (for instance at 4mn30s), and then after 5 seconds seek to the initial stream at 10 seconds. The stream plays from about 40 seconds not 10 seconds (reproduced on nightly build page). In brief, when a switch stream occurs, the executed requests array need to be cleaned : the source of the video is changed, buffered data are reseted.

Nico