### PR TITLE
Show dialog when there is an error on the player

### DIFF
--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -206,6 +206,15 @@ a:hover {
 }
 
 /****************************
+    ERROR MODAL
+*****************************/
+
+.errorModalHeader {
+    background-color: #ff1a1a;
+    color: white;
+}
+
+/****************************
     CHARTING AND CHART TABS
 *****************************/
 

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -200,6 +200,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.fastSwitchSelected = true;
     $scope.ABRStrategy = 'abrDynamic';
 
+    // Error management
+    $scope.error = '';
+    $scope.errorType = '';
+
     ////////////////////////////////////////
     //
     // Player Setup
@@ -229,7 +233,12 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.version = $scope.player.getVersion();
 
     $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) { /* jshint ignore:line */
-        console.error(e.error + ' : ' + e.event.message);
+        var message = e.event.message ? e.event.message : typeof e.event === 'string' ? e.event: e.event.url ? e.event.url : '';
+        $scope.$apply(function () {
+            $scope.error = message;
+            $scope.errorType = e.error;
+        });
+        $("#errorModal").modal('show');
     }, $scope);
 
     $scope.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, function (e) { /* jshint ignore:line */

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -387,6 +387,23 @@
             </div>
         </div>
 
+        <!-- ERROR MODAL -->
+        <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="errorModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header errorModalHeader">
+                        <h5 class="modal-title" id="errorModalLabel">Error {{errorType}}</h5>
+                    </div>
+                    <div class="modal-body">
+                        {{error}}
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+      </div>
+
         <!-- CHARTING -->
        <div class="chart-panel">
             <div class="chart-controls">


### PR DESCRIPTION
Fix #2379 
Show a dialog when there is an error on the player instead of only logging on console. As errors are not unified it tries to guess the best string to show. When #2179 is fixed, it can show a more user friendly error.