### PR TITLE
Basic ClearKey support

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -190,6 +190,13 @@
         {
           "name": "1080p with W3C Clear Key, single key",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "nrQFDeRLSAKTLifXUIPiZg": "FmY0xnWCPCNaSpRG-tUuTQ"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {
@@ -243,6 +250,13 @@
         {
            "name": "2160p with W3C Clear Key, single key",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "nrQFDeRLSAKTLifXUIPiZg": "FmY0xnWCPCNaSpRG-tUuTQ"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -262,6 +262,17 @@
         {
            "name": "2160p with W3C Clear Key, multiple keys",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-MultiKey/Manifest_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "gDmb9YohQBSAU-J-dI6YwA": "3aHppzZ2g3Y3wK1uNnUXmg",
+                "kJU-CWyySaOiYHpf7-rUmQ": "zsmKW7Mq9Unz5R7oUGeF8w",
+                "Dk2pK9DoSmaMP8Jal-tlMg": "UmYYfGb7znuoFAQM79ayHw",
+                "WF8jPzByRvGfpG3CLGagFA": "jayKpC3tmPq4YKXkapa8FA",
+                "QiK9eLxFQb-2Pm-BTcOR3w": "GAMi9v92b9ca5yBwaptN-Q"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {
@@ -315,6 +326,17 @@
         {
           "name": "Audio with W3C Clear Key, multiple keys",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-MultiKey/Manifest_AudioOnly_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "gDmb9YohQBSAU-J-dI6YwA": "3aHppzZ2g3Y3wK1uNnUXmg",
+                "kJU-CWyySaOiYHpf7-rUmQ": "zsmKW7Mq9Unz5R7oUGeF8w",
+                "Dk2pK9DoSmaMP8Jal-tlMg": "UmYYfGb7znuoFAQM79ayHw",
+                "WF8jPzByRvGfpG3CLGagFA": "jayKpC3tmPq4YKXkapa8FA",
+                "QiK9eLxFQb-2Pm-BTcOR3w": "GAMi9v92b9ca5yBwaptN-Q"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {
@@ -344,6 +366,17 @@
         {
           "name": "Multi-period 1080p with W3C Clear Key, multiple keys",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-MultiKey-MultiPeriod/Manifest_1080p_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "gDmb9YohQBSAU-J-dI6YwA": "3aHppzZ2g3Y3wK1uNnUXmg",
+                "kJU-CWyySaOiYHpf7-rUmQ": "zsmKW7Mq9Unz5R7oUGeF8w",
+                "Dk2pK9DoSmaMP8Jal-tlMg": "UmYYfGb7znuoFAQM79ayHw",
+                "WF8jPzByRvGfpG3CLGagFA": "jayKpC3tmPq4YKXkapa8FA",
+                "QiK9eLxFQb-2Pm-BTcOR3w": "GAMi9v92b9ca5yBwaptN-Q"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -63,6 +63,7 @@ class Constants {
         this.ABR_STRATEGY_THROUGHPUT = 'abrThroughput';
         this.MOVING_AVERAGE_SLIDING_WINDOW = 'slidingWindow';
         this.MOVING_AVERAGE_EWMA = 'ewma';
+        this.CLEARKEY_ORG_STRING = 'org.w3.clearkey';
     }
 
     constructor () {

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -119,7 +119,7 @@ class CommonEncryption {
         if (data === null)
             return [];
 
-        let dv = new DataView(data);
+        let dv = new DataView(data.buffer || data); // data.buffer first for Uint8Array support
         let done = false;
         let pssh = {};
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -478,7 +478,7 @@ function ProtectionController(config) {
 
         // Perform any special handling for ClearKey
         if (protectionKeyController.isClearKey(keySystem)) {
-            const clearkeys = protectionKeyController.processClearKeyLicenseRequest(protData, message);
+            const clearkeys = protectionKeyController.processClearKeyLicenseRequest(keySystem, protData, message);
             if (clearkeys)  {
                 log('DRM: ClearKey license request handled by application!');
                 sendLicenseRequestCompleteEvent(eventData);

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -169,6 +169,8 @@ function ProtectionController(config) {
             } catch (error) {
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Error creating key session! ' + error.message});
             }
+        } else if (initData) {
+            protectionModel.createKeySession(initData, sessionType, cdmData);
         } else {
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Selected key system is ' + keySystem.systemString + '.  needkey/encrypted event contains no initData corresponding to that key system!'});
         }
@@ -418,6 +420,12 @@ function ProtectionController(config) {
                     for (let i = 0; i < pendingNeedKeyData.length; i++) {
                         for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
                             if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {
+                                if (pendingNeedKeyData[i][ksIdx].initData === null && protData.hasOwnProperty('clearkeys')) {
+                                    var initData = { kids: Object.keys(protData.clearkeys) };
+
+                                    pendingNeedKeyData[i][ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
+                                }
+
                                 createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
                                 break;
                             }

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -30,6 +30,7 @@
  */
 import CommonEncryption from './../CommonEncryption';
 import KeySystemClearKey from './../drm/KeySystemClearKey';
+import KeySystemW3CClearKey from './../drm/KeySystemW3CClearKey';
 import KeySystemWidevine from './../drm/KeySystemWidevine';
 import KeySystemPlayReady from './../drm/KeySystemPlayReady';
 import DRMToday from './../servers/DRMToday';
@@ -49,7 +50,8 @@ function ProtectionKeyController() {
         log,
         keySystems,
         BASE64,
-        clearkeyKeySystem;
+        clearkeyKeySystem,
+        clearkeyW3CKeySystem;
 
     function setConfig(config) {
         if (!config) return;
@@ -80,6 +82,11 @@ function ProtectionKeyController() {
         keySystem = KeySystemClearKey(context).getInstance({BASE64: BASE64});
         keySystems.push(keySystem);
         clearkeyKeySystem = keySystem;
+
+        // W3C ClearKey
+        keySystem = KeySystemW3CClearKey(context).getInstance({BASE64: BASE64, log: log});
+        keySystems.push(keySystem);
+        clearkeyW3CKeySystem = keySystem;
     }
 
     /**
@@ -131,7 +138,7 @@ function ProtectionKeyController() {
      * @instance
      */
     function isClearKey(keySystem) {
-        return (keySystem === clearkeyKeySystem);
+        return (keySystem === clearkeyKeySystem || keySystem === clearkeyW3CKeySystem);
     }
 
     /**
@@ -274,6 +281,7 @@ function ProtectionKeyController() {
     /**
      * Allows application-specific retrieval of ClearKey keys.
      *
+     * @param {KeySystem} clearkeyKeySystem They exact ClearKey System to be used
      * @param {ProtectionData} protData protection data to use for the
      * request
      * @param {ArrayBuffer} message the key message from the CDM
@@ -282,7 +290,7 @@ function ProtectionKeyController() {
      * @memberof module:ProtectionKeyController
      * @instance
      */
-    function processClearKeyLicenseRequest(protData, message) {
+    function processClearKeyLicenseRequest(clearkeyKeySystem, protData, message) {
         try {
             return clearkeyKeySystem.getClearKeysFromProtectionData(protData, message);
         } catch (error) {

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -186,18 +186,11 @@ function ProtectionKeyController() {
 
                         // Look for DRM-specific ContentProtection
                         let initData = ks.getInitData(cp);
-                        if (!!initData) {
-                            supportedKS.push({
-                                ks: keySystems[ksIdx],
-                                initData: initData,
-                                cdmData: ks.getCDMData()
-                            });
-                        } else if (this.isClearKey(ks)) {
-                            supportedKS.push({
-                                ks: ks,
-                                initData: null
-                            });
-                        }
+                        supportedKS.push({
+                            ks: keySystems[ksIdx],
+                            initData: initData,
+                            cdmData: ks.getCDMData()
+                        });
                     }
                 }
             }

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -37,6 +37,7 @@ import DRMToday from './../servers/DRMToday';
 import PlayReady from './../servers/PlayReady';
 import Widevine from './../servers/Widevine';
 import ClearKey from './../servers/ClearKey';
+import Constants from '../../constants/Constants';
 
 /**
  * @module ProtectionKeyController
@@ -271,7 +272,7 @@ function ProtectionKeyController() {
             licenseServerData = Widevine(context).getInstance();
         } else if (keySystem.systemString === 'com.microsoft.playready') {
             licenseServerData = PlayReady(context).getInstance();
-        } else if (keySystem.systemString === 'org.w3.clearkey') {
+        } else if (keySystem.systemString === Constants.CLEARKEY_ORG_STRING) {
             licenseServerData = ClearKey(context).getInstance();
         }
 

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -192,6 +192,11 @@ function ProtectionKeyController() {
                                 initData: initData,
                                 cdmData: ks.getCDMData()
                             });
+                        } else if (this.isClearKey(ks)) {
+                            supportedKS.push({
+                                ks: ks,
+                                initData: null
+                            });
                         }
                     }
                 }

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -32,9 +32,10 @@
 import KeyPair from '../vo/KeyPair';
 import ClearKeyKeySet from '../vo/ClearKeyKeySet';
 import CommonEncryption from '../CommonEncryption';
+import Constants from '../../constants/Constants';
 
 const uuid = 'e2719d58-a985-b3c9-781a-b030af78d30e';
-const systemString = 'org.w3.clearkey';
+const systemString = Constants.CLEARKEY_ORG_STRING;
 const schemeIdURI = 'urn:uuid:' + uuid;
 
 function KeySystemClearKey(config) {

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -33,7 +33,7 @@ import KeyPair from '../vo/KeyPair';
 import ClearKeyKeySet from '../vo/ClearKeyKeySet';
 import CommonEncryption from '../CommonEncryption';
 
-const uuid = '1077efec-c0b2-4d02-ace3-3c1e52e2fb4b';
+const uuid = 'e2719d58-a985-b3c9-781a-b030af78d30e';
 const systemString = 'org.w3.clearkey';
 const schemeIdURI = 'urn:uuid:' + uuid;
 

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -1,0 +1,114 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import KeyPair from '../vo/KeyPair';
+import ClearKeyKeySet from '../vo/ClearKeyKeySet';
+import CommonEncryption from '../CommonEncryption';
+
+const uuid = '1077efec-c0b2-4d02-ace3-3c1e52e2fb4b';
+const systemString = 'org.w3.clearkey';
+const schemeIdURI = 'urn:uuid:' + uuid;
+
+function KeySystemW3CClearKey(config) {
+    let instance;
+    let BASE64 = config.BASE64;
+    let log = config.log;
+    /**
+     * Returns desired clearkeys (as specified in the CDM message) from protection data
+     *
+     * @param {ProtectionData} protectionData the protection data
+     * @param {ArrayBuffer} message the ClearKey CDM message
+     * @returns {ClearKeyKeySet} the key set or null if none found
+     * @throws {Error} if a keyID specified in the CDM message was not found in the
+     * protection data
+     * @memberof KeySystemClearKey
+     */
+    function getClearKeysFromProtectionData(protectionData, message) {
+        let clearkeySet = null;
+        if (protectionData) {
+            // ClearKey is the only system that does not require a license server URL, so we
+            // handle it here when keys are specified in protection data
+            let jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
+            let keyPairs = [];
+            for (let i = 0; i < jsonMsg.kids.length; i++) {
+                let clearkeyID = jsonMsg.kids[i];
+                let clearkey = (protectionData.clearkeys.hasOwnProperty(clearkeyID)) ? protectionData.clearkeys[clearkeyID] : null;
+                if (!clearkey) {
+                    throw new Error('DRM: ClearKey keyID (' + clearkeyID + ') is not known!');
+                }
+                // KeyIDs from CDM are not base64 padded.  Keys may or may not be padded
+                keyPairs.push(new KeyPair(clearkeyID, clearkey));
+            }
+            clearkeySet = new ClearKeyKeySet(keyPairs);
+
+            log('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. Please use e2719d58-a985-b3c9-781a-b030af78d30e');
+        }
+        return clearkeySet;
+    }
+
+    function getInitData(cp) {
+        return CommonEncryption.parseInitDataFromContentProtection(cp, BASE64);
+    }
+
+    function getRequestHeadersFromMessage(/*message*/) {
+        return null;
+    }
+
+    function getLicenseRequestFromMessage(message) {
+        return new Uint8Array(message);
+    }
+
+    function getLicenseServerURLFromInitData(/*initData*/) {
+        return null;
+    }
+
+    function getCDMData() {
+        return null;
+    }
+
+    instance = {
+        uuid: uuid,
+        schemeIdURI: schemeIdURI,
+        systemString: systemString,
+        getInitData: getInitData,
+        getRequestHeadersFromMessage: getRequestHeadersFromMessage,
+        getLicenseRequestFromMessage: getLicenseRequestFromMessage,
+        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
+        getCDMData: getCDMData,
+        getClearKeysFromProtectionData: getClearKeysFromProtectionData
+    };
+
+    return instance;
+}
+
+KeySystemW3CClearKey.__dashjs_factory_name = 'KeySystemW3CClearKey';
+export default dashjs.FactoryMaker.getSingletonFactory(KeySystemW3CClearKey); /* jshint ignore:line */
+

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -32,9 +32,10 @@
 import KeyPair from '../vo/KeyPair';
 import ClearKeyKeySet from '../vo/ClearKeyKeySet';
 import CommonEncryption from '../CommonEncryption';
+import Constants from '../../constants/Constants';
 
 const uuid = '1077efec-c0b2-4d02-ace3-3c1e52e2fb4b';
-const systemString = 'org.w3.clearkey';
+const systemString = Constants.CLEARKEY_ORG_STRING;
 const schemeIdURI = 'urn:uuid:' + uuid;
 
 function KeySystemW3CClearKey(config) {
@@ -69,7 +70,7 @@ function KeySystemW3CClearKey(config) {
             }
             clearkeySet = new ClearKeyKeySet(keyPairs);
 
-            log('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. Please use e2719d58-a985-b3c9-781a-b030af78d30e');
+            log('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
         }
         return clearkeySet;
     }

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -42,6 +42,7 @@ import NeedKey from '../vo/NeedKey';
 import KeyError from '../vo/KeyError';
 import KeyMessage from '../vo/KeyMessage';
 import KeySystemAccess from '../vo/KeySystemAccess';
+import Constants from '../../constants/Constants';
 
 function ProtectionModel_21Jan2015(config) {
 
@@ -182,7 +183,7 @@ function ProtectionModel_21Jan2015(config) {
         let ks = this.getKeySystem();
 
         // Generate initial key request
-        session.generateRequest(ks.systemString === 'org.w3.clearkey' ? 'keyids' : 'cenc', initData).then(function () {
+        session.generateRequest(ks.systemString === Constants.CLEARKEY_ORG_STRING ? 'keyids' : 'cenc', initData).then(function () {
             log('DRM: Session created.  SessionID = ' + sessionToken.getSessionID());
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: sessionToken});
         }).catch(function (error) {

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -179,9 +179,10 @@ function ProtectionModel_21Jan2015(config) {
 
         let session = mediaKeys.createSession(sessionType);
         let sessionToken = createSessionToken(session, initData, sessionType);
+        let ks = this.getKeySystem();
 
         // Generate initial key request
-        session.generateRequest('cenc', initData).then(function () {
+        session.generateRequest(ks.systemString === 'org.w3.clearkey' ? 'keyids' : 'cenc', initData).then(function () {
             log('DRM: Session created.  SessionID = ' + sessionToken.getSessionID());
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: sessionToken});
         }).catch(function (error) {

--- a/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
+++ b/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
@@ -1,0 +1,53 @@
+/* jshint expr: true */
+
+import KeySystemW3CClearKey from '../../src/streaming/protection/drm/KeySystemW3CClearKey';
+import BASE64 from '../../externals/base64';
+
+const chai = require('chai');
+const expect = chai.expect;
+const spies = require('chai-spies');
+
+chai.use(spies);
+
+describe('KeySystemW3CClearKey', function () {
+
+    let context;
+    let config;
+    let keySystem;
+    let message = new Uint8Array([123,34,107,105,100,115,34,58,91,34,97,75,69,114,88,72,78,71,98,51,103,97,68,98,89,98,95,114,111,99,112,119,34,93,44,34,116,121,112,101,34,58,34,116,101,109,112,111,114,97,114,121,34,125]);
+
+    const protData = {
+        'clearkeys': {
+            'aKErXHNGb3gaDbYb_rocpw': 'FmY0xnWCPCNaSpRG-tUuTQ'
+        }
+    };
+
+    beforeEach(function () {
+        config = { BASE64, log: chai.spy() };
+        context = {};
+    });
+
+    it('should exist', () => {
+        expect(KeySystemW3CClearKey).to.exist;
+    });
+
+    it('CDMData to be null', function () {
+        keySystem = KeySystemW3CClearKey(context).getInstance(config);
+        expect(keySystem.getCDMData.apply(keySystem)).to.be.null;
+    });
+
+    it('should warn when using this system', function () {
+        keySystem = KeySystemW3CClearKey(context).getInstance(config);
+        keySystem.getClearKeysFromProtectionData(protData, message);
+        expect(config.log).to.have.been.called.with('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
+    });
+
+    it('returns clearkey pair', function () {
+        keySystem = KeySystemW3CClearKey(context).getInstance(config);
+        const keyPairs = keySystem.getClearKeysFromProtectionData(protData, message).keyPairs;
+
+        expect(keyPairs.length).to.equal(1);
+        expect(keyPairs[0].keyID).to.equal(Object.keys(protData.clearkeys)[0]);
+        expect(keyPairs[0].key).to.equal(protData.clearkeys[Object.keys(protData.clearkeys)[0]]);
+    });
+});


### PR DESCRIPTION
Hello!

I was experiencing the similar issues as in https://github.com/Dash-Industry-Forum/dash.js/issues/2249

### Why am I Submitting this?
After quite a bit of digging, I discovered that the ClearKey `ContentProtection` information in my manifest was being ignored since they did not have `pssh` entry. This is not the case with the Shaka player so I am submitting this as a fix. My understanding is that ClearKeys only need the key id specified and the actual key used should simply be provided to the player for use at the time of playback.

### What did I do?
In the case of a ClearKey key system, I would still push that as a supported KeySystem. Since, at that time, I do not yet have the actual decryption key, I need to set `initData` to `null` so that I can properly set it later with my key. I'm not sure if this is the best way of doing it but it seems to follow the correct event handlers since ClearKey doesn't need to communicate with a CDM

I'm extremely new to everything involved in dash and DRM systems in general so please please let me know if I'm way off base here with my proposed solution.

### My Testing
I tested this solution by encrypting a video file with the following very simple `crypt.xml` file:
```
<?xml version="1.0" encoding="UTF-8"?>
<GPACDRM type="CENC AES-CTR">
  <CrypTrack IV_size="16" isEncrypted="1" saiSavedBox="senc" trackID="1">
    <key KID="0x02030507011013017019023029031037" value="0x03050701302303204201080425098033"/>
  </CrypTrack>
</GPACDRM>
```

The command I used was:
```
mp4box -segment-name oceans_encrypted_%s -profile live -dash-strict 10000 -sample-groups-traf -bs-switching no -out "manifest.mpd" audio_only_encrypted.m4a video_only_encrypted.mp4
```

This would produce the following manifest (after I switched the generic `xmlns` to the proper `keyids` one:
```
<?xml version="1.0"?>
<!-- MPD file Generated with GPAC version 0.7.2-DEV-revUNKNOWN-master  at 2017-11-01T20:11:12.294Z-->
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H0M46.614S" maxSegmentDuration="PT0H0M13.430S" profiles="urn:mpeg:dash:profile:isoff-live:2011" xmlns:cenc="urn:mpeg:cenc:2013">
 <ProgramInformation moreInformationURL="http://gpac.io">
  <Title>manifest.mpd generated by GPAC</Title>
 </ProgramInformation>

 <Period duration="PT0H0M46.614S">
  <AdaptationSet segmentAlignment="true" lang="und">
   <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b" cenc:default_KID="02030507-0110-1301-7019-023029031037"/>
   <Representation id="1" mimeType="audio/mp4" codecs="mp4a.40.2" startWithSAP="1" bandwidth="97849">
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    <SegmentTemplate media="oceans_encrypted_audio_only_encrypted$Number$.m4s" timescale="48000" startNumber="1" duration="479232" initialization="oceans_encrypted_audio_only_encryptedinit.mp4"/>
   </Representation>
  </AdaptationSet>
  <AdaptationSet segmentAlignment="true" maxWidth="960" maxHeight="400" maxFrameRate="24000/1001" par="960:400" lang="und">
   <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b" cenc:default_KID="02030507-0110-1301-7019-023029031037"/>
   <Representation id="2" mimeType="video/mp4" codecs="avc1.42C01E" width="960" height="400" frameRate="24000/1001" sar="1:1" startWithSAP="1" bandwidth="3866238">
    <SegmentTemplate media="oceans_encrypted_video_only_encrypted$Number$.m4s" timescale="24000" startNumber="1" duration="269019" initialization="oceans_encrypted_video_only_encryptedinit.mp4"/>
   </Representation>
  </AdaptationSet>
 </Period>
</MPD>
```

After all this, I'm currently using the related `video-dash-contrib` plugin and initializing it like so:
```
player.ready(() => {
  player.src({
    src: 'http://localhost:8080/serve/files/manifest.mpd',
    type: 'application/dash+xml',
    keySystemOptions: [
      {
        name: 'org.w3.clearkey',
        options: {
          clearkeys: {
            'AgMFBwEQEwFwGQIwKQMQNw' : 'AwUHATAjAyBCAQgEJQmAMw'
          }
        }
      }
    ]
  });
})
```

This all works on my current branch when loading all libraries locally. On the `development` branch, the video buffers forever and no DRM events are logged.