### PR TITLE
Allow buffer removal when MediaSource is ended

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -539,7 +539,7 @@ function BufferController(config) {
             streamProcessor.getScheduleController().setSeekTarget(currentTime);
             adapter.setIndexHandlerTime(streamProcessor, currentTime);
         }
-        sourceBufferController.remove(buffer, range.start, range.end, mediaSource);
+        sourceBufferController.remove(buffer, range.start, range.end, mediaSource, range.force);
     }
 
     function onRemoved(e) {
@@ -589,7 +589,8 @@ function BufferController(config) {
                 log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
                 clearBuffers([{
                     start: 0,
-                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD
+                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD,
+                    force: true // Force buffer removal even when buffering is completed and MediaSource is ended
                 }]);
                 lastIndex = Number.POSITIVE_INFINITY;
                 streamProcessor.getFragmentModel().abortRequests();

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -319,7 +319,7 @@ function SourceBufferController(config) {
         });
     }
 
-    function remove(buffer, start, end, mediaSource) {
+    function remove(buffer, start, end, mediaSource, forceRemoval) {
         if (!buffer) {
             eventBus.trigger(Events.SOURCEBUFFER_REMOVE_COMPLETED, {
                 buffer: buffer,
@@ -332,7 +332,7 @@ function SourceBufferController(config) {
         // make sure that the given time range is correct. Otherwise we will get InvalidAccessError
         waitForUpdateEnd(buffer, function () {
             try {
-                if ((start >= 0) && (end > start) && (mediaSource.readyState !== 'ended')) {
+                if ((start >= 0) && (end > start) && (forceRemoval || mediaSource.readyState !== 'ended')) {
                     buffer.remove(start, end);
                 }
                 // updating is in progress, we should wait for it to complete before signaling that this operation is done


### PR DESCRIPTION
Fix #2415.
 
In some situations, like when there are track changes, we have to allow the buffer to be removed even when it has reached the end of the stream. This PR adds the possibility of indicating to SourceBufferController that a buffer must be removed, independently of the playback context, and use it to force removal of buffers when there are track switches.