### PR TITLE
add TTML_TO_PARSE event

### DIFF
--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -159,16 +159,28 @@ function MssHandler(config) {
         }
     }
 
+    function onTTMLPreProcess(ttmlSubtitles) {
+        if (!ttmlSubtitles || !ttmlSubtitles.data) {
+            return;
+        }
+
+        while (ttmlSubtitles.data.indexOf('http://www.w3.org/2006/10/ttaf1') !== -1) {
+            ttmlSubtitles.data = ttmlSubtitles.data.replace('http://www.w3.org/2006/10/ttaf1', 'http://www.w3.org/ns/ttml');
+        }
+    }
+
     function registerEvents() {
         eventBus.on(events.INIT_REQUESTED, onInitializationRequested, instance, dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH); /* jshint ignore:line */
         eventBus.on(events.PLAYBACK_SEEK_ASKED, onPlaybackSeekAsked, instance, dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH); /* jshint ignore:line */
         eventBus.on(events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH); /* jshint ignore:line */
+        eventBus.on(events.TTML_TO_PARSE, onTTMLPreProcess, instance);
     }
 
     function reset() {
         eventBus.off(events.INIT_REQUESTED, onInitializationRequested, this);
         eventBus.off(events.PLAYBACK_SEEK_ASKED, onPlaybackSeekAsked, this);
         eventBus.off(events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, this);
+        eventBus.off(events.TTML_TO_PARSE, onTTMLPreProcess, this);
     }
 
     function createMssParser() {

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -195,6 +195,12 @@ class MediaPlayerEvents extends EventsBase {
         this.TTML_PARSED = 'ttmlParsed';
 
         /**
+         * Triggered when a ttml chunk has to be parsed.
+         * @event MediaPlayerEvents#TTML_PARSED
+         */
+        this.TTML_TO_PARSE = 'ttmlToParse';
+
+        /**
          * Sent when enough data is available that the media can be played,
          * at least for a couple of frames.  This corresponds to the
          * HAVE_ENOUGH_DATA readyState.

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -72,6 +72,8 @@ function TTMLParser() {
         let startTime,
             endTime;
 
+        let content = {};
+
         let embeddedImages = {};
         let currentImageId = '';
         let accumulated_image_data = '';
@@ -107,11 +109,15 @@ function TTMLParser() {
             throw new Error(errorMsg);
         }
 
-        let imsc1doc = fromXML(data, function (msg) {
+        content.data = data;
+
+        eventBus.trigger(Events.TTML_TO_PARSE, content);
+
+        let imsc1doc = fromXML(content.data, function (msg) {
             errorMsg = msg;
         },
             metadataHandler);
-        eventBus.trigger(Events.TTML_PARSED, {ttmlString: data, ttmlDoc: imsc1doc});
+        eventBus.trigger(Events.TTML_PARSED, {ttmlString: content.data, ttmlDoc: imsc1doc});
 
         let mediaTimeEvents = imsc1doc.getMediaTimeEvents();
 


### PR DESCRIPTION
Hi,

this PR has to add the new event called TTML_TO_PARSE. This event is triggered before ttml content is parsing by imsc1 library.
In MSS use case, it allows to replace wrong namespaces according to IMSC1 point of view. A test can be made with mss stream Prince Of Persia - Live. Subtitles style is not taken into a count but text is correctly shown.

Nico