### PR TITLE
Clean URIQueryAndFragmentModel

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -40,7 +40,7 @@ import Capabilities from './utils/Capabilities';
 import TextTracks from './text/TextTracks';
 import RequestModifier from './utils/RequestModifier';
 import TextController from './text/TextController';
-import URIQueryAndFragmentModel from './models/URIQueryAndFragmentModel';
+import URIFragmentModel from './models/URIFragmentModel';
 import ManifestModel from './models/ManifestModel';
 import MediaPlayerModel from './models/MediaPlayerModel';
 import MetricsModel from './models/MetricsModel';
@@ -2365,9 +2365,8 @@ function MediaPlayer() {
 
         eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
 
-        let uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
-        uriQueryFragModel.initialize();
-        manifestLoader.load(uriQueryFragModel.parseURI(url));
+        URIFragmentModel(context).getInstance().initialize(url);
+        manifestLoader.load(url);
     }
 
     /**
@@ -2403,12 +2402,10 @@ function MediaPlayer() {
         }
 
         if (typeof urlOrManifest === 'string') {
-            let uriQueryFragModel = URIQueryAndFragmentModel(context).getInstance();
-            uriQueryFragModel.initialize();
-            source = uriQueryFragModel.parseURI(urlOrManifest);
-        } else {
-            source = urlOrManifest;
+            URIFragmentModel(context).getInstance().initialize(urlOrManifest);
         }
+
+        source = urlOrManifest;
 
         if (streamingInitialized || playbackInitialized) {
             resetPlaybackControllers();

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -30,7 +30,7 @@
  */
 import Constants from '../constants/Constants';
 import BufferController from './BufferController';
-import URIQueryAndFragmentModel from '../models/URIQueryAndFragmentModel';
+import URIFragmentModel from '../models/URIFragmentModel';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
@@ -250,7 +250,7 @@ function PlaybackController() {
     }
 
     function getStartTimeFromUriParameters() {
-        const fragData = URIQueryAndFragmentModel(context).getInstance().getURIFragmentData();
+        const fragData = URIFragmentModel(context).getInstance().getURIFragmentData();
         let uriParameters;
         if (fragData) {
             uriParameters = {};

--- a/src/streaming/models/URIFragmentModel.js
+++ b/src/streaming/models/URIFragmentModel.js
@@ -32,91 +32,56 @@
 import URIFragmentData from '../vo/URIFragmentData';
 import FactoryMaker from '../../core/FactoryMaker';
 
-function URIQueryAndFragmentModel() {
+/**
+ * Model class managing URI fragments.
+ */
+function URIFragmentModel() {
 
     let instance,
-        URIFragmentDataVO,
-        URIQueryData,
-        isHTTPS;
+        URIFragmentDataVO;
 
-    function initialize() {
+    /**
+     * @param {string} uri The URI to parse for fragment extraction
+     * @memberof module:URIFragmentModel
+     * @instance
+     */
+    function initialize(uri) {
         URIFragmentDataVO = new URIFragmentData();
-        URIQueryData = [];
-        isHTTPS = false;
+
+        if (!uri) return null;
+
+        const hashIndex = uri.indexOf('#');
+        if (hashIndex !== -1) {
+            const fragments = uri.substr(hashIndex + 1).split('&');
+            for (let i = 0, len = fragments.length; i < len; ++i) {
+                const fragment = fragments[i];
+                const equalIndex = fragment.indexOf('=');
+                if (equalIndex !== -1) {
+                    const key = fragment.substring(0,equalIndex);
+                    if (URIFragmentDataVO.hasOwnProperty(key)) {
+                        URIFragmentDataVO[key] = fragment.substr(equalIndex + 1);
+                    }
+                }
+            }
+        }
     }
 
+    /**
+     * @returns {URIFragmentData} Object containing supported URI fragments
+     * @memberof module:URIFragmentModel
+     * @instance
+     */
     function getURIFragmentData() {
         return URIFragmentDataVO;
     }
 
-    function getURIQueryData() {
-        return URIQueryData;
-    }
-
-    function isManifestHTTPS() {
-        return isHTTPS;
-    }
-
-    function parseURI(uri) {
-        if (!uri) return null;
-
-        let URIFragmentData = [];
-        let mappedArr;
-
-        let testQuery = new RegExp(/[?]/);
-        let testFragment = new RegExp(/[#]/);
-        let testHTTPS = new RegExp(/^(https:)?\/\//i);
-        let isQuery = testQuery.test(uri);
-        let isFragment = testFragment.test(uri);
-
-        isHTTPS = testHTTPS.test(uri);
-
-        function reduceArray(previousValue, currentValue, index, array) {
-            let arr =  array[0].split(/[=]/);
-            array.push({key: arr[0], value: arr[1]});
-            array.shift();
-            return array;
-        }
-
-        function mapArray(currentValue, index, array) {
-            if (index > 0)
-            {
-                if (isQuery && URIQueryData.length === 0) {
-                    URIQueryData = array[index].split(/[&]/);
-                } else if (isFragment) {
-                    URIFragmentData = array[index].split(/[&]/);
-                }
-            }
-
-            return array;
-        }
-
-        mappedArr = uri.split(/[?#]/).map(mapArray);
-
-        if (URIQueryData.length > 0) {
-            URIQueryData = URIQueryData.reduce(reduceArray, null);
-        }
-
-        if (URIFragmentData.length > 0) {
-            URIFragmentData = URIFragmentData.reduce(reduceArray, null);
-            URIFragmentData.forEach(function (object) {
-                URIFragmentDataVO[object.key] = object.value;
-            });
-        }
-
-        return uri;
-    }
-
     instance = {
         initialize: initialize,
-        parseURI: parseURI,
-        getURIFragmentData: getURIFragmentData,
-        getURIQueryData: getURIQueryData,
-        isManifestHTTPS: isManifestHTTPS
+        getURIFragmentData: getURIFragmentData
     };
 
     return instance;
 }
 
-URIQueryAndFragmentModel.__dashjs_factory_name = 'URIQueryAndFragmentModel';
-export default FactoryMaker.getSingletonFactory(URIQueryAndFragmentModel);
+URIFragmentModel.__dashjs_factory_name = 'URIFragmentModel';
+export default FactoryMaker.getSingletonFactory(URIFragmentModel);


### PR DESCRIPTION
This PR provides a clean version of URIQueryAndFragmentModel.

Currently, URIQueryAndFragmentModel parses the URI of the attach manifest to detect if HTTPS is used, and extract data from the query string and the fragment part. However, only the fragment part is really used by dash.js.

This clean version removes the code parsing unused data. Only supported keys are extracted from the fragment part of the URI (t, xywh, track, id, s, r).

EDIT: by the way, I renamed this class to URIFragmentModel to better express its main purpose.