### PR TITLE
Fix #2487 - remove dependency on round10

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
   "dependencies": {
     "codem-isoboxer": "0.3.5",
     "fast-deep-equal": "1.1.0",
-    "imsc": "^1.0.1-rc.1",
-    "round10": "^1.0.3"
+    "imsc": "^1.0.1-rc.1"
   },
   "repository": {
     "type": "git",

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -31,7 +31,7 @@
 import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import FactoryMaker from '../core/FactoryMaker';
 import MetricsConstants from '../streaming/constants/MetricsConstants';
-import { round10 } from 'round10';
+import Round10 from './utils/Round10';
 
 /**
  * @module DashMetrics
@@ -122,7 +122,7 @@ function DashMetrics(config) {
         const vo = getLatestBufferLevelVO(metrics);
 
         if (vo) {
-            return round10(vo.level / 1000, -3);
+            return Round10.round10(vo.level / 1000, -3);
         }
 
         return 0;

--- a/src/dash/utils/Round10.js
+++ b/src/dash/utils/Round10.js
@@ -1,0 +1,83 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Static methods for rounding decimals
+ *
+ * Modified version of the CC0-licenced example at:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+ *
+ * @export
+ * @class Round10
+ */
+export default class Round10 {
+    /**
+    * Decimal round.
+    *
+    * @param {Number}  value The number.
+    * @param {Integer} exp   The exponent (the 10 logarithm of the adjustment base).
+    * @returns {Number} The adjusted value.
+    */
+    static round10(value, exp) {
+        return _decimalAdjust('round', value, exp);
+    }
+}
+
+/**
+ * Decimal adjustment of a number.
+ *
+ * @param {String}  type  The type of adjustment.
+ * @param {Number}  value The number.
+ * @param {Integer} exp   The exponent (the 10 logarithm of the adjustment base).
+ * @returns {Number} The adjusted value.
+ */
+function _decimalAdjust(type, value, exp) {
+    // If the exp is undefined or zero...
+    if (typeof exp === 'undefined' || +exp === 0) {
+        return Math[type](value);
+    }
+
+    value = +value;
+    exp = +exp;
+
+    // If the value is not a number or the exp is not an integer...
+    if (value === null || isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+        return NaN;
+    }
+
+    // Shift
+    value = value.toString().split('e');
+    value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+
+    // Shift back
+    value = value.toString().split('e');
+    return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+}

--- a/test/unit/dash.utils.Round10.js
+++ b/test/unit/dash.utils.Round10.js
@@ -1,0 +1,27 @@
+import Round10 from '../../src/dash/utils/Round10';
+
+const expect = require('chai').expect;
+
+describe('Round10', () => {
+    it('should round numbers as expected', () => {
+
+        /*
+         * These examples modified from CC0-licenced code sample at:
+         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+         */
+        expect(Round10.round10(55.55, -1)).to.equal(55.6);
+        expect(Round10.round10(55.549, -1)).to.equal(55.5);
+        expect(Round10.round10(55, 1)).to.equal(60);
+        expect(Round10.round10(54.9, 1)).to.equal(50);
+        expect(Round10.round10(-55.55, -1)).to.equal(-55.5);
+        expect(Round10.round10(-55.551, -1)).to.equal(-55.6);
+        expect(Round10.round10(-55, 1)).to.equal(-50);
+        expect(Round10.round10(-55.1, 1)).to.equal(-60);
+        expect(Round10.round10(1.005, -2)).to.equal(1.01);
+        expect(Round10.round10(-1.005, -2)).to.equal(-1.0);
+
+        // some real-world examples of how we actually use the method
+        expect(Round10.round10(21.782228000000003, -3)).to.equal(21.782);
+        expect(Round10.round10(23.193893000000003, -3)).to.equal(23.194);
+    });
+});


### PR DESCRIPTION
The licence associated with dependency round10 is unclear, as reported in #2487, so have reimplemented the required method natively.