### PR TITLE
set default value to responseType of XMLHttpRequest.

### DIFF
--- a/src/streaming/vo/TextRequest.js
+++ b/src/streaming/vo/TextRequest.js
@@ -41,7 +41,7 @@ class TextRequest extends FragmentRequest {
         this.url = url || null;
         this.type = type || null;
         this.mediaType = Constants.STREAM;
-        this.responseType = Constants.TEXT;
+        this.responseType = ''; //'text' value returns a bad encoding response in Firefox
     }
 }
 


### PR DESCRIPTION
Hi,

this PR has to solve an issue in Firefox with MSS streams (for instance : http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest). ResponseType of XMLHttpRequest was set to 'text' value, the responses body was not well encoded. The use of default responseType solve this issue.

Nico