### PR TITLE
Make cache thresholds customizable

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -172,6 +172,7 @@ declare namespace dashjs {
         setBufferTimeAtTopQualityLongForm(value: number): void;
         setLongFormContentDurationThreshold(value: number): void;
         setRichBufferThreshold(value: number): void;
+        setCacheLoadThresholdForType(type: 'video' | 'audio', value: number): void;
         getProtectionController(): ProtectionController;
         attachProtectionController(value: ProtectionController): void;
         setProtectionData(value: ProtectionData): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -172,6 +172,7 @@ declare namespace dashjs {
         setBufferTimeAtTopQualityLongForm(value: number): void;
         setLongFormContentDurationThreshold(value: number): void;
         setRichBufferThreshold(value: number): void;
+        setCacheLoadThresholdForType(type: 'video' | 'audio', value: number): void;
         getProtectionController(): ProtectionController;
         attachProtectionController(value: ProtectionController): void;
         setProtectionData(value: ProtectionData): void;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1524,7 +1524,7 @@ function MediaPlayer() {
     }
 
     /**
-     * Obsolete since version 2.6.0.
+     * @deprecated since version 2.6.0.
      * ABR rules now switch from Throughput to Buffer Occupancy mode when there is sufficient buffer.
      * This renders the rich buffer mechanism redundant.
      *
@@ -1534,6 +1534,21 @@ function MediaPlayer() {
      */
     function setRichBufferThreshold(value) {
         throw new Error('Calling obsolete function - setRichBufferThreshold(' + value + ') has no effect.');
+    }
+
+    /**
+     * For a given media type, the threshold which defines if the response to a fragment
+     * request is coming from browser cache or not.
+     * Valid media types are "video", "audio"
+     *
+     * @default 50 milliseconds for video fragment requests; 5 milliseconds for audio fragment requests.
+     * @param {string} type 'video' or 'audio' are the type options.
+     * @param {number} value Threshold value in milliseconds.
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setCacheLoadThresholdForType(type, value) {
+        mediaPlayerModel.setCacheLoadThresholdForType(type, value);
     }
 
     /**
@@ -2786,6 +2801,7 @@ function MediaPlayer() {
         getXHRWithCredentialsForType: getXHRWithCredentialsForType,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setRichBufferThreshold: setRichBufferThreshold,
+        setCacheLoadThresholdForType: setCacheLoadThresholdForType,
         getProtectionController: getProtectionController,
         attachProtectionController: attachProtectionController,
         setProtectionData: setProtectionData,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -55,6 +55,9 @@ const BUFFER_TIME_AT_TOP_QUALITY = 30;
 const BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 60;
 const LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;
 
+const CACHE_LOAD_THRESHOLD_VIDEO = 50;
+const CACHE_LOAD_THRESHOLD_AUDIO = 5;
+
 const FRAGMENT_RETRY_ATTEMPTS = 3;
 const FRAGMENT_RETRY_INTERVAL = 1000;
 
@@ -96,7 +99,8 @@ function MediaPlayerModel() {
         xhrWithCredentials,
         fastSwitchEnabled,
         customABRRule,
-        movingAverageMethod;
+        movingAverageMethod,
+        cacheLoadThresholds;
 
     function setup() {
         UTCTimingSources = [];
@@ -150,6 +154,10 @@ function MediaPlayerModel() {
             [HTTPRequest.INDEX_SEGMENT_TYPE]:               FRAGMENT_RETRY_INTERVAL,
             [HTTPRequest.OTHER_TYPE]:                       FRAGMENT_RETRY_INTERVAL
         };
+
+        cacheLoadThresholds = {};
+        cacheLoadThresholds[Constants.VIDEO] = CACHE_LOAD_THRESHOLD_VIDEO;
+        cacheLoadThresholds[Constants.AUDIO] = CACHE_LOAD_THRESHOLD_AUDIO;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -259,6 +267,14 @@ function MediaPlayerModel() {
 
     function getLongFormContentDurationThreshold() {
         return longFormContentDurationThreshold;
+    }
+
+    function setCacheLoadThresholdForType(type, value) {
+        cacheLoadThresholds[type] = value;
+    }
+
+    function getCacheLoadThresholdForType(type) {
+        return cacheLoadThresholds[type];
     }
 
     function setBufferToKeep(value) {
@@ -470,6 +486,8 @@ function MediaPlayerModel() {
         getBufferTimeAtTopQualityLongForm: getBufferTimeAtTopQualityLongForm,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         getLongFormContentDurationThreshold: getLongFormContentDurationThreshold,
+        getCacheLoadThresholdForType: getCacheLoadThresholdForType,
+        setCacheLoadThresholdForType: setCacheLoadThresholdForType,
         setBufferToKeep: setBufferToKeep,
         getBufferToKeep: getBufferToKeep,
         setBufferPruningInterval: setBufferPruningInterval,

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -52,9 +52,6 @@ function ThroughputHistory(config) {
     const EWMA_LATENCY_SLOW_HALF_LIFE_COUNT = 2;
     const EWMA_LATENCY_FAST_HALF_LIFE_COUNT = 1;
 
-    const CACHE_LOAD_THRESHOLD_VIDEO = 50;
-    const CACHE_LOAD_THRESHOLD_AUDIO = 5;
-
     const mediaPlayerModel = config.mediaPlayerModel;
 
     let throughputDict,
@@ -74,9 +71,9 @@ function ThroughputHistory(config) {
 
     function isCachedResponse(mediaType, latencyMs, downloadTimeMs) {
         if (mediaType === Constants.VIDEO) {
-            return downloadTimeMs < CACHE_LOAD_THRESHOLD_VIDEO;
+            return downloadTimeMs < mediaPlayerModel.getCacheLoadThresholdForType(Constants.VIDEO);
         } else if (mediaType === Constants.AUDIO) {
-            return downloadTimeMs < CACHE_LOAD_THRESHOLD_AUDIO;
+            return downloadTimeMs < mediaPlayerModel.getCacheLoadThresholdForType(Constants.AUDIO);
         }
     }
 
@@ -89,7 +86,7 @@ function ThroughputHistory(config) {
         const downloadTimeInMilliseconds = (httpRequest._tfinish.getTime() - httpRequest.tresponse.getTime()) || 1; //Make sure never 0 we divide by this value. Avoid infinity!
         const downloadBytes = httpRequest.trace.reduce((a, b) => a + b.b[0], 0);
         const throughputMeasureTime = useDeadTimeLatency ? downloadTimeInMilliseconds : latencyTimeInMilliseconds + downloadTimeInMilliseconds;
-        let throughput = Math.round((8 * downloadBytes) / throughputMeasureTime); // bits/ms = kbits/s
+        const throughput = Math.round((8 * downloadBytes) / throughputMeasureTime); // bits/ms = kbits/s
 
         checkSettingsForMediaType(mediaType);
 
@@ -155,7 +152,7 @@ function ThroughputHistory(config) {
         } else if (isThroughput) {
             // if throughput samples vary a lot, average over a wider sample
             for (let i = 1; i < sampleSize; ++i) {
-                let ratio = arr[-i] / arr[-i - 1];
+                const ratio = arr[-i] / arr[-i - 1];
                 if (ratio >= THROUGHPUT_INCREASE_SCALE || ratio <= 1 / THROUGHPUT_DECREASE_SCALE) {
                     sampleSize += 1;
                     if (sampleSize === arr.length) { // cannot increase sampleSize beyond arr.length
@@ -175,8 +172,8 @@ function ThroughputHistory(config) {
     }
 
     function getAverageSlidingWindow(isThroughput, mediaType, isDynamic) {
-        let sampleSize = getSampleSize(isThroughput, mediaType, isDynamic);
-        let dict = isThroughput ? throughputDict : latencyDict;
+        const sampleSize = getSampleSize(isThroughput, mediaType, isDynamic);
+        const dict = isThroughput ? throughputDict : latencyDict;
         let arr = dict[mediaType];
 
         if (sampleSize === 0 || !arr || arr.length === 0) {
@@ -189,8 +186,8 @@ function ThroughputHistory(config) {
     }
 
     function getAverageEwma(isThroughput, mediaType) {
-        let halfLife = isThroughput ? ewmaHalfLife.throughputHalfLife : ewmaHalfLife.latencyHalfLife;
-        let ewmaObj = isThroughput ? ewmaThroughputDict[mediaType] : ewmaLatencyDict[mediaType];
+        const halfLife = isThroughput ? ewmaHalfLife.throughputHalfLife : ewmaHalfLife.latencyHalfLife;
+        const ewmaObj = isThroughput ? ewmaThroughputDict[mediaType] : ewmaLatencyDict[mediaType];
 
         if (!ewmaObj || ewmaObj.totalWeight <= 0) {
             return NaN;

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -32,6 +32,7 @@ import {
     HTTPRequest
 }
 from '../../../src/streaming/vo/metrics/HTTPRequest';
+import Constants from '../../../src/streaming/constants/Constants';
 
 const DEFAULT_UTC_TIMING_SOURCE = {
     scheme: 'urn:mpeg:dash:utc:http-xsdate:2014',
@@ -66,6 +67,9 @@ const XLINK_RETRY_INTERVAL = 500;
 const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
 
 const DEFAULT_XHR_WITH_CREDENTIALS = false;
+
+const CACHE_LOAD_THRESHOLD_VIDEO = 50;
+const CACHE_LOAD_THRESHOLD_AUDIO = 5;
 
 class MediaPlayerModelMock {
 
@@ -191,6 +195,10 @@ class MediaPlayerModelMock {
         this.retryIntervals = {
             [HTTPRequest.MPD_TYPE]: MANIFEST_RETRY_INTERVAL, [HTTPRequest.XLINK_EXPANSION_TYPE]: XLINK_RETRY_INTERVAL, [HTTPRequest.MEDIA_SEGMENT_TYPE]: FRAGMENT_RETRY_INTERVAL, [HTTPRequest.INIT_SEGMENT_TYPE]: FRAGMENT_RETRY_INTERVAL, [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: FRAGMENT_RETRY_INTERVAL, [HTTPRequest.INDEX_SEGMENT_TYPE]: FRAGMENT_RETRY_INTERVAL, [HTTPRequest.OTHER_TYPE]: FRAGMENT_RETRY_INTERVAL
         };
+
+        this.cacheLoadThresholds = {};
+        this.cacheLoadThresholds[Constants.VIDEO] = CACHE_LOAD_THRESHOLD_VIDEO;
+        this.cacheLoadThresholds[Constants.AUDIO] = CACHE_LOAD_THRESHOLD_AUDIO;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -292,6 +300,14 @@ class MediaPlayerModelMock {
 
     getLongFormContentDurationThreshold() {
         return this.longFormContentDurationThreshold;
+    }
+
+    setCacheLoadThresholdForType(type, value) {
+        this.cacheLoadThresholds[type] = value;
+    }
+
+    getCacheLoadThresholdForType(type) {
+        return this.cacheLoadThresholds[type];
     }
 
     setBufferToKeep(value) {

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -8,6 +8,7 @@ import MediaPlayer from './../../src/streaming/MediaPlayer';
 import MediaPlayerModelMock from './mocks//MediaPlayerModelMock';
 import MediaControllerMock from './mocks/MediaControllerMock';
 import ObjectUtils from './../../src/streaming/utils/ObjectUtils';
+import Constants from '../../src/streaming/constants/Constants';
 
 const expect = require('chai').expect;
 
@@ -25,21 +26,21 @@ describe('MediaPlayer', function () {
     let dummyUrl = specHelper.getDummyUrl();
 
     // init mock
-    let videoElementMock = new VideoElementMock();
-    let capaMock = new CapabilitiesMock();
-    let streamControllerMock = new StreamControllerMock();
-    let abrControllerMock = new AbrControllerMock();
-    let playbackControllerMock = new PlaybackControllerMock();
-    let mediaPlayerModel = new MediaPlayerModelMock();
-    let mediaControllerMock = new MediaControllerMock();
-    let objectUtils = ObjectUtils(context).getInstance();
+    const videoElementMock = new VideoElementMock();
+    const capaMock = new CapabilitiesMock();
+    const streamControllerMock = new StreamControllerMock();
+    const abrControllerMock = new AbrControllerMock();
+    const playbackControllerMock = new PlaybackControllerMock();
+    const mediaPlayerModel = new MediaPlayerModelMock();
+    const mediaControllerMock = new MediaControllerMock();
+    const objectUtils = ObjectUtils(context).getInstance();
     let player;
 
     beforeEach(function () {
         player = MediaPlayer().create();
 
         // to avoid unwanted log
-        let debug = player.getDebug();
+        const debug = player.getDebug();
         expect(debug).to.exist; // jshint ignore:line
         debug.setLogToBrowserConsole(false);
 
@@ -60,7 +61,7 @@ describe('MediaPlayer', function () {
     describe('Init Functions', function () {
         describe('When it is not initialized', function () {
             it('Method isReady should return false', function () {
-                let isReady = player.isReady();
+                const isReady = player.isReady();
                 expect(isReady).to.be.false; // jshint ignore:line
             });
         });
@@ -70,7 +71,7 @@ describe('MediaPlayer', function () {
                 capaMock.setMediaSourceSupported(false);
                 player.initialize(videoElementMock, dummyUrl, false);
 
-                let isReady = player.isReady();
+                const isReady = player.isReady();
                 expect(isReady).to.be.false; // jshint ignore:line
 
                 capaMock.setMediaSourceSupported(true);
@@ -78,10 +79,10 @@ describe('MediaPlayer', function () {
 
             it('Method initialize should send an error if MSE is not supported', function (done) {
                 capaMock.setMediaSourceSupported(false);
-                let playerError = function (/*e*/) {
+                const playerError = function (/*e*/) {
                     player.off('error', playerError);
 
-                    let isReady = player.isReady();
+                    const isReady = player.isReady();
                     expect(isReady).to.be.false; // jshint ignore:line
 
                     // reinit mock
@@ -99,7 +100,7 @@ describe('MediaPlayer', function () {
                 player.initialize(videoElementMock, dummyUrl, false);
             });
             it('Method isReady should return true', function () {
-                let isReady = player.isReady();
+                const isReady = player.isReady();
                 expect(isReady).to.be.true; // jshint ignore:line
             });
         });
@@ -249,15 +250,15 @@ describe('MediaPlayer', function () {
                 let playbackRate = videoElementMock.playbackRate;
                 expect(playbackRate).to.equal(0);
 
-                let newPlaybackRate = 5;
+                const newPlaybackRate = 5;
                 player.setPlaybackRate(newPlaybackRate);
                 playbackRate = videoElementMock.playbackRate;
                 expect(playbackRate).to.equal(newPlaybackRate);
             });
 
             it('Method setPlaybackRate should return video element playback rate', function () {
-                let elementPlayBackRate = videoElementMock.playbackRate;
-                let playerPlayBackRate = player.getPlaybackRate();
+                const elementPlayBackRate = videoElementMock.playbackRate;
+                const playerPlayBackRate = player.getPlaybackRate();
                 expect(playerPlayBackRate).to.equal(elementPlayBackRate);
             });
 
@@ -338,12 +339,7 @@ describe('MediaPlayer', function () {
                 duration = player.duration();
                 expect(duration).to.equal(4);
             });
-            //
-            //            it('Method timeAsUTC should throw an exception', function () {});
-            //
-            //            it('Method durationAsUTC should throw an exception', function () {});
         });
-
     });
 
     describe('AbrController Functions', function () {
@@ -507,7 +503,6 @@ describe('MediaPlayer', function () {
         });
 
         describe('When it is initialized', function () {
-
             beforeEach(function () {
                 player.initialize(videoElementMock, dummyUrl, false);
             });
@@ -786,6 +781,24 @@ describe('MediaPlayer', function () {
             expect(LongFormContentDurationThreshold).to.equal(50);
         });
 
+        it('should configure cacheLoadThresholds', function () {
+            let cacheLoadThresholdForVideo = mediaPlayerModel.getCacheLoadThresholdForType(Constants.VIDEO);
+            expect(cacheLoadThresholdForVideo).to.equal(50);
+
+            player.setCacheLoadThresholdForType(Constants.VIDEO, 10);
+
+            cacheLoadThresholdForVideo = mediaPlayerModel.getCacheLoadThresholdForType(Constants.VIDEO);
+            expect(cacheLoadThresholdForVideo).to.equal(10);
+
+            let cacheLoadThresholdForAudio = mediaPlayerModel.getCacheLoadThresholdForType(Constants.AUDIO);
+            expect(cacheLoadThresholdForAudio).to.equal(5);
+
+            player.setCacheLoadThresholdForType(Constants.AUDIO, 2);
+
+            cacheLoadThresholdForAudio = mediaPlayerModel.getCacheLoadThresholdForType(Constants.AUDIO);
+            expect(cacheLoadThresholdForAudio).to.equal(2);
+        });
+
         it('should configure BandwidthSafetyFactor', function () {
             let BandwidthSafetyFactor = mediaPlayerModel.getBandwidthSafetyFactor();
             expect(BandwidthSafetyFactor).to.equal(0.9);
@@ -870,7 +883,6 @@ describe('MediaPlayer', function () {
     });
 
     describe('Text Management Functions', function () {
-
         describe('When it is not initialized', function () {
             it('Method setTextTrack should throw an exception', function () {
                 expect(player.setTextTrack).to.throw(MediaPlayer.PLAYBACK_NOT_INITIALIZED_ERROR);
@@ -896,6 +908,7 @@ describe('MediaPlayer', function () {
                 expect(player.getVideoElement).to.throw(MediaPlayer.ELEMENT_NOT_ATTACHED_ERROR);
             });
         });
+
         describe('When it is initialized', function () {
             beforeEach(function () {
                 player.initialize(videoElementMock, dummyUrl, false);
@@ -903,34 +916,32 @@ describe('MediaPlayer', function () {
 
             it('Method getVideoElement should return video element', function () {
 
-                let element = player.getVideoElement();
-                let areEquals = objectUtils.areEqual(element, videoElementMock);
+                const element = player.getVideoElement();
+                const areEquals = objectUtils.areEqual(element, videoElementMock);
                 expect(areEquals).to.be.true; // jshint ignore:line
             });
 
             it('should be able to attach video container', function () {
-
                 let videoContainer = player.getVideoContainer();
                 expect(videoContainer).to.be.undefined; // jshint ignore:line
 
-                let myVideoContainer = {
+                const myVideoContainer = {
                     videoContainer: 'videoContainer'
                 };
                 player.attachVideoContainer(myVideoContainer);
 
                 videoContainer = player.getVideoContainer();
-                let areEquals = objectUtils.areEqual(myVideoContainer, videoContainer);
+                const areEquals = objectUtils.areEqual(myVideoContainer, videoContainer);
                 expect(areEquals).to.be.true; // jshint ignore:line
             });
 
             it('should be able to attach view', function () {
-
                 let element = player.getVideoElement();
-                let objectUtils = ObjectUtils(context).getInstance();
+                const objectUtils = ObjectUtils(context).getInstance();
                 let areEquals = objectUtils.areEqual(element, videoElementMock);
                 expect(areEquals).to.be.true; // jshint ignore:line
 
-                let myNewView = {
+                const myNewView = {
                     view: 'view'
                 };
 
@@ -943,18 +954,17 @@ describe('MediaPlayer', function () {
             });
 
             it('should be able to attach TTML renderer div', function () {
-
                 let ttmlRenderer = player.getTTMLRenderingDiv();
                 expect(ttmlRenderer).to.be.undefined; // jshint ignore:line
 
-                let myTTMLRenderer = {
+                const myTTMLRenderer = {
                     style: {}
                 };
 
                 player.attachTTMLRenderingDiv(myTTMLRenderer);
 
                 ttmlRenderer = player.getTTMLRenderingDiv();
-                let areEquals = objectUtils.areEqual(ttmlRenderer, myTTMLRenderer);
+                const areEquals = objectUtils.areEqual(ttmlRenderer, myTTMLRenderer);
                 expect(areEquals).to.be.true; // jshint ignore:line
             });
         });
@@ -1021,17 +1031,17 @@ describe('MediaPlayer', function () {
             });
 
             it('Method getBitrateInfoListFor should return bitrate info list', function () {
-                let bitrateList = player.getBitrateInfoListFor();
+                const bitrateList = player.getBitrateInfoListFor();
                 expect(bitrateList.length).to.equal(2);
             });
 
             it('Method getTracksFor should return tracks', function () {
-                let tracks = player.getTracksFor();
+                const tracks = player.getTracksFor();
                 expect(tracks.length).to.equal(2);
             });
 
             it('Method getCurrentTrackFor should return current track', function () {
-                let track = player.getCurrentTrackFor();
+                const track = player.getCurrentTrackFor();
                 expect(track).to.equal('track1');
             });
 
@@ -1088,7 +1098,6 @@ describe('MediaPlayer', function () {
     });
 
     describe('Metrics Functions', function () {
-
         describe('When it is initialized', function () {
             beforeEach(function () {
                 player.initialize(videoElementMock, dummyUrl, false);
@@ -1108,5 +1117,4 @@ describe('MediaPlayer', function () {
             });
         });
     });
-
 });


### PR DESCRIPTION
See discussion in #1992.

Allow the user to define its own thresholds for the cache detection mechanism. This threshold is used by the ABR algorithm to detect when the response to a request is coming from browser cache. 

After lot of empirical tests trying to find optimum values for cache load thresholds, I didn't find ones that behave better than the ones currently defined (they highly depends on the bitrate of the video/audio and the cpu/gpu of the device). So, this PR is keeping default values as they are and is adding a new method to MediaPlayer (`setCacheLoadThresholdForType`) that allows to change them.
  