### PR TITLE
Implement duration change for MPD Validity Expiration events

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -33,7 +33,6 @@ import DashConstants from '../constants/DashConstants';
 import DashJSError from '../../streaming/vo/DashJSError';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
-import MediaPlayerEvents from '../../streaming/MediaPlayerEvents';
 import FactoryMaker from '../../core/FactoryMaker';
 import Representation from '../vo/Representation';
 
@@ -68,6 +67,7 @@ function RepresentationController() {
         eventBus.on(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.on(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);
+        eventBus.on(Events.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, instance);
     }
 
     function setConfig(config) {
@@ -145,6 +145,7 @@ function RepresentationController() {
         eventBus.off(Events.REPRESENTATION_UPDATED, onRepresentationUpdated, instance);
         eventBus.off(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, instance);
         eventBus.off(Events.BUFFER_LEVEL_UPDATED, onBufferLevelUpdated, instance);
+        eventBus.off(Events.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, instance);
 
         resetInitialSettings();
     }
@@ -271,7 +272,7 @@ function RepresentationController() {
         };
 
         updating = false;
-        eventBus.trigger(MediaPlayerEvents.AST_IN_FUTURE, { delay: delay });
+        eventBus.trigger(Events.AST_IN_FUTURE, { delay: delay });
         setTimeout(update, delay);
     }
 
@@ -359,6 +360,16 @@ function RepresentationController() {
                 domStorage.setSavedBitrateSettings(e.mediaType, bitrate);
             }
             addRepresentationSwitch();
+        }
+    }
+
+    function onManifestValidityChanged(e) {
+        if (e.newDuration) {
+            const representation = getCurrentRepresentation();
+            if (representation && representation.adaptation.period) {
+                const period = representation.adaptation.period;
+                period.duration = e.newDuration;
+            }
         }
     }
 

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -247,6 +247,11 @@ class MediaPlayerEvents extends EventsBase {
          * @event MediaPlayerEvents#PLAYBACK_TIME_UPDATED
          */
         this.PLAYBACK_TIME_UPDATED = 'playbackTimeUpdated';
+        /**
+         * Manifest validity changed - As a result of an MPD validity expiration event.
+         * @event MediaPlayerEvents#MANIFEST_VALIDITY_CHANGED
+         */
+        this.MANIFEST_VALIDITY_CHANGED = 'manifestValidityChanged';
     }
 }
 

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -205,7 +205,7 @@ function EventController() {
                             activeEvents[eventId] = curr;
                         }
                         if (curr.eventStream.schemeIdUri == MPD_RELOAD_SCHEME && curr.eventStream.value == MPD_RELOAD_VALUE) {
-                            if (event.duration !== 0 || event.presentationTimeDelta !== 0) { //If both are set to zero, it indicates the media is over at this point. Don't reload the manifest.
+                            if (curr.duration !== 0 || curr.presentationTimeDelta !== 0) { //If both are set to zero, it indicates the media is over at this point. Don't reload the manifest.
                                 refreshManifest();
                             }
                         } else {

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -32,6 +32,7 @@
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
 
 function EventController() {
 
@@ -120,11 +121,34 @@ function EventController() {
         for (var i = 0; i < values.length; i++) {
             var event = values[i];
             if (!(event.id in inbandEvents)) {
+                if (event.eventStream.schemeIdUri === MPD_RELOAD_SCHEME && inbandEvents[event.id] === undefined) {
+                    handleManifestReloadEvent(event);
+                }
                 inbandEvents[event.id] = event;
                 log('Add inband event with id ' + event.id);
             } else {
                 log('Repeated event with id ' + event.id);
             }
+        }
+    }
+
+    function handleManifestReloadEvent(event) {
+        if (event.eventStream.value == MPD_RELOAD_VALUE) {
+            const timescale = event.eventStream.timescale || 1;
+            const validUntil = event.presentationTime / timescale;
+            let newDuration;
+            if (event.presentationTime == 0xFFFFFFFF) {//0xFF... means remaining duration unknown
+                newDuration = NaN;
+            } else {
+                newDuration = (event.presentationTime + event.duration) / timescale;
+            }
+            log('Manifest validity changed: Valid until: ' + validUntil + '; remaining duration: ' + newDuration);
+            eventBus.trigger(Events.MANIFEST_VALIDITY_CHANGED, {
+                id: event.id,
+                validUntil: validUntil,
+                newDuration: newDuration,
+                newManifestValidAfter: NaN //event.message_data - this is an arraybuffer with a timestring in it, but not used yet
+            });
         }
     }
 
@@ -181,7 +205,9 @@ function EventController() {
                             activeEvents[eventId] = curr;
                         }
                         if (curr.eventStream.schemeIdUri == MPD_RELOAD_SCHEME && curr.eventStream.value == MPD_RELOAD_VALUE) {
-                            refreshManifest();
+                            if (event.duration !== 0 || event.presentationTimeDelta !== 0) { //If both are set to zero, it indicates the media is over at this point. Don't reload the manifest.
+                                refreshManifest();
+                            }
                         } else {
                             eventBus.trigger(curr.eventStream.schemeIdUri, {event: curr});
                         }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -136,6 +136,7 @@ function StreamController() {
         eventBus.on(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdated, this);
         eventBus.on(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
+        eventBus.on(Events.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, this);
         eventBus.on(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
     }
 
@@ -671,6 +672,12 @@ function StreamController() {
         manifestUpdater.setManifest(manifest);
     }
 
+    function onManifestValidityChanged(e) {
+        if (!isNaN(e.newDuration)) {
+            setMediaDuration(e.newDuration);
+        }
+    }
+
     function setConfig(config) {
         if (!config) return;
 
@@ -769,6 +776,7 @@ function StreamController() {
         eventBus.off(Events.MANIFEST_UPDATED, onManifestUpdated, this);
         eventBus.off(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
         eventBus.off(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
+        eventBus.off(Events.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, this);
 
         baseURLController.reset();
         manifestUpdater.reset();

--- a/test/unit/streaming.controllers.EventController.js
+++ b/test/unit/streaming.controllers.EventController.js
@@ -1,5 +1,7 @@
 import EventController from '../../src/streaming/controllers/EventController';
 import EventBus from '../../src/core/EventBus';
+import Events from '../../src/core/events/Events';
+import Debug from '../../src/core/Debug';
 
 import PlaybackControllerMock from './mocks/PlaybackControllerMock';
 import ManifestModelMock from './mocks/ManifestModelMock';
@@ -10,11 +12,29 @@ const context = {};
 const eventBus = EventBus(context).getInstance();
 
 describe('EventController', function () {
+    const debug = Debug(context).getInstance();
+    debug.setLogToBrowserConsole(false);
     let eventController;
 
     let manifestUpdaterMock = new ManifestUpdaterMock();
     let playbackControllerMock = new PlaybackControllerMock();
     let manifestModelMock = new ManifestModelMock();
+
+    const manifestExpiredEventStub = {
+        'duration': 0,
+        'presentationTime': 30 * 48000,
+        'id': 1819112295,
+        'messageData': { },
+        'eventStream': {
+            'adaptionSet': null,
+            'representation': null,
+            'period': null,
+            'timescale': 48000,
+            'value': '1',
+            'schemeIdUri': 'urn:mpeg:dash:event:2012'
+        },
+        'presentationTimeDelta': 0
+    };
 
     beforeEach(function () {
         eventController = EventController(context).create();
@@ -92,6 +112,37 @@ describe('EventController', function () {
 
             eventController.addInlineEvents(events);
             eventController.start();
+        });
+
+        it('should fire MANIFEST_VALIDITY_CHANGED events immediately', function (done) {
+            const manifestValidityExpiredHandler = function (event) {
+                expect(event.id).to.equal(manifestExpiredEventStub.id);
+                expect(event.validUntil).to.equal(manifestExpiredEventStub.presentationTime / manifestExpiredEventStub.eventStream.timescale);
+                expect(event.newDuration).to.equal((manifestExpiredEventStub.presentationTime + manifestExpiredEventStub.duration) / manifestExpiredEventStub.eventStream.timescale);
+
+                eventBus.off(Events.MANIFEST_VALIDITY_CHANGED, manifestValidityExpiredHandler, this);
+                done();
+            };
+
+            eventBus.on(Events.MANIFEST_VALIDITY_CHANGED, manifestValidityExpiredHandler, this);
+
+            eventController.addInbandEvents([manifestExpiredEventStub]);
+        });
+
+        it('should not fire manifest validity expiration events if an event with that ID has already been received', function () {
+            let triggerCount = 0;
+            const manifestValidityExpiredHandler = function () {
+                triggerCount++;
+            };
+
+            eventBus.on(Events.MANIFEST_VALIDITY_CHANGED, manifestValidityExpiredHandler, this);
+
+            eventController.addInbandEvents([manifestExpiredEventStub]);
+            eventController.addInbandEvents([manifestExpiredEventStub]);
+
+            expect(triggerCount).to.equal(1);
+
+            eventBus.off(Events.MANIFEST_VALIDITY_CHANGED, manifestValidityExpiredHandler, this);
         });
     });
 });


### PR DESCRIPTION
Implements the event duration portion of the spec for emsg MPD Validity Expiration events, so the event duration field can be used to set the remaining duration of a live stream. It also allows a stream to be ended at the event time when presentation_time_delta and event_duration are 0.

It **does not** implement the checking of the message_data field or the presentation_time_delta field to verify that the reloaded manifest has the correct validity