### PR TITLE
hasInitialization must return true if there is an initialization range

### DIFF
--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -62,8 +62,7 @@ class Representation {
     }
 
     static hasInitialization(r) {
-        return (r.initialization !== null) ||
-            ((r.segmentInfoType === DashConstants.BASE_URL || r.segmentInfoType === DashConstants.SEGMENT_BASE ) && (r.range !== null));
+        return (r.initialization !== null || r.range !== null);
     }
 
     static hasSegments(r) {


### PR DESCRIPTION
Fix #2425, coming from a regression introduced in #2336. hasInitialization must return true whenever an initialization url or an initialization range is defined, no matter what is the value of segmentInfoType. 
This was also wrong in 2.6.4 and before (always returned true) although didn't make fail the stream in #2425.