### PR TITLE
Add an event when a track change has rendered.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -256,7 +256,7 @@ declare namespace dashjs {
         PLAYBACK_TIME_UPDATED: 'playbackTimeUpdated';
         PROTECTION_CREATED: 'public_protectioncreated';
         PROTECTION_DESTROYED: 'public_protectiondestroyed';
-        TRACK_CHANGE_RENDERED: 'trackChangeRequested';
+        TRACK_CHANGE_RENDERED: 'trackChangeRendered';
         QUALITY_CHANGE_RENDERED: 'qualityChangeRequested';
         QUALITY_CHANGE_REQUESTED: 'qualityChangeRendered';
         STREAM_INITIALIZED: 'streamInitialized';

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,6 +256,7 @@ declare namespace dashjs {
         PLAYBACK_TIME_UPDATED: 'playbackTimeUpdated';
         PROTECTION_CREATED: 'public_protectioncreated';
         PROTECTION_DESTROYED: 'public_protectiondestroyed';
+        TRACK_CHANGE_RENDERED: 'trackChangeRequested';
         QUALITY_CHANGE_RENDERED: 'qualityChangeRequested';
         QUALITY_CHANGE_REQUESTED: 'qualityChangeRendered';
         STREAM_INITIALIZED: 'streamInitialized';
@@ -467,6 +468,13 @@ declare namespace dashjs {
     export interface ProtectionDestroyedEvent extends Event {
         type: MediaPlayerEvents['PROTECTION_DESTROYED'];
         data: string;
+    }
+
+    export interface TrackChangeRenderedEvent extends Event {
+        type: MediaPlayerEvents['TRACK_CHANGE_RENDERED'];
+        mediaType: 'video' | 'audio' | 'fragmentedText';
+        oldMediaInfo: MediaInfo;
+        newMediaInfo: MediaInfo;
     }
 
     export interface QualityChangeRenderedEvent extends Event {

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -129,7 +129,7 @@ class MediaPlayerEvents extends EventsBase {
         this.PERIOD_SWITCH_STARTED = 'periodSwitchStarted';
 
         /**
-         * Triggered when an ABR up /down switch is initialed; either by user in manual mode or auto mode via ABR rules.
+         * Triggered when an ABR up /down switch is initiated; either by user in manual mode or auto mode via ABR rules.
          * @event MediaPlayerEvents#QUALITY_CHANGE_REQUESTED
          */
         this.QUALITY_CHANGE_REQUESTED = 'qualityChangeRequested';
@@ -139,6 +139,12 @@ class MediaPlayerEvents extends EventsBase {
          * @event MediaPlayerEvents#QUALITY_CHANGE_RENDERED
          */
         this.QUALITY_CHANGE_RENDERED = 'qualityChangeRendered';
+
+        /**
+         * Triggered when the new track is being rendered on-screen.
+         * @event MediaPlayerEvents#TRACK_CHANGE_RENDERED
+         */
+        this.TRACK_CHANGE_RENDERED = 'trackChangeRendered';
 
         /**
          * Triggered when the source is setup and ready.

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -141,7 +141,7 @@ class MediaPlayerEvents extends EventsBase {
         this.QUALITY_CHANGE_RENDERED = 'qualityChangeRendered';
 
         /**
-         * Triggered when the new track is being rendered on-screen.
+         * Triggered when the new track is being rendered.
          * @event MediaPlayerEvents#TRACK_CHANGE_RENDERED
          */
         this.TRACK_CHANGE_RENDERED = 'trackChangeRendered';

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -327,6 +327,13 @@ function ScheduleController(config) {
                 threshold: 0
             })[0];
             if (item && playbackController.getTime() >= item.startTime) {
+                if ((!lastFragmentRequest.mediaInfo || (item.mediaInfo.type === lastFragmentRequest.mediaInfo.type && item.mediaInfo.id !== lastFragmentRequest.mediaInfo.id)) && trigger) {
+                    eventBus.trigger(Events.TRACK_CHANGE_RENDERED, {
+                        mediaType: type,
+                        oldMediaInfo: lastFragmentRequest.mediaInfo,
+                        newMediaInfo: item.mediaInfo
+                    });
+                }
                 if ((item.quality !== lastFragmentRequest.quality || item.adaptationIndex !== lastFragmentRequest.adaptationIndex) && trigger) {
                     eventBus.trigger(Events.QUALITY_CHANGE_RENDERED, {
                         mediaType: type,
@@ -335,6 +342,7 @@ function ScheduleController(config) {
                     });
                 }
                 lastFragmentRequest = {
+                    mediaInfo: item.mediaInfo,
                     quality: item.quality,
                     adaptationIndex: item.adaptationIndex
                 };
@@ -613,6 +621,7 @@ function ScheduleController(config) {
         initialRequest = true;
         lastInitQuality = NaN;
         lastFragmentRequest = {
+            mediaInfo: undefined,
             quality: NaN,
             adaptationIndex: NaN
         };


### PR DESCRIPTION
This follows the already established method for identifying when a quality change has been rendered to allow us to dispatch an event when a track change has been rendered.  This is helpful when switching audio or video tracks for UI feedback.