### PR TITLE
Webpack integration and JS declarations fixes

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -153,12 +153,14 @@ declare namespace dashjs {
         reset(): void;
     }
 
-    export interface MediaPlayer {
-        (): {
-            create(): MediaPlayerClass;
-        };
+    export interface MediaPlayerFactory {
+        create(): MediaPlayerClass;
+    }
 
-        events: MediaPlayerEvents;
+    export function MediaPlayer(): MediaPlayerFactory;
+
+    export namespace MediaPlayer {
+        export const events: MediaPlayerEvents;
     }
 
     interface MediaPlayerEvents {

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,12 +153,14 @@ declare namespace dashjs {
         reset(): void;
     }
 
-    export interface MediaPlayer {
-        (): {
-            create(): MediaPlayerClass;
-        };
+    export interface MediaPlayerFactory {
+        create(): MediaPlayerClass;
+    }
 
-        events: MediaPlayerEvents;
+    export function MediaPlayer(): MediaPlayerFactory;
+
+    export namespace MediaPlayer {
+        export const events: MediaPlayerEvents;
     }
 
     interface MediaPlayerEvents {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import './index_mediaplayerOnly';
+import { MediaPlayer } from './index_mediaplayerOnly';
 
 import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import Protection from './src/streaming/protection/Protection';
@@ -40,4 +40,4 @@ dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
 
 export default dashjs;
-export { Protection, MetricsReporting, MediaPlayerFactory};
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory};

--- a/samples/modules/README.md
+++ b/samples/modules/README.md
@@ -8,3 +8,7 @@ file will be placed in `out/out.js`.
 If you are using [WebPack](https://webpack.github.io/) with the [Babel Loader](https://github.com/babel/babel-loader) 
 and the [ES2015 Preset](https://babeljs.io/docs/plugins/preset-es2015/) you can consume the dash.js modules directly from source.
 To see an example of this check out the files in the `webpack` directory.
+
+## WebPack with Typescript
+Sample similar to the previous one but using Typescript instead of Babel/ES2015 presets
+To see an example of this check out the files in the `typescript` directory. 

--- a/samples/modules/README.md
+++ b/samples/modules/README.md
@@ -4,13 +4,13 @@ These samples give examples of how the dash.js library can be consumed in differ
 Each directory contains a standalone package with a build setup to run with `npm run build`. The result
 file will be placed in `out/out.js`.
 
-Please, take into account there were some issues with the way dash.js modules/classes were exported and in its declaration files that make these samples don't work with dash.js v2.6.3 and below. Please, read the project FAQ to get information about how to use dash.js in webpack based projects for dash.js 2.6.3 and below.
+Please, take into account there were some issues with the way dash.js modules/classes were exported and in its declaration files that make these samples don't work with dash.js v2.6.3 and below. Please, read the project [FAQ](https://github.com/Dash-Industry-Forum/dash.js/wiki/FAQ) to get information about how to use dash.js in webpack based projects for dash.js 2.6.3 and below.
 
 ## WebPack with Babel Loader
-If you are using [WebPack](https://webpack.github.io/) with the [Babel Loader](https://github.com/babel/babel-loader) 
+If you are using [WebPack](https://webpack.github.io/) with the [Babel Loader](https://github.com/babel/babel-loader)
 and the [ES2015 Preset](https://babeljs.io/docs/plugins/preset-es2015/) you can consume the dash.js modules directly from source.
 To see an example of this check out the files in the `webpack` directory.
 
 ## WebPack with Typescript
 Sample similar to the previous one but using Typescript instead of Babel/ES2015 presets
-To see an example of this check out the files in the `typescript` directory. 
+To see an example of this check out the files in the `typescript` directory.

--- a/samples/modules/README.md
+++ b/samples/modules/README.md
@@ -4,6 +4,8 @@ These samples give examples of how the dash.js library can be consumed in differ
 Each directory contains a standalone package with a build setup to run with `npm run build`. The result
 file will be placed in `out/out.js`.
 
+Please, take into account there were some issues with the way dash.js modules/classes were exported and in its declaration files that make these samples don't work with dash.js v2.6.3 and below. Please, read the project FAQ to get information about how to use dash.js in webpack based projects for dash.js 2.6.3 and below.
+
 ## WebPack with Babel Loader
 If you are using [WebPack](https://webpack.github.io/) with the [Babel Loader](https://github.com/babel/babel-loader) 
 and the [ES2015 Preset](https://babeljs.io/docs/plugins/preset-es2015/) you can consume the dash.js modules directly from source.

--- a/samples/modules/typescript/index.html
+++ b/samples/modules/typescript/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Dash.js Rocks</title>
+
+        <style>
+            video {
+                width: 640px;
+                height: 360px;
+            }
+        </style>
+    </head>
+    <body>
+        <div>
+            <video id="myMainVideoPlayer" controls></video>
+        </div>
+    </body>
+</html>

--- a/samples/modules/typescript/package.json
+++ b/samples/modules/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dashjs-typescript-sample",
+  "version": "1.0.0",
+  "description": "Test using dash.js in a Typescript based project",
+  "dependencies": {
+    "dashjs": "^2.6.3"
+  },
+  "scripts": {
+    "build": "node_modules/webpack/bin/webpack.js"
+  },
+  "author": "Jesus Oliva",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "awesome-typescript-loader": "^3.2.1",
+    "html-webpack-plugin": "^2.30.1",
+    "typescript": "^2.2.2",
+    "webpack": "^1.12.13"
+  }
+}

--- a/samples/modules/typescript/src/entry.ts
+++ b/samples/modules/typescript/src/entry.ts
@@ -1,0 +1,5 @@
+import {MediaPlayer} from 'dashjs';
+
+let url = "https://dash.akamaized.net/envivio/Envivio-dash2/manifest.mpd";
+let player = MediaPlayer().create();
+player.initialize(document.querySelector('#myMainVideoPlayer'), url, true);

--- a/samples/modules/typescript/webpack.config.js
+++ b/samples/modules/typescript/webpack.config.js
@@ -1,0 +1,33 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    entry: './src/entry.ts',
+    output: {
+        path: './out',
+        filename: 'out.js'
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            inject: true,
+            filename: 'index.html',
+            template: 'index.html'
+        })
+    ],
+    module: {
+        // Webpack doesn't understand TypeScript files and a loader is needed.
+        // `node_modules` folder is excluded in order to prevent problems with
+        // the library dependencies, as well as `__tests__` folders that
+        // contain the tests for the library
+        loaders: [{
+            test: /\.tsx?$/,
+            loader: 'awesome-typescript-loader',
+            exclude: /node_modules/,
+            query: {
+                // we don't want any declaration file in the bundles
+                // folder since it wouldn't be of any use ans the source
+                // map already include everything for debugging
+                declaration: false,
+            }
+        }]
+    }
+};

--- a/samples/modules/webpack/index.html
+++ b/samples/modules/webpack/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Dash.js Rocks</title>
+
+        <style>
+            video {
+                width: 640px;
+                height: 360px;
+            }
+        </style>
+    </head>
+    <body>
+        <div>
+            <video id="myMainVideoPlayer" controls></video>
+        </div>
+    </body>
+</html>

--- a/samples/modules/webpack/package.json
+++ b/samples/modules/webpack/package.json
@@ -3,15 +3,18 @@
   "version": "1.0.0",
   "description": "Test including dash.js into a WebPack project",
   "dependencies": {
-    "babel-core": "^6.5.2",
-    "babel-loader": "^6.2.2",
-    "babel-preset-es2015": "^6.5.0",
-    "dashjs": "^2.0.0",
-    "webpack": "^1.12.13"
+    "dashjs": "^2.6.4"
   },
   "scripts": {
     "build": "node_modules/webpack/bin/webpack.js"
   },
   "author": "Aaron Boushley",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "babel-core": "^6.5.2",
+    "babel-loader": "^6.2.2",
+    "babel-preset-es2015": "^6.5.0",
+    "html-webpack-plugin": "^2.30.1",
+    "webpack": "^1.12.13"
+  }
 }

--- a/samples/modules/webpack/webpack.config.js
+++ b/samples/modules/webpack/webpack.config.js
@@ -1,21 +1,29 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
-	entry: './src/entry.js',
-	output: {
-		path: './out',
-		filename: 'out.js'
-	},
-	module: {
-		loaders: [
-			{
-				test: /\.js$/,
-				loader: require.resolve('babel-loader'),
-				query: {
-					presets: [
-						'es2015'
-					]
-				}
-			}
-		]
-	}
+    entry: './src/entry.js',
+    output: {
+        path: './out',
+        filename: 'out.js'
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            inject: true,
+            filename: 'index.html',
+            template: 'index.html'
+        })
+    ],
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                loader: require.resolve('babel-loader'),
+                query: {
+                    presets: [
+                        'es2015'
+                    ]
+                }
+            }
+        ]
+    }
 };


### PR DESCRIPTION
This PR Fixes the issue related with dash.js and Webpack integration (#2300).

It includes MediaPlayer in the main module export, apart from setting it as a property of the dashjs object as we did before.

This PR also fixes the declaration files, that were previously generating issues both in Babel and Typescript based projects. For testing purposes a new sample has been added that shows how to use dash.js in typescript based projects.

Note: Please, note both samples (webpack and typescript one) are fetching dash.js library from npm. This means this change can't be tested as usual until the new version is released and published in npm. In the meantime the way of testing this is retrieving all package.json dependencies as always (npm install) and then, replacing the content of dash.js package with the result of building this PR. Another option is, once this PR is accepted, replace package reference in package.json of these samples with: 
`"dashjs": "git://github.com/Dash-Industry-Forum/dash.js.git#development"`