### PR TITLE
New TTML_PARSED event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,7 @@ declare namespace dashjs {
         on(type: QualityChangeRequestedEvent['type'], listener: (e: QualityChangeRequestedEvent) => void, scope?: object): void;
         on(type: StreamInitializedEvent['type'], listener: (e: StreamInitializedEvent) => void, scope?: object): void;
         on(type: TextTracksAddedEvent['type'], listener: (e: TextTracksAddedEvent) => void, scope?: object): void;
+        on(type: TtmlParsedEvent['type'], listener: (e: TtmlParsedEvent) => void, scope?: object): void;
         on(type: string, listener: (e: Event) => void, scope?: object): void;
         off(type: string, listener: (e: any) => void, scope?: object): void;
         extend(parentNameString: string, childInstance: object, override: boolean): void;
@@ -249,6 +250,7 @@ declare namespace dashjs {
         STREAM_INITIALIZED: 'streamInitialized';
         TEXT_TRACKS_ADDED: 'allTextTracksAdded';
         TEXT_TRACK_ADDED: 'textTrackAdded';
+        TTML_PARSED: 'ttmlParsed';
     }
 
     export interface Event {
@@ -482,6 +484,12 @@ declare namespace dashjs {
         enabled: boolean;
         index: number;
         tracks: TextTrackInfo[];
+    }
+
+    export interface TtmlParsedEvent extends Event {
+        type: MediaPlayerEvents['TTML_PARSED'];
+        ttmlString: string;
+        ttmlDoc: object;
     }
 
     export class BitrateInfo {

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -170,6 +170,12 @@ class MediaPlayerEvents extends EventsBase {
         this.TEXT_TRACK_ADDED = 'textTrackAdded';
 
         /**
+         * Triggered when a ttml chunk is parsed.
+         * @event MediaPlayerEvents#TTML_PARSED
+         */
+        this.TTML_PARSED = 'ttmlParsed';
+
+        /**
          * Sent when enough data is available that the media can be played,
          * at least for a couple of frames.  This corresponds to the
          * HAVE_ENOUGH_DATA readyState.

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -30,12 +30,15 @@
  */
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
 import { fromXML, generateISD } from 'imsc';
 
 function TTMLParser() {
 
     let context = this.context;
     let log = Debug(context).getInstance().log;
+    let eventBus = EventBus(context).getInstance();
 
     /*
      * This TTML parser follows "EBU-TT-D SUBTITLING DISTRIBUTION FORMAT - tech3380" spec - https://tech.ebu.ch/docs/tech/tech3380.pdf.
@@ -108,6 +111,8 @@ function TTMLParser() {
             errorMsg = msg;
         },
             metadataHandler);
+        eventBus.trigger(Events.TTML_PARSED, {ttmlString: data, ttmlDoc: imsc1doc});
+
         let mediaTimeEvents = imsc1doc.getMediaTimeEvents();
 
         for (i = 0; i < mediaTimeEvents.length; i++) {


### PR DESCRIPTION
This PR provides a new TTML_PARSED event emitted every time a TTML (XML) string has been parsed to get a JavaScript object representing the TTML document.

TTML_PARSED events have the following structure:
```
{
    type: "ttmlParsed", // dashjs.MediaPlayer.events.TTML_PARSED
    ttmlString: string,
    ttmlDoc: Object
}
```

* The `ttmlString` property is the content of the downloaded TTML segment as string.
* The `ttmlDoc` property is the result of the `ttmlString` parsing. This a JavaScript object.

TTML_EVENT offers the opportunity to change the content of captions or the value of TTML properties before they are processed for screen rendering. This is useful to fix invalid or unadapted values.