### PR TITLE
Fix css issues in controlbar and reference player

### DIFF
--- a/contrib/akamai/controlbar/controlbar.css
+++ b/contrib/akamai/controlbar/controlbar.css
@@ -19,9 +19,7 @@
 }
 
 :-webkit-full-screen {
-    position: fixed;
     width: 100%;
-    height: 100%;
     top:0;
     z-index: -100;
     background: none;
@@ -284,8 +282,9 @@ input[type="range"]::-ms-thumb {
     width: 100%;
     height: 7px;
     margin-top: 16px;
-    background: #dfdfdfbb;
+    background: #999a99;
     position: relative;
+    overflow: hidden;
 }
 
 .seekbar-buffer {

--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -134,6 +134,8 @@ a:hover {
 
 .col-md-9 video {
     width: 100%;
+    height: auto;
+    margin: auto;
 }
 
 .col-md-9 {


### PR DESCRIPTION
This PR fixes a couple of css issues of our Reference Player:
*  In Chrome, while staying in fullscreen mode, as soon as control bar is hidden the layout of the player  gets broken (screen gets white and player is moved out of the display area). I have checked this is happening at least since dash.js v2.4.0.

* In Edge/IE, the new control bar is not rendered correctly. Background of the progress bar is never drawn.

