### PR TITLE
Buffer management changes

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -415,7 +415,7 @@ function DashAdapter() {
         checkStreamProcessor(streamProcessor);
 
         const indexHandler = streamProcessor.getIndexHandler();
-        if (indexHandler) {
+        if (indexHandler && !isNaN(value)) {
             indexHandler.setCurrentTime(value);
         }
     }

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -39,10 +39,8 @@ import FactoryMaker from '../core/FactoryMaker';
 import Debug from '../core/Debug';
 import URLUtils from '../streaming/utils/URLUtils';
 import Representation from './vo/Representation';
-
 import {replaceTokenForTemplate, getTimeBasedSegment, getSegmentByIndex} from './utils/SegmentsUtils';
 import SegmentsGetter from './utils/SegmentsGetter';
-
 import SegmentBaseLoader from './SegmentBaseLoader';
 import WebmSegmentBaseLoader from './WebmSegmentBaseLoader';
 
@@ -50,17 +48,17 @@ const SEGMENTS_UNAVAILABLE_ERROR_CODE = 1;
 
 function DashHandler(config) {
 
-    let context = this.context;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
     const urlUtils = URLUtils(context).getInstance();
 
-    let segmentBaseLoader;
-    let timelineConverter = config.timelineConverter;
-    let dashMetrics = config.dashMetrics;
-    let metricsModel = config.metricsModel;
-    let mediaPlayerModel = config.mediaPlayerModel;
-    let errHandler = config.errHandler;
+    const timelineConverter = config.timelineConverter;
+    const dashMetrics = config.dashMetrics;
+    const metricsModel = config.metricsModel;
+    const mediaPlayerModel = config.mediaPlayerModel;
+    const errHandler = config.errHandler;
     const baseURLController = config.baseURLController;
+    let segmentBaseLoader;
 
     let instance,
         log,
@@ -89,15 +87,14 @@ function DashHandler(config) {
     }
 
     function isWebM (mimeType) {
-        let type = mimeType.split('/')[1];
-
+        const type = mimeType.split('/')[1];
         return 'webm' === type.toLowerCase();
     }
 
     function initialize(StreamProcessor) {
         streamProcessor = StreamProcessor;
 
-        let isDynamic = streamProcessor ? streamProcessor.getStreamInfo().manifestInfo.isDynamic : null;
+        const isDynamic = streamProcessor ? streamProcessor.getStreamInfo().manifestInfo.isDynamic : null;
 
         segmentBaseLoader.initialize();
 
@@ -142,7 +139,7 @@ function DashHandler(config) {
 
     function replaceIDForTemplate(url, value) {
         if (value === null || url === null || url.indexOf('$RepresentationID$') === -1) { return url; }
-        let v = value.toString();
+        const v = value.toString();
         return url.split('$RepresentationID$').join(v);
     }
 
@@ -173,7 +170,6 @@ function DashHandler(config) {
     }
 
     function generateInitRequest(representation, mediaType) {
-
         const request = new FragmentRequest();
         const period = representation.adaptation.period;
         const presentationStartTime = period.start;
@@ -201,7 +197,6 @@ function DashHandler(config) {
     }
 
     function isMediaFinished(representation) {
-
         let isFinished = false;
         const isDynamic = streamProcessor ? streamProcessor.getStreamInfo().manifestInfo.isDynamic : null;
 
@@ -243,7 +238,6 @@ function DashHandler(config) {
     }
 
     function updateSegmentList(voRepresentation) {
-
         if (!voRepresentation) {
             throw new Error('no representation');
         }
@@ -329,12 +323,12 @@ function DashHandler(config) {
             return null;
         }
 
-        let request = new FragmentRequest();
-        let representation = segment.representation;
-        let bandwidth = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
+        const request = new FragmentRequest();
+        const representation = segment.representation;
+        const bandwidth = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
             AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].bandwidth;
-        let url = segment.media;
         const type = streamProcessor ? streamProcessor.getType() : null;
+        let url = segment.media;
 
         url = replaceTokenForTemplate(url, 'Number', segment.replacementNumber);
         url = replaceTokenForTemplate(url, 'Time', segment.replacementTime);
@@ -368,10 +362,10 @@ function DashHandler(config) {
 
         const type = streamProcessor ? streamProcessor.getType() : null;
         const isDynamic = streamProcessor ? streamProcessor.getStreamInfo().manifestInfo.isDynamic : null;
-        let idx = index;
-        let keepIdx = options ? options.keepIdx : false;
-        let timeThreshold = options ? options.timeThreshold : null;
-        let ignoreIsFinished = (options && options.ignoreIsFinished) ? true : false;
+        const idx = index;
+        const keepIdx = options ? options.keepIdx : false;
+        const timeThreshold = options ? options.timeThreshold : null;
+        const ignoreIsFinished = (options && options.ignoreIsFinished) ? true : false;
 
         if (!representation) {
             return null;
@@ -379,7 +373,7 @@ function DashHandler(config) {
 
         if (requestedTime !== time) { // When playing at live edge with 0 delay we may loop back with same time and index until it is available. Reduces verboseness of logs.
             requestedTime = time;
-            log('Getting the request for ' + type + ' time : ' + time);
+            log('Getting the request for ' + type + ' time : ' + time + ', keepIdx: ' + keepIdx);
         }
 
         updateSegments(representation);
@@ -439,10 +433,10 @@ function DashHandler(config) {
         requestedTime = null;
         index++;
 
-        log('Getting the next request at index: ' + index);
+        log('Getting the next request at index: ' + index + ', type: ' + type);
 
         // check that there is a segment in this index. If none, update segments and wait for next time loop is called
-        let seg = getSegmentByIndex(index, representation);
+        const seg = getSegmentByIndex(index, representation);
         if (!seg && isDynamic) {
             log('No segment found at index: ' + index + '. Wait for next loop');
             updateSegments(representation);
@@ -478,8 +472,7 @@ function DashHandler(config) {
     }
 
     function onInitializationLoaded(e) {
-        let representation = e.representation;
-        //log("Got an initialization.");
+        const representation = e.representation;
         if (!representation.segments) return;
 
         eventBus.trigger(Events.REPRESENTATION_UPDATED, {sender: this, representation: representation});
@@ -491,8 +484,8 @@ function DashHandler(config) {
         if (e.error || (type !== e.mediaType)) return;
 
         const fragments = e.segments;
-        let representation = e.representation;
-        let segments = [];
+        const representation = e.representation;
+        const segments = [];
         let count = 0;
 
         let i,
@@ -550,7 +543,7 @@ function DashHandler(config) {
 }
 
 DashHandler.__dashjs_factory_name = 'DashHandler';
-let factory = FactoryMaker.getClassFactory(DashHandler);
+const factory = FactoryMaker.getClassFactory(DashHandler);
 factory.SEGMENTS_UNAVAILABLE_ERROR_CODE = SEGMENTS_UNAVAILABLE_ERROR_CODE;
 FactoryMaker.updateClassFactory(DashHandler.__dashjs_factory_name, factory);
 export default factory;

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -395,7 +395,7 @@ function DashHandler(config) {
             request.index = index;
             request.mediaType = type;
             request.mediaInfo = streamProcessor.getMediaInfo();
-            log('Signal complete.', request);
+            log('Signal complete in getSegmentRequestForTime - ', type, ' - Request:', request);
 
         } else {
             segment = getSegmentByIndex(index, representation);
@@ -451,7 +451,7 @@ function DashHandler(config) {
             request.index = index;
             request.mediaType = type;
             request.mediaInfo = streamProcessor.getMediaInfo();
-            log('Signal complete.');
+            log('Signal complete -', type);
         } else {
             updateSegments(representation);
             segment = getSegmentByIndex(index, representation);

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -304,10 +304,14 @@ function DashHandler(config) {
             i;
 
         if (segments && ln > 0) {
+            // In case timeThreshold is not provided, let's use the default value set in MediaPlayerModel
+            timeThreshold = (timeThreshold === undefined || timeThreshold === null) ?
+                mediaPlayerModel.getSegmentOverlapToleranceTime() : timeThreshold;
             for (i = 0; i < ln; i++) {
                 frag = segments[i];
                 ft = frag.presentationStartTime;
                 fd = frag.duration;
+                // In case timeThreshold is null, set epsilon to half the fragment duration
                 epsilon = (timeThreshold === undefined || timeThreshold === null) ? fd / 2 : timeThreshold;
                 if ((time + epsilon) >= ft &&
                     (time - epsilon) < (ft + fd)) {

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -104,7 +104,6 @@ function TimelineConverter() {
     }
 
     function calcPresentationTimeFromWallTime(wallTime, period) {
-        //console.log("XXX", wallTime.getTime() - period.mpd.availabilityStartTime.getTime(), clientServerTimeShift * 1000, clientServerTimeShift, period.mpd.availabilityStartTime.getTime())
         return ((wallTime.getTime() - period.mpd.availabilityStartTime.getTime() + clientServerTimeShift * 1000) / 1000);
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -82,10 +82,10 @@ function MediaPlayer() {
     const SOURCE_NOT_ATTACHED_ERROR = 'You must first call attachSource() with a valid source before calling this method';
     const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
 
-    let context = this.context;
-    let eventBus = EventBus(context).getInstance();
-    let debug = Debug(context).getInstance();
-    let log = debug.log;
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+    const debug = Debug(context).getInstance();
+    const log = debug.log;
 
     let instance,
         source,
@@ -395,7 +395,7 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        let s = playbackController.getIsDynamic() ? getDVRSeekOffset(value) : value;
+        const s = playbackController.getIsDynamic() ? getDVRSeekOffset(value) : value;
         playbackController.seek(s);
     }
 
@@ -546,7 +546,7 @@ function MediaPlayer() {
      * @instance
      */
     function getDVRWindowSize() {
-        let metric = getDVRInfoMetric();
+        const metric = getDVRInfoMetric();
         if (!metric) {
             return 0;
         }
@@ -565,14 +565,12 @@ function MediaPlayer() {
      * @instance
      */
     function getDVRSeekOffset(value) {
-        let metric = getDVRInfoMetric();
-
+        const metric = getDVRInfoMetric();
         if (!metric) {
             return 0;
         }
 
         let val = metric.range.start + value;
-
         if (val > metric.range.end) {
             val = metric.range.end;
         }
@@ -601,7 +599,7 @@ function MediaPlayer() {
             t = streamController.getTimeRelativeToStreamId(t, streamId);
 
         } else if (playbackController.getIsDynamic()) {
-            let metric = getDVRInfoMetric();
+            const metric = getDVRInfoMetric();
             t = (metric === null) ? 0 : duration() - (metric.range.end - metric.time);
         }
 
@@ -623,7 +621,7 @@ function MediaPlayer() {
 
         if (playbackController.getIsDynamic()) {
 
-            let metric = getDVRInfoMetric();
+            const metric = getDVRInfoMetric();
             let range;
 
             if (!metric) {
@@ -1135,7 +1133,7 @@ function MediaPlayer() {
     }
 
     /**
-     * Obsolete since version 2.6.0.
+     * @deprecated since version 2.6.0.
      * Buffer-occupancy ABR is now switched on and off dynamically.
      * @see {@link module:MediaPlayer#setABRStrategy setABRStrategy()}
      *
@@ -1293,7 +1291,7 @@ function MediaPlayer() {
      */
     function addUTCTimingSource(schemeIdUri, value) {
         removeUTCTimingSource(schemeIdUri, value); //check if it already exists and remove if so.
-        let vo = new UTCTiming();
+        const vo = new UTCTiming();
         vo.schemeIdUri = schemeIdUri;
         vo.value = value;
         mediaPlayerModel.getUTCTimingSources().push(vo);
@@ -1309,7 +1307,7 @@ function MediaPlayer() {
      * @instance
      */
     function removeUTCTimingSource(schemeIdUri, value) {
-        let UTCTimingSources = mediaPlayerModel.getUTCTimingSources();
+        const UTCTimingSources = mediaPlayerModel.getUTCTimingSources();
         UTCTimingSources.forEach(function (obj, idx) {
             if (obj.schemeIdUri === schemeIdUri && obj.value === value) {
                 UTCTimingSources.splice(idx, 1);
@@ -1368,7 +1366,8 @@ function MediaPlayer() {
     /**
      * This value influences the buffer pruning logic.
      * Allows you to modify the buffer that is kept in source buffer in seconds.
-     *  0|-----------bufferToPrune-----------|-----bufferToKeep-----|currentTime|
+     *
+     * <pre>0|-----------bufferToPrune-----------|-----bufferToKeep-----|currentTime|</pre>
      *
      * @default 30 seconds
      * @param {int} value
@@ -1423,14 +1422,6 @@ function MediaPlayer() {
         return mediaPlayerModel.getStableBufferTime();
     }
 
-    /**
-     * The time that the internal buffer target will be set to once playing the top quality.
-     * If there are multiple bitrates in your adaptation, and the media is playing at the highest
-     * bitrate, then we try to build a larger buffer at the top quality to increase stability
-     * and to maintain media quality.
-     *
-     * @default 30 seconds.
-     * @param {int} value
     /**
      * The time that the internal buffer target will be set to once playing the top quality.
      * If there are multiple bitrates in your adaptation, and the media is playing at the highest
@@ -1502,7 +1493,7 @@ function MediaPlayer() {
     }
 
     /**
-     * Obsolete since version 2.6.0.
+     * @deprecated since version 2.6.0.
      * ABR rules now switch from Throughput to Buffer Occupancy mode when there is sufficient buffer.
      * This renders the rich buffer mechanism redundant.
      *
@@ -1512,6 +1503,26 @@ function MediaPlayer() {
      */
     function setRichBufferThreshold(value) {
         throw new Error('Calling obsolete function - setRichBufferThreshold(' + value + ') has no effect.');
+    }
+
+    /**
+     * The overlap tolerance time, at both the head and the tail of segments, considered when doing time to segment conversions.
+     *
+     * This is used when calculating which of the loaded segments of a representation corresponds with a given time position.
+     * Its value is never used for calculating the segment index in seeking operations in which it assumes overlap time threshold is zero.
+     *
+     * <pre>
+     * |-o-|--- segment X ----|-o-|
+     *                        |-o-|---- segment X+1 -----|-o-|
+     *                                                   |-o-|---- segment X+2 -----|-o-|
+     * </pre>
+     * @default 0.05 seconds.
+     * @param {number} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setSegmentOverlapToleranceTime(value) {
+        mediaPlayerModel.setSegmentOverlapToleranceTime(value);
     }
 
     /**
@@ -1717,7 +1728,7 @@ function MediaPlayer() {
      * @instance
      */
     function displayCaptionsOnTop(value) {
-        let textTracks = TextTracks(context).getInstance();
+        const textTracks = TextTracks(context).getInstance();
         textTracks.setConfig({
             videoModel: videoModel
         });
@@ -1834,7 +1845,7 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        let stream = getActiveStream();
+        const stream = getActiveStream();
         return stream ? stream.getBitrateListFor(type) : [];
     }
 
@@ -1863,7 +1874,7 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        let streamInfo = streamController.getActiveStreamInfo();
+        const streamInfo = streamController.getActiveStreamInfo();
         if (!streamInfo) return [];
         return mediaController.getTracksFor(type, streamInfo);
     }
@@ -1898,7 +1909,7 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        let streamInfo = streamController.getActiveStreamInfo();
+        const streamInfo = streamController.getActiveStreamInfo();
 
         if (!streamInfo) return null;
 
@@ -2084,8 +2095,8 @@ function MediaPlayer() {
      * @instance
      */
     function retrieveManifest(url, callback) {
-        let manifestLoader = createManifestLoader();
-        let self = this;
+        const manifestLoader = createManifestLoader();
+        const self = this;
 
         const handler = function (e) {
             if (!e.error) {
@@ -2099,7 +2110,7 @@ function MediaPlayer() {
 
         eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
 
-        let uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
+        const uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
         uriQueryFragModel.initialize();
         manifestLoader.load(uriQueryFragModel.parseURI(url));
     }
@@ -2137,7 +2148,7 @@ function MediaPlayer() {
         }
 
         if (typeof urlOrManifest === 'string') {
-            let uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
+            const uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
             uriQueryFragModel.initialize();
             source = uriQueryFragModel.parseURI(urlOrManifest);
         } else {
@@ -2178,9 +2189,9 @@ function MediaPlayer() {
     function convertToTimeCode(value) {
         value = Math.max(value, 0);
 
-        let h = Math.floor(value / 3600);
-        let m = Math.floor((value % 3600) / 60);
-        let s = Math.floor((value % 3600) % 60);
+        const h = Math.floor(value / 3600);
+        const m = Math.floor((value % 3600) / 60);
+        const s = Math.floor((value % 3600) % 60);
         return (h === 0 ? '' : (h < 10 ? '0' + h.toString() + ':' : h.toString() + ':')) + (m < 10 ? '0' + m.toString() : m.toString()) + ':' + (s < 10 ? '0' + s.toString() : s.toString());
     }
 
@@ -2305,9 +2316,9 @@ function MediaPlayer() {
     function createPlaybackControllers() {
 
         // creates or get objects instances
-        let manifestLoader = createManifestLoader();
+        const manifestLoader = createManifestLoader();
 
-        let sourceBufferController = SourceBufferController(context).getInstance({
+        const sourceBufferController = SourceBufferController(context).getInstance({
             textController: textController
         });
 
@@ -2393,9 +2404,9 @@ function MediaPlayer() {
             return protectionController;
         }
         // do not require Protection as dependencies as this is optional and intended to be loaded separately
-        let Protection = dashjs.Protection; /* jshint ignore:line */
+        const Protection = dashjs.Protection; /* jshint ignore:line */
         if (typeof Protection === 'function') { //TODO need a better way to register/detect plugin components
-            let protection = Protection(context).create();
+            const protection = Protection(context).create();
             Events.extend(Protection.events);
             MediaPlayerEvents.extend(Protection.events, {
                 publicOnly: true
@@ -2422,9 +2433,9 @@ function MediaPlayer() {
             return;
         }
         // do not require MetricsReporting as dependencies as this is optional and intended to be loaded separately
-        let MetricsReporting = dashjs.MetricsReporting; /* jshint ignore:line */
+        const MetricsReporting = dashjs.MetricsReporting; /* jshint ignore:line */
         if (typeof MetricsReporting === 'function') { //TODO need a better way to register/detect plugin components
-            let metricsReporting = MetricsReporting(context).create();
+            const metricsReporting = MetricsReporting(context).create();
 
             metricsReportingController = metricsReporting.createMetricsReporting({
                 log: log,
@@ -2444,7 +2455,7 @@ function MediaPlayer() {
             return;
         }
         // do not require MssHandler as dependencies as this is optional and intended to be loaded separately
-        let MssHandler = dashjs.MssHandler; /* jshint ignore:line */
+        const MssHandler = dashjs.MssHandler; /* jshint ignore:line */
         if (typeof MssHandler === 'function') { //TODO need a better way to register/detect plugin components
             mssHandler = MssHandler(context).create({
                 eventBus: eventBus,
@@ -2464,12 +2475,12 @@ function MediaPlayer() {
     }
 
     function getDVRInfoMetric() {
-        let metric = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
+        const metric = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
         return dashMetrics.getCurrentDVRInfo(metric);
     }
 
     function getAsUTC(valToConvert) {
-        let metric = getDVRInfoMetric();
+        const metric = getDVRInfoMetric();
         let availableFrom,
             utcValue;
 
@@ -2485,7 +2496,7 @@ function MediaPlayer() {
         if (!playbackInitialized) {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
-        let streamInfo = streamController.getActiveStreamInfo();
+        const streamInfo = streamController.getActiveStreamInfo();
         return streamInfo ? streamController.getStreamById(streamInfo.id) : null;
     }
 
@@ -2625,6 +2636,7 @@ function MediaPlayer() {
         getXHRWithCredentialsForType: getXHRWithCredentialsForType,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setRichBufferThreshold: setRichBufferThreshold,
+        setSegmentOverlapToleranceTime: setSegmentOverlapToleranceTime,
         getProtectionController: getProtectionController,
         attachProtectionController: attachProtectionController,
         setProtectionData: setProtectionData,
@@ -2644,7 +2656,7 @@ function MediaPlayer() {
 }
 
 MediaPlayer.__dashjs_factory_name = 'MediaPlayer';
-let factory = FactoryMaker.getClassFactory(MediaPlayer);
+const factory = FactoryMaker.getClassFactory(MediaPlayer);
 factory.events = MediaPlayerEvents;
 FactoryMaker.updateClassFactory(MediaPlayer.__dashjs_factory_name, factory);
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -120,7 +120,11 @@ function Stream(config) {
         let ln = streamProcessors ? streamProcessors.length : 0;
         for (let i = 0; i < ln; i++) {
             let fragmentModel = streamProcessors[i].getFragmentModel();
-            fragmentModel.removeExecutedRequestsBeforeTime(getStartTime() + getDuration());
+            fragmentModel.removeExecutedRequestsInRange({
+                from: getStartTime(),
+                to: getStartTime() + getDuration(),
+                endSignalSent: true
+            });
             streamProcessors[i].reset();
         }
         //all stream processors have been destroyed, stream has to reset abrController which has reference on stream processors.

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -184,15 +184,15 @@ function ScheduleController(config) {
             bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())) {
 
             const getNextFragment = function () {
-                log('ScheduleController ' + type + '- getNextFragment');
+                log('ScheduleController ' + type + ' - getNextFragment');
                 const fragmentController = streamProcessor.getFragmentController();
                 if (switchTrack) {
-                    log('ScheduleController ' + type + '- switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
+                    log('ScheduleController ' + type + ' - switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
                     streamProcessor.switchInitData(currentRepresentationInfo.id);
                     lastInitQuality = currentRepresentationInfo.quality;
                     switchTrack = false;
                 } else if (currentRepresentationInfo.quality !== lastInitQuality) {
-                    log('ScheduleController ' + type + '- quality has changed, get init request');
+                    log('ScheduleController ' + type + ' - quality has changed, get init request');
                     lastInitQuality = currentRepresentationInfo.quality;
 
                     streamProcessor.switchInitData(currentRepresentationInfo.id);
@@ -205,10 +205,10 @@ function ScheduleController(config) {
                     } else {
                         const request = nextFragmentRequestRule.execute(streamProcessor, replacement);
                         if (request) {
-                            log('ScheduleController ' + type + '- getNextFragment - request is ' + request.url);
+                            log('ScheduleController ' + type + ' - getNextFragment - request is ' + request.url);
                             fragmentModel.executeRequest(request);
                         } else { //Use case - Playing at the bleeding live edge and frag is not available yet. Cycle back around.
-                            log('getNextFragment ' + type + '- Playing at the bleeding live edge and frag is not available yet');
+                            log('getNextFragment ' + type + ' - Playing at the bleeding live edge and frag is not available yet');
                             isFragmentProcessingInProgress = false;
                             startScheduleTimer(500);
                         }
@@ -387,7 +387,7 @@ function ScheduleController(config) {
 
         stop();
         isFragmentProcessingInProgress = false;
-        log('Stream is complete');
+        log('Stream is complete - ', type);
     }
 
     function onFragmentLoadingCompleted(e) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -442,7 +442,7 @@ function ScheduleController(config) {
 
         // after the data has been removed from the buffer we should remove the requests from the list of
         // the executed requests for which playback time is inside the time interval that has been removed from the buffer
-        fragmentModel.removeExecutedRequestsBeforeTime(e.to);
+        fragmentModel.removeExecutedRequestsInRange(e);
 
         if (e.hasEnoughSpaceToAppend && isStopped) {
             start();

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -108,7 +108,6 @@ function ScheduleController(config) {
             eventBus.on(Events.TIMED_TEXT_REQUESTED, onTimedTextRequested, this);
         }
 
-        //eventBus.on(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, this);
         eventBus.on(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, this);
         eventBus.on(Events.DATA_UPDATE_STARTED, onDataUpdateStarted, this);
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
@@ -583,7 +582,6 @@ function ScheduleController(config) {
     }
 
     function reset() {
-        //eventBus.off(Events.LIVE_EDGE_SEARCH_COMPLETED, onLiveEdgeSearchCompleted, this);
         eventBus.off(Events.DATA_UPDATE_STARTED, onDataUpdateStarted, this);
         eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -306,12 +306,12 @@ function SourceBufferController(config) {
         });
     }
 
-    function remove(buffer, start, end, mediaSource) {
+    function remove(buffer, start, end, mediaSource, forceRemoval) {
 
         // make sure that the given time range is correct. Otherwise we will get InvalidAccessError
         waitForUpdateEnd(buffer, function () {
             try {
-                if ((start >= 0) && (end > start) && (mediaSource.readyState !== 'ended')) {
+                if ((start >= 0) && (end > start) && (forceRemoval || mediaSource.readyState !== 'ended')) {
                     buffer.remove(start, end);
                 }
                 // updating is in progress, we should wait for it to complete before signaling that this operation is done

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -159,7 +159,6 @@ function StreamController() {
         if (e.timeToEnd <= STREAM_END_THRESHOLD) {
             // In some cases the ended event is not triggered at the end of the stream, do it artificially here.
             // This should only be a fallback, put an extra STREAM_END_TIMEOUT_DELAY to give the real ended event time to trigger.
-
             if (endedTimeout) {
                 clearTimeout(endedTimeout);
                 endedTimeout = undefined;

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -53,7 +53,7 @@ function ManifestParsing (config) {
                 if (metric.hasOwnProperty('metrics')) {
                     metricEntry.metrics = metric.metrics;
                 } else {
-                    //console.log("Invalid Metrics. metrics must be set. Ignoring.");
+                    // Invalid Metrics. metrics must be set. Ignoring
                     return;
                 }
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -54,6 +54,7 @@ const DEFAULT_MIN_BUFFER_TIME_FAST_SWITCH = 20;
 const BUFFER_TIME_AT_TOP_QUALITY = 30;
 const BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 60;
 const LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;
+const SEGMENT_OVERLAP_TOLERANCE_TIME = 0.05;
 
 const FRAGMENT_RETRY_ATTEMPTS = 3;
 const FRAGMENT_RETRY_INTERVAL = 1000;
@@ -86,6 +87,7 @@ function MediaPlayerModel() {
         bufferTimeAtTopQuality,
         bufferTimeAtTopQualityLongForm,
         longFormContentDurationThreshold,
+        segmentOverlapToleranceTime,
         bandwidthSafetyFactor,
         abandonLoadTimeout,
         retryAttempts,
@@ -122,6 +124,7 @@ function MediaPlayerModel() {
         bufferTimeAtTopQuality = BUFFER_TIME_AT_TOP_QUALITY;
         bufferTimeAtTopQualityLongForm = BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM;
         longFormContentDurationThreshold = LONG_FORM_CONTENT_DURATION_THRESHOLD;
+        segmentOverlapToleranceTime = SEGMENT_OVERLAP_TOLERANCE_TIME;
         bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
@@ -185,8 +188,7 @@ function MediaPlayerModel() {
     }
 
     function addABRCustomRule(type, rulename, rule) {
-
-        let index = findABRCustomRule(rulename);
+        const index = findABRCustomRule(rulename);
         if (index === -1) {
             // add rule
             customABRRule.push({
@@ -202,7 +204,7 @@ function MediaPlayerModel() {
     }
 
     function removeABRCustomRule(rulename) {
-        let index = findABRCustomRule(rulename);
+        const index = findABRCustomRule(rulename);
         if (index !== -1) {
             // remove rule
             customABRRule.splice(index, 1);
@@ -259,6 +261,14 @@ function MediaPlayerModel() {
 
     function getLongFormContentDurationThreshold() {
         return longFormContentDurationThreshold;
+    }
+
+    function setSegmentOverlapToleranceTime(value) {
+        segmentOverlapToleranceTime = value;
+    }
+
+    function getSegmentOverlapToleranceTime() {
+        return segmentOverlapToleranceTime;
     }
 
     function setBufferToKeep(value) {
@@ -470,6 +480,8 @@ function MediaPlayerModel() {
         getBufferTimeAtTopQualityLongForm: getBufferTimeAtTopQualityLongForm,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         getLongFormContentDurationThreshold: getLongFormContentDurationThreshold,
+        setSegmentOverlapToleranceTime: setSegmentOverlapToleranceTime,
+        getSegmentOverlapToleranceTime: getSegmentOverlapToleranceTime,
         setBufferToKeep: setBufferToKeep,
         getBufferToKeep: getBufferToKeep,
         setBufferPruningInterval: setBufferPruningInterval,

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -59,7 +59,6 @@ function BufferLevelRule(config) {
             } else {
                 bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
             }
-            // console.log('videoBufferLevel  - ' + videoBufferLevel + ' target : ' + bufferTarget);
         } else {
             const streamInfo = representationInfo.mediaInfo.streamInfo;
             if (abrController.isPlayingAtTopQuality(streamInfo)) {

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -81,7 +81,8 @@ function NextFragmentRequestRule(config) {
             });
         } else {
             request = adapter.getFragmentRequestForTime(streamProcessor, representationInfo, time, {
-                keepIdx: !hasSeekTarget
+                keepIdx: !hasSeekTarget,
+                timeThreshold: hasSeekTarget ? 0 : undefined
             });
             while ( streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
                 // loop until we found not loaded fragment, or no fragment

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -31,6 +31,7 @@
 import Constants from '../../constants/Constants';
 import Debug from '../../../core/Debug';
 import FactoryMaker from '../../../core/FactoryMaker';
+import FragmentRequest from '../../../streaming/vo/FragmentRequest';
 
 function NextFragmentRequestRule(config) {
 
@@ -84,7 +85,7 @@ function NextFragmentRequestRule(config) {
                 keepIdx: !hasSeekTarget,
                 timeThreshold: hasSeekTarget ? 0 : undefined
             });
-            while ( streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
+            while (request && request.action !== FragmentRequest.ACTION_COMPLETE && streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
                 // loop until we found not loaded fragment, or no fragment
                 request = adapter.getNextFragmentRequest(streamProcessor, representationInfo);
             }

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -31,7 +31,6 @@
 import Constants from '../../constants/Constants';
 import Debug from '../../../core/Debug';
 import FactoryMaker from '../../../core/FactoryMaker';
-import FragmentRequest from '../../../streaming/vo/FragmentRequest';
 
 function NextFragmentRequestRule(config) {
 
@@ -85,7 +84,7 @@ function NextFragmentRequestRule(config) {
                 keepIdx: !hasSeekTarget,
                 timeThreshold: hasSeekTarget ? 0 : undefined
             });
-            while (request && request.action !== FragmentRequest.ACTION_COMPLETE && streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
+            while (streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
                 // loop until we found not loaded fragment, or no fragment
                 request = adapter.getNextFragmentRequest(streamProcessor, representationInfo);
             }

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -31,6 +31,7 @@
 import Constants from '../../constants/Constants';
 import Debug from '../../../core/Debug';
 import FactoryMaker from '../../../core/FactoryMaker';
+import FragmentRequest from '../../vo/FragmentRequest';
 
 function NextFragmentRequestRule(config) {
 
@@ -84,7 +85,7 @@ function NextFragmentRequestRule(config) {
                 keepIdx: !hasSeekTarget,
                 timeThreshold: hasSeekTarget ? 0 : undefined
             });
-            while (streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
+            while (request && request.action !== FragmentRequest.ACTION_COMPLETE && streamProcessor.getFragmentModel().isFragmentLoaded(request)) {
                 // loop until we found not loaded fragment, or no fragment
                 request = adapter.getNextFragmentRequest(streamProcessor, representationInfo);
             }

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -52,6 +52,7 @@ const DEFAULT_MIN_BUFFER_TIME_FAST_SWITCH = 20;
 const BUFFER_TIME_AT_TOP_QUALITY = 30;
 const BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 60;
 const LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;
+const SEGMENT_OVERLAP_TOLERANCE_TIME = 0.05;
 
 const FRAGMENT_RETRY_ATTEMPTS = 3;
 const FRAGMENT_RETRY_INTERVAL = 1000;
@@ -176,6 +177,7 @@ class MediaPlayerModelMock {
         this.bufferTimeAtTopQuality = BUFFER_TIME_AT_TOP_QUALITY;
         this.bufferTimeAtTopQualityLongForm = BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM;
         this.longFormContentDurationThreshold = LONG_FORM_CONTENT_DURATION_THRESHOLD;
+        this.segmentOverlapToleranceTime = SEGMENT_OVERLAP_TOLERANCE_TIME;
         this.bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         this.abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         this.wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
@@ -292,6 +294,14 @@ class MediaPlayerModelMock {
 
     getLongFormContentDurationThreshold() {
         return this.longFormContentDurationThreshold;
+    }
+
+    setSegmentOverlapToleranceTime(value) {
+        this.segmentOverlapToleranceTime = value;
+    }
+
+    getSegmentOverlapToleranceTime() {
+        return this.segmentOverlapToleranceTime;
     }
 
     setBufferToKeep(value) {

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -786,6 +786,15 @@ describe('MediaPlayer', function () {
             expect(LongFormContentDurationThreshold).to.equal(50);
         });
 
+        it('should configure setSegmentOverlapToleranceTime', function () {
+            let val = mediaPlayerModel.getSegmentOverlapToleranceTime();
+            expect(val).to.equal(0.05);
+
+            player.setSegmentOverlapToleranceTime(1.5);
+            val = mediaPlayerModel.getSegmentOverlapToleranceTime();
+            expect(val).to.equal(1.5);
+        });
+
         it('should configure BandwidthSafetyFactor', function () {
             let BandwidthSafetyFactor = mediaPlayerModel.getBandwidthSafetyFactor();
             expect(BandwidthSafetyFactor).to.equal(0.9);

--- a/test/unit/streaming.controllers.SourceBufferController.js
+++ b/test/unit/streaming.controllers.SourceBufferController.js
@@ -13,12 +13,10 @@ const context = {};
 const eventBus = EventBus(context).getInstance();
 
 describe('SourceBufferController', function () {
-
     let sourceBufferController;
     let textControllerMock;
 
     beforeEach(function () {
-
         textControllerMock = new TextControllerMock();
         sourceBufferController = SourceBufferController(context).getInstance({
             textController: textControllerMock
@@ -31,56 +29,56 @@ describe('SourceBufferController', function () {
 
     describe('Method createSourceBuffer', function () {
         it('should create and return a buffer', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(buffer).to.be.instanceOf(MediaSourceBufferMock);
         });
 
         it('should create and return a text buffer if codec is of type application/mp4;codecs="stpp"', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'application/mp4;codecs="stpp"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(buffer).to.be.instanceOf(TextBufferMock);
         });
 
         it('should create and return a text buffer if codec is of type application/mp4;codecs="wvtt"', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'application/mp4;codecs="wvtt"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(buffer).to.be.instanceOf(TextBufferMock);
         });
 
         it('should create and return a text buffer if codec is of type text', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'text',
                 isText: true
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(buffer).to.be.instanceOf(TextBufferMock);
         });
 
         it('should throw an error if codec is unknonw', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'unknown'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             // http://chaijs.com/api/bdd/#method_throw
             expect(function () {
                 sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
@@ -90,29 +88,28 @@ describe('SourceBufferController', function () {
 
     describe('Method removeSourceBuffer', function () {
         it('should remove a created buffer', function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
 
             sourceBufferController.removeSourceBuffer(mediaSource, buffer);
             expect(mediaSource.buffers).to.have.lengthOf(0);
-
         });
     });
 
     describe('Method getBufferRange', function () {
         let buffer;
         beforeEach(function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
         });
@@ -152,7 +149,7 @@ describe('SourceBufferController', function () {
                 start: 10.1,
                 end: 11
             });
-            let range = sourceBufferController.getBufferRange(buffer, 10);
+            const range = sourceBufferController.getBufferRange(buffer, 10);
             expect(range.start).to.equal(9);
             expect(range.end).to.equal(11);
         });
@@ -174,7 +171,7 @@ describe('SourceBufferController', function () {
                 start: 10.5,
                 end: 11
             });
-            let range = sourceBufferController.getBufferRange(buffer, 10);
+            const range = sourceBufferController.getBufferRange(buffer, 10);
             expect(range).to.be.null; // jshint ignore:line
         });
 
@@ -195,7 +192,7 @@ describe('SourceBufferController', function () {
                 start: 10.1,
                 end: 11
             });
-            let range = sourceBufferController.getBufferRange(buffer, 10);
+            const range = sourceBufferController.getBufferRange(buffer, 10);
             expect(range.start).to.equal(10.1);
             expect(range.end).to.equal(11);
         });
@@ -204,11 +201,11 @@ describe('SourceBufferController', function () {
     describe('Method getAllRanges', function () {
         let buffer;
         beforeEach(function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
         });
@@ -226,7 +223,7 @@ describe('SourceBufferController', function () {
                 start: 9,
                 end: 11
             });
-            let ranges = sourceBufferController.getAllRanges(buffer);
+            const ranges = sourceBufferController.getAllRanges(buffer);
             expect(ranges.length).to.equal(3);
             expect(ranges.start(0)).to.equal(2);
             expect(ranges.end(0)).to.equal(5);
@@ -240,23 +237,21 @@ describe('SourceBufferController', function () {
     describe('Method getTotalBufferedTime', function () {
         let buffer;
         beforeEach(function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
         });
 
         it('should return 0 if no buffer', function () {
-
-            let totalBufferedTime = sourceBufferController.getTotalBufferedTime(buffer);
+            const totalBufferedTime = sourceBufferController.getTotalBufferedTime(buffer);
             expect(totalBufferedTime).to.equal(0);
         });
 
         it('should return totalBufferedTime ', function () {
-
             buffer.addRange({
                 start: 2,
                 end: 5
@@ -265,7 +260,7 @@ describe('SourceBufferController', function () {
                 start: 8,
                 end: 9
             });
-            let totalBufferedTime = sourceBufferController.getTotalBufferedTime(buffer);
+            const totalBufferedTime = sourceBufferController.getTotalBufferedTime(buffer);
             expect(totalBufferedTime).to.equal(4);
         });
     });
@@ -273,33 +268,30 @@ describe('SourceBufferController', function () {
     describe('Method getBufferLength', function () {
         let buffer;
         beforeEach(function () {
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
         });
 
         it('should return 0 if no buffer', function () {
-
-            let totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
+            const totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
             expect(totalBufferedLength).to.equal(0);
         });
 
         it('should return 0 if no data buffered in time', function () {
-
             buffer.addRange({
                 start: 2,
                 end: 5
             });
-            let totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
+            const totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
             expect(totalBufferedLength).to.equal(0);
         });
 
         it('should return buffer length ', function () {
-
             buffer.addRange({
                 start: 2,
                 end: 5
@@ -313,21 +305,125 @@ describe('SourceBufferController', function () {
                 start: 9,
                 end: 11
             });
-            let totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
+            const totalBufferedLength = sourceBufferController.getBufferLength(buffer, 10);
             expect(totalBufferedLength).to.equal(1);
         });
     });
 
-    describe('Method append', function () {
-
-        it('should append data to buffer', function (done) {
-
-            let mediaInfo = {
+    describe('Method getRangesAsSingleRange', function () {
+        let buffer;
+        beforeEach(function () {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const mediaSource = new MediaSourceMock();
+            buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            expect(mediaSource.buffers).to.have.lengthOf(1);
+        });
+
+        it('should return null if no buffer', function () {
+            const range = sourceBufferController.getRangesAsSingleRange(buffer);
+            expect(range).to.be.null; // jshint ignore:line
+        });
+
+        it('should return null if no data buffered in time', function () {
+            buffer.addRange({
+                start: 2,
+                end: 5
+            });
+            const range = sourceBufferController.getRangesAsSingleRange(buffer, 6);
+            expect(range).to.be.null; // jshint ignore:line
+        });
+
+        it('should return a single range combining all buffer ranges', function () {
+            buffer.addRange({
+                start: 2,
+                end: 5
+            });
+            buffer.addRange({
+                start: 8,
+                end: 9
+            });
+
+            buffer.addRange({
+                start: 9,
+                end: 11
+            });
+
+            buffer.addRange({
+                start: 40,
+                end: 100
+            });
+
+            const range = sourceBufferController.getRangesAsSingleRange(buffer);
+            expect(range.start).to.equal(2);
+            expect(range.end).to.equal(100);
+        });
+
+        it('should return a single range combining all buffer ranges filtering by buffer start time', function () {
+            buffer.addRange({
+                start: 2,
+                end: 5
+            });
+            buffer.addRange({
+                start: 8,
+                end: 9
+            });
+
+            buffer.addRange({
+                start: 9,
+                end: 11
+            });
+
+            buffer.addRange({
+                start: 40,
+                end: 100
+            });
+
+            let range = sourceBufferController.getRangesAsSingleRange(buffer, 4);
+            expect(range.start).to.equal(8);
+            expect(range.end).to.equal(100);
+
+            range = sourceBufferController.getRangesAsSingleRange(buffer, 12);
+            expect(range.start).to.equal(40);
+            expect(range.end).to.equal(100);
+        });
+
+        it('should return a single range including ranges whose range(i).start is greater than fromTime', function () {
+            buffer.addRange({
+                start: 2,
+                end: 5
+            });
+            buffer.addRange({
+                start: 8,
+                end: 9
+            });
+
+            buffer.addRange({
+                start: 9,
+                end: 11
+            });
+
+            buffer.addRange({
+                start: 40,
+                end: 100
+            });
+
+            const range = sourceBufferController.getRangesAsSingleRange(buffer, 8);
+            expect(range.start).to.equal(9);
+            expect(range.end).to.equal(100);
+        });
+    });
+
+    describe('Method append', function () {
+        it('should append data to buffer', function (done) {
+            const mediaInfo = {
+                codec: 'video/webm; codecs="vp8, vorbis"'
+            };
+
+            const mediaSource = new MediaSourceMock();
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
 
             function onAppend(/*e*/) {
@@ -341,15 +437,14 @@ describe('SourceBufferController', function () {
         });
 
         it('should append data to text buffer', function (done) {
-
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'text',
                 isText: true
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
 
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(buffer).to.be.instanceOf(TextBufferMock);
 
             function onAppend(/*e*/) {
@@ -364,15 +459,13 @@ describe('SourceBufferController', function () {
     });
 
     describe('Method remove', function () {
-
         it('should remove data from buffer', function (done) {
-
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const mediaSource = new MediaSourceMock();
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
 
             function onAppend(/*e*/) {
@@ -395,15 +488,13 @@ describe('SourceBufferController', function () {
     });
 
     describe('Method abort', function () {
-
         it('should abort', function () {
-
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const mediaSource = new MediaSourceMock();
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
 
             expect(buffer.aborted).to.be.false; // jshint ignore:line
@@ -412,14 +503,13 @@ describe('SourceBufferController', function () {
         });
 
         it('should not abort if media source is not opened', function () {
-
-            let mediaInfo = {
+            const mediaInfo = {
                 codec: 'video/webm; codecs="vp8, vorbis"'
             };
 
-            let mediaSource = new MediaSourceMock();
+            const mediaSource = new MediaSourceMock();
             mediaSource.readyState = 'closed';
-            let buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
+            const buffer = sourceBufferController.createSourceBuffer(mediaSource, mediaInfo);
             expect(mediaSource.buffers).to.have.lengthOf(1);
 
             expect(buffer.aborted).to.be.false; // jshint ignore:line
@@ -427,5 +517,4 @@ describe('SourceBufferController', function () {
             expect(buffer.aborted).to.be.false; // jshint ignore:line
         });
     });
-
 });


### PR DESCRIPTION
Changes in buffer management to fix issues #2187 and #2239.

- epsilon value used for time -> segment index conversion is now configurable using MediaPlayer. setSegmentOverlapToleranceTime. Its default value has also been reduced to be 0.05 seconds.
- epsilon value is never taken into account for seeking operations. This is to ensure segments lists are always updated taking into account the specified time, ensuring video/audio alignment that was the root of the issue behind #2187.
- Changes in "pruning" logic. Previous approach was pruning just buffer behind playback position what caused unrecoverable failures when a user did multiple seek back operations (quota exceeded reported by browser that couldn't be fixed pruning previous buffer as most of allocated buffer was ahead). In the current approach we still are optimistic to ensure efficiency, in pruning operations we continue removing just buffer behind playback position but, in case of a quota exceed situation, we remove buffer ahead that is further than the defined stable buffer length. Also related with #2187.
- Taking advantage of changes doing in previous point, modifications has also been done to fix #2239. This fully removes the buffer when there is a track change and its switch mode is set to "always replace". With this, audio track transitions are instantaneous.

This PR depends on #2220. Don't merge before that one. 