### PR TITLE
Load persistent sessions

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -441,6 +441,11 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         $scope.controlbar.enable();
     };
 
+    $scope.doStop = function () {
+        $scope.player.attachSource(null);
+        $scope.controlbar.reset();
+    }
+
     $scope.changeTrackSwitchMode = function (mode, type) {
         $scope.player.setTrackSwitchModeFor(type, mode);
     };

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -202,7 +202,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.ABRStrategy = 'abrDynamic';
 
     // Persistent license
-    $scope.licenseSessionId = {};
+    $scope.persistentSessionId = {};
     $scope.selectedKeySystem = null;
 
     // Error management
@@ -308,7 +308,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         if (e.data) {
             var session = e.data;
             if (session.getSessionType() === 'persistent-license') {
-                $scope.licenseSessionId[$scope.selectedItem.url] = session.getSessionID();
+                $scope.persistentSessionId[$scope.selectedItem.url] = session.getSessionID();
             }
         }
     }, $scope);
@@ -385,7 +385,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         }
 
         // Check if persistent license session ID is stored for current stream
-        var sessionId = $scope.licenseSessionId[$scope.selectedItem.url];
+        var sessionId = $scope.persistentSessionId[$scope.selectedItem.url];
         if (sessionId) {
             protData[$scope.selectedKeySystem].sessionId = sessionId;
         }

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -201,6 +201,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.fastSwitchSelected = true;
     $scope.ABRStrategy = 'abrDynamic';
 
+    // Persistent license
+    $scope.licenseSessionId = {};
+    $scope.selectedKeySystem = null;
+
     // Error management
     $scope.error = '';
     $scope.errorType = '';
@@ -294,6 +298,20 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         }
     }, $scope);
 
+    $scope.player.on(dashjs.MediaPlayer.events.KEY_SYSTEM_SELECTED, function (e) { /* jshint ignore:line */
+        if (e.data) {
+            $scope.selectedKeySystem = e.data.keySystem.systemString;
+        }
+    }, $scope);
+
+    $scope.player.on(dashjs.MediaPlayer.events.KEY_SESSION_CREATED, function (e) { /* jshint ignore:line */
+        if (e.data) {
+            var session = e.data;
+            if (session.getSessionType() === 'persistent-license') {
+                $scope.licenseSessionId[$scope.selectedItem.url] = session.getSessionID();
+            }
+        }
+    }, $scope);
 
     ////////////////////////////////////////
     //
@@ -364,6 +382,12 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             };
         } else {
             protData = null;
+        }
+
+        // Check if persistent license session ID is stored for current stream
+        var sessionId = $scope.licenseSessionId[$scope.selectedItem.url];
+        if (sessionId) {
+            protData[$scope.selectedKeySystem].sessionId = sessionId;
         }
 
         var bufferConfig = {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -837,6 +837,16 @@
         {
           "name": "Unified Streaming Live",
           "url": "http://live.unified-streaming.com/loop/loop.isml/loop.mpd?format=mp4&session_id=25020"
+        },
+        {
+          "name": "Unified Streaming (Widevine, persistent)",
+          "url": "http://demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-dash-widevine.ism/.mpd",
+          "protData": {
+              "com.widevine.alpha": {
+                  "serverURL": "https://cwip-shaka-proxy.appspot.com/no_auth",
+                  "sessionType": "persistent-license"
+              }
+          }
         }
       ]
     },

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -122,6 +122,7 @@
                 <input type="text" class="form-control" ng-model="selectedItem.url">
                 <span class="input-group-btn">
                     <button class="btn btn-default" ng-click="toggleOptionsGutter(!optionsGutter)" ng-cloak>{{getOptionsButtonLabel()}}</button>
+                    <button class="btn btn-default" type="button" ng-click="doStop()">Stop</button>
                     <button class="btn btn-primary" type="button" ng-click="doLoad()">Load</button>
                 </span>
             </div>

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -383,7 +383,13 @@ function ProtectionController(config) {
                         } else {
                             log('DRM: KeySystem Access Granted');
                             eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: event.data});
-                            createKeySession(supportedKS[ksIdx].initData, supportedKS[ksIdx].cdmData);
+                            if (supportedKS[ksIdx].sessionId) {
+                                // Load MediaKeySession with sessionId
+                                loadKeySession(supportedKS[ksIdx].sessionId, supportedKS[ksIdx].initData);
+                            } else if (supportedKS[ksIdx].initData) {
+                                // Create new MediaKeySession with initData
+                                createKeySession(supportedKS[ksIdx].initData, supportedKS[ksIdx].cdmData);
+                            }
                         }
                     };
                     eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
@@ -435,7 +441,13 @@ function ProtectionController(config) {
                                     const initData = { kids: Object.keys(protData.clearkeys) };
                                     pendingNeedKeyData[i][ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
                                 }
-                                createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
+                                if (pendingNeedKeyData[i][ksIdx].sessionId) {
+                                    // Load MediaKeySession with sessionId
+                                    loadKeySession(pendingNeedKeyData[i][ksIdx].sessionId, pendingNeedKeyData[i][ksIdx].initData);
+                                } else if (pendingNeedKeyData[i][ksIdx].initData !== null) {
+                                    // Create new MediaKeySession with initData
+                                    createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
+                                }
                                 break;
                             }
                         }

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -184,12 +184,13 @@ function ProtectionController(config) {
      * essentially creates a new key session
      *
      * @param {string} sessionID
+     * @param {string} initData
      * @memberof module:ProtectionController
      * @instance
      * @fires ProtectionController#KeySessionCreated
      */
-    function loadKeySession(sessionID) {
-        protectionModel.loadKeySession(sessionID);
+    function loadKeySession(sessionID, initData) {
+        protectionModel.loadKeySession(sessionID, initData, getSessionType(keySystem));
     }
 
     /**

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -168,12 +168,12 @@ function ProtectionController(config) {
                 }
             }
             try {
-                protectionModel.createKeySession(initDataForKS, protData, sessionType, cdmData);
+                protectionModel.createKeySession(initDataForKS, protData, getSessionType(keySystem), cdmData);
             } catch (error) {
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Error creating key session! ' + error.message});
             }
         } else if (initData) {
-            protectionModel.createKeySession(initData, protData, sessionType, cdmData);
+            protectionModel.createKeySession(initData, protData, getSessionType(keySystem), cdmData);
         } else {
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Selected key system is ' + keySystem.systemString + '.  needkey/encrypted event contains no initData corresponding to that key system!'});
         }
@@ -338,6 +338,7 @@ function ProtectionController(config) {
         const videoCapabilities = [];
         const audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
         const videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
+        const ksSessionType = getSessionType(keySystem);
 
         if (audioInfo) {
             audioCapabilities.push(new MediaCapability(audioInfo.codec, audioRobustness));
@@ -348,8 +349,14 @@ function ProtectionController(config) {
 
         return new KeySystemConfiguration(
             audioCapabilities, videoCapabilities, 'optional',
-            (sessionType === 'temporary') ? 'optional' : 'required',
-            [sessionType]);
+            (ksSessionType === 'temporary') ? 'optional' : 'required',
+            [ksSessionType]);
+    }
+
+    function getSessionType(keySystem) {
+        const protData = getProtData(keySystem);
+        const ksSessionType = (protData && protData.sessionType) ? protData.sessionType : sessionType;
+        return ksSessionType;
     }
 
     function selectKeySystem(supportedKS, fromManifest) {

--- a/src/streaming/protection/drm/KeySystem.js
+++ b/src/streaming/protection/drm/KeySystem.js
@@ -123,3 +123,11 @@
  * @name MediaPlayer.dependencies.protection.KeySystem#getCDMData
  * @returns {ArrayBuffer} the CDM (custom) data
  */
+
+ /**
+ * Returns MediaKeySession session ID.
+ *
+ * @function
+ * @name MediaPlayer.dependencies.protection.KeySystem#getSessionId
+ * @returns {String} the MediaKeySession session ID
+ */

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -95,6 +95,10 @@ function KeySystemClearKey(config) {
         return null;
     }
 
+    function getSessionId(/*cp*/) {
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -104,6 +108,7 @@ function KeySystemClearKey(config) {
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
         getCDMData: getCDMData,
+        getSessionId: getSessionId,
         getClearKeysFromProtectionData: getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -273,6 +273,10 @@ function KeySystemPlayReady(config) {
         return null;
     }
 
+    function getSessionId(/*cp*/) {
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -282,6 +286,7 @@ function KeySystemPlayReady(config) {
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
         getCDMData: getCDMData,
+        getSessionId: getSessionId,
         setPlayReadyMessageFormat: setPlayReadyMessageFormat,
         init: init
     };

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -95,6 +95,10 @@ function KeySystemW3CClearKey(config) {
         return null;
     }
 
+    function getSessionId(/*cp*/) {
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -104,6 +108,7 @@ function KeySystemW3CClearKey(config) {
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
         getCDMData: getCDMData,
+        getSessionId: getSessionId,
         getClearKeysFromProtectionData: getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -76,6 +76,16 @@ function KeySystemWidevine(config) {
         return null;
     }
 
+    function getSessionId(cp) {
+        // Get sessionId from protectionData or from manifest
+        if (protData && protData.sessionId) {
+            return protData.sessionId;
+        } else if (cp && cp.sessionId) {
+            return cp.sessionId;
+        }
+        return null;
+    }
+
     instance = {
         uuid: uuid,
         schemeIdURI: schemeIdURI,
@@ -85,7 +95,8 @@ function KeySystemWidevine(config) {
         getRequestHeadersFromMessage: getRequestHeadersFromMessage,
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
-        getCDMData: getCDMData
+        getCDMData: getCDMData,
+        getSessionId: getSessionId
     };
 
     return instance;

--- a/src/streaming/protection/models/ProtectionModel.js
+++ b/src/streaming/protection/models/ProtectionModel.js
@@ -144,6 +144,8 @@ let ProtectionModel = function () { };
  * @memberof ProtectionModel
  * @param {string} sessionID the session ID corresponding to the persisted
  * session data to be loaded
+ * @param {ArrayBuffer} the corresponding initData PSSH box for the currently
+ * selected key system.
  */
 
 /**

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -115,7 +115,9 @@ function ProtectionModel_21Jan2015(config) {
     function getAllInitData() {
         const retVal = [];
         for (let i = 0; i < sessions.length; i++) {
-            retVal.push(sessions[i].initData);
+            if (sessions[i].initData) {
+                retVal.push(sessions[i].initData);
+            }
         }
         return retVal;
     }

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -217,8 +217,16 @@ function ProtectionModel_21Jan2015(config) {
             throw new Error('Can not load sessions until you have selected a key system');
         }
 
+        // Check if session Id is not already loaded or loading
+        for (let i = 0; i < sessions.length; i++) {
+            if (sessionID === sessions[i].sessionId) {
+                log('DRM: Ignoring session ID because we have already seen it!');
+                return;
+            }
+        }
+
         const session = mediaKeys.createSession(sessionType);
-        const sessionToken = createSessionToken(session, initData, sessionType);
+        const sessionToken = createSessionToken(session, initData, sessionType, sessionID);
 
         // Load persisted session data into our newly created session object
         session.load(sessionID).then(function (success) {
@@ -325,10 +333,11 @@ function ProtectionModel_21Jan2015(config) {
 
     // Function to create our session token objects which manage the EME
     // MediaKeySession and session-specific event handler
-    function createSessionToken(session, initData, sessionType) {
+    function createSessionToken(session, initData, sessionType, sessionID) {
         const token = { // Implements SessionToken
             session: session,
             initData: initData,
+            sessionId: sessionID,
 
             // This is our main event handler for all desired MediaKeySession events
             // These events are translated into our API-independent versions of the

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -210,23 +210,25 @@ function ProtectionModel_21Jan2015(config) {
         });
     }
 
-    function loadKeySession(sessionID) {
+    function loadKeySession(sessionID, initData, sessionType) {
         if (!keySystem || !mediaKeys) {
             throw new Error('Can not load sessions until you have selected a key system');
         }
 
-        const session = mediaKeys.createSession();
+        const session = mediaKeys.createSession(sessionType);
+        const sessionToken = createSessionToken(session, initData, sessionType);
 
         // Load persisted session data into our newly created session object
         session.load(sessionID).then(function (success) {
             if (success) {
-                const sessionToken = createSessionToken(session);
-                log('DRM: Session created.  SessionID = ' + sessionToken.getSessionID());
+                log('DRM: Session loaded.  SessionID = ' + sessionToken.getSessionID());
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: sessionToken});
             } else {
+                removeSession(sessionToken);
                 eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Could not load session! Invalid Session ID (' + sessionID + ')'});
             }
         }).catch(function (error) {
+            removeSession(sessionToken);
             eventBus.trigger(events.KEY_SESSION_CREATED, {data: null, error: 'Could not load session (' + sessionID + ')! ' + error.name});
         });
     }


### PR DESCRIPTION
This PR adds support for persistent MediaKeySession loading.
This can be operated on chrome since chrome and Widevine CDM now support persistent sessions.

With this PR, if your license server can deliver persistent licences, you can configure the stream protection data to setup key system access with support of persistent licenses:

```
  protData = {
    "com.widevine.alpha": {
      "sessionType": "persistent-license"
    }
  }
```

Once such kind of stream is loaded and a persistent license is obtained, the session ID can be reused, when playing the same stream, to load a MediaKeySession with the persistent session ID, instead of creating a new MediaKeySession and request again the license.

The dash-if-reference sample provides functionnality to playback a session with a persistent session ID.
Once a protected stream has been playback with a persistent license, the application stores the persistent session ID for the stream. Then, in the same browser tab instance, if the same stream is loaded, the persistent session ID will be reused and loaded, avoiding requesting a new license.

A sample test stream is provided: "Other samples / Unified Streaming (Widevine, persistent)"
