### PR TITLE
Multiperiod with uri start time bug fix

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -249,6 +249,17 @@ function PlaybackController() {
         }
     }
 
+    function getStartTimeFromUriParameters() {
+        const fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
+        let uriParameters;
+        if (fragData) {
+            uriParameters = {};
+            uriParameters.fragS = parseInt(fragData.s, 10);
+            uriParameters.fragT = parseInt(fragData.t, 10);
+        }
+        return uriParameters;
+    }
+
     /**
      * @param {boolean} ignoreStartOffset - ignore URL fragment start offset if true
      * @param {number} liveEdge - liveEdge value
@@ -257,14 +268,12 @@ function PlaybackController() {
      */
     function getStreamStartTime(ignoreStartOffset, liveEdge) {
         let presentationStartTime;
-        const fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
         let startTimeOffset = NaN;
+        const uriParameters = getStartTimeFromUriParameters();
 
-        if (fragData) {
-            const fragS = parseInt(fragData.s, 10);
-            const fragT = parseInt(fragData.t, 10);
+        if (uriParameters) {
             if (!ignoreStartOffset) {
-                startTimeOffset = !isNaN(fragS) ? fragS : fragT;
+                startTimeOffset = !isNaN(uriParameters.fragS) ? uriParameters.fragS : uriParameters.fragT;
             } else {
                 startTimeOffset = streamInfo.start;
             }
@@ -570,6 +579,7 @@ function PlaybackController() {
     instance = {
         initialize: initialize,
         setConfig: setConfig,
+        getStartTimeFromUriParameters: getStartTimeFromUriParameters,
         getStreamStartTime: getStreamStartTime,
         getTimeToStreamEnd: getTimeToStreamEnd,
         getTime: getTime,

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -440,7 +440,13 @@ function StreamController() {
             if (!activeStream) {
                 //const initStream = streamsInfo[0].manifestInfo.isDynamic ? streams[streams.length -1] : streams[0];
                 //TODO we need to figure out what the correct starting period is here and not just go to first or last in array.
-                switchStream(null, streams[0], NaN);
+                const startTimeFormUriParameters = playbackController.getStartTimeFromUriParameters();
+                let initialStream = null;
+                if (startTimeFormUriParameters) {
+                    const initialTime = !isNaN(startTimeFormUriParameters.fragS) ? startTimeFormUriParameters.fragS : startTimeFormUriParameters.fragT;
+                    initialStream = getStreamForTime(initialTime);
+                }
+                switchStream(null, initialStream !== null ? initialStream : streams[0], NaN);
             }
 
             eventBus.trigger(Events.STREAMS_COMPOSED);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -438,8 +438,7 @@ function StreamController() {
             }
 
             if (!activeStream) {
-                //const initStream = streamsInfo[0].manifestInfo.isDynamic ? streams[streams.length -1] : streams[0];
-                //TODO we need to figure out what the correct starting period is here and not just go to first or last in array.
+                // we need to figure out what the correct starting period is
                 const startTimeFormUriParameters = playbackController.getStartTimeFromUriParameters();
                 let initialStream = null;
                 if (startTimeFormUriParameters) {


### PR DESCRIPTION
Hi,

since dash.js 2.6.0 version, the definition of start time, in uri parameters, for multi period streams may not be taken into account. This could happen if the desired time is not in first period range.

In order to fix it, this PR adds, in composeStreams function, the selection of period based on uri parameters. If no period is found, the first one is selected which is the previous behavior.

Nico