### PR TITLE
Revert ProtectionController

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -400,7 +400,9 @@ function ProtectionController(config) {
                 if (event.error) {
                     keySystem = undefined;
                     eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
-                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: null, error: 'DRM: KeySystem Access Denied! -- ' + event.error});
+                    if (!fromManifest) {
+                        eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: null, error: 'DRM: KeySystem Access Denied! -- ' + event.error});
+                    }
                 } else {
                     keySystemAccess = event.data;
                     log('DRM: KeySystem Access Granted (' + keySystemAccess.keySystem.systemString + ')!  Selecting key system...');


### PR DESCRIPTION
This PR reverts a modification mistakenly done in PR #2435.
That concerns key system access error not being triggered when selecting key system from manifest.

BTW, does anyone know why it has been done this way? I thought it could be to handle use case where key systems declared in manifest can't be accessed while pssh of additional key systems are contained in the stream. Then it gives priority to pssh in the stream.
Can anyone confirm or complete?