### PR TITLE
Fix issue with codec definition and EME

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -277,13 +277,13 @@ function DashManifestModel(config) {
         return adaptations[0];
     }
 
-    function getCodec(adaptation, representationId) {
+    function getCodec(adaptation, representationId, addResolutionInfo) {
         if (adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0) {
             const representation = isInteger(representationId) && representationId >= 0 && representationId < adaptation.Representation_asArray.length ?
                 adaptation.Representation_asArray[representationId] : adaptation.Representation_asArray[0];
-            let codec = representation.mimeType + ';codecs="' + representation.codecs;
-            if (representation.width !== undefined) {
-                codec += '";width="' + representation.width + '";height="' + representation.height + '"';
+            let codec = representation.mimeType + ';codecs="' + representation.codecs + '"';
+            if (addResolutionInfo && representation.width !== undefined) {
+                codec += ';width="' + representation.width + '";height="' + representation.height + '"';
             }
             return codec;
         }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -452,7 +452,7 @@ function Stream(config) {
             // keep at least codec from lowest representation
             if (i === 0) return true;
 
-            const codec = dashManifestModel.getCodec(realAdaptation, i);
+            const codec = dashManifestModel.getCodec(realAdaptation, i, true);
             if (!capabilities.supportsCodec(codec)) {
                 log('[Stream] codec not supported: ' + codec);
                 return false;


### PR DESCRIPTION
Fix an issue that appeared after merging #2328.

Although passing resolution (with/height) information to isTypeSupported method is fully valid, seems EME has some issues with that. Both Chrome and Firefox fails when selecting the keysystem if we use a MediaKeySystemMediaCapability whose contentType field includes width/height information. Following spec (https://www.w3.org/TR/encrypted-media/#bib-RFC6381, https://tools.ietf.org/html/rfc6381) I don't see any indication that says width or height parameters could be allowed parameters for contentType field.

This issue is making any stream using DRM not working.