### PR TITLE
Fix condition in hasInitialization

### DIFF
--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -63,7 +63,7 @@ class Representation {
 
     static hasInitialization(r) {
         return (r.initialization !== null) ||
-            ((r.segmentInfoType !== DashConstants.BASE_URL || r.segmentInfoType !== DashConstants.SEGMENT_BASE ) && (r.range !== null));
+            ((r.segmentInfoType === DashConstants.BASE_URL || r.segmentInfoType === DashConstants.SEGMENT_BASE ) && (r.range !== null));
     }
 
     static hasSegments(r) {


### PR DESCRIPTION
Fix issue #2327. HasInitialization is true if range is defined and segmentInfoType is either BASE_URL or SEGMENT_BASE. 