### PR TITLE
update track switch mode for audio and video

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -226,6 +226,22 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.defaultStableBufferDelay = $scope.player.getStableBufferTime();
     $scope.defaultBufferTimeAtTopQuality = $scope.player.getBufferTimeAtTopQuality();
     $scope.defaultBufferTimeAtTopQualityLongForm = $scope.player.getBufferTimeAtTopQualityLongForm();
+    
+    const initVideoTrackSwitchMode = $scope.player.getTrackSwitchModeFor('video');
+    const initAudioTrackSwitchMode = $scope.player.getTrackSwitchModeFor('audio');
+   
+    //get default track switch mode
+    if(initVideoTrackSwitchMode === 'alwaysReplace') {
+        document.getElementById('always-replace-video').checked = true;
+    } else {
+        document.getElementById('never-replace-video').checked = true;
+    }
+
+    if(initAudioTrackSwitchMode === 'alwaysReplace') {
+        document.getElementById('always-replace-audio').checked = true;
+    } else {
+        document.getElementById('never-replace-audio').checked = true;
+    }
 
     $scope.controlbar = new ControlBar($scope.player); /* jshint ignore:line */
     $scope.controlbar.initialize();

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -218,14 +218,26 @@
             <div class="options-item">
                 <div class="options-item-title">Track Switch Mode</div>
                 <div class="options-item-body">
+                    <label class="options-label">Audio:</label>
                     <label data-toggle="tooltip" data-placement="right"
                            title="When a track is switched, the portion of the buffer that contains old track data is cleared">
-                        <input  type="radio" id="always-replace" autocomplete="off" name="track-switch" checked="checked" ng-click="changeTrackSwitchMode('alwaysReplace', 'video')" >
+                        <input  type="radio" id="always-replace-audio" autocomplete="off" name="track-switch-audio" checked="checked" ng-click="changeTrackSwitchMode('alwaysReplace', 'audio')" >
                         always replace
                     </label>
                     <label data-toggle="tooltip" data-placement="right"
                            title="When a track is switched, the portion of the buffer that contains old track data is NOT cleared">
-                        <input type="radio" id="never-replace" autocomplete="off" name="track-switch" ng-click="changeTrackSwitchMode('neverReplace', 'video')">
+                        <input type="radio" id="never-replace-audio" autocomplete="off" name="track-switch-audio" ng-click="changeTrackSwitchMode('neverReplace', 'audio')">
+                        never replace
+                    </label>
+                    <label class="options-label">Video:</label>
+                    <label data-toggle="tooltip" data-placement="right"
+                           title="When a track is switched, the portion of the buffer that contains old track data is cleared">
+                        <input  type="radio" id="always-replace-video" autocomplete="off" name="track-switch-video" checked="checked" ng-click="changeTrackSwitchMode('alwaysReplace', 'video')" >
+                        always replace
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                           title="When a track is switched, the portion of the buffer that contains old track data is NOT cleared">
+                        <input type="radio" id="never-replace-video" autocomplete="off" name="track-switch-video" ng-click="changeTrackSwitchMode('neverReplace', 'video')">
                         never replace
                     </label>
                 </div>


### PR DESCRIPTION
Hi,

this PR has to show track switch mode for audio and video, not only for video as it is now. By default, track switch mode is neverReplace for video and alwaysReplace for audio.

Nico