### PR TITLE
[text tracks] take into account  the video element parent container s…

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -294,11 +294,11 @@ function VideoModel() {
     }
 
     function getVideoRelativeOffsetTop() {
-        return element && element.parentNode ? element.offsetTop - element.parentNode.offsetTop : NaN;
+        return element && element.parentNode ? element.getBoundingClientRect().top - element.parentNode.getBoundingClientRect().top : NaN;
     }
 
     function getVideoRelativeOffsetLeft() {
-        return element && element.parentNode ? element.getBoundingClientRect().x - element.parentNode.getBoundingClientRect().x : NaN;
+        return element && element.parentNode ? element.getBoundingClientRect().left - element.parentNode.getBoundingClientRect().left : NaN;
     }
 
     function getTextTracks() {

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -293,6 +293,14 @@ function VideoModel() {
         return element ? element.videoHeight : NaN;
     }
 
+    function getVideoRelativeOffsetTop() {
+        return element && element.parentNode ? element.offsetTop - element.parentNode.offsetTop : NaN;
+    }
+
+    function getVideoRelativeOffsetLeft() {
+        return element && element.parentNode ? element.getBoundingClientRect().x - element.parentNode.getBoundingClientRect().x : NaN;
+    }
+
     function getTextTracks() {
         return element ? element.textTracks : [];
     }
@@ -364,7 +372,9 @@ function VideoModel() {
         appendChild: appendChild,
         removeChild: removeChild,
         getVideoWidth: getVideoWidth,
-        getVideoHeight: getVideoHeight
+        getVideoHeight: getVideoHeight,
+        getVideoRelativeOffsetTop: getVideoRelativeOffsetTop,
+        getVideoRelativeOffsetLeft: getVideoRelativeOffsetLeft
     };
 
     return instance;

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -204,15 +204,13 @@ function TextTracks() {
 
         if (videoPictureAspect > aspectRatio) {
             videoPictureHeightAspect = videoPictureHeight;
-            videoPictureWidthAspect = videoPictureHeight / (1 / aspectRatio);
-            videoPictureXAspect = (viewWidth - videoPictureWidthAspect) / 2;
-            videoPictureYAspect = 0;
+            videoPictureWidthAspect = videoPictureHeight * aspectRatio;
         } else {
             videoPictureWidthAspect = videoPictureWidth;
             videoPictureHeightAspect = videoPictureWidth / aspectRatio;
-            videoPictureXAspect = 0;
-            videoPictureYAspect = (viewHeight - videoPictureHeightAspect) / 2;
         }
+        videoPictureXAspect = (viewWidth - videoPictureWidthAspect) / 2;
+        videoPictureYAspect = (viewHeight - videoPictureHeightAspect) / 2;
 
         if (use80Percent) {
             return {
@@ -236,7 +234,9 @@ function TextTracks() {
         const clientHeight = videoModel.getClientHeight();
         const videoWidth = videoModel.getVideoWidth();
         const videoHeight = videoModel.getVideoHeight();
-        let aspectRatio =  clientWidth / clientHeight;
+        const videoOffsetTop = videoModel.getVideoRelativeOffsetTop();
+        const videoOffsetLeft = videoModel.getVideoRelativeOffsetLeft();
+        let aspectRatio =  videoWidth / videoHeight;
         let use80Percent = false;
         if (track.isFromCEA608) {
             // If this is CEA608 then use predefined aspect ratio
@@ -250,8 +250,8 @@ function TextTracks() {
         const newVideoHeight = realVideoSize.h;
 
         if (newVideoWidth != actualVideoWidth || newVideoHeight != actualVideoHeight) {
-            actualVideoLeft = realVideoSize.x;
-            actualVideoTop = realVideoSize.y;
+            actualVideoLeft = realVideoSize.x + videoOffsetLeft;
+            actualVideoTop = realVideoSize.y + videoOffsetTop;
             actualVideoWidth = newVideoWidth;
             actualVideoHeight = newVideoHeight;
             captionContainer.style.left = actualVideoLeft + 'px';

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -248,10 +248,12 @@ function TextTracks() {
 
         const newVideoWidth = realVideoSize.w;
         const newVideoHeight = realVideoSize.h;
+        const newVideoLeft = realVideoSize.x;
+        const newVideoTop = realVideoSize.y;
 
-        if (newVideoWidth != actualVideoWidth || newVideoHeight != actualVideoHeight) {
-            actualVideoLeft = realVideoSize.x + videoOffsetLeft;
-            actualVideoTop = realVideoSize.y + videoOffsetTop;
+        if (newVideoWidth != actualVideoWidth || newVideoHeight != actualVideoHeight || newVideoLeft != actualVideoLeft || newVideoTop != actualVideoTop) {
+            actualVideoLeft = newVideoLeft + videoOffsetLeft;
+            actualVideoTop = newVideoTop + videoOffsetTop;
             actualVideoWidth = newVideoWidth;
             actualVideoHeight = newVideoHeight;
             captionContainer.style.left = actualVideoLeft + 'px';


### PR DESCRIPTION
Fix issue #2241 
This PR takes into account the fact that the parent container of the video element can have a different size than the video element itself.
It also takes into account the relative positioning of the video element inside its parent (ex: vertically centered video element in fullscreen mode)

@Gontran-Molotov : could you check if it is OK for your use cases ?