### PR TITLE
Fix TimeSyncController/ManifestUpdater race condition

### DIFF
--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -103,11 +103,16 @@ function ManifestUpdater() {
         }
     }
 
-    function startManifestRefreshTimer() {
+    function startManifestRefreshTimer(delay) {
         stopManifestRefreshTimer();
-        if (!isNaN(refreshDelay)) {
-            log('Refresh manifest in ' + refreshDelay + ' seconds.');
-            refreshTimer = setTimeout(onRefreshTimer, refreshDelay * 1000);
+
+        if (isNaN(delay) && !isNaN(refreshDelay)) {
+            delay = refreshDelay * 1000;
+        }
+
+        if (!isNaN(delay)) {
+            log('Refresh manifest in ' + delay + ' milliseconds.');
+            refreshTimer = setTimeout(onRefreshTimer, delay);
         }
     }
 
@@ -139,7 +144,13 @@ function ManifestUpdater() {
     }
 
     function onRefreshTimer() {
-        if (isPaused && !mediaPlayerModel.getScheduleWhilePaused() || isUpdating) return;
+        if (isPaused && !mediaPlayerModel.getScheduleWhilePaused()) {
+            return;
+        }
+        if (isUpdating) {
+            startManifestRefreshTimer(mediaPlayerModel.getManifestUpdateRetryInterval());
+            return;
+        }
         refreshManifest();
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1765,6 +1765,36 @@ function MediaPlayer() {
         return mediaPlayerModel.getSmallGapLimit();
     }
 
+    /**
+     * For live streams, set the interval-frequency in milliseconds at which
+     * dash.js will check if the current manifest is still processed before
+     * downloading the next manifest once the minimumUpdatePeriod time has
+     * expired.
+     * @param {int} value
+     * @default 100
+     * @memberof module:MediaPlayer
+     * @instance
+     * @see {@link module:MediaPlayer#getManifestUpdateRetryInterval getManifestUpdateRetryInterval()}
+     *
+     */
+    function setManifestUpdateRetryInterval(value) {
+        mediaPlayerModel.setManifestUpdateRetryInterval(value);
+    }
+
+    /**
+     * For live streams, get the interval-frequency in milliseconds at which
+     * dash.js will check if the current manifest is still processed before
+     * downloading the next manifest once the minimumUpdatePeriod time has
+     * expired.
+     * @returns {int} Current retry delay for manifest update
+     * @memberof module:MediaPlayer
+     * @instance
+     * @see {@link module:MediaPlayer#setManifestUpdateRetryInterval setManifestUpdateRetryInterval()}
+     */
+    function getManifestUpdateRetryInterval() {
+        return mediaPlayerModel.getManifestUpdateRetryInterval();
+    }
+
     /*
     ---------------------------------------------------------------------------
 
@@ -2835,6 +2865,8 @@ function MediaPlayer() {
         getJumpGaps: getJumpGaps,
         setSmallGapLimit: setSmallGapLimit,
         getSmallGapLimit: getSmallGapLimit,
+        setManifestUpdateRetryInterval: setManifestUpdateRetryInterval,
+        getManifestUpdateRetryInterval: getManifestUpdateRetryInterval,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,
         setSegmentOverlapToleranceTime: setSegmentOverlapToleranceTime,
         setCacheLoadThresholdForType: setCacheLoadThresholdForType,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -57,6 +57,7 @@ const BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 60;
 const LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;
 const SEGMENT_OVERLAP_TOLERANCE_TIME = 0.05;
 const SMALL_GAP_LIMIT = 0.8;
+const MANIFEST_UPDATE_RETRY_INTERVAL = 100;
 
 const CACHE_LOAD_THRESHOLD_VIDEO = 50;
 const CACHE_LOAD_THRESHOLD_AUDIO = 5;
@@ -107,7 +108,8 @@ function MediaPlayerModel() {
         movingAverageMethod,
         cacheLoadThresholds,
         jumpGaps,
-        smallGapLimit;
+        smallGapLimit,
+        manifestUpdateRetryInterval;
 
     function setup() {
         UTCTimingSources = [];
@@ -140,6 +142,7 @@ function MediaPlayerModel() {
         wallclockTimeUpdateInterval = WALLCLOCK_TIME_UPDATE_INTERVAL;
         jumpGaps = false;
         smallGapLimit = SMALL_GAP_LIMIT;
+        manifestUpdateRetryInterval = MANIFEST_UPDATE_RETRY_INTERVAL;
         xhrWithCredentials = {
             default: DEFAULT_XHR_WITH_CREDENTIALS
         };
@@ -498,6 +501,13 @@ function MediaPlayerModel() {
         return smallGapLimit;
     }
 
+    function setManifestUpdateRetryInterval(value) {
+        manifestUpdateRetryInterval = value;
+    }
+
+    function getManifestUpdateRetryInterval() {
+        return manifestUpdateRetryInterval;
+    }
     function reset() {
         //TODO need to figure out what props to persist across sessions and which to reset if any.
         //setup();
@@ -574,6 +584,8 @@ function MediaPlayerModel() {
         getJumpGaps: getJumpGaps,
         setSmallGapLimit: setSmallGapLimit,
         getSmallGapLimit: getSmallGapLimit,
+        setManifestUpdateRetryInterval: setManifestUpdateRetryInterval,
+        getManifestUpdateRetryInterval: getManifestUpdateRetryInterval,
         reset: reset
     };
 

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -74,6 +74,8 @@ const CACHE_LOAD_THRESHOLD_AUDIO = 5;
 
 const SMALL_GAP_LIMIT = 0.8;
 
+const MANIFEST_UPDATE_RETRY_INTERVAL = 100;
+
 class MediaPlayerModelMock {
 
     // Constants
@@ -141,6 +143,10 @@ class MediaPlayerModelMock {
         return MANIFEST_RETRY_INTERVAL;
     }
 
+    static get MANIFEST_UPDATE_RETRY_INTERVAL() {
+        return MANIFEST_UPDATE_RETRY_INTERVAL;
+    }
+
     static get XLINK_RETRY_ATTEMPTS() {
         return XLINK_RETRY_ATTEMPTS;
     }
@@ -205,6 +211,7 @@ class MediaPlayerModelMock {
         this.cacheLoadThresholds[Constants.AUDIO] = CACHE_LOAD_THRESHOLD_AUDIO;
         this.jumpGaps = false;
         this.smallGapLimit = SMALL_GAP_LIMIT;
+        this.manifestUpdateRetryInterval = MANIFEST_UPDATE_RETRY_INTERVAL;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.
@@ -500,6 +507,14 @@ class MediaPlayerModelMock {
 
     getJumpGaps() {
         return this.jumpGaps;
+    }
+
+    setManifestUpdateRetryInterval(value) {
+        this.manifestUpdateRetryInterval = value;
+    }
+
+    getManifestUpdateRetryInterval() {
+        return this.manifestUpdateRetryInterval;
     }
 
     setSmallGapLimit(value) {

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -816,6 +816,19 @@ describe('MediaPlayer', function () {
             expect(smallGapLimit).to.equal(0.5);
         });
 
+        it('should configure manifestUpdateRetryInterval', function () {
+            let manifestUpdateRetryInterval = player.getManifestUpdateRetryInterval();
+            expect(manifestUpdateRetryInterval).to.equal(MediaPlayerModelMock.MANIFEST_UPDATE_RETRY_INTERVAL);
+
+            player.setManifestUpdateRetryInterval(200);
+
+            manifestUpdateRetryInterval = mediaPlayerModel.getManifestUpdateRetryInterval();
+            expect(manifestUpdateRetryInterval).to.equal(200);
+
+            manifestUpdateRetryInterval = player.getManifestUpdateRetryInterval();
+            expect(manifestUpdateRetryInterval).to.equal(200);
+        });
+
         it('should configure BandwidthSafetyFactor', function () {
             let BandwidthSafetyFactor = mediaPlayerModel.getBandwidthSafetyFactor();
             expect(BandwidthSafetyFactor).to.equal(0.9);


### PR DESCRIPTION
This PR fixes #2501 

It also adds new `setManifestUpdateRetryInterval()` and `getManifestUpdateRetryInterval()` method to manage the interval-frequency at which ManifestUpdater will check if the current manifest is still processed before downloading the next manifest once the minimumUpdatePeriod delay has expired.