### PR TITLE
Fix creation of buffers

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -109,7 +109,6 @@ function Stream(config) {
             initializeMedia(mediaSource);
             isStreamActivated = true;
         }
-        createBuffers();
     }
 
     /**


### PR DESCRIPTION
This PR fixes a double call to the `createBuffers()` method in `Stream.activate()`.

There is no need to call `createBuffers()` again as it is already called by `initializeMedia()` just above.