### PR TITLE
onManifestUpdated and getStreamsInfo optimizations

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -309,7 +309,7 @@ function DashAdapter() {
         voAdaptations = {};
     }
 
-    function getStreamsInfo(externalManifest, limit) {
+    function getStreamsInfo(externalManifest, maxStreamsInfo) {
         const streams = [];
         let voLocalPeriods = voPeriods;
 
@@ -321,10 +321,10 @@ function DashAdapter() {
             voLocalPeriods = dashManifestModel.getRegularPeriods(mpd);
         }
 
-        if (!limit) {
-            limit = voLocalPeriods.length;
+        if (!maxStreamsInfo) {
+            maxStreamsInfo = voLocalPeriods.length;
         }
-        for (let i = 0; i < limit; i++) {
+        for (let i = 0; i < maxStreamsInfo; i++) {
             streams.push(convertPeriodToStreamInfo(voLocalPeriods[i]));
         }
 

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -309,7 +309,7 @@ function DashAdapter() {
         voAdaptations = {};
     }
 
-    function getStreamsInfo(externalManifest) {
+    function getStreamsInfo(externalManifest, limit) {
         const streams = [];
         let voLocalPeriods = voPeriods;
 
@@ -321,7 +321,10 @@ function DashAdapter() {
             voLocalPeriods = dashManifestModel.getRegularPeriods(mpd);
         }
 
-        for (let i = 0; i < voLocalPeriods.length; i++) {
+        if (!limit) {
+            limit = voLocalPeriods.length;
+        }
+        for (let i = 0; i < limit; i++) {
             streams.push(convertPeriodToStreamInfo(voLocalPeriods[i]));
         }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2103,7 +2103,7 @@ function MediaPlayer() {
             throw STREAMING_NOT_INITIALIZED_ERROR;
         }
 
-        streamInfo = streamInfo || adapter.getStreamsInfo(manifest)[0];
+        streamInfo = streamInfo || adapter.getStreamsInfo(manifest, 1)[0];
 
         return streamInfo ? adapter.getAllMediaInfoForType(streamInfo, type, manifest) : [];
     }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -588,7 +588,7 @@ function StreamController() {
             //is SegmentTimeline to avoid using time source
             const manifest = e.manifest;
             adapter.updatePeriods(manifest);
-            const streamInfo = adapter.getStreamsInfo(manifest)[0];
+            const streamInfo = adapter.getStreamsInfo(undefined, 1)[0];
             const mediaInfo = (
                 adapter.getMediaInfoForType(streamInfo, Constants.VIDEO) ||
                 adapter.getMediaInfoForType(streamInfo, Constants.AUDIO)


### PR DESCRIPTION
This PR optimizes the `StreamController.onManifestUpdated()` method. It removes the manifest passed as argument to `adapter.getStreamsInfo()` because the `DashAdapter` instance already got regular periods for the current manifest. So it is useless to re-analyze the manifest once again to get them.

This PR also adds a new `limit` argument to `DashAdapter.getStreamsInfo()`. It allows to specify for how many streams we want to get info. Currently, some classes calls `getStreamInfos()` to uselessly get info for all streams but only use the first one.