### PR TITLE
Improve seek velocity

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -188,7 +188,6 @@ function ScheduleController(config) {
             bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())) {
 
             const getNextFragment = function () {
-                log('ScheduleController - ' + type + ' - getNextFragment');
                 const fragmentController = streamProcessor.getFragmentController();
                 if (switchTrack) {
                     log('ScheduleController - ' + type + ' - switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -432,8 +432,11 @@ function ScheduleController(config) {
         if (e.streamProcessor !== streamProcessor) {
             return;
         }
-        log('[ScheduleController][' + type + '] Request ' + e.request.url + ' has been aborted');
-        replaceRequest(e.request);
+        log('[ScheduleController][onFragmentLoadingAbandoned] for ' + type + ', request: ' + e.request.url + ' has been aborted');
+        if (!playbackController.isSeeking()) {
+            log('[ScheduleController][onFragmentLoadingAbandoned] for ' + type + ', request: ' + e.request.url + ' has to be downloaded again, origin is not seeking process');
+            replaceRequest(e.request);
+        }
         isFragmentProcessingInProgress = false;
         startScheduleTimer(0);
     }
@@ -512,6 +515,9 @@ function ScheduleController(config) {
         //if, during the seek command, the scheduleController is waiting : stop waiting, request chunk as soon as possible
         if (!isFragmentProcessingInProgress) {
             startScheduleTimer(0);
+        } else {
+            log('[ScheduleController][onPlaybackSeeking] for ' + type + ', call fragmentModel.abortRequests in order to seek quicker');
+            fragmentModel.abortRequests();
         }
     }
 


### PR DESCRIPTION
Hi,

when a seek command occurs, dash.js has to download as quick as possible datas at the new specific time. In the log message, just below, we can see that between the seek command and the call to the new video segment for the time 544.31, some video datas have been appended. Those datas are timestamped at the time before the seek.

````
[125688] Seeking to: 544.31 <= A seek command occurs

[125689] Waiting for more buffer before starting playback for video 
[125689] Waiting for more buffer before starting playback for audio 
[125693] AbrController (audio) stay on 0/0 (buffer: 0) 
[125693] ScheduleController - audio - getNextFragment 
[125693] Getting the request for audio time : 544.31 
[125694] Index for audio time 544.31 is 135 
[125694] SegmentTemplate: 541.44 / 634.566 
[125694] ScheduleController - audio - getNextFragment - request is https://dash.akamaized.net/akamai/bbb_30fps/bbb_a64k/bbb_a64k_136.m4a 
[126356] Got enough buffer to start for audio 
[126358] Buffered Range for type: audio : 124.330666  -  136.362666 
[126358] Buffered Range for type: audio : 188.501333  -  196.522666 
[126359] Buffered Range for type: audio : 200.533333  -  212.565332 
[126359] Buffered Range for type: audio : 385.024  -  457.215999 
[126359] Buffered Range for type: audio : 541.44  -  545.450666 
[126362] ThroughputRule requesting switch to index:  0 type:  audio Average throughput 15703 kbps 
[126363] AbrController (audio) stay on 0/0 (buffer: 1.141) 
[126364] ScheduleController - audio - getNextFragment 
[126364] Getting the request for audio time : 545.4506666666667 
[126364] Index for audio time 545.4506666666667 is 135 
[126365] SegmentTemplate: 541.44 / 634.566 
[126365] Getting the next request at index: 136 
[126365] SegmentTemplate: 545.45067 / 634.566 
[126366] ScheduleController - audio - getNextFragment - request is https://dash.akamaized.net/akamai/bbb_30fps/bbb_a64k/bbb_a64k_137.m4a

[126369] Buffered Range for type: video : 124  -  139.999999 <= A video segment has been appended.
[126369] Buffered Range for type: video : 188  -  191.999999 
[126370] Buffered Range for type: video : 200  -  215.999999 
[126370] Buffered Range for type: video : 388  -  455.999999 

[126372] Switch history rule index: 7 samples: 8 drops: 1 
[126373] AbrController (video) stay on 7/9 (buffer: 0) 
[126373] ScheduleController - video - getNextFragment 
[126373] Getting the request for video time : 544.31 
[126374] Index for video time 544.31 is 135 
[126374] SegmentTemplate: 540 / 634.566 
[126375] ScheduleController - video - getNextFragment - request is https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps_1280x720_4000k/bbb_30fps_1280x720_4000k_136.m4v
````
 So, this PR has to abort requests that are downloading in order to seek quicker.
