### PR TITLE
Optimization of manifest processing (ObjectIron)

### DIFF
--- a/externals/objectiron.js
+++ b/externals/objectiron.js
@@ -16,199 +16,89 @@
  * copyright dash-if 2012
  */
 
-/*
- * var parent,
- *     child,
- *     properties = [
-                    {
-                        name: 'profiles',
-                        merge: false
-                    }
-                ];
- *
- * parent = {};
- * parent.name = "ParentNode";
- * parent.isRoor = false;
- * parent.isArray = false;
- * parent.children = [];
- * parent.properties = properties;
- *
- * child = {};
- * child.name = "ChildNode";
- * child.isRoor = false;
- * child.isArray = true;
- * child.children = null;
- * child.properties = properties;
- * parent.children.push(child);
- *
- */
+export default class ObjectIron{
 
-function ObjectIron(map) {
+    constructor(mappers) {
+        this.mappers = mappers;
+    }
 
-    var lookup,
-        len,
-        i;
-
-    // create a list of top level items to search for
-    lookup = [];
-    for (i = 0, len = map.length; i < len; i += 1) {
-        if (map[i].isRoot) {
-            lookup.push("root");
-        } else {
-            lookup.push(map[i].name);
+    mergeValues(parentItem, childItem) {
+        for (let name in parentItem) {
+            if (!childItem.hasOwnProperty(name)) {
+                childItem[name] = parentItem[name];
+            }
         }
     }
 
-    var mergeValues = function (parentItem, childItem) {
-            var name,
-                parentValue,
-                childValue;
+    mapProperties(properties, parent, child) {
+        for (let i = 0, len = properties.length; i < len; ++i) {
+            const property = properties[i];
 
-            if (parentItem === null || childItem === null) {
-                return;
-            }
+            if (parent[property.name]) {
+                if (child[property.name]) {
+                    // check to see if we should merge
+                    if (property.merge) {
+                       const parentValue = parent[property.name];
+                       const childValue = child[property.name];
 
-            for (name in parentItem) {
-                if (parentItem.hasOwnProperty(name)) {
-                    if (!childItem.hasOwnProperty(name)) {
-                        childItem[name] = parentItem[name];
-                    }
-                }
-            }
-        },
-
-        mapProperties = function (properties, parent, child) {
-            var i,
-                len,
-                property,
-                parentValue,
-                childValue;
-
-            if (properties === null || properties.length === 0) {
-                return;
-            }
-
-            for (i = 0, len = properties.length; i < len; i += 1) {
-                property = properties[i];
-
-                if (parent.hasOwnProperty(property.name)) {
-                    if (child.hasOwnProperty(property.name)) {
-                        // check to see if we should merge
-                        if (property.merge) {
-                           parentValue = parent[property.name];
-                           childValue = child[property.name];
-
-                            // complex objects; merge properties
-                            if (typeof parentValue === 'object' && typeof childValue === 'object') {
-                                mergeValues(parentValue, childValue);
-                            }
-                            // simple objects; merge them together
-                            else {
-                                if (property.mergeFunction != null) {
-                                    child[property.name] = property.mergeFunction(parentValue, childValue);
-                                } else {
-                                    child[property.name] = parentValue + childValue;
-                                }
-                            }
+                        // complex objects; merge properties
+                        if (typeof parentValue === 'object' && typeof childValue === 'object') {
+                            this.mergeValues(parentValue, childValue);
                         }
-                    } else {
-                        // just add the property
-                        child[property.name] = parent[property.name];
-                    }
-                }
-            }
-        },
-
-        mapItem = function (obj, node) {
-            var item = obj,
-                i,
-                len,
-                v,
-                len2,
-                array,
-                childItem,
-                childNode,
-                property;
-
-            if (item.children === null || item.children.length === 0) {
-                return;
-            }
-
-            for (i = 0, len = item.children.length; i < len; i += 1) {
-                childItem = item.children[i];
-
-                if (node.hasOwnProperty(childItem.name)) {
-                    if (childItem.isArray) {
-                        array = node[childItem.name + "_asArray"];
-                        for (v = 0, len2 = array.length; v < len2; v += 1) {
-                            childNode = array[v];
-                            mapProperties(item.properties, node, childNode);
-                            mapItem(childItem, childNode);
-                        }
-                    } else {
-                        childNode = node[childItem.name];
-                        mapProperties(item.properties, node, childNode);
-                        mapItem(childItem, childNode);
-                    }
-                }
-            }
-        },
-
-        performMapping = function (source) {
-            var i,
-                len,
-                pi,
-                pp,
-                item,
-                node,
-                array;
-
-            if (source === null) {
-                return source;
-            }
-
-            if (typeof source !== 'object') {
-                return source;
-            }
-
-            // first look to see if anything cares about the root node
-            for (i = 0, len = lookup.length; i < len; i += 1) {
-                if (lookup[i] === "root") {
-                    item = map[i];
-                    node = source;
-                    mapItem(item, node);
-                }
-            }
-
-            // iterate over the objects and look for any of the items we care about
-            for (pp in source) {
-                if (source.hasOwnProperty(pp) && pp != "__children") {
-                    pi = lookup.indexOf(pp);
-                    if (pi !== -1) {
-                        item = map[pi];
-
-                        if (item.isArray) {
-                            array = source[pp + "_asArray"];
-                            for (i = 0, len = array.length; i < len; i += 1) {
-                                node = array[i];
-                                mapItem(item, node);
-                            }
-                        } else {
-                            node = source[pp];
-                            mapItem(item, node);
+                        // simple objects; merge them together
+                        else {
+                            child[property.name] = parentValue + childValue;
                         }
                     }
-                    // now check this to see if he has any of the properties we care about
-                    performMapping(source[pp]);
+                } else {
+                    // just add the property
+                    child[property.name] = parent[property.name];
                 }
             }
+        }
+    }
 
+    mapItem(item, node) {
+        for (let i = 0, len = item.children.length; i < len; ++i) {
+            const childItem = item.children[i];
+
+            const array = node[childItem.name + '_asArray'];
+            if (array) {
+                for (let v = 0, len2 = array.length; v < len2; ++v) {
+                    const childNode = array[v];
+                    this.mapProperties(item.properties, node, childNode);
+                    this.mapItem(childItem, childNode);
+                }
+            }
+        }
+    }
+
+    run(source) {
+
+        if (source === null || typeof source !== 'object') {
             return source;
-        };
+        }
 
-    return {
-        run: performMapping
-    };
+        const mappers = this.mappers;
+        if ('period' in mappers) {
+            const periodMapper = mappers.period;
+            const periods = source.Period_asArray;
+            for (let i = 0, len = periods.length; i < len; ++i) {
+                const period = periods[i];
+                this.mapItem(periodMapper, period);
+
+                if ('adaptationset' in mappers) {
+                    const adaptationSets = period.AdaptationSet_asArray;
+                    if (adaptationSets) {
+                        const adaptationSetMapper = mappers.adaptationset;
+                        for (let i = 0, len = adaptationSets.length; i < len; ++i) {
+                            this.mapItem(adaptationSetMapper, adaptationSets[i]);
+                        }
+                    }
+                }
+            }
+        }
+
+        return source;
+    }
 }
-
-export default ObjectIron;

--- a/externals/objectiron.js
+++ b/externals/objectiron.js
@@ -38,8 +38,8 @@ export default class ObjectIron{
                 if (child[property.name]) {
                     // check to see if we should merge
                     if (property.merge) {
-                       const parentValue = parent[property.name];
-                       const childValue = child[property.name];
+                        const parentValue = parent[property.name];
+                        const childValue = child[property.name];
 
                         // complex objects; merge properties
                         if (typeof parentValue === 'object' && typeof childValue === 'object') {

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -70,10 +70,10 @@ function DashParser(config) {
             matchers:           matchers
         });
 
-        objectIron = new ObjectIron([
-            new RepresentationBaseValuesMap(),
-            new SegmentValuesMap()
-        ]);
+        objectIron = new ObjectIron({
+            adaptationset: new RepresentationBaseValuesMap(),
+            period: new SegmentValuesMap()
+        });
     }
 
     function checkConfig() {

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -30,7 +30,7 @@
  */
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
-import ObjectIron from '../../../externals/objectiron';
+import ObjectIron from './objectiron';
 import X2JS from '../../../externals/xml2json';
 import StringMatcher from './matchers/StringMatcher';
 import DurationMatcher from './matchers/DurationMatcher';
@@ -70,7 +70,7 @@ function DashParser(config) {
             matchers:           matchers
         });
 
-        objectIron = new ObjectIron({
+        objectIron = ObjectIron(context).create({
             adaptationset: new RepresentationBaseValuesMap(),
             period: new SegmentValuesMap()
         });

--- a/src/dash/parser/maps/CommonProperty.js
+++ b/src/dash/parser/maps/CommonProperty.js
@@ -33,14 +33,12 @@
  */
 
 class CommonProperty {
-    constructor(name, merge) {
+    constructor(name) {
         const getDefaultMergeForName =
               (n) => n && n.length && n.charAt(0) === n.charAt(0).toUpperCase();
 
         this._name = name;
-        this._merge = merge !== undefined ?
-            merge :
-            getDefaultMergeForName(name);
+        this._merge = getDefaultMergeForName(name);
     }
 
     get name() {

--- a/src/dash/parser/maps/MapNode.js
+++ b/src/dash/parser/maps/MapNode.js
@@ -34,12 +34,10 @@
 import CommonProperty from './CommonProperty';
 
 class MapNode {
-    constructor(name, properties, children, isRoot, isArray) {
+    constructor(name, properties, children) {
         this._name = name || '';
         this._properties = [];
         this._children = children || [];
-        this._isRoot = isRoot || false;
-        this._isArray = isArray || true ;
 
         if (Array.isArray(properties)) {
             properties.forEach(p => {
@@ -50,14 +48,6 @@ class MapNode {
 
     get name() {
         return this._name;
-    }
-
-    get isRoot() {
-        return this._isRoot;
-    }
-
-    get isArray() {
-        return this._isArray;
     }
 
     get children() {

--- a/src/dash/parser/objectiron.js
+++ b/src/dash/parser/objectiron.js
@@ -16,13 +16,11 @@
  * copyright dash-if 2012
  */
 
-export default class ObjectIron{
+import FactoryMaker from '../../core/FactoryMaker';
 
-    constructor(mappers) {
-        this.mappers = mappers;
-    }
+function ObjectIron(mappers) {
 
-    mergeValues(parentItem, childItem) {
+    function mergeValues(parentItem, childItem) {
         for (let name in parentItem) {
             if (!childItem.hasOwnProperty(name)) {
                 childItem[name] = parentItem[name];
@@ -30,7 +28,7 @@ export default class ObjectIron{
         }
     }
 
-    mapProperties(properties, parent, child) {
+    function mapProperties(properties, parent, child) {
         for (let i = 0, len = properties.length; i < len; ++i) {
             const property = properties[i];
 
@@ -43,7 +41,7 @@ export default class ObjectIron{
 
                         // complex objects; merge properties
                         if (typeof parentValue === 'object' && typeof childValue === 'object') {
-                            this.mergeValues(parentValue, childValue);
+                            mergeValues(parentValue, childValue);
                         }
                         // simple objects; merge them together
                         else {
@@ -58,7 +56,7 @@ export default class ObjectIron{
         }
     }
 
-    mapItem(item, node) {
+    function mapItem(item, node) {
         for (let i = 0, len = item.children.length; i < len; ++i) {
             const childItem = item.children[i];
 
@@ -66,33 +64,32 @@ export default class ObjectIron{
             if (array) {
                 for (let v = 0, len2 = array.length; v < len2; ++v) {
                     const childNode = array[v];
-                    this.mapProperties(item.properties, node, childNode);
-                    this.mapItem(childItem, childNode);
+                    mapProperties(item.properties, node, childNode);
+                    mapItem(childItem, childNode);
                 }
             }
         }
     }
 
-    run(source) {
+    function run(source) {
 
         if (source === null || typeof source !== 'object') {
             return source;
         }
 
-        const mappers = this.mappers;
         if ('period' in mappers) {
             const periodMapper = mappers.period;
             const periods = source.Period_asArray;
             for (let i = 0, len = periods.length; i < len; ++i) {
                 const period = periods[i];
-                this.mapItem(periodMapper, period);
+                mapItem(periodMapper, period);
 
                 if ('adaptationset' in mappers) {
                     const adaptationSets = period.AdaptationSet_asArray;
                     if (adaptationSets) {
                         const adaptationSetMapper = mappers.adaptationset;
                         for (let i = 0, len = adaptationSets.length; i < len; ++i) {
-                            this.mapItem(adaptationSetMapper, adaptationSets[i]);
+                            mapItem(adaptationSetMapper, adaptationSets[i]);
                         }
                     }
                 }
@@ -101,4 +98,13 @@ export default class ObjectIron{
 
         return source;
     }
+
+    return {
+        run: run
+    };
 }
+
+
+ObjectIron.__dashjs_factory_name = 'ObjectIron';
+const factory = FactoryMaker.getClassFactory(ObjectIron);
+export default factory;

--- a/src/dash/parser/objectiron.js
+++ b/src/dash/parser/objectiron.js
@@ -1,21 +1,33 @@
-/*
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * author Digital Primates
- * copyright dash-if 2012
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 import FactoryMaker from '../../core/FactoryMaker';
 
 function ObjectIron(mappers) {

--- a/test/unit/dash.parser.maps.CommonProperty.js
+++ b/test/unit/dash.parser.maps.CommonProperty.js
@@ -6,22 +6,11 @@ describe('CommonProperty', function () {
 
     it('should return a CommonProperty with values as supplied', () => {
         const name = 'lowerCaseFirstCharacter';
-        const merge = true;
 
-        const commonProperty = new CommonProperty(name, merge);
+        const commonProperty = new CommonProperty(name);
 
         expect(commonProperty).to.be.instanceof(CommonProperty); // jshint ignore:line
         expect(commonProperty.name).to.equal(name); // jshint ignore:line
-        expect(commonProperty.merge).to.equal(merge); // jshint ignore:line
-    });
-
-    it('should not use the default value of merge when merge is false', () => {
-        const name = 'UpperCaseFirstCharacter';
-        const merge = false;
-
-        const commonProperty = new CommonProperty(name, merge);
-
-        expect(commonProperty.merge).to.equal(false); // jshint ignore:line
     });
 
     it('should default merge property to false when not supplied and name is lowercase', () => {

--- a/test/unit/dash.parser.maps.MapNode.js
+++ b/test/unit/dash.parser.maps.MapNode.js
@@ -14,14 +14,12 @@ describe('MapNode', function () {
         expect(mapNode.properties).to.be.empty; // jshint ignore:line
         expect(mapNode.children).to.be.instanceOf(Array); // jshint ignore:line
         expect(mapNode.children).to.be.empty; // jshint ignore:line
-        expect(mapNode.isRoot).to.equal(false); // jshint ignore:line
-        expect(mapNode.isArray).to.equal(true); // jshint ignore:line
     });
 
     it('should throw an exception if attempting to use setters', () => {
         const mapNode = new MapNode();
 
-        ['name', 'properties', 'children', 'isRoot', 'isArray'].forEach(p => {
+        ['name', 'properties', 'children'].forEach(p => {
             const f = () => mapNode[p] = p;
             expect(f).to.throw(Error);
         });


### PR DESCRIPTION
This PR is a refactoring of `objectiron.js` in order to greatly reduce the time to process manifests, especially on low resource devices like Chromecast. This reduces join time, and improves UX for live streams as manifests are downloaded repeatedly.

ObjectIron is used to apply inheritance of XML attributes and elements in the manifest. For example, SegmentBase, SegmentTemplate and SegmentList elements may be present in the Representation element. In addition, to express default values, they may be present in the Period and AdaptationSet ancestors. In the Representation element, SegmentBase, SegmentTemplate and SegmentList shall inherit attributes and elements from the same element on a higher level. This is processed using ObjectIron.

ObjectIron uses _mappers_ to define which elements and attributes must be inherited:
* the SegmentValuesMap.js mapper is used to apply inheritance of SegmentBase, SegmentTemplate and SegmentList elements through the Period > AdaptationSet > Representation hierarchy
* the RepresentationBaseValuesMap.js is used to apply inheritance of common Adaptation Set, Representation and Sub-Representation attributes and elements through the AdaptationSet > Representation > SubRepresentation hierarchy

The main drawback of the current ObjectIron implementation is that it loops recursively over all the node hierarchy of the manifest to find Period and Representation elements at any level. This is inefficient as Period elements are only children of the MPD element, and AdaptationSet elements are only children of Period elements. This PR optimizes this by targeting specifically MPD > Period and Period > AdaptationSet elements to apply inheritance, without looping over the full node tree.

Additional changes include:
* Make ObjectIron a JS class. Remove unused local variables. Fix lint errors.
* Removed useless `isRoot` and `isArray` properties from `MapNode` (`isRoot` is never set to true, `isArray` is always true). Removed dead code depending on those properties from ObjectIron
* Removed unused `merge` parameter from the CommonProperty constructor.
* Updated unit tests for MapNode and CommonProperty accordingly

Please test with different types of manifests. Comments and Feedback are welcomed.