### PR TITLE
Add support for MultiKey DRM

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -231,6 +231,17 @@
         {
           "name": "1080p with W3C Clear Key, multiple keys",
           "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-MultiKey/Manifest_1080p_ClearKey.mpd",
+          "protData": {
+            "org.w3.clearkey": {
+              "clearkeys": {
+                "gDmb9YohQBSAU-J-dI6YwA": "3aHppzZ2g3Y3wK1uNnUXmg",
+                "kJU-CWyySaOiYHpf7-rUmQ": "zsmKW7Mq9Unz5R7oUGeF8w",
+                "Dk2pK9DoSmaMP8Jal-tlMg": "UmYYfGb7znuoFAQM79ayHw",
+                "WF8jPzByRvGfpG3CLGagFA": "jayKpC3tmPq4YKXkapa8FA",
+                "QiK9eLxFQb-2Pm-BTcOR3w": "GAMi9v92b9ca5yBwaptN-Q"
+              }
+            }
+          },
           "moreInfo": "https://github.com/Axinom/dash-test-vectors"
         },
         {

--- a/samples/protection/getLicense.html
+++ b/samples/protection/getLicense.html
@@ -37,7 +37,7 @@
 
         function getLicense() {
 
-            // Configuration for stream "Axinom Test Content (conservative/legacy) / 1080p with PlayReady and Widevine DRM, single key 
+            // Configuration for stream "Axinom Test Content (conservative/legacy) / 1080p with PlayReady and Widevine DRM, single key
             var config = {
                 // From manifest
                 KID: '6e5a1d26-2757-47d7-8046-eaa5d1d34b5a',
@@ -62,12 +62,10 @@
             };
             protectionController.setProtectionData(protData);
 
-            // Set session type to 'persistent'
-            // protectionController.setSessionType('persistent-license');
-
             // Create audio/video infos
             var audioInfo = {
                 codec: 'audio/mp4;codecs="mp4a.40.2"',
+                type: 'audio',
                 contentProtection: [{
                     value: 'Widevine',
                     schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
@@ -80,6 +78,7 @@
             };
             var videoInfo = {
                 codec: 'video/mp4;codecs="avc1.640015"',
+                type: 'video',
                 contentProtection: [{
                     value: 'Widevine',
                     schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
@@ -109,7 +108,7 @@
                     sessionToken = e.data;
                 }
             });
-                            
+
             // Listen for 'licenseRequestComplete' to check for licenser request/response error
             mediaPlayer.on(dashjs.MediaPlayer.events.LICENSE_REQUEST_COMPLETE, function (e) {
                 if (e.error) {
@@ -148,7 +147,7 @@
                     console.log('[DASHJS-PROTECTION-PLUGIN] KEY_SESSION_CLOSED: ', e);
                 }
             });
-            
+
             // Listen for errors
             mediaPlayer.on(dashjs.MediaPlayer.events.ERROR, function (e) {
                 if (e.error === 'key_session' || e.error === 'key_message') {
@@ -162,7 +161,7 @@
             });
 
             // Initialize ProtectionController in order to initialize MediaKey session and then initiate license retrieval process
-            protectionController.initialize(null, audioInfo, videoInfo);
+            protectionController.initializeForMedia(videoInfo);
         }
     </script>
 </body>

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2576,7 +2576,6 @@ function MediaPlayer() {
                 videoModel: videoModel,
                 capabilities: capabilities,
                 eventBus: eventBus,
-                adapter: adapter,
                 events: Events,
                 BASE64: BASE64,
                 constants: Constants

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -471,8 +471,15 @@ function Stream(config) {
         if (!isMediaInitialized) {
             return;
         }
+
         if (protectionController) {
-            protectionController.initialize(manifestModel.getValue(), getMediaInfo(Constants.AUDIO), getMediaInfo(Constants.VIDEO));
+            for (let i = 0; i < ln; i++) {
+                if (streamProcessors[i].getType() === Constants.AUDIO ||
+                    streamProcessors[i].getType() === Constants.VIDEO ||
+                    streamProcessors[i].getType() === Constants.FRAGMENTED_TEXT) {
+                    protectionController.initializeForMedia(streamProcessors[i].getMediaInfo());
+                }
+            }
         }
         eventBus.trigger(Events.STREAM_INITIALIZED, {
             streamInfo: streamInfo,

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -126,12 +126,11 @@ function Protection() {
             controller = ProtectionController(context).create({
                 protectionModel: protectionModel,
                 protectionKeyController: protectionKeyController,
-                adapter: config.adapter,
                 eventBus: config.eventBus,
                 log: config.log,
                 events: config.events,
                 BASE64: config.BASE64,
-                Constants: config.Constants
+                constants: config.constants
             });
             config.capabilities.setEncryptedMediaSupported(true);
         }

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -270,11 +270,11 @@ function ProtectionModel_21Jan2015(config) {
                 keySystemAccess.mksa = mediaKeySystemAccess;
                 eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, {data: keySystemAccess});
 
-            }).catch(function () {
+            }).catch(function (error) {
                 if (++i < ksConfigurations.length) {
                     requestKeySystemAccessInternal(ksConfigurations, i);
                 } else {
-                    eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, {error: 'Key system access denied!'});
+                    eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, {error: 'Key system access denied! ' + error.message});
                 }
             });
         })(idx);


### PR DESCRIPTION
This PR adds support for MultiKey DRM (Fix #1595). Tested sucessfully with Clear Key, Widevine and PlayReady.

When initializing a stream, Stream class uses ProtectionController to initialize all possible adaptations of the current period. Later on, in the session creation process and once each keysystem is selected and initData available, we will create just the sessions with unique combinations of initData/keysystem.