### PR TITLE
Fast Audio track switching

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -517,37 +517,6 @@ function BufferController(config) {
         return clearRanges;
     }
 
-    function getClearRange(threshold) {
-        if (!buffer) return null;
-        if (!buffer.buffered || buffer.buffered.length === 0) return null;
-
-        // we need to remove data that is more than one fragment before the video currentTime
-        const currentTime = playbackController.getTime();
-        const req = streamProcessor.getFragmentModel().getRequests({ state: FragmentModel.FRAGMENT_MODEL_EXECUTED, time: currentTime, threshold: threshold })[0];
-        const range = sourceBufferController.getBufferRange(buffer, currentTime);
-
-        const removeStart = buffer.buffered.start(0);
-        let removeEnd = (req && !isNaN(req.startTime)) ? req.startTime : Math.floor(currentTime);
-        if ((range === null) && (buffer.buffered.length > 0)) {
-            removeEnd = buffer.buffered.end(buffer.buffered.length - 1);
-        }
-
-        if ((removeStart <= currentTime) && (removeEnd >= currentTime)) {
-            // Don't allow remove a buffer that encloses currentTime position
-            removeEnd = Math.floor(currentTime);
-        }
-
-        return {
-            start: removeStart,
-            end: removeEnd
-        };
-    }
-
-    function clearBuffer(range) {
-        if (!range || !buffer) return;
-        clearBuffers([range]);
-    }
-
     function clearBuffers(ranges) {
         if (!ranges || !buffer || ranges.length === 0) return;
 
@@ -567,8 +536,12 @@ function BufferController(config) {
         isPruningInProgress = true;
 
         // If removing buffer ahead current playback position, update maxAppendedIndex
-        if (playbackController.getTime() < range.end) {
+        const currentTime = playbackController.getTime();
+        if (currentTime < range.end) {
+            isBufferingCompleted = false;
             maxAppendedIndex = 0;
+            streamProcessor.getScheduleController().setSeekTarget(currentTime);
+            adapter.setIndexHandlerTime(streamProcessor, currentTime);
         }
         sourceBufferController.remove(buffer, range.start, range.end, mediaSource);
     }
@@ -616,8 +589,15 @@ function BufferController(config) {
     function onCurrentTrackChanged(e) {
         if (!buffer || (e.newMediaInfo.type !== type) || (e.newMediaInfo.streamInfo.id !== streamProcessor.getStreamInfo().id)) return;
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
-            clearBuffer(getClearRange(0));
-            streamProcessor.getFragmentModel().abortRequests();
+            if (buffer.buffered && buffer.buffered.length > 0) {
+                log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
+                clearBuffers([{
+                    start: 0,
+                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD
+                }]);
+                lastIndex = Number.POSITIVE_INFINITY;
+                streamProcessor.getFragmentModel().abortRequests();
+            }
         }
     }
 

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -75,7 +75,6 @@ function NextFragmentRequestRule(config) {
 
         let request;
         if (requestToReplace) {
-            // log('requestToReplace :' + requestToReplace.url);
             time = requestToReplace.startTime + (requestToReplace.duration / 2);
             request = adapter.getFragmentRequestForTime(streamProcessor, representationInfo, time, {
                 timeThreshold: 0,


### PR DESCRIPTION
Fixes #2239 and enables fast switch of tracks. Whenever a request for track change is received, and if track switching mode is set to TRACK_SWITCH_MODE_ALWAYS_REPLACE, BufferController will remove its buffer completely so track change is effective immediately.