### PR TITLE
Incorrect definition of time in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ declare namespace dashjs {
         isMuted(): boolean;
         setVolume(value: number): void;
         getVolume(): number;
-        time(streamId: string): number;
+        time(streamId: string | undefined): number;
         duration(): number;
         timeAsUTC(): number;
         durationAsUTC(): number;


### PR DESCRIPTION
Hi
This PR fixes an incorrect definition in index.d.ts file : 

In MediaPlayer.js, undefined can be passed as argument of time function, not in typescript.
This PR adds undefined type to time function declaration

Jérémie