### PR TITLE
Don't do initial seek if there is another seek running

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -513,7 +513,9 @@ function PlaybackController() {
                     ranges = bufferedRange[streamInfo.id].video;
                 }
                 if (checkTimeInRanges(earliestTime, ranges)) {
-                    seek(earliestTime);
+                    if (!isSeeking()) {
+                        seek(earliestTime);
+                    }
                     commonEarliestTime[streamInfo.id] = false;
                 }
             }
@@ -521,7 +523,9 @@ function PlaybackController() {
             //current stream has only audio or only video content
             if (commonEarliestTime[streamInfo.id][type]) {
                 earliestTime = commonEarliestTime[streamInfo.id][type] > initialStartTime ? commonEarliestTime[streamInfo.id][type] : initialStartTime;
-                seek(earliestTime);
+                if (!isSeeking()) {
+                    seek(earliestTime);
+                }
                 commonEarliestTime[streamInfo.id] = false;
             }
         }


### PR DESCRIPTION
Fix for issue #2238. This fix avoids doing initial seeking operation, that takes into account buffer status, in cases in which the user did a seek operation while the stream was loading.