### PR TITLE
Fix an issue when using ClearKey with license server

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -154,6 +154,7 @@ function ProtectionController(config) {
      */
     function createKeySession(initData, cdmData) {
         const initDataForKS = CommonEncryption.getPSSHForKeySystem(keySystem, initData);
+        const protData = getProtData(keySystem);
         if (initDataForKS) {
 
             // Check for duplicate initData
@@ -165,12 +166,12 @@ function ProtectionController(config) {
                 }
             }
             try {
-                protectionModel.createKeySession(initDataForKS, sessionType, cdmData);
+                protectionModel.createKeySession(initDataForKS, protData, sessionType, cdmData);
             } catch (error) {
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Error creating key session! ' + error.message});
             }
         } else if (initData) {
-            protectionModel.createKeySession(initData, sessionType, cdmData);
+            protectionModel.createKeySession(initData, protData, sessionType, cdmData);
         } else {
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Selected key system is ' + keySystem.systemString + '.  needkey/encrypted event contains no initData corresponding to that key system!'});
         }

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -72,20 +72,20 @@ function ProtectionKeyController() {
         let keySystem;
 
         // PlayReady
-        keySystem = KeySystemPlayReady(context).getInstance({BASE64: BASE64});
+        keySystem = KeySystemPlayReady(context).getInstance({ BASE64: BASE64 });
         keySystems.push(keySystem);
 
         // Widevine
-        keySystem = KeySystemWidevine(context).getInstance({BASE64: BASE64});
+        keySystem = KeySystemWidevine(context).getInstance({ BASE64: BASE64 });
         keySystems.push(keySystem);
 
         // ClearKey
-        keySystem = KeySystemClearKey(context).getInstance({BASE64: BASE64});
+        keySystem = KeySystemClearKey(context).getInstance({ BASE64: BASE64 });
         keySystems.push(keySystem);
         clearkeyKeySystem = keySystem;
 
         // W3C ClearKey
-        keySystem = KeySystemW3CClearKey(context).getInstance({BASE64: BASE64, log: log});
+        keySystem = KeySystemW3CClearKey(context).getInstance({ BASE64: BASE64, log: log });
         keySystems.push(keySystem);
         clearkeyW3CKeySystem = keySystem;
     }
@@ -191,14 +191,20 @@ function ProtectionKeyController() {
                 for (cpIdx = 0; cpIdx < cps.length; ++cpIdx) {
                     cp = cps[cpIdx];
                     if (cp.schemeIdUri.toLowerCase() === ks.schemeIdURI) {
-
                         // Look for DRM-specific ContentProtection
                         let initData = ks.getInitData(cp);
-                        supportedKS.push({
-                            ks: keySystems[ksIdx],
-                            initData: initData,
-                            cdmData: ks.getCDMData()
-                        });
+                        if (!!initData) {
+                            supportedKS.push({
+                                ks: keySystems[ksIdx],
+                                initData: initData,
+                                cdmData: ks.getCDMData()
+                            });
+                        } else if (this.isClearKey(ks)) {
+                            supportedKS.push({
+                                ks: ks,
+                                initData: null
+                            });
+                        }
                     }
                 }
             }
@@ -267,7 +273,7 @@ function ProtectionKeyController() {
 
         let licenseServerData = null;
         if (protData && protData.hasOwnProperty('drmtoday')) {
-            licenseServerData = DRMToday(context).getInstance({BASE64: BASE64});
+            licenseServerData = DRMToday(context).getInstance({ BASE64: BASE64 });
         } else if (keySystem.systemString === ProtectionConstants.WIDEVINE_KEYSTEM_STRING) {
             licenseServerData = Widevine(context).getInstance();
         } else if (keySystem.systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING) {

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -63,7 +63,7 @@ function KeySystemClearKey(config) {
             const keyPairs = [];
             for (let i = 0; i < jsonMsg.kids.length; i++) {
                 const clearkeyID = jsonMsg.kids[i];
-                const clearkey = (protectionData.clearkeys.hasOwnProperty(clearkeyID)) ? protectionData.clearkeys[clearkeyID] : null;
+                const clearkey = (protectionData.clearkeys && protectionData.clearkeys.hasOwnProperty(clearkeyID)) ? protectionData.clearkeys[clearkeyID] : null;
                 if (!clearkey) {
                     throw new Error('DRM: ClearKey keyID (' + clearkeyID + ') is not known!');
                 }

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -60,8 +60,8 @@ function KeySystemW3CClearKey(config) {
             const jsonMsg = JSON.parse(String.fromCharCode.apply(null, new Uint8Array(message)));
             const keyPairs = [];
             for (let i = 0; i < jsonMsg.kids.length; i++) {
-                let clearkeyID = jsonMsg.kids[i];
-                let clearkey = (protectionData.clearkeys.hasOwnProperty(clearkeyID)) ? protectionData.clearkeys[clearkeyID] : null;
+                const clearkeyID = jsonMsg.kids[i];
+                const clearkey = (protectionData.clearkeys && protectionData.clearkeys.hasOwnProperty(clearkeyID)) ? protectionData.clearkeys[clearkeyID] : null;
                 if (!clearkey) {
                     throw new Error('DRM: ClearKey keyID (' + clearkeyID + ') is not known!');
                 }

--- a/src/streaming/protection/models/ProtectionModel.js
+++ b/src/streaming/protection/models/ProtectionModel.js
@@ -112,6 +112,8 @@ let ProtectionModel = function () { };
  * @memberof ProtectionModel
  * @param {ArrayBuffer} initData PSSH box for the currently selected
  * key system.
+ * @param {ProtectionData} protData Protection data for the currently selected
+ * key system.
  * @param {string} sessionType the desired session type.  One of "temporary",
  * "persistent-license", "persistent-release-message".  CDM implementations
  * are not required to support anything except "temporary"

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -194,7 +194,7 @@ function ProtectionModel_01b(config) {
         }
     }
 
-    function createKeySession(initData /*, keySystemType */) {
+    function createKeySession(initData /*, protData, keySystemType */) {
         if (!keySystem) {
             throw new Error('Can not create sessions until you have selected a key system');
         }

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -172,7 +172,7 @@ function ProtectionModel_21Jan2015(config) {
         });
     }
 
-    function createKeySession(initData, sessionType) {
+    function createKeySession(initData, protData, sessionType) {
         if (!keySystem || !mediaKeys) {
             throw new Error('Can not create sessions until you have selected a key system');
         }
@@ -181,8 +181,10 @@ function ProtectionModel_21Jan2015(config) {
         const sessionToken = createSessionToken(session, initData, sessionType);
         const ks = this.getKeySystem();
 
-        // Generate initial key request
-        session.generateRequest(ks.systemString === ProtectionConstants.CLEARKEY_KEYSTEM_STRING ? 'keyids' : 'cenc', initData).then(function () {
+        // Generate initial key request.
+        // keyids type is used for clearkey when keys are provided directly in the protection data and then request to a license server is not needed
+        const dataType = ks.systemString === ProtectionConstants.CLEARKEY_KEYSTEM_STRING && protData && protData.clearkeys ? 'keyids' : 'cenc';
+        session.generateRequest(dataType, initData).then(function () {
             log('DRM: Session created.  SessionID = ' + sessionToken.getSessionID());
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: sessionToken});
         }).catch(function (error) {

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -192,7 +192,7 @@ function ProtectionModel_3Feb2014(config) {
         }
     }
 
-    function createKeySession(initData, sessionType, cdmData) {
+    function createKeySession(initData, protData, sessionType, cdmData) {
 
         if (!keySystem || !mediaKeys || !keySystemAccess) {
             throw new Error('Can not create sessions until you have selected a key system');


### PR DESCRIPTION
ClearKey + License server worked before 2.6.4 and was broken after adding Basic ClearKey support (ClearKey support with keys passed as parameters instead of using a license server). This PR is recovering ClearKey + License server support while keeping the new Basic ClearKey functionality.