### PR TITLE
Set a specific version for codem-isoboxer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "xmldom": "^0.1.16"
   },
   "dependencies": {
-    "codem-isoboxer": "^0.3.3",
+    "codem-isoboxer": "0.3.5",
     "imsc": "^1.0.0-beta.3",
     "round10": "^1.0.3",
     "deep-equal": "^1.0.1"


### PR DESCRIPTION
Upgrade codem-isoboxer dep to use, specifically, its version 0.3.5