### PR TITLE
Fix #2355 - check for correct DOM error on XML parse failure

### DIFF
--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -537,7 +537,7 @@ function X2JS(config) {
             var parsererrorNS = null;
             try {
                 xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
-                if(xmlDoc.getElementsByTagNameNS("*", "parseerror").length > 0) {
+                if(xmlDoc.getElementsByTagNameNS("*", "parsererror").length > 0) {
                     xmlDoc = null;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "iron-node": "^3.0.15",
     "istanbul": "^0.4.1",
     "jsdoc": "^3.4.0",
+    "jsdom": "^11.5.1",
     "load-grunt-tasks": "^3.1.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",
     "time-grunt": "^1.2.0",
-    "uglify-js": "^2.4.21",
-    "xmldom": "^0.1.16"
+    "uglify-js": "^2.4.21"
   },
   "dependencies": {
     "codem-isoboxer": "0.3.5",

--- a/test/unit/dash.DashParser.js
+++ b/test/unit/dash.DashParser.js
@@ -1,7 +1,8 @@
 import DashParser from '../../src/dash/parser/DashParser';
-
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
+
 const expect = require('chai').expect;
+const jsdom = require('jsdom').JSDOM;
 
 const context = {};
 
@@ -15,7 +16,8 @@ describe('DashParser', function () {
                     now: function () {
                         return Date.now();
                     }
-                }
+                },
+                DOMParser:  new jsdom().window.DOMParser
             };
         }
     });
@@ -38,6 +40,13 @@ describe('DashParser', function () {
         const errorHandlerMock = new ErrorHandlerMock();
         dashParser = DashParser(context).create({errorHandler: errorHandlerMock});
         dashParser.parse();
+        expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
+    });
+
+    it('should throw an error when parse is called with invalid data', function () {
+        const errorHandlerMock = new ErrorHandlerMock();
+        dashParser = DashParser(context).create({errorHandler: errorHandlerMock});
+        dashParser.parse('<MPD');
         expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
     });
 });

--- a/test/unit/mss.parser.MssParser.js
+++ b/test/unit/mss.parser.MssParser.js
@@ -4,7 +4,7 @@ import Debug from '../../src/core/Debug';
 
 const expect = require('chai').expect;
 const fs = require('fs');
-const domParser = require('xmldom').DOMParser;
+const jsdom = require('jsdom').JSDOM;
 const context = {};
 
 describe('MssParser', function () {
@@ -20,7 +20,7 @@ describe('MssParser', function () {
                         return Date.now();
                     }
                 },
-                DOMParser: domParser
+                DOMParser:  new jsdom().window.DOMParser
             };
         }
     });

--- a/test/unit/mss.parser.MssParser.js
+++ b/test/unit/mss.parser.MssParser.js
@@ -2,6 +2,8 @@ import MssParser from '../../src/mss/parser/MssParser';
 import MediaPlayerModel from '../../src/streaming/models/MediaPlayerModel';
 import Debug from '../../src/core/Debug';
 
+import ErrorHandlerMock from './mocks/ErrorHandlerMock';
+
 const expect = require('chai').expect;
 const fs = require('fs');
 const jsdom = require('jsdom').JSDOM;
@@ -9,7 +11,8 @@ const context = {};
 
 describe('MssParser', function () {
 
-    let mssParser;
+    let mssParser,
+        errorHandlerMock;
     const mediaPlayerModel = MediaPlayerModel().getInstance();
 
     beforeEach(function () {
@@ -30,9 +33,11 @@ describe('MssParser', function () {
     });
 
     beforeEach(function () {
+        errorHandlerMock = new ErrorHandlerMock();
         mssParser = MssParser().create({
             mediaPlayerModel: mediaPlayerModel,
-            log: Debug(context).getInstance().log
+            log: Debug(context).getInstance().log,
+            errHandler: errorHandlerMock
         });
 
         expect(mssParser).to.exist; // jshint ignore:line
@@ -71,5 +76,9 @@ describe('MssParser', function () {
         expect(adaptations).to.be.an.instanceof(Array);
         expect(adaptations).to.have.lengthOf(1);
         expect(adaptations[0].contentType).to.equal('audio');
+    });
+    it('should throw an error when parse is called with invalid smooth data', function () {
+        mssParser.parse('<SmoothStreamingMedia');
+        expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
     });
 });

--- a/test/unit/streaming.controllers.XLinkController.js
+++ b/test/unit/streaming.controllers.XLinkController.js
@@ -7,7 +7,7 @@ import EventBus from '../../src/core/EventBus';
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 
 const fs = require('fs');
-const domParser = require('xmldom').DOMParser;
+const jsdom = require('jsdom').JSDOM;
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -49,7 +49,7 @@ describe('XlinkController', function () {
                         return Date.now();
                     }
                 },
-                DOMParser: domParser
+                DOMParser: new jsdom().window.DOMParser
             };
         }
     });

--- a/test/unit/streaming.protection.servers.PlayReady.js
+++ b/test/unit/streaming.protection.servers.PlayReady.js
@@ -2,7 +2,7 @@ import PlayReady from '../../src/streaming/protection/servers/PlayReady';
 
 const expect = require('chai').expect;
 const fs = require('fs');
-const domParser = require('xmldom').DOMParser;
+const jsdom = require('jsdom').JSDOM;
 
 describe('PlayReady', function () {
 
@@ -17,7 +17,7 @@ describe('PlayReady', function () {
         beforeEach(function () {
             if (typeof window === 'undefined') {
                 global.window = {
-                    DOMParser: domParser
+                    DOMParser: new jsdom().window.DOMParser
                 };
             }
             licenseServerData = PlayReady(context).getInstance();


### PR DESCRIPTION
Also added a test.

Requires jsdom as no other node xml parser I can find seems to follow the spec wrt `parsererror`. We could consider replacing xmldom used elsewhere to cut out a dev dependency.