### PR TITLE
Play initialization

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -49,7 +49,7 @@ declare namespace dashjs {
         codec: string | null;
         contentProtection: any | null;
     }
-    
+
     export interface MediaPlayerClass {
         initialize(view?: HTMLElement, source?: string, autoPlay?: boolean): void;
         on(type: AstInFutureEvent['type'], listener: (e: AstInFutureEvent) => void, scope?: object): void;
@@ -82,6 +82,7 @@ declare namespace dashjs {
         on(type: QualityChangeRequestedEvent['type'], listener: (e: QualityChangeRequestedEvent) => void, scope?: object): void;
         on(type: StreamInitializedEvent['type'], listener: (e: StreamInitializedEvent) => void, scope?: object): void;
         on(type: TextTracksAddedEvent['type'], listener: (e: TextTracksAddedEvent) => void, scope?: object): void;
+        on(type: TtmlParsedEvent['type'], listener: (e: TtmlParsedEvent) => void, scope?: object): void;
         on(type: string, listener: (e: Event) => void, scope?: object): void;
         off(type: string, listener: (e: any) => void, scope?: object): void;
         extend(parentNameString: string, childInstance: object, override: boolean): void;
@@ -202,6 +203,7 @@ declare namespace dashjs {
         getJumpGaps(): boolean;
         setSmallGapLimit(value: number): void;
         getSmallGapLimit(): number;
+        preload(): void;
         reset(): void;
     }
 
@@ -256,11 +258,13 @@ declare namespace dashjs {
         PLAYBACK_TIME_UPDATED: 'playbackTimeUpdated';
         PROTECTION_CREATED: 'public_protectioncreated';
         PROTECTION_DESTROYED: 'public_protectiondestroyed';
+        TRACK_CHANGE_RENDERED: 'trackChangeRendered';
         QUALITY_CHANGE_RENDERED: 'qualityChangeRendered';
         QUALITY_CHANGE_REQUESTED: 'qualityChangeRequested';
         STREAM_INITIALIZED: 'streamInitialized';
         TEXT_TRACKS_ADDED: 'allTextTracksAdded';
         TEXT_TRACK_ADDED: 'textTrackAdded';
+        TTML_PARSED: 'ttmlParsed';
     }
 
     export interface Event {
@@ -469,6 +473,13 @@ declare namespace dashjs {
         data: string;
     }
 
+    export interface TrackChangeRenderedEvent extends Event {
+        type: MediaPlayerEvents['TRACK_CHANGE_RENDERED'];
+        mediaType: 'video' | 'audio' | 'fragmentedText';
+        oldMediaInfo: MediaInfo;
+        newMediaInfo: MediaInfo;
+    }
+
     export interface QualityChangeRenderedEvent extends Event {
         type: MediaPlayerEvents['QUALITY_CHANGE_RENDERED'];
         mediaType: 'video' | 'audio' | 'fragmentedText';
@@ -499,6 +510,12 @@ declare namespace dashjs {
         enabled: boolean;
         index: number;
         tracks: TextTrackInfo[];
+    }
+
+    export interface TtmlParsedEvent extends Event {
+        type: MediaPlayerEvents['TTML_PARSED'];
+        ttmlString: string;
+        ttmlDoc: object;
     }
 
     export class BitrateInfo {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -98,10 +98,7 @@ function PlaybackController() {
     }
 
     function play() {
-        if (!streamInfo) {
-            return;
-        }
-        if (videoModel && videoModel.getElement()) {
+        if (streamInfo && videoModel && videoModel.getElement()) {
             videoModel.play();
         } else {
             playOnceInitialized = true;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -98,6 +98,9 @@ function PlaybackController() {
     }
 
     function play() {
+        if (!streamInfo) {
+            return;
+        }
         if (videoModel && videoModel.getElement()) {
             videoModel.play();
         } else {
@@ -106,21 +109,21 @@ function PlaybackController() {
     }
 
     function isPaused() {
-        return videoModel ? videoModel.isPaused() : null;
+        return streamInfo && videoModel ? videoModel.isPaused() : null;
     }
 
     function pause() {
-        if (videoModel) {
+        if (streamInfo && videoModel) {
             videoModel.pause();
         }
     }
 
     function isSeeking() {
-        return videoModel ? videoModel.isSeeking() : null;
+        return streamInfo && videoModel ? videoModel.isSeeking() : null;
     }
 
     function seek(time) {
-        if (videoModel) {
+        if (streamInfo && videoModel) {
             eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
             log('Requesting seek to time: ' + time);
             videoModel.setCurrentTime(time);
@@ -128,19 +131,19 @@ function PlaybackController() {
     }
 
     function getTime() {
-        return videoModel ? videoModel.getTime() : null;
+        return streamInfo && videoModel ? videoModel.getTime() : null;
     }
 
     function getPlaybackRate() {
-        return videoModel ? videoModel.getPlaybackRate() : null;
+        return streamInfo && videoModel ? videoModel.getPlaybackRate() : null;
     }
 
     function getPlayedRanges() {
-        return videoModel ? videoModel.getPlayedRanges() : null;
+        return streamInfo && videoModel ? videoModel.getPlayedRanges() : null;
     }
 
     function getEnded() {
-        return videoModel ? videoModel.getEnded() : null;
+        return streamInfo && videoModel ? videoModel.getEnded() : null;
     }
 
     function getIsDynamic() {

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -46,6 +46,12 @@ describe('PlaybackController', function () {
 
             expect(playbackController.getIsDynamic()).to.not.exist; // jshint ignore:line
             expect(playbackController.getLiveStartTime()).to.be.NaN; // jshint ignore:line
+            expect(playbackController.isPaused()).to.be.null; // jshint ignore:line
+            expect(playbackController.isSeeking()).to.be.null; // jshint ignore:line
+            expect(playbackController.getTime()).to.be.null; // jshint ignore:line
+            expect(playbackController.getPlaybackRate()).to.be.null; // jshint ignore:line
+            expect(playbackController.getPlayedRanges()).to.be.null; // jshint ignore:line
+            expect(playbackController.getEnded()).to.be.null; // jshint ignore:line
 
             let streamInfo = {
                 manifestInfo: {


### PR DESCRIPTION
Fix #2184 

This PR changes the behavior of PlaybackController so it operates with VideoModel only in case PlaybackController was previously initialized and then there is an active stream. Otherwise, there are situations in which a call to MediaPlayer.play() before stream is initialized (and then the MediaSource associated) brings video element to an unstable state and some of its events are not fired (for example, the "play" event that is used to launch processes like the manifest update one). Example code to reproduce the issue:

```
player.initialize();
player.attachView(video);
player.attachSource(url);
player.play();
```

This is broken since v2.6.0. Dash.js v2.5.0 and before were working fine because they were establishing the video element during PlaybackController initialization.