### PR TITLE
Fix SeekBar style (ControlBar)

### DIFF
--- a/contrib/akamai/controlbar/controlbar.css
+++ b/contrib/akamai/controlbar/controlbar.css
@@ -288,7 +288,6 @@ input[type="range"]::-ms-thumb {
 }
 
 .seekbar-buffer {
-    z-index: 100;
     position: absolute;
     left: 0px;
     top: 0px;
@@ -298,7 +297,6 @@ input[type="range"]::-ms-thumb {
 }
 
 .seekbar-play {
-    z-index: 1000;
     position: absolute;
     left: 0px;
     top: 0px;

--- a/contrib/akamai/controlbar/snippet.html
+++ b/contrib/akamai/controlbar/snippet.html
@@ -22,8 +22,8 @@
     <span id="videoDuration" class="duration-display">00:00:00</span>
     <div class="seekContainer">
         <div id="seekbar" class="seekbar seekbar-complete">
-            <div id="seekbar-play" class="seekbar seekbar-play"></div>
             <div id="seekbar-buffer" class="seekbar seekbar-buffer"></div>
+            <div id="seekbar-play" class="seekbar seekbar-play"></div>
         </div>
     </div>
     <div id="thumbnail-container" class="thumbnail-container">

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -280,8 +280,8 @@
                         <span id="videoDuration" class="duration-display">00:00:00</span>
                         <div class="seekContainer">
                             <div id="seekbar" class="seekbar seekbar-complete">
-                                <div id="seekbar-play" class="seekbar seekbar-play"></div>
                                 <div id="seekbar-buffer" class="seekbar seekbar-buffer"></div>
+                                <div id="seekbar-play" class="seekbar seekbar-play"></div>
                             </div>
                         </div>
                         <div id="thumbnail-container" class="thumbnail-container">


### PR DESCRIPTION
This PR fixes #2460. 

Simplified the layout of Seekbar component and its associated css. This removes the need of using z-index properties in the seeking bar because it could interfere with other components of the web layout. 