### PR TITLE
#2330 Add 'r' parameter to specify relative start time in a live stream

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -254,6 +254,10 @@ function PlaybackController() {
         let uriParameters;
         if (fragData) {
             uriParameters = {};
+            const r = parseInt(fragData.r, 10);
+            if (r >= 0 && streamInfo && r < streamInfo.manifestInfo.DVRWindowSize && fragData.t === null) {
+                fragData.t = Math.floor(Date.now() / 1000) - streamInfo.manifestInfo.DVRWindowSize + r;
+            }
             uriParameters.fragS = parseInt(fragData.s, 10);
             uriParameters.fragT = parseInt(fragData.t, 10);
         }
@@ -314,7 +318,10 @@ function PlaybackController() {
         if (!DVRWindow) return NaN;
         if (currentTime > DVRWindow.end) {
             actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
-        } else if (currentTime < DVRWindow.start) {
+        } else if (currentTime + 0.250 < DVRWindow.start) {
+            // Checking currentTime plus 250ms as the 'timeupdate' is fired with a frequency between 4Hz and 66Hz
+            // https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate
+            // http://w3c.github.io/html/single-page.html#offsets-into-the-media-resource
             actualTime = DVRWindow.start;
         } else {
             return currentTime;

--- a/src/streaming/vo/URIFragmentData.js
+++ b/src/streaming/vo/URIFragmentData.js
@@ -39,6 +39,7 @@ class URIFragmentData {
         this.track = null;
         this.id = null;
         this.s = null;
+        this.r = null;
     }
 }
 


### PR DESCRIPTION
This PR adds a new parameter 'r' to specify relative start time of a live stream as specified in #2330. This parameter has a value between 0 and the DVR window size in seconds.

Also, it fixes a problem when the live stream play time was at the beginning of the DVR window, as it starting seeking from time to time. This was due to currentTime of the player is updated at the 'timeupdate' event. This event can take up 250ms to be fired. Therefore, when checking if the currentTime is behind the DVR window size, the delayed of the event is taken into account.