### PR TITLE
Adding new IMSC1 sample to reference player

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -112,6 +112,10 @@
           "moreInfo": "http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/"
         },
         {
+            "url": "https://dash.akamaized.net/dash264/CTA/imsc1/IT1-20171027_dash.mpd",
+            "name": "IMSC1 Text Subtitles via sidecar file"
+        },
+        {
           "url": "https://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img.mpd",
           "name": "IMSC1 (CMAF) Image Subtitles",
           "moreInfo": "https://vm2.dashif.org/dash/vod/testpic_2s/imsc1_img_subs_info.html"


### PR DESCRIPTION
This sample was provided by the CTA and contains an aggressive exercising of many features of the IMSC1 standard. Uses IMSC1 Text contained in a sidecar .ttml file. 