### PR TITLE
Set up continuous deployment process for development branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "4"
-  - "6"
+  - stable
 before_install: npm install -g grunt-cli
 install: npm install
+after_success:
+  - test $TRAVIS_BRANCH = "development" && grunt deploy --ftp-host=$DEPLOY_HOST --ftp-user=$DEPLOY_USER --ftp-pass=$DEPLOY_PASSWORD

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -331,6 +331,32 @@ module.exports = function (grunt) {
             all: {
                 'pre-commit': 'lint'
             }
+        },
+        ftp_push: {
+            deployment: {
+                options: {
+                    host: grunt.option('ftp-host'),
+                    dest: '/',
+                    username: grunt.option('ftp-user'),
+                    password: grunt.option('ftp-pass'),
+                    hideCredentials: true,
+                    // disabling incrementalUpdates because this option is not working fine
+                    incrementalUpdates: false,
+                    debug: false,
+                    port: 21
+                },
+                files: [
+                    {
+                        expand: true,
+                        cwd: '.',
+                        src: [
+                            'contrib/**',
+                            'dist/**',
+                            'samples/dash-if-reference-player/**'
+                        ]
+                    }
+                ]
+            }
         }
     });
 
@@ -346,4 +372,5 @@ module.exports = function (grunt) {
     grunt.registerTask('lint', ['jshint', 'jscs']);
     grunt.registerTask('prepublish', ['githooks', 'dist']);
     grunt.registerTask('dev', ['browserSync', 'watch-dev']);
+    grunt.registerTask('deploy', ['ftp_push']);
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exorcise": "^2.1.0",
+    "grunt-ftp-push": "^1.2.1",
     "grunt-githash": "^0.1.3",
     "grunt-githooks": "^0.5.0",
     "grunt-jscs": "^2.5.0",


### PR DESCRIPTION
Configures a continuous deployment process for development branch. Whenever changes are pushed to development branch, and only if build and test tasks were successful, resulting files are automatically deployed and can be tested using the url http://reference.dashif.org/dash.js/development/samples/dash-if-reference-player/index.html.

Deployment is done in development folder (instead of nightly one) to not interfere in current auto deployment process. Once this change is pushed and tested successfully for a few weeks, we will replace nightly build with this new process.