### PR TITLE
Don't clear buffer when we are close to the end of stream

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -585,7 +585,8 @@ function BufferController(config) {
     function onCurrentTrackChanged(e) {
         if (!buffer || (e.newMediaInfo.type !== type) || (e.newMediaInfo.streamInfo.id !== streamProcessor.getStreamInfo().id)) return;
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
-            if (buffer.buffered && buffer.buffered.length > 0) {
+            // Clearing buffer when we are very close to the end of the stream causes playback stall issues
+            if (buffer.buffered && buffer.buffered.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
                 log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
                 clearBuffers([{
                     start: 0,


### PR DESCRIPTION
This PR fixes an issue reported by @nicosang. There were playback stall issues while clearing completely the buffer (because an audio track switch, for example) when playback was very close to the end of the stream. 