### PR TITLE
Speed up build time in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
     username: epiclabsdash1
     access_key:
       secure: v5IPr/NWJT6QEA1lyMn08dsiTEXqL0zb/lB9b7FcpGB08+5fC4KbyBv/xIWQy/j9RMX19tqDgPjGl8lRGYOApcoeIbNE6/5XzdHxFD1zwDDBeyuoXyRRKVrtFoDfYAcmfVJFAP8bcLZXu6mhjO1EYaD0//s4URmb6VlPGTiP5w0=
+cache:
+  directories:
+    - node_modules
 stages:
   - name: build
     # Run build stage except if cron job

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha test/unit --require mochahook",
     "test-functional": "node node_modules/intern/runner.js config=test/functional/testsCommon.js browsers=$BROWSER selenium=remote app=remote_all && node node_modules/intern/runner.js config=test/functional/testsCommon.js browsers=$BROWSER selenium=remote app=remote_mss",
     "dev": "grunt watch:dev",
+    "prepublish": "grunt githooks",
     "prepublishOnly": "grunt prepublish",
     "debug": "iron-mocha --require mochahook",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha --require mochahook -- test/"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/unit --require mochahook",
     "test-functional": "node node_modules/intern/runner.js config=test/functional/testsCommon.js browsers=$BROWSER selenium=remote app=remote_all && node node_modules/intern/runner.js config=test/functional/testsCommon.js browsers=$BROWSER selenium=remote app=remote_mss",
     "dev": "grunt watch:dev",
-    "prepublish": "grunt prepublish",
+    "prepublishOnly": "grunt prepublish",
     "debug": "iron-mocha --require mochahook",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha --require mochahook -- test/"
   },


### PR DESCRIPTION
These changes reduce build time from 3-4 minutes to around 2 minutes. Changes:

* Setup cache for node_modules folder to speed up build times in Travis and so our CI process
* Don't build on prepublish npm task. That implies Travis building two times the project per request (one after npm install, the other one to prepare the deployment). Furthermore, for local environment, I don't see any reason for building the project during npm install. 
