### PR TITLE
Multiperiod pause and end detection bug fix

### DIFF
--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -129,7 +129,7 @@ function MssHandler(config) {
                         processor.getType() === constants.AUDIO ||
                         processor.getType() === constants.FRAGMENTED_TEXT) {
 
-                        // check taht there is no fragment info controller registered to processor
+                        // check that there is no fragment info controller registered to processor
                         let i;
                         let alreadyRegistered = false;
                         let externalControllers = processor.getExternalControllers();

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -109,9 +109,6 @@ function Stream(config) {
             initializeMedia(mediaSource);
             isStreamActivated = true;
         }
-        //else { // TODO Check track change mode but why is this here. commented it out for now to check.
-        //    createBuffers();
-        //}
     }
 
     /**

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -252,7 +252,8 @@ function BufferController(config) {
         if (isBufferingCompleted) {
             seekClearedBufferingCompleted = true;
             isBufferingCompleted = false;
-            maxAppendedIndex = 0;
+            //a seek command has occured, reset lastIndex value, it will be set next time that onStreamCompleted will be called.
+            lastIndex = Number.POSITIVE_INFINITY;
         }
         seekStartTime = undefined;
         onPlaybackProgression();

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -148,10 +148,6 @@ function StreamController() {
                 metricsModel.addDroppedFrames(Constants.VIDEO, playbackQuality);
             }
         }
-
-        // Sometimes after seeking timeUpdateHandler is called before seekingHandler and a new stream starts
-        // from beginning instead of from a chosen position. So we do nothing if the player is in the seeking state
-        if (playbackController.isSeeking()) return;
     }
 
     function onPlaybackSeeking(e) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -362,8 +362,8 @@ function StreamController() {
 
         activeStream.activate(mediaSource);
 
-        isAudioTrackPresent();
-        isVideoTrackPresent();
+        audioTrackDetected = checkTrackPresence(Constants.AUDIO);
+        videoTrackDetected = checkTrackPresence(Constants.VIDEO);
 
         if (!initialPlayback) {
             if (!isNaN(seekTime)) {
@@ -547,16 +547,10 @@ function StreamController() {
     }
 
     function isAudioTrackPresent() {
-        if (audioTrackDetected === undefined) {
-            audioTrackDetected = checkTrackPresence(Constants.AUDIO);
-        }
         return audioTrackDetected;
     }
 
     function isVideoTrackPresent() {
-        if (videoTrackDetected === undefined) {
-            videoTrackDetected = checkTrackPresence(Constants.VIDEO);
-        }
         return videoTrackDetected;
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -167,6 +167,7 @@ function StreamController() {
     }
 
     function onPlaybackStarted( /*e*/ ) {
+        log('[StreamController][onPlaybackStarted]');
         if (initialPlayback) {
             initialPlayback = false;
             addPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
@@ -179,6 +180,7 @@ function StreamController() {
     }
 
     function onPlaybackPaused(e) {
+        log('[StreamController][onPlaybackPaused]');
         if (!e.ended) {
             isPaused = true;
             flushPlaylistMetrics(PlayListTrace.USER_REQUEST_STOP_REASON);
@@ -188,7 +190,7 @@ function StreamController() {
     function onStreamBufferingCompleted() {
         const isLast = getActiveStreamInfo().isLast;
         if (mediaSource && isLast) {
-            log('[StreamController] onStreamBufferingCompleted calls signalEndOfStream of mediaSourceController');
+            log('[StreamController][onStreamBufferingCompleted] calls signalEndOfStream of mediaSourceController.');
             mediaSourceController.signalEndOfStream(mediaSource);
         } else if (mediaSource && playbackEndedTimerId === undefined) {
             //send PLAYBACK_ENDED in order switch to a new period, wait until the end of playing

--- a/test/unit/streaming.controllers.StreamController.js
+++ b/test/unit/streaming.controllers.StreamController.js
@@ -56,16 +56,16 @@ describe('StreamController', function () {
             expect(activeStreamProcessorsArray).to.be.empty;                // jshint ignore:line
         });
 
-        it('should return false when attempting to call isAudioTrackPresent while no activeStream has been defined', function () {
+        it('should return undefined when attempting to call isAudioTrackPresent while no activeStream has been defined', function () {
             const isAudioTrackPresent = streamController.isAudioTrackPresent();
 
-            expect(isAudioTrackPresent).to.be.false;    // jshint ignore:line
+            expect(isAudioTrackPresent).to.be.undefined;    // jshint ignore:line
         });
 
-        it('should return false when attempting to call isVideoTrackPresent while no activeStream has been defined', function () {
+        it('should return undefined when attempting to call isVideoTrackPresent while no activeStream has been defined', function () {
             const isVideoTrackPresent = streamController.isVideoTrackPresent();
 
-            expect(isVideoTrackPresent).to.be.false;    // jshint ignore:line
+            expect(isVideoTrackPresent).to.be.undefined;    // jshint ignore:line
         });
     });
 });


### PR DESCRIPTION
Hi,

this PR has to solve an issue with multi period stream. For instance, the user is watching the first period of a VOD stream. The end of period stream buffering is detected, but the user decide to do a pause. Before this PR, the timer in StreamController which had to send PLAYBACK_ENDED event was not stopped.

I still have some questions about the same behavior with a Live stream : what is the player expected to do?

Nico