### PR TITLE
Jump gaps feature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,10 @@ declare namespace dashjs {
         attachVideoContainer(container: HTMLElement): void;
         attachTTMLRenderingDiv(div: HTMLDivElement): void;
         getCurrentTextTrackIndex(): number;
+        setJumpGaps(value: boolean): void;
+        getJumpGaps(): boolean;
+        setSmallGapLimit(value: number): void;
+        getSmallGapLimit(): number;
         reset(): void;
     }
 

--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -60,7 +60,7 @@ a:hover {
         OPTIONS PANEL
 *****************************/
 .options-show {
-    height: 235px;
+    height: 260px;
     transition-property: all;
     transition-duration: .5s;
 }

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -197,6 +197,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.loopSelected = true;
     $scope.scheduleWhilePausedSelected = true;
     $scope.localStorageSelected = true;
+    $scope.jumpGapsSelected = true;
     $scope.fastSwitchSelected = true;
     $scope.ABRStrategy = 'abrDynamic';
 
@@ -214,7 +215,8 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.player = dashjs.MediaPlayer().create(); /* jshint ignore:line */
 
     $scope.player.initialize($scope.video, null, $scope.autoPlaySelected);
-    $scope.player.setFastSwitchEnabled(true);
+    $scope.player.setFastSwitchEnabled($scope.fastSwitchSelected);
+    $scope.player.setJumpGaps($scope.jumpGapsSelected);
     $scope.player.attachVideoContainer(document.getElementById('videoContainer'));
     // Add HTML-rendered TTML subtitles except for Firefox < v49 (issue #1164)
     if (doesTimeMarchesOn()) {
@@ -320,6 +322,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.toggleLocalStorage = function () {
         $scope.player.enableLastBitrateCaching($scope.localStorageSelected);
         $scope.player.enableLastMediaSettingsCaching($scope.localStorageSelected);
+    };
+
+    $scope.toggleJumpGaps = function () {
+        $scope.player.setJumpGaps($scope.jumpGapsSelected);
     };
 
     $scope.setStream = function (item) {

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -153,6 +153,11 @@
                         Allow Local Storage
                     </label>
                     <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                           title="Enables jump small gaps (discontinuities) in the media streams">
+                        <input type="checkbox" id="jumpGapsCB" ng-model="jumpGapsSelected" ng-change="toggleJumpGaps()" ng-checked="jumpGapsSelected">
+                        Jump Small Gaps
+                    </label>
+                    <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
                            title="Enables faster ABR switching (time to render). Only when the new quality is higher than the current.">
                         <input type="checkbox" id="fastSwitchCB" ng-model="fastSwitchSelected" ng-change="toggleFastSwitch()" ng-checked="fastSwitchSelected">
                         Fast Switching ABR

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1688,6 +1688,52 @@ function MediaPlayer() {
         return mediaPlayerModel.getXHRWithCredentialsForType(type);
     }
 
+    /**
+     * Sets whether player should jump small gaps (discontinuities) in the buffer.
+     *
+     * @param {boolean} value
+     * @default false
+     * @memberof module:MediaPlayer
+     * @instance
+     *
+     */
+    function setJumpGaps(value) {
+        mediaPlayerModel.setJumpGaps(value);
+    }
+
+    /**
+     * Gets current status of jump gaps feature.
+     * @returns {boolean} The current jump gaps state.
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getJumpGaps() {
+        return mediaPlayerModel.getJumpGaps();
+    }
+
+    /**
+     * Time in seconds for a gap to be considered small.
+     *
+     * @param {boolean} value
+     * @default 0.8
+     * @memberof module:MediaPlayer
+     * @instance
+     *
+     */
+    function setSmallGapLimit(value) {
+        mediaPlayerModel.setSmallGapLimit(value);
+    }
+
+    /**
+     * Time in seconds for a gap to be considered small.
+     * @returns {boolean} Current small gap limit
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getSmallGapLimit() {
+        return mediaPlayerModel.getSmallGapLimit();
+    }
+
     /*
     ---------------------------------------------------------------------------
 
@@ -2740,6 +2786,10 @@ function MediaPlayer() {
         setManifestLoaderRetryInterval: setManifestLoaderRetryInterval,
         setXHRWithCredentialsForType: setXHRWithCredentialsForType,
         getXHRWithCredentialsForType: getXHRWithCredentialsForType,
+        setJumpGaps: setJumpGaps,
+        getJumpGaps: getJumpGaps,
+        setSmallGapLimit: setSmallGapLimit,
+        getSmallGapLimit: getSmallGapLimit,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setSegmentOverlapToleranceTime: setSegmentOverlapToleranceTime,
         setCacheLoadThresholdForType: setCacheLoadThresholdForType,

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -208,10 +208,10 @@ function StreamController() {
         // If there is a safe position to jump to, do the seeking
         if (seekToPosition > 0) {
             if (!isNaN(timeToStreamEnd) && seekToPosition >= time + timeToStreamEnd) {
-                log('Jump gap due to media gap (discontinuity) at time ', time, '. Jumping to end of the stream');
+                log('Jumping media gap (discontinuity) at time ', time, '. Jumping to end of the stream');
                 onEnded();
             } else {
-                log('Jump gap due to media gap (discontinuity) at time ', time, '. Jumping to time position', seekToPosition);
+                log('Jumping media gap (discontinuity) at time ', time, '. Jumping to time position', seekToPosition);
                 playbackController.seek(seekToPosition);
             }
         }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -49,9 +49,12 @@ import BaseURLController from './BaseURLController';
 import MediaSourceController from './MediaSourceController';
 
 function StreamController() {
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    // Check whether there is a gap every 20 wallClockUpdateEvent times
+    const STALL_THRESHOLD_TO_CHECK_GAPS = 20;
+
+    const context = this.context;
+    const log = Debug(context).getInstance().log;
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
         capabilities,
@@ -92,7 +95,9 @@ function StreamController() {
         videoTrackDetected,
         audioTrackDetected,
         isStreamBufferingCompleted,
-        playbackEndedTimerId;
+        playbackEndedTimerId,
+        wallclockTicked,
+        lastPlaybackTime;
 
     function setup() {
         timeSyncController = TimeSyncController(context).getInstance();
@@ -134,6 +139,7 @@ function StreamController() {
         eventBus.on(Events.MANIFEST_UPDATED, onManifestUpdated, this);
         eventBus.on(Events.STREAM_BUFFERING_COMPLETED, onStreamBufferingCompleted, this);
         eventBus.on(Events.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, this);
+        eventBus.on(Events.WALLCLOCK_TIME_UPDATED, onWallclockTimeUpdated, this);
         eventBus.on(MediaPlayerEvents.METRIC_ADDED, onMetricAdded, this);
     }
 
@@ -146,6 +152,67 @@ function StreamController() {
             const playbackQuality = videoModel.getPlaybackQuality();
             if (playbackQuality) {
                 metricsModel.addDroppedFrames(Constants.VIDEO, playbackQuality);
+            }
+        }
+    }
+
+    function onWallclockTimeUpdated(e) {
+        if (!mediaPlayerModel.getJumpGaps() || isPaused || isStreamSwitchingInProgress ||
+            !activeStream || playbackController.isSeeking()) {
+            return;
+        }
+
+        wallclockTicked++;
+        if (wallclockTicked >= STALL_THRESHOLD_TO_CHECK_GAPS) {
+            const currentTime = playbackController.getTime();
+            if (lastPlaybackTime === currentTime) {
+                log('Warning - Playback stalled for', (wallclockTicked * mediaPlayerModel.getWallclockTimeUpdateInterval()) ,'milliseconds. Time for a jump?');
+                jumpGap(currentTime, e.timeToEnd);
+            } else {
+                lastPlaybackTime = currentTime;
+            }
+            wallclockTicked = 0;
+        }
+    }
+
+    function jumpGap(time, timeToStreamEnd) {
+        const streamProcessors = activeStream.getProcessors();
+        let seekToPosition;
+
+        // Find out what is the right time position to jump to taking
+        // into account state of buffer
+        for (let i = 0; i < streamProcessors.length; i ++) {
+            const mediaBuffer = streamProcessors[i].getBuffer();
+            const ranges = sourceBufferController.getAllRanges(mediaBuffer);
+            let nextRangeStartTime;
+            if (!ranges || ranges.length <= 1) continue;
+
+            // Get the range just after current time position
+            for (let j = 0; j < ranges.length; j++) {
+                if (time < ranges.start(j)) {
+                    nextRangeStartTime = ranges.start(j);
+                    break;
+                }
+            }
+
+            if (nextRangeStartTime > 0) {
+                const gap = nextRangeStartTime - time;
+                if (gap > 0 && gap <= mediaPlayerModel.getSmallGapLimit()) {
+                    if (seekToPosition === undefined || nextRangeStartTime > seekToPosition) {
+                        seekToPosition = nextRangeStartTime;
+                    }
+                }
+            }
+        }
+
+        // If there is a safe position to jump to, do the seeking
+        if (seekToPosition > 0) {
+            if (!isNaN(timeToStreamEnd) && seekToPosition >= time + timeToStreamEnd) {
+                log('Jump gap due to media gap (discontinuity) at time ', time, '. Jumping to end of the stream');
+                onEnded();
+            } else {
+                log('Jump gap due to media gap (discontinuity) at time ', time, '. Jumping to time position', seekToPosition);
+                playbackController.seek(seekToPosition);
             }
         }
     }
@@ -319,7 +386,6 @@ function StreamController() {
     }
 
     function switchStream(oldStream, newStream, seekTime) {
-
         if (isStreamSwitchingInProgress || !newStream || oldStream === newStream) return;
         isStreamSwitchingInProgress = true;
 
@@ -340,7 +406,6 @@ function StreamController() {
     }
 
     function openMediaSource(seekTime, oldStream) {
-
         let sourceUrl;
 
         function onMediaSourceOpen() {
@@ -369,7 +434,6 @@ function StreamController() {
     }
 
     function activateStream(seekTime) {
-
         activeStream.activate(mediaSource);
 
         audioTrackDetected = checkTrackPresence(Constants.AUDIO);
@@ -413,7 +477,6 @@ function StreamController() {
     }
 
     function composeStreams() {
-
         try {
             const streamsInfo = adapter.getStreamsInfo();
             if (streamsInfo.length === 0) {
@@ -429,14 +492,12 @@ function StreamController() {
             });
 
             for (let i = 0, ln = streamsInfo.length; i < ln; i++) {
-
                 // If the Stream object does not exist we probably loaded the manifest the first time or it was
                 // introduced in the updated manifest, so we need to create a new Stream and perform all the initialization operations
                 const streamInfo = streamsInfo[i];
                 let stream = getComposedStream(streamInfo);
 
                 if (!stream) {
-
                     stream = Stream(context).create({
                         manifestModel: manifestModel,
                         dashManifestModel: dashManifestModel,
@@ -460,7 +521,6 @@ function StreamController() {
                     });
                     streams.push(stream);
                     stream.initialize(streamInfo, protectionController);
-
                 } else {
                     stream.updateData(streamInfo);
                 }
@@ -509,10 +569,10 @@ function StreamController() {
         if (!e.error) {
             //Since streams are not composed yet , need to manually look up useCalculatedLiveEdgeTime to detect if stream
             //is SegmentTimeline to avoid using time source
-            let manifest = e.manifest;
+            const manifest = e.manifest;
             adapter.updatePeriods(manifest);
-            let streamInfo = adapter.getStreamsInfo(manifest)[0];
-            let mediaInfo = (
+            const streamInfo = adapter.getStreamsInfo(manifest)[0];
+            const mediaInfo = (
                 adapter.getMediaInfoForType(streamInfo, Constants.VIDEO) ||
                 adapter.getMediaInfoForType(streamInfo, Constants.AUDIO)
             );
@@ -582,7 +642,7 @@ function StreamController() {
         if (playListMetrics) {
             if (activeStream) {
                 activeStream.getProcessors().forEach(p => {
-                    let ctrlr = p.getScheduleController();
+                    const ctrlr = p.getScheduleController();
                     if (ctrlr) {
                         ctrlr.finalisePlayList(time, reason);
                     }
@@ -611,7 +671,6 @@ function StreamController() {
 
 
     function onPlaybackError(e) {
-
         if (!e.error) return;
 
         let msg = '';
@@ -768,6 +827,7 @@ function StreamController() {
         playListMetrics = null;
         playbackEndedTimerId = undefined;
         isStreamBufferingCompleted = false;
+        wallclockTicked = 0;
     }
 
     function reset() {
@@ -782,7 +842,7 @@ function StreamController() {
         );
 
         for (let i = 0, ln = streams ? streams.length : 0; i < ln; i++) {
-            let stream = streams[i];
+            const stream = streams[i];
             stream.reset(hasMediaError);
         }
 
@@ -856,5 +916,4 @@ function StreamController() {
 }
 
 StreamController.__dashjs_factory_name = 'StreamController';
-
 export default FactoryMaker.getSingletonFactory(StreamController);

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -56,6 +56,7 @@ const BUFFER_TIME_AT_TOP_QUALITY = 30;
 const BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 60;
 const LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;
 const SEGMENT_OVERLAP_TOLERANCE_TIME = 0.05;
+const SMALL_GAP_LIMIT = 0.8;
 
 const CACHE_LOAD_THRESHOLD_VIDEO = 50;
 const CACHE_LOAD_THRESHOLD_AUDIO = 5;
@@ -104,7 +105,9 @@ function MediaPlayerModel() {
         fastSwitchEnabled,
         customABRRule,
         movingAverageMethod,
-        cacheLoadThresholds;
+        cacheLoadThresholds,
+        jumpGaps,
+        smallGapLimit;
 
     function setup() {
         UTCTimingSources = [];
@@ -135,6 +138,8 @@ function MediaPlayerModel() {
         bandwidthSafetyFactor = BANDWIDTH_SAFETY_FACTOR;
         abandonLoadTimeout = ABANDON_LOAD_TIMEOUT;
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
+        jumpGaps = false;
+        smallGapLimit = SMALL_GAP_LIMIT;
         xhrWithCredentials = {
             default: DEFAULT_XHR_WITH_CREDENTIALS
         };
@@ -461,7 +466,6 @@ function MediaPlayerModel() {
         return useCreds;
     }
 
-
     function getFastSwitchEnabled() {
         return fastSwitchEnabled;
     }
@@ -476,6 +480,22 @@ function MediaPlayerModel() {
 
     function getMovingAverageMethod() {
         return movingAverageMethod;
+    }
+
+    function setJumpGaps(value) {
+        jumpGaps = value;
+    }
+
+    function getJumpGaps() {
+        return jumpGaps;
+    }
+
+    function setSmallGapLimit(value) {
+        smallGapLimit = value;
+    }
+
+    function getSmallGapLimit() {
+        return smallGapLimit;
     }
 
     function reset() {
@@ -550,6 +570,10 @@ function MediaPlayerModel() {
         getFastSwitchEnabled: getFastSwitchEnabled,
         setMovingAverageMethod: setMovingAverageMethod,
         getMovingAverageMethod: getMovingAverageMethod,
+        setJumpGaps: setJumpGaps,
+        getJumpGaps: getJumpGaps,
+        setSmallGapLimit: setSmallGapLimit,
+        getSmallGapLimit: getSmallGapLimit,
         reset: reset
     };
 

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -72,6 +72,8 @@ const DEFAULT_XHR_WITH_CREDENTIALS = false;
 const CACHE_LOAD_THRESHOLD_VIDEO = 50;
 const CACHE_LOAD_THRESHOLD_AUDIO = 5;
 
+const SMALL_GAP_LIMIT = 0.8;
+
 class MediaPlayerModelMock {
 
     // Constants
@@ -201,6 +203,8 @@ class MediaPlayerModelMock {
         this.cacheLoadThresholds = {};
         this.cacheLoadThresholds[Constants.VIDEO] = CACHE_LOAD_THRESHOLD_VIDEO;
         this.cacheLoadThresholds[Constants.AUDIO] = CACHE_LOAD_THRESHOLD_AUDIO;
+        this.jumpGaps = false;
+        this.smallGapLimit = SMALL_GAP_LIMIT;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -482,13 +486,28 @@ class MediaPlayerModelMock {
         return useCreds;
     }
 
-
     getFastSwitchEnabled() {
         return this.fastSwitchEnabled;
     }
 
     setFastSwitchEnabled(value) {
         this.fastSwitchEnabled = value;
+    }
+
+    setJumpGaps(value) {
+        this.jumpGaps = value;
+    }
+
+    getJumpGaps() {
+        return this.jumpGaps;
+    }
+
+    setSmallGapLimit(value) {
+        this.smallGapLimit = value;
+    }
+
+    getSmallGapLimit() {
+        return this.smallGapLimit;
     }
 
     reset() {

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -808,6 +808,24 @@ describe('MediaPlayer', function () {
             expect(cacheLoadThresholdForAudio).to.equal(2);
         });
 
+        it('should configure jumpGap feature', function () {
+            let jumpGaps = mediaPlayerModel.getJumpGaps();
+            expect(jumpGaps).to.equal(false);
+
+            player.setJumpGaps(true);
+
+            jumpGaps = mediaPlayerModel.getJumpGaps();
+            expect(jumpGaps).to.equal(true);
+
+            let smallGapLimit = mediaPlayerModel.getSmallGapLimit();
+            expect(smallGapLimit).to.equal(0.8);
+
+            player.setSmallGapLimit(0.5);
+
+            smallGapLimit = mediaPlayerModel.getSmallGapLimit();
+            expect(smallGapLimit).to.equal(0.5);
+        });
+
         it('should configure BandwidthSafetyFactor', function () {
             let BandwidthSafetyFactor = mediaPlayerModel.getBandwidthSafetyFactor();
             expect(BandwidthSafetyFactor).to.equal(0.9);


### PR DESCRIPTION
Enable dash.js to jump over small time gaps in the stream. A gap is defined as small when it is shorter or equal to the limit defined with the `MediaPlayer` method `setSmallGapLimit`. By default, `smallGapLimit` value is set to 0.8.

By default jump gap feature is disabled. If you want to enable it you must use the `MediaPlayer` method `setJumpGaps`. 

This PR also adds a new UI control to Dash Reference Player that allows the user to enable/disable jump gap feature with the UI. By default jump gaps feature is enabled for the Dash Reference Player.

Note: Some of the work done here is based on a PR previously sent by @Weiren1991 (#2102). There were some things to fix there and some conflicts to resolve, so I preferred to sent a new PR and keep everything as cleaner as possible. Anyway, Thanks @Weirein1991 for your efforts and contribution. 