### PR TITLE
Check streamprocessors while initializing protection

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -496,7 +496,9 @@ function Stream(config) {
         }
 
         if (protectionController) {
-            for (let i = 0; i < ln; i++) {
+            // Need to check if streamProcessors exists because streamProcessors
+            // could be cleared in case an error is detected while initializing DRM keysystem
+            for (let i = 0; i < ln && streamProcessors[i]; i++) {
                 if (streamProcessors[i].getType() === Constants.AUDIO ||
                     streamProcessors[i].getType() === Constants.VIDEO ||
                     streamProcessors[i].getType() === Constants.FRAGMENTED_TEXT) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -156,8 +156,9 @@ function StreamController() {
     }
 
     function onWallclockTimeUpdated(e) {
-        if (!mediaPlayerModel.getJumpGaps() || isPaused || isStreamSwitchingInProgress ||
-            !activeStream || playbackController.isSeeking()) {
+        if (!mediaPlayerModel.getJumpGaps() || !activeStream || activeStream.getProcessors().length === 0 ||
+            playbackController.isSeeking() || isPaused || isStreamSwitchingInProgress ||
+            hasMediaError || hasInitialisationError) {
             return;
         }
 
@@ -165,7 +166,6 @@ function StreamController() {
         if (wallclockTicked >= STALL_THRESHOLD_TO_CHECK_GAPS) {
             const currentTime = playbackController.getTime();
             if (lastPlaybackTime === currentTime) {
-                log('Warning - Playback stalled for', (wallclockTicked * mediaPlayerModel.getWallclockTimeUpdateInterval()) ,'milliseconds. Time for a jump?');
                 jumpGap(currentTime, e.timeToEnd);
             } else {
                 lastPlaybackTime = currentTime;


### PR DESCRIPTION
Fix #2458 

As @bbcrddave stated, in case there is an issue while initializing Protection for any of the media types, stream is reset and then streamProcessors array. We need to take this into account while iterating streamProcessors.