### PR TITLE
Improve audio switch

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -116,7 +116,8 @@ function StreamProcessor(config) {
             streamController: streamController,
             textController: textController,
             sourceBufferController: sourceBufferController,
-            streamProcessor: instance
+            streamProcessor: instance,
+            mediaController: mediaController
         });
 
         representationController = RepresentationController(context).create();

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -292,9 +292,9 @@ function StreamProcessor(config) {
         return bufferController.getBufferLevel();
     }
 
-    function switchInitData(representationId) {
+    function switchInitData(representationId, bufferResetEnabled) {
         if (bufferController) {
-            bufferController.switchInitData(getStreamInfo().id, representationId);
+            bufferController.switchInitData(getStreamInfo().id, representationId, bufferResetEnabled);
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -40,6 +40,8 @@ import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import InitCache from '../utils/InitCache';
 
+import {HTTPRequest} from '../vo/metrics/HTTPRequest';
+
 const BUFFER_LOADED = 'bufferLoaded';
 const BUFFER_EMPTY = 'bufferStalled';
 const STALL_THRESHOLD = 0.5;
@@ -203,6 +205,8 @@ function BufferController(config) {
     }
 
     function onAppended(e) {
+        let ranges = null;
+
         if (buffer === e.buffer) {
             if (e.error) {
                 if (e.error.code === SourceBufferController.QUOTA_EXCEEDED_ERROR_CODE) {
@@ -230,10 +234,12 @@ function BufferController(config) {
                 checkIfBufferingCompleted();
             }
 
-            const ranges = sourceBufferController.getAllRanges(buffer);
-            showBufferRanges(ranges);
+            if (appendedBytesInfo.segmentType === HTTPRequest.MEDIA_SEGMENT_TYPE) {
+                ranges = sourceBufferController.getAllRanges(buffer);
+                showBufferRanges(ranges);
+                onPlaybackProgression();
+            }
 
-            onPlaybackProgression();
             isAppendingInProgress = false;
             if (appendedBytesInfo) {
                 eventBus.trigger(Events.BYTES_APPENDED, {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -622,15 +622,10 @@ function BufferController(config) {
 
     function onCurrentTrackChanged(e) {
         if (!buffer || (e.newMediaInfo.type !== type) || (e.newMediaInfo.streamInfo.id !== streamProcessor.getStreamInfo().id)) return;
+
+        log('[BufferController][' + type + '] track change asked');
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
-            // Clearing buffer when we are very close to the end of the stream causes playback stall issues
             if (buffer.buffered && buffer.buffered.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
-                log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
-                clearBuffers([{
-                    start: 0,
-                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD,
-                    force: true // Force buffer removal even when buffering is completed and MediaSource is ended
-                }]);
                 lastIndex = Number.POSITIVE_INFINITY;
                 streamProcessor.getFragmentModel().abortRequests();
             }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -627,6 +627,7 @@ function BufferController(config) {
         log('[BufferController][' + type + '] track change asked');
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
             if (buffer.buffered && buffer.buffered.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
+                isBufferingCompleted = false;
                 lastIndex = Number.POSITIVE_INFINITY;
                 streamProcessor.getFragmentModel().abortRequests();
             }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -199,7 +199,7 @@ function BufferController(config) {
     function showBufferRanges(ranges) {
         if (ranges && ranges.length > 0) {
             for (let i = 0, len = ranges.length; i < len; i++) {
-                log('Buffered Range for type:', type, ':', ranges.start(i), ' - ', ranges.end(i));
+                log('Buffered Range for type:', type, ':', ranges.start(i), ' - ', ranges.end(i), ' currentTime = ', playbackController.getTime());
             }
         }
     }
@@ -551,7 +551,7 @@ function BufferController(config) {
     function onRemoved(e) {
         if (buffer !== e.buffer) return;
 
-        log('Removed', type, 'buffer from:', e.from, 'to', e.to);
+        log('[BufferController][', type,'] onRemoved buffer from:', e.from, 'to', e.to);
 
         const ranges = sourceBufferController.getAllRanges(buffer);
         showBufferRanges(ranges);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -81,7 +81,6 @@ function BufferController(config) {
         bufferState,
         appendedBytesInfo,
         wallclockTicked,
-        appendingMediaChunk,
         isAppendingInProgress,
         isPruningInProgress,
         initCache,
@@ -698,7 +697,6 @@ function BufferController(config) {
         lastIndex = Number.POSITIVE_INFINITY;
         maxAppendedIndex = 0;
         appendedBytesInfo = null;
-        appendingMediaChunk = false;
         isBufferingCompleted = false;
         isAppendingInProgress = false;
         isPruningInProgress = false;

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -186,7 +186,7 @@ function BufferController(config) {
 
         if (bufferResetInProgress) {
             mediaChunk = chunk;
-            if (buffer.buffered && buffer.buffered.length > 0) {
+            if (buffer.buffered && buffer.buffered.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
                 log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
                 clearBuffers([{
                     start: 0,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -190,7 +190,8 @@ function BufferController(config) {
                 log('Clearing buffer because track changed - ' + (buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD));
                 clearBuffers([{
                     start: 0,
-                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD
+                    end: buffer.buffered.end(buffer.buffered.length - 1) + BUFFER_END_THRESHOLD,
+                    force: true // Force buffer removal even when buffering is completed and MediaSource is ended
                 }]);
             }
         } else {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -265,7 +265,7 @@ function ScheduleController(config) {
     }
 
     function startScheduleTimer(value) {
-        log('[ScheduleController][', type,'] - startScheduleTimer in ', value,' ms');
+        //log('[ScheduleController][', type,'] - startScheduleTimer in ', value,' ms');
         clearTimeout(scheduleTimeout);
         scheduleTimeout = setTimeout(schedule, value);
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -263,6 +263,7 @@ function ScheduleController(config) {
     function startScheduleTimer(value) {
         log('[ScheduleController][', type,'] - startScheduleTimer in ', value,' ms');
         clearTimeout(scheduleTimeout);
+        scheduleTimeout = setTimeout(schedule, value);
     }
 
     function onInitRequested(e) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -137,7 +137,7 @@ function ScheduleController(config) {
         if (!currentRepresentationInfo || streamProcessor.isBufferingCompleted()) {
             return;
         }
-
+        log('[ScheduleController][', type,'] start');
         addPlaylistTraceMetrics();
         isStopped = false;
 
@@ -146,18 +146,15 @@ function ScheduleController(config) {
         }
 
         startScheduleTimer(0);
-
-        log('Schedule controller starting for ' + type);
     }
 
     function stop() {
         if (isStopped) {
             return;
         }
-
+        log('[ScheduleController][', type,'] stop');
         isStopped = true;
         clearTimeout(scheduleTimeout);
-        log('Schedule controller stopping for ' + type);
     }
 
     function hasTopQualityChanged(type, id) {
@@ -175,7 +172,7 @@ function ScheduleController(config) {
 
     function schedule() {
         if (isStopped || isFragmentProcessingInProgress || !streamProcessor.getBufferController() || playbackController.isPaused() && !scheduleWhilePaused) {
-            log('ScheduleController ' + type + ' - schedule stop!');
+            log('[ScheduleController][', type,'] - schedule stop!');
             return;
         }
 
@@ -264,8 +261,8 @@ function ScheduleController(config) {
     }
 
     function startScheduleTimer(value) {
+        log('[ScheduleController][', type,'] - startScheduleTimer in ', value,' ms');
         clearTimeout(scheduleTimeout);
-        scheduleTimeout = setTimeout(schedule, value);
     }
 
     function onInitRequested(e) {
@@ -403,7 +400,7 @@ function ScheduleController(config) {
         if (e.sender !== fragmentModel) {
             return;
         }
-        log('[ScheduleController] onFragmentLoadingCompleted for', type);
+        log('[ScheduleController][', type,'] - onFragmentLoadingCompleted');
         if (dashManifestModel.getIsTextTrack(type)) {
             isFragmentProcessingInProgress = false;
         }
@@ -465,7 +462,7 @@ function ScheduleController(config) {
 
     function onBufferLevelStateChanged(e) {
         if ((e.sender.getStreamProcessor() === streamProcessor) && e.state === BufferController.BUFFER_EMPTY && !playbackController.isSeeking()) {
-            log('Buffer is empty! Stalling!');
+            log('[ScheduleController][', type,'] - Buffer is empty! Stalling!');
             clearPlayListTraceMetrics(new Date(), PlayListTrace.REBUFFERING_REASON);
         }
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -82,7 +82,8 @@ function ScheduleController(config) {
         lastInitQuality,
         replaceRequestArray,
         switchTrack,
-        bufferResetInProgress;
+        bufferResetInProgress,
+        mediaRequest;
 
     function setup() {
         log = Debug(context).getInstance().log.bind(instance);
@@ -423,6 +424,10 @@ function ScheduleController(config) {
             setFragmentProcessState(false);
             startScheduleTimer(0);
         }
+
+        if (bufferResetInProgress) {
+            mediaRequest = e.request;
+        }
     }
 
     function onPlaybackTimeUpdated() {
@@ -436,6 +441,7 @@ function ScheduleController(config) {
 
         if (bufferResetInProgress && !isNaN(e.startTime)) {
             bufferResetInProgress = false;
+            fragmentModel.addExecutedRequest(mediaRequest);
         }
 
         setFragmentProcessState(false);
@@ -614,6 +620,7 @@ function ScheduleController(config) {
         isStopped = true;
         switchTrack = false;
         bufferResetInProgress = false;
+        mediaRequest = null;
     }
 
     function reset() {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -39,6 +39,7 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
+import MediaController from './MediaController';
 
 function ScheduleController(config) {
 
@@ -58,6 +59,7 @@ function ScheduleController(config) {
     const sourceBufferController = config.sourceBufferController;
     const type = config.type;
     const streamProcessor = config.streamProcessor;
+    const mediaController = config.mediaController;
 
     let instance,
         log,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -139,6 +139,7 @@ function ScheduleController(config) {
 
     function start() {
         if (!currentRepresentationInfo || streamProcessor.isBufferingCompleted()) {
+            log('[ScheduleController][', type,'] start denied');
             return;
         }
         log('[ScheduleController][', type,'] start');

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -325,6 +325,10 @@ function FragmentModel(config) {
         resetInitialSettings();
     }
 
+    function addExecutedRequest(request) {
+        executedRequests.push(request);
+    }
+
     instance = {
         setStreamProcessor: setStreamProcessor,
         getStreamProcessor: getStreamProcessor,
@@ -335,7 +339,8 @@ function FragmentModel(config) {
         syncExecutedRequestsWithBufferedRange: syncExecutedRequestsWithBufferedRange,
         abortRequests: abortRequests,
         executeRequest: executeRequest,
-        reset: reset
+        reset: reset,
+        addExecutedRequest: addExecutedRequest
     };
 
     setup();

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -67,7 +67,7 @@ function NextFragmentRequestRule(config) {
          * */
         if (buffer) {
             const range = sourceBufferController.getBufferRange(buffer, time);
-            if (range !== null) {
+            if (range !== null && !hasSeekTarget) {
                 log('Prior to making a request for time, NextFragmentRequestRule is aligning index handler\'s currentTime with bufferedRange.end for', mediaType, '.', time, 'was changed to', range.end);
                 time = range.end;
             }


### PR DESCRIPTION
Hi,

this PR has to improve fast audio switch. The main idea is that when an audio switch occurs, the stream has not to stop playing. In order to achieve this goal, those steps are executed :

- push the new initialize segment
- request media segment at the current playing time of stream
- when this new media segment has been downloaded, fully clean audio buffer and push this new media segment

A test can be done with the stream : http://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd

Nico