### PR TITLE
Overwrite initData when user provided parameters for generating it

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -256,7 +256,6 @@ function Stream(config) {
             errHandler.capabilityError('encryptedmedia');
         } else if (!capabilities.supportsCodec(codec)) {
             msg = type + 'Codec (' + codec + ') is not supported.';
-            errHandler.manifestError(msg, 'codec', manifestModel.getValue());
             log(msg);
             return false;
         }

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -424,7 +424,9 @@ function ProtectionController(config) {
                     for (let i = 0; i < pendingNeedKeyData.length; i++) {
                         for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
                             if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {
-                                if (pendingNeedKeyData[i][ksIdx].initData === null && protData && protData.hasOwnProperty('clearkeys')) {
+                                // For Clearkey: if parameters for generating init data was provided by the user, use them for generating
+                                // initData and overwrite possible initData indicated in encrypted event (EME)
+                                if (protectionKeyController.isClearKey(keySystem) && protData && protData.hasOwnProperty('clearkeys')) {
                                     const initData = { kids: Object.keys(protData.clearkeys) };
                                     pendingNeedKeyData[i][ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
                                 }

--- a/src/streaming/utils/ErrorHandler.js
+++ b/src/streaming/utils/ErrorHandler.js
@@ -63,7 +63,7 @@ function ErrorHandler() {
         eventBus.trigger(Events.ERROR, {error: 'download', event: {id: id, url: url, request: request}});
     }
 
-    // {message: "", id: "codec"|"parse"|"nostreams", manifest: {parsed manifest}}
+    // {message: "", id: "parse"|"nostreams", manifest: {parsed manifest}}
     function manifestError(message, id, manifest, err) {
         eventBus.trigger(Events.ERROR, {error: 'manifestError', event: {message: message, id: id, manifest: manifest, event: err}});
     }


### PR DESCRIPTION
Fix #2326

For ClearKey KeySystem, whenever the user provides ClearKey parameters we should use them instead of the ones that comes with the "encrypted" event.