### PR TITLE
Use protection module without video element

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -10,13 +10,13 @@ declare namespace dashjs {
     interface VideoModel { }
 
     interface ProtectionController {
-        initialize(manifest: object, audioInfo: StreamInfo, videoInfo: StreamInfo): void;
-        setProtectionData(protData: object);
+        initialize(manifest: object | null, audioInfo: ProtectionMediaInfo, videoInfo: ProtectionMediaInfo): void;
+        setProtectionData(protData: object): void;
         setRobustnessLevel(level: string): void;
-        setSessionType(type: string);
-        loadKeySession(id: string);
-        closeSession(session: SessionToken);
-        removeKeySession(session: SessionToken);
+        setSessionType(type: string): void;
+        loadKeySession(id: string): void;
+        closeKeySession(session: SessionToken): void;
+        removeKeySession(session: SessionToken): void;
     }
 
     export interface Bitrate {
@@ -45,6 +45,11 @@ declare namespace dashjs {
         bitrateList: Bitrate[];
     }
 
+    export class ProtectionMediaInfo {
+        codec: string | null;
+        contentProtection: any | null;
+    }
+    
     export interface MediaPlayerClass {
         initialize(view?: HTMLElement, source?: string, autoPlay?: boolean): void;
         on(type: AstInFutureEvent['type'], listener: (e: AstInFutureEvent) => void, scope?: object): void;

--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -10,7 +10,13 @@ declare namespace dashjs {
     interface VideoModel { }
 
     interface ProtectionController {
+        initialize(manifest: object, audioInfo: StreamInfo, videoInfo: StreamInfo): void;
+        setProtectionData(protData: object);
         setRobustnessLevel(level: string): void;
+        setSessionType(type: string);
+        loadKeySession(id: string);
+        closeSession(session: SessionToken);
+        removeKeySession(session: SessionToken);
     }
 
     export interface Bitrate {

--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -60,6 +60,7 @@ declare namespace dashjs {
         on(type: KeyMessageEvent['type'], listener: (e: KeyMessageEvent) => void, scope?: object): void;
         on(type: KeySessionClosedEvent['type'], listener: (e: KeySessionClosedEvent) => void, scope?: object): void;
         on(type: KeySessionEvent['type'], listener: (e: KeySessionEvent) => void, scope?: object): void;
+        on(type: KeyStatusesChangedEvent['type'], listener: (e: KeyStatusesChangedEvent) => void, scope?: object): void;
         on(type: KeySystemSelectedEvent['type'], listener: (e: KeySystemSelectedEvent) => void, scope?: object): void;
         on(type: LicenseRequestCompleteEvent['type'], listener: (e: LicenseRequestCompleteEvent) => void, scope?: object): void;
         on(type: LogEvent['type'], listener: (e: LogEvent) => void, scope?: object): void;
@@ -352,9 +353,14 @@ declare namespace dashjs {
     }
 
     export interface KeySessionEvent extends Event {
-        type: MediaPlayerEvents['KEY_SESSION_CREATED' | 'KEY_STATUSES_CHANGED'];
+        type: MediaPlayerEvents['KEY_SESSION_CREATED'];
         data: SessionToken | null;
         error?: string;
+    }
+
+    export interface KeyStatusesChangedEvent extends Event {
+        type: MediaPlayerEvents['KEY_STATUSES_CHANGED'];
+        data: SessionToken;
     }
 
     export interface KeySystemSelectedEvent extends Event {

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,13 +10,13 @@ declare namespace dashjs {
     interface VideoModel { }
 
     interface ProtectionController {
-        initialize(manifest: object, audioInfo: StreamInfo, videoInfo: StreamInfo): void;
-        setProtectionData(protData: object);
+        initialize(manifest: object | null, audioInfo: ProtectionMediaInfo, videoInfo: ProtectionMediaInfo): void;
+        setProtectionData(protData: object): void;
         setRobustnessLevel(level: string): void;
-        setSessionType(type: string);
-        loadKeySession(id: string);
-        closeSession(session: SessionToken);
-        removeKeySession(session: SessionToken);
+        setSessionType(type: string): void;
+        loadKeySession(id: string): void;
+        closeKeySession(session: SessionToken): void;
+        removeKeySession(session: SessionToken): void;
     }
 
     export interface Bitrate {
@@ -45,6 +45,11 @@ declare namespace dashjs {
         bitrateList: Bitrate[];
     }
 
+    export class ProtectionMediaInfo {
+        codec: string | null;
+        contentProtection: any | null;
+    }
+    
     export interface MediaPlayerClass {
         initialize(view?: HTMLElement, source?: string, autoPlay?: boolean): void;
         on(type: AstInFutureEvent['type'], listener: (e: AstInFutureEvent) => void, scope?: object): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,13 @@ declare namespace dashjs {
     interface VideoModel { }
 
     interface ProtectionController {
+        initialize(manifest: object, audioInfo: StreamInfo, videoInfo: StreamInfo): void;
+        setProtectionData(protData: object);
         setRobustnessLevel(level: string): void;
+        setSessionType(type: string);
+        loadKeySession(id: string);
+        closeSession(session: SessionToken);
+        removeKeySession(session: SessionToken);
     }
 
     export interface Bitrate {

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ declare namespace dashjs {
         on(type: KeyMessageEvent['type'], listener: (e: KeyMessageEvent) => void, scope?: object): void;
         on(type: KeySessionClosedEvent['type'], listener: (e: KeySessionClosedEvent) => void, scope?: object): void;
         on(type: KeySessionEvent['type'], listener: (e: KeySessionEvent) => void, scope?: object): void;
+        on(type: KeyStatusesChangedEvent['type'], listener: (e: KeyStatusesChangedEvent) => void, scope?: object): void;
         on(type: KeySystemSelectedEvent['type'], listener: (e: KeySystemSelectedEvent) => void, scope?: object): void;
         on(type: LicenseRequestCompleteEvent['type'], listener: (e: LicenseRequestCompleteEvent) => void, scope?: object): void;
         on(type: LogEvent['type'], listener: (e: LogEvent) => void, scope?: object): void;
@@ -352,9 +353,14 @@ declare namespace dashjs {
     }
 
     export interface KeySessionEvent extends Event {
-        type: MediaPlayerEvents['KEY_SESSION_CREATED' | 'KEY_STATUSES_CHANGED'];
+        type: MediaPlayerEvents['KEY_SESSION_CREATED'];
         data: SessionToken | null;
         error?: string;
+    }
+
+    export interface KeyStatusesChangedEvent extends Event {
+        type: MediaPlayerEvents['KEY_STATUSES_CHANGED'];
+        data: SessionToken;
     }
 
     export interface KeySystemSelectedEvent extends Event {

--- a/samples/protection/getLicense.html
+++ b/samples/protection/getLicense.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>Dash.js Protection Module testing</title>
+
+    <script src="../../dist/dash.all.debug.js"></script>
+    <!--dash.all.min.js should be used in production over dash.all.debug.js
+        Debug files are not compressed or obfuscated making the file size much larger compared with dash.all.min.js-->
+    <!--<script src="../../dist/dash.all.min.js"></script>-->
+
+    <style>
+        .inputForm div {
+            margin-bottom: 10px;
+        }
+
+        label {
+            width: 135px;
+            display: inline-block;
+        }
+
+        input[type="text"] {
+            width: 500px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="inputForm">
+        <div>
+            <input type="button" value="GetLicense" onclick="getLicense()">
+        </div>
+    </div>
+
+    <script>
+
+        function getLicense() {
+
+            // Configuration for stream "Axinom Test Content (conservative/legacy) / 1080p with PlayReady and Widevine DRM, single key 
+            var config = {
+                // From manifest
+                KID: '6e5a1d26-2757-47d7-8046-eaa5d1d34b5a',
+                audioPssh: 'AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQblodJidXR9eARuql0dNLWg==',
+                videoPssh: 'AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQblodJidXR9eARuql0dNLWg==',
+                // From protData['com.widevine.alpha']
+                serverURL: 'https://drm-widevine-licensing.axtest.net/AcquireLicense',
+                httpRequestHeaders: {
+                    "X-AxDRM-Message": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiNmU1YTFkMjYtMjc1Ny00N2Q3LTgwNDYtZWFhNWQxZDM0YjVhIn1dfX0.yF7PflOPv9qHnu3ZWJNZ12jgkqTabmwXbDWk_47tLNE"
+                },
+                audioRobustness: "SW_SECURE_CRYPTO",
+                videoRobustness: "SW_SECURE_DECODE"
+            }
+
+            // Create MediaPlayer and get ProtectionController
+            var mediaPlayer = dashjs.MediaPlayer().create();
+            var protectionController = mediaPlayer.getProtectionController();
+
+            // Set ProtectionData for Widevine key system
+            var protData = {
+                'com.widevine.alpha': config
+            };
+            protectionController.setProtectionData(protData);
+
+            // Set session type to 'persistent'
+            // protectionController.setSessionType('persistent-license');
+
+            // Create audio/video infos
+            var audioInfo = {
+                codec: 'audio/mp4;codecs="mp4a.40.2"',
+                contentProtection: [{
+                    value: 'Widevine',
+                    schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
+                    pssh: {
+                        __prefix: 'cenc',
+                        __text: config.audioPssh
+                    },
+                    'cenc:default_KID': config.KID
+                }]
+            };
+            var videoInfo = {
+                codec: 'video/mp4;codecs="avc1.640015"',
+                contentProtection: [{
+                    value: 'Widevine',
+                    schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
+                    pssh: {
+                        __prefix: 'cenc',
+                        __text: config.videoPssh
+                    },
+                    'cenc:default_KID': config.KID
+                }]
+            };
+
+            var sessionToken = null;
+
+            // Listen for 'keySystemAccessComplete' event to check if KeySystem is available
+            mediaPlayer.on(dashjs.MediaPlayer.events.KEY_SYSTEM_ACCESS_COMPLETE, function (e) {
+                if (e.error) {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] KEY_SYSTEM_ACCESS_COMPLETE: ', e);
+                }
+            });
+
+            // Listen for 'keySessionCreated' event to get session token
+            mediaPlayer.on(dashjs.MediaPlayer.events.KEY_SESSION_CREATED, function (e) {
+                if (e.error) {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] KEY_SESSION_CREATED: ', e);
+                } else {
+                    console.log('[DASHJS-PROTECTION-PLUGIN] KEY_SESSION_CREATED: ', e);
+                    sessionToken = e.data;
+                }
+            });
+                            
+            // Listen for 'licenseRequestComplete' to check for licenser request/response error
+            mediaPlayer.on(dashjs.MediaPlayer.events.LICENSE_REQUEST_COMPLETE, function (e) {
+                if (e.error) {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] LICENSE_REQUEST_COMPLETE: ', e);
+                } else {
+                    console.log('[DASHJS-PROTECTION-PLUGIN] LICENSE_REQUEST_COMPLETE: ', e);
+                }
+            });
+
+            // Listen for 'keystatuseschange' event to check if license has been successfully received and stored
+            mediaPlayer.on(dashjs.MediaPlayer.events.KEY_STATUSES_CHANGED, function (e) {
+                console.log('[DASHJS-PROTECTION-PLUGIN] KEY_STATUSES_CHANGED: ', e);
+                e.data.session.keyStatuses.forEach(function(status, keyId) {
+                    console.log("[DASHJS-PROTECTION-PLUGIN] status = " + status + " for session " + sessionToken.session.sessionId);
+                    switch (status) {
+                        case "expired":
+                            break;
+                        case "output-restricted":
+                            break;
+                        case "usable":
+                            // console.log('[DASHJS-PROTECTION-PLUGIN] SESSION: ', sessionToken.session);
+                            // Now, since license has been received, close the MediaKeySession to release its resources
+                            protectionController.closeKeySession(sessionToken);
+                            break;
+                        default:
+                    }
+                });
+
+            });
+
+            // Listen for 'keySessionClosed' event to ensure session has been successfully closed in order to enable (re)loading it afterwards (and avoid QutoExceededError)
+            mediaPlayer.on(dashjs.MediaPlayer.events.KEY_SESSION_CLOSED, function (e) {
+                if (e.error) {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] KEY_SESSION_CLOSED: ', e);
+                } else {
+                    console.log('[DASHJS-PROTECTION-PLUGIN] KEY_SESSION_CLOSED: ', e);
+                }
+            });
+            
+            // Listen for errors
+            mediaPlayer.on(dashjs.MediaPlayer.events.ERROR, function (e) {
+                if (e.error === 'key_session' || e.error === 'key_message') {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] PROTECTION ERROR: ', e);
+                } else {
+                    console.error('[DASHJS-PROTECTION-PLUGIN] ERROR: ', e);
+                }
+            });
+            mediaPlayer.on(dashjs.MediaPlayer.events.KEY_ERROR, function (e) {
+                console.error('[DASHJS-PROTECTION-PLUGIN] KEY_ERROR: ', e);
+            });
+
+            // Initialize ProtectionController in order to initialize MediaKey session and then initiate license retrieval process
+            protectionController.initialize(null, audioInfo, videoInfo);
+        }
+    </script>
+</body>
+
+</html>

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2570,6 +2570,9 @@ function MediaPlayer() {
             MediaPlayerEvents.extend(Protection.events, {
                 publicOnly: true
             });
+            if (!capabilities) {
+                capabilities = Capabilities(context).getInstance();
+            }
             protectionController = protection.createProtectionSystem({
                 log: log,
                 errHandler: errHandler,

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -143,10 +143,11 @@ function Protection() {
         let log = config.log;
         let eventBus = config.eventBus;
         let errHandler = config.errHandler;
-        let videoElement = config.videoModel.getElement();
+        let videoElement = config.videoModel ? config.videoModel.getElement() : null;
 
-        if (videoElement.onencrypted !== undefined &&
-            videoElement.mediaKeys !== undefined &&
+        if ((!videoElement || videoElement.onencrypted !== undefined) &&
+            (!videoElement || videoElement.mediaKeys !== undefined) &&
+            window.MediaKeys !== undefined &&
             navigator.requestMediaKeySystemAccess !== undefined &&
             typeof navigator.requestMediaKeySystemAccess === 'function') {
 

--- a/src/streaming/protection/ProtectionEvents.js
+++ b/src/streaming/protection/ProtectionEvents.js
@@ -115,7 +115,7 @@ class ProtectionEvents extends EventsBase {
          * has completed
          * @ignore
          */
-        this.KEY_SYSTEM_ACCESS_COMPLETE = 'keySystemAccessComplete';
+        this.KEY_SYSTEM_ACCESS_COMPLETE = 'public_keySystemAccessComplete';
 
         /**
          * Event ID for events delivered when a key system selection procedure

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -109,6 +109,8 @@ function ProtectionController(config) {
             videoInfo = vInfo || (streamInfo ? adapter.getMediaInfoForType(streamInfo, Constants.VIDEO) : null);
             const mediaInfo = (videoInfo) ? videoInfo : audioInfo; // We could have audio or video only
 
+            eventBus.on(events.INTERNAL_KEY_MESSAGE, onKeyMessage, this);
+
             // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
             // and video will be the same.  Just use one valid MediaInfo object
             const supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection);
@@ -305,6 +307,9 @@ function ProtectionController(config) {
      * @instance
      */
     function reset() {
+
+        eventBus.off(events.INTERNAL_KEY_MESSAGE, onKeyMessage, this);
+
         setMediaElement(null);
 
         keySystem = undefined;//TODO-Refactor look at why undefined is needed for this. refactor

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -251,11 +251,9 @@ function ProtectionController(config) {
         if (element) {
             protectionModel.setMediaElement(element);
             eventBus.on(events.NEED_KEY, onNeedKey, this);
-            eventBus.on(events.INTERNAL_KEY_MESSAGE, onKeyMessage, this);
         } else if (element === null) {
             protectionModel.setMediaElement(element);
             eventBus.off(events.NEED_KEY, onNeedKey, this);
-            eventBus.off(events.INTERNAL_KEY_MESSAGE, onKeyMessage, this);
         }
     }
 

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -132,6 +132,8 @@ function ProtectionModel_21Jan2015(config) {
                 videoElement.setMediaKeys(mediaKeys).then(function () {
                     eventBus.trigger(events.INTERNAL_KEY_SYSTEM_SELECTED);
                 });
+            } else {
+                eventBus.trigger(events.INTERNAL_KEY_SYSTEM_SELECTED);
             }
 
         }).catch(function () {


### PR DESCRIPTION
This PR enables using protection controller in order to deal with licenses without attaching a video element to the player.

This can be useful to obtain a license without playing a stream.
As to anticipate persistent license support in chrome, an example use case is to retrieve and store licensein CDM when recording a stream in order to enable playback afterwards while being disconnected from network.

A sample is provided to demonstrate license acquisition using ProtectionController.

Additionnaly, we could eventually add an API in MediaPlayer or ProtectionController to get a license as it is done in the sample.