### PR TITLE
handle parse error for chrome

### DIFF
--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -100,7 +100,7 @@ function DashParser(config) {
 
             manifest = converter.xml_str2json(data);
 
-            if (!manifest) {
+            if (!manifest || (manifest.body && manifest.body.parsererror)) {
                 throw new Error('parser error');
             }
 


### PR DESCRIPTION
When Chrome fails to parse an XML document, it returns a hash with a `body.parsererror`. This PR makes dash.js actually throw an error when Chrome fails to parse an XML document.