### PR TITLE
Multi period live bug

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -293,6 +293,8 @@ function StreamController() {
         const nextStream = getNextStream();
         if (nextStream) {
             switchStream(activeStream, nextStream, NaN);
+        } else {
+            log('StreamController::onEnded no next stream found');
         }
         flushPlaylistMetrics(nextStream ? PlayListTrace.END_OF_PERIOD_STOP_REASON : PlayListTrace.END_OF_CONTENT_STOP_REASON);
     }
@@ -450,6 +452,7 @@ function StreamController() {
                     });
                     streams.push(stream);
                     stream.initialize(streamInfo, protectionController);
+                    log('StreamController::composeStreams stream id = ' + stream.getStreamInfo().id + ' has been added to streams array. Its start is : ' + stream.getStreamInfo().start);
 
                 } else {
                     stream.updateData(streamInfo);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -465,6 +465,17 @@ function StreamController() {
                 //const initStream = streamsInfo[0].manifestInfo.isDynamic ? streams[streams.length -1] : streams[0];
                 //TODO we need to figure out what the correct starting period is here and not just go to first or last in array.
                 switchStream(null, streams[0], NaN);
+            } else {
+                const currentTime = playbackController.getTime();
+                if (Math.ceil(currentTime) === Math.ceil(activeStream.getStartTime() + activeStream.getDuration())) {
+                    log('StreamController::composeStreams player needs to go to next period');
+                    const nextStream = getNextStream();
+                    if (nextStream) {
+                        switchStream(activeStream, nextStream, NaN);
+                    } else {
+                        log('StreamController::composeStreams no next stream found');
+                    }
+                }
             }
 
             eventBus.trigger(Events.STREAMS_COMPOSED);


### PR DESCRIPTION
Hi,

this PR has to solve the issue #2306. When a new manifest version is downloaded, in composeStreams function, player has to detect it has reached the end of the current period and try to switch to the next one. This use case could happend if the manifest update frequence is greater than a period stream duration or that the new version of manifest has no new period.

Nico