### PR TITLE
Optimization of track addition

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -384,10 +384,7 @@ function Stream(config) {
                 textController.addEmbeddedTrack(mediaInfo);
             } else {
                 if (!isMediaSupported(mediaInfo)) continue;
-
-                if (mediaController.isMultiTrackSupportedByType(mediaInfo.type)) {
-                    mediaController.addTrack(mediaInfo, streamInfo);
-                }
+                mediaController.addTrack(mediaInfo);
             }
         }
 

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -115,25 +115,27 @@ function MediaController() {
      * @memberof MediaController#
      */
     function addTrack(track) {
-        let mediaType = track ? track.type : null;
-        let streamId = track ? track.streamInfo.id : null;
-        let initSettings = getInitialSettings(mediaType);
+        if (!track) return;
 
-        if (!track || (!isMultiTrackSupportedByType(mediaType))) return;
+        let mediaType = track.type;
+        if (!isMultiTrackSupportedByType(mediaType)) return;
 
-        tracks[streamId] = tracks[streamId] || createTrackInfo();
+        let streamId = track.streamInfo.id;
+        if (!tracks[streamId]) {
+            tracks[streamId] = createTrackInfo();
+        }
 
-        const len = tracks[streamId][mediaType].list.length;
-
-        for (let i = 0; i < len; i++) {
+        const mediaTracks = tracks[streamId][mediaType].list;
+        for (let i = 0, len = mediaTracks.length; i < len; ++i) {
             //track is already set.
-            if (isTracksEqual(tracks[streamId][mediaType].list[i], track)) {
+            if (isTracksEqual(mediaTracks[i], track)) {
                 return;
             }
         }
 
-        tracks[streamId][mediaType].list.push(track);
+        mediaTracks.push(track);
 
+        let initSettings = getInitialSettings(mediaType);
         if (initSettings && (matchSettings(initSettings, track)) && !getCurrentTrackFor(mediaType, track.streamInfo)) {
             setTrack(track);
         }


### PR DESCRIPTION
This PR is a small optimization for the addition of tracks:

In `Stream.initializeMediaForType()`:
* remove call to `MediaController.isMultiTrackSupportedByType()` as it is also done in `MediaController.addTrack()`
* fix: remove unused second argument passed to `MediaController.addTrack()`

The `MediaController.addTrack()` is also slightly refactored to:
* return early if no track passed or track type is not suppored
* use a direct reference to the track list to which passed track should be added.