### PR TITLE
Multi period bug fix

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -265,6 +265,8 @@ function PlaybackController() {
             const fragT = parseInt(fragData.t, 10);
             if (!ignoreStartOffset) {
                 startTimeOffset = !isNaN(fragS) ? fragS : fragT;
+            } else {
+                startTimeOffset = streamInfo.start;
             }
         } else {
             // handle case where no media fragments are parsed from the manifest URL
@@ -287,10 +289,7 @@ function PlaybackController() {
                 presentationStartTime = startTimeOffset;
             } else {
                 let earliestTime = commonEarliestTime[streamInfo.id]; //set by ready bufferStart after first onBytesAppended
-                if (earliestTime === undefined) {
-                    earliestTime = streamController.getActiveStreamCommonEarliestTime(); //deal with calculated PST that is none 0 when streamInfo.start is 0
-                }
-                presentationStartTime = Math.max(earliestTime, streamInfo.start);
+                presentationStartTime = earliestTime !== undefined ? Math.max(earliestTime.audio, earliestTime.video, streamInfo.start) : streamInfo.start;
             }
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -470,7 +470,7 @@ function PlaybackController() {
             initialStartTime;
         let ranges = e.bufferedRanges;
         if (!ranges || !ranges.length) return;
-        if (commonEarliestTime[streamInfo.id] === false) {
+        if (commonEarliestTime[streamInfo.id] && commonEarliestTime[streamInfo.id].started === true) {
             //stream has already been started.
             return;
         }
@@ -485,6 +485,7 @@ function PlaybackController() {
 
         if (commonEarliestTime[streamInfo.id] === undefined) {
             commonEarliestTime[streamInfo.id] = [];
+            commonEarliestTime[streamInfo.id].started = false;
         }
 
         if (commonEarliestTime[streamInfo.id][type] === undefined) {
@@ -515,7 +516,7 @@ function PlaybackController() {
                     if (!isSeeking()) {
                         seek(earliestTime);
                     }
-                    commonEarliestTime[streamInfo.id] = false;
+                    commonEarliestTime[streamInfo.id].started = true;
                 }
             }
         } else {
@@ -525,7 +526,7 @@ function PlaybackController() {
                 if (!isSeeking()) {
                     seek(earliestTime);
                 }
-                commonEarliestTime[streamInfo.id] = false;
+                commonEarliestTime[streamInfo.id].started = true;
             }
         }
     }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -262,16 +262,6 @@ function StreamController() {
         return activeStream ? activeStream.getProcessors() : [];
     }
 
-    function getActiveStreamCommonEarliestTime() {
-        let commonEarliestTime = [];
-        if (activeStream) {
-            activeStream.getProcessors().forEach(p => {
-                commonEarliestTime.push(p.getIndexHandler().getEarliestTime());
-            });
-        }
-        return Math.min.apply(Math, commonEarliestTime);
-    }
-
     function onEnded() {
         const nextStream = getNextStream();
         if (nextStream) {
@@ -815,7 +805,6 @@ function StreamController() {
         load: load,
         loadWithManifest: loadWithManifest,
         getActiveStreamProcessors: getActiveStreamProcessors,
-        getActiveStreamCommonEarliestTime: getActiveStreamCommonEarliestTime,
         setConfig: setConfig,
         reset: reset
     };

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -347,7 +347,6 @@ function StreamController() {
                 activeStream.getProcessors().forEach(p => {
                     adapter.setIndexHandlerTime(p, startTime);
                 });
-                playbackController.seek(startTime); //seek to period start time
             }
         } else {
             videoTrackDetected = checkTrackPresence(Constants.VIDEO);

--- a/test/unit/streaming.controllers.StreamController.js
+++ b/test/unit/streaming.controllers.StreamController.js
@@ -67,11 +67,5 @@ describe('StreamController', function () {
 
             expect(isVideoTrackPresent).to.be.false;    // jshint ignore:line
         });
-
-        it('should return Infinity when attempting to call getActiveStreamCommonEarliestTime while no activeStream has been defined', function () {
-            const earliestTime = streamController.getActiveStreamCommonEarliestTime();
-
-            expect(earliestTime).to.be.Infinity;    // jshint ignore:line
-        });
     });
 });


### PR DESCRIPTION
Hi,

as described in issue #2344 , a regression has appeared after PR #2341 has been merged. Indeed, the idea of this PR was to not execute a initial programmatic seek if a seek command was processing : good improvement. In multi period VOD stream, there was too many seek commands, so the switch between periods was broken.

@spiterikevin , could you, please, take a look at this PR?

thanks,

Nico