### PR TITLE
Add DRM error for insecure origin

### DIFF
--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -147,10 +147,7 @@ function Protection() {
 
         if ((!videoElement || videoElement.onencrypted !== undefined) &&
             (!videoElement || videoElement.mediaKeys !== undefined) &&
-            window.MediaKeys !== undefined &&
-            navigator.requestMediaKeySystemAccess !== undefined &&
-            typeof navigator.requestMediaKeySystemAccess === 'function') {
-
+            window.MediaKeys !== undefined) {
             log('EME detected on this user agent! (ProtectionModel_21Jan2015)');
             return ProtectionModel_21Jan2015(context).create({log: log, eventBus: eventBus, events: config.events});
 

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -146,8 +146,7 @@ function Protection() {
         let videoElement = config.videoModel ? config.videoModel.getElement() : null;
 
         if ((!videoElement || videoElement.onencrypted !== undefined) &&
-            (!videoElement || videoElement.mediaKeys !== undefined) &&
-            window.MediaKeys !== undefined) {
+            (!videoElement || videoElement.mediaKeys !== undefined)) {
             log('EME detected on this user agent! (ProtectionModel_21Jan2015)');
             return ProtectionModel_21Jan2015(context).create({log: log, eventBus: eventBus, events: config.events});
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -400,10 +400,7 @@ function ProtectionController(config) {
                 if (event.error) {
                     keySystem = undefined;
                     eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
-
-                    if (!fromManifest) {
-                        eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: null, error: 'DRM: KeySystem Access Denied! -- ' + event.error});
-                    }
+                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: null, error: 'DRM: KeySystem Access Denied! -- ' + event.error});
                 } else {
                     keySystemAccess = event.data;
                     log('DRM: KeySystem Access Granted (' + keySystemAccess.keySystem.systemString + ')!  Selecting key system...');

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -250,6 +250,13 @@ function ProtectionModel_21Jan2015(config) {
     }
 
     function requestKeySystemAccessInternal(ksConfigurations, idx) {
+
+        if (navigator.requestMediaKeySystemAccess === undefined ||
+            typeof navigator.requestMediaKeySystemAccess !== 'function') {
+            eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, {error: 'Insecure origins are not allowed'});
+            return;
+        }
+
         (function (i) {
             const keySystem = ksConfigurations[i].ks;
             const configs = ksConfigurations[i].configs;


### PR DESCRIPTION
Hi,

this PR has to return a DRM error when key system access is not available due to an [insecure origin](https://www.chromestatus.com/feature/5724389932793856). So, dash.js can't use requestMediaKeySystemAccess function to detect EME version, but has to return a explicit error in this use case.
In order to validate this PR, dash-if reference page has to be opened in chrome (use ip address not localhost) and try to play a widevine protected content.

Nico 