### PR TITLE
Fix issue with live stream thumbnails

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -141,6 +141,10 @@
         {
           "name": "Two adaption sets with different thumb resolutions",
           "url": "http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd"
+        },
+        {
+          "name": "Live stream, Single adaptation set, 1x1 tiles",
+          "url": "http://vm2.dashif.org/livesim-dev/testpic_2s/Manifest_thumbs.mpd"
         }
       ]
     },

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2231,7 +2231,7 @@ function MediaPlayer() {
             return null;
         }
 
-        const timeInPeriod = streamController.getTimeRelativeToStreamId(time, stream.getId());
+        const timeInPeriod = streamController.getTimeRelativeToStreamId(s, stream.getId());
         return thumbnailController.get(timeInPeriod);
     }
 


### PR DESCRIPTION
This PR fixes #2359 and then enable Thumbnails support for live streams. 

@TobbeEdgeware, for your information, I have added the live stream with thumbnails stream that you created to the Dash reference player list of sample streams. Thanks to it I was able to detect the issue. Thanks!