### PR TITLE
Fire a waiting event if a playing event comes out while the stream is stalled

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2289,6 +2289,7 @@ function MediaPlayer() {
             abrController.reset();
             mediaController.reset();
             textController.reset();
+            videoModel.reset();
             if (protectionController) {
                 protectionController.reset();
                 protectionController = null;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1781,6 +1781,9 @@ function MediaPlayer() {
         if (!mediaPlayerInitialized) {
             throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
         }
+        if (videoModel) {
+            videoModel.reset();
+        }
         videoModel = null;
         if (element) {
             videoModel = VideoModel(context).getInstance();
@@ -2289,7 +2292,6 @@ function MediaPlayer() {
             abrController.reset();
             mediaController.reset();
             textController.reset();
-            videoModel.reset();
             if (protectionController) {
                 protectionController.reset();
                 protectionController = null;

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -51,6 +51,14 @@ function VideoModel() {
         stalledStreams = [];
     }
 
+    function setup() {
+        eventBus.on(Events.PLAYBACK_PLAYING, onPlaying, this);
+    }
+
+    function reset() {
+        eventBus.off(Events.PLAYBACK_PLAYING, onPlaying, this);
+    }
+
     function onPlaybackCanPlay() {
         element.playbackRate = previousPlaybackRate || 1;
         element.removeEventListener('canplay', onPlaybackCanPlay);
@@ -189,6 +197,15 @@ function VideoModel() {
             addStalledStream(type);
         } else {
             removeStalledStream(type);
+        }
+    }
+
+    //Calling play on the element will emit playing - even if the stream is stalled. If the stream is stalled, emit a waiting event.
+    function onPlaying() {
+        if (element && isStalled() && element.playbackRate === 0) {
+            const event = document.createEvent('Event');
+            event.initEvent('waiting', true, false);
+            element.dispatchEvent(event);
         }
     }
 
@@ -364,8 +381,11 @@ function VideoModel() {
         appendChild: appendChild,
         removeChild: removeChild,
         getVideoWidth: getVideoWidth,
-        getVideoHeight: getVideoHeight
+        getVideoHeight: getVideoHeight,
+        reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -49,9 +49,6 @@ function VideoModel() {
 
     function initialize() {
         stalledStreams = [];
-    }
-
-    function setup() {
         eventBus.on(Events.PLAYBACK_PLAYING, onPlaying, this);
     }
 
@@ -384,8 +381,6 @@ function VideoModel() {
         getVideoHeight: getVideoHeight,
         reset: reset
     };
-
-    setup();
 
     return instance;
 }


### PR DESCRIPTION
A playing event is fired by the media element if you pause then play on the element while stalled - . This PR watches for such a playing event, and if it fires while the player is still stalled, it fires the waiting event, so if watching the events, you still have the correct player state.