### PR TITLE
Max value limited by portal size

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -126,6 +126,7 @@ declare namespace dashjs {
         enableLastMediaSettingsCaching(enable: boolean, ttl?: number): void;
         setMaxAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedBitrateFor(type: 'video' | 'audio'): number;
+        getTopQualityBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
         setMaxAllowedRepresentationRatioFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedRepresentationRatioFor(type: 'video' | 'audio'): number;
         setAutoPlay(value: boolean): void;

--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -126,7 +126,7 @@ declare namespace dashjs {
         enableLastMediaSettingsCaching(enable: boolean, ttl?: number): void;
         setMaxAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedBitrateFor(type: 'video' | 'audio'): number;
-        getTopQualityBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
+        getTopBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
         setMaxAllowedRepresentationRatioFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedRepresentationRatioFor(type: 'video' | 'audio'): number;
         setAutoPlay(value: boolean): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ declare namespace dashjs {
         enableLastMediaSettingsCaching(enable: boolean, ttl?: number): void;
         setMaxAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedBitrateFor(type: 'video' | 'audio'): number;
+        getTopQualityBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
         setMaxAllowedRepresentationRatioFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedRepresentationRatioFor(type: 'video' | 'audio'): number;
         setAutoPlay(value: boolean): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ declare namespace dashjs {
         enableLastMediaSettingsCaching(enable: boolean, ttl?: number): void;
         setMaxAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedBitrateFor(type: 'video' | 'audio'): number;
-        getTopQualityBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
+        getTopBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
         setMaxAllowedRepresentationRatioFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedRepresentationRatioFor(type: 'video' | 'audio'): number;
         setAutoPlay(value: boolean): void;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -768,6 +768,9 @@ function MediaPlayer() {
      * @instance
      */
     function getTopQualityBitrateInfoFor(type) {
+        if (!streamingInitialized) {
+            throw STREAMING_NOT_INITIALIZED_ERROR;
+        }
         return abrController.getTopQualityBitrateInfoFor(type);
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -767,11 +767,11 @@ function MediaPlayer() {
      * @returns {BitrateInfo | null}
      * @instance
      */
-    function getTopQualityBitrateInfoFor(type) {
+    function getTopBitrateInfoFor(type) {
         if (!streamingInitialized) {
             throw STREAMING_NOT_INITIALIZED_ERROR;
         }
-        return abrController.getTopQualityBitrateInfoFor(type);
+        return abrController.getTopBitrateInfoFor(type);
     }
 
     /**
@@ -2802,7 +2802,7 @@ function MediaPlayer() {
         enableLastMediaSettingsCaching: enableLastMediaSettingsCaching,
         setMaxAllowedBitrateFor: setMaxAllowedBitrateFor,
         getMaxAllowedBitrateFor: getMaxAllowedBitrateFor,
-        getTopQualityBitrateInfoFor: getTopQualityBitrateInfoFor,
+        getTopBitrateInfoFor: getTopBitrateInfoFor,
         setMinAllowedBitrateFor: setMinAllowedBitrateFor,
         getMinAllowedBitrateFor: getMinAllowedBitrateFor,
         setMaxAllowedRepresentationRatioFor: setMaxAllowedRepresentationRatioFor,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -758,6 +758,20 @@ function MediaPlayer() {
     }
 
     /**
+     * Gets the top quality BitrateInfo checking portal limit and max allowed.
+     *
+     * It calls getTopQualityIndexFor internally
+     *
+     * @param {string} type - 'video' or 'audio' are the type options.
+     * @memberof module:MediaPlayer
+     * @returns {BitrateInfo | null}
+     * @instance
+     */
+    function getTopQualityBitrateInfoFor(type) {
+        return abrController.getTopQualityBitrateInfoFor(type);
+    }
+
+    /**
      * @param {string} type - 'video' or 'audio' are the type options.
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setMinAllowedBitrateFor setMinAllowedBitrateFor()}
@@ -2785,6 +2799,7 @@ function MediaPlayer() {
         enableLastMediaSettingsCaching: enableLastMediaSettingsCaching,
         setMaxAllowedBitrateFor: setMaxAllowedBitrateFor,
         getMaxAllowedBitrateFor: getMaxAllowedBitrateFor,
+        getTopQualityBitrateInfoFor: getTopQualityBitrateInfoFor,
         setMinAllowedBitrateFor: setMinAllowedBitrateFor,
         getMinAllowedBitrateFor: getMinAllowedBitrateFor,
         setMaxAllowedRepresentationRatioFor: setMaxAllowedRepresentationRatioFor,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -232,7 +232,7 @@ function AbrController() {
      * @param {string} type - 'video' or 'audio' are the type options.
      * @returns {BitrateInfo | null}
      */
-    function getTopQualityBitrateInfoFor(type) {
+    function getTopBitrateInfoFor(type) {
         if (type  && streamProcessorDict && streamProcessorDict[type]) {
             const streamInfo = streamProcessorDict[type].getStreamInfo();
             if (streamInfo.id) {
@@ -731,7 +731,7 @@ function AbrController() {
         getBitrateList: getBitrateList,
         getQualityForBitrate: getQualityForBitrate,
         getMaxAllowedBitrateFor: getMaxAllowedBitrateFor,
-        getTopQualityBitrateInfoFor: getTopQualityBitrateInfoFor,
+        getTopBitrateInfoFor: getTopBitrateInfoFor,
         getMinAllowedBitrateFor: getMinAllowedBitrateFor,
         setMaxAllowedBitrateFor: setMaxAllowedBitrateFor,
         setMinAllowedBitrateFor: setMinAllowedBitrateFor,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -228,6 +228,23 @@ function AbrController() {
     }
 
     /**
+     * Gets top BitrateInfo for the player
+     * @param {string} type - 'video' or 'audio' are the type options.
+     * @returns {BitrateInfo | null}
+     */
+    function getTopQualityBitrateInfoFor(type) {
+        if (type  && streamProcessorDict && streamProcessorDict[type]) {
+            const streamInfo = streamProcessorDict[type].getStreamInfo();
+            if (streamInfo.id) {
+                const idx = getTopQualityIndexFor(type, streamInfo.id);
+                const bitrates = getBitrateList(streamProcessorDict[type].getMediaInfo());
+                return bitrates[idx] ? bitrates[idx] : null;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @param {string} type
      * @returns {number} A value of the initial bitrate, kbps
      * @memberof AbrController#
@@ -714,6 +731,7 @@ function AbrController() {
         getBitrateList: getBitrateList,
         getQualityForBitrate: getQualityForBitrate,
         getMaxAllowedBitrateFor: getMaxAllowedBitrateFor,
+        getTopQualityBitrateInfoFor: getTopQualityBitrateInfoFor,
         getMinAllowedBitrateFor: getMinAllowedBitrateFor,
         setMaxAllowedBitrateFor: setMaxAllowedBitrateFor,
         setMinAllowedBitrateFor: setMinAllowedBitrateFor,

--- a/test/unit/helpers/ObjectsHelper.js
+++ b/test/unit/helpers/ObjectsHelper.js
@@ -9,7 +9,7 @@ class ObjectsHelper {
         return {
             getType: () => type,
             getCurrentTrack: () => {},
-            getStreamInfo: () => { return { id: 'some_id', manifestInfo: {isDynamic: true} }; },
+            getStreamInfo: () => { return { id: 'DUMMY_STREAM-01', manifestInfo: {isDynamic: true} }; },
             getMediaInfo: () => { return { bitrateList: [
                                                 { bandwidth: 1000000 },
                                                 { bandwidth: 2000000 },

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -41,6 +41,8 @@ class AbrControllerMock{
 
     getTopQualityIndexFor() {}
 
+    getTopQualityBitrateInfoFor() {}
+
     getInitialBitrateFor(type) {
         if (!this.bitrateDict.hasOwnProperty(type)) {
             return null;

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -41,7 +41,7 @@ class AbrControllerMock{
 
     getTopQualityIndexFor() {}
 
-    getTopQualityBitrateInfoFor() {}
+    getTopBitrateInfoFor() {}
 
     getInitialBitrateFor(type) {
         if (!this.bitrateDict.hasOwnProperty(type)) {

--- a/test/unit/mocks/DashManifestModelMock.js
+++ b/test/unit/mocks/DashManifestModelMock.js
@@ -5,6 +5,22 @@ class DashManifestModelMock {
     getIsTextTrack() {
         return false;
     }
+
+    getAdaptationForType() {
+        return {
+            Representation: [
+                {
+                    width: 500
+                },
+                {
+                    width: 750
+                },
+                {
+                    width: 900
+                }
+            ]
+        };
+    }
 }
 
 export default DashManifestModelMock;

--- a/test/unit/mocks/VideoModelMock.js
+++ b/test/unit/mocks/VideoModelMock.js
@@ -13,7 +13,8 @@ class VideoModelMock {
         this.tracks = [];
         this.source = null;
         this.element = new VideoElementMock();
-
+        this.height = 600;
+        this.width = 800;
         this.events = {};
     }
 
@@ -50,6 +51,35 @@ class VideoModelMock {
         for (let i = 0; i < l; i++) {
             evs[i].apply(null, args);
         }
+    }
+
+    getPlaybackQuality() {
+        let element = this.element;
+        if (!element) { return null; }
+        let hasWebKit = ('webkitDroppedFrameCount' in element) && ('webkitDecodedFrameCount' in element);
+        let hasQuality = ('getVideoPlaybackQuality' in element);
+        let result = null;
+
+        if (hasQuality) {
+            result = element.getVideoPlaybackQuality();
+        }
+        else if (hasWebKit) {
+            result = {
+                droppedVideoFrames: element.webkitDroppedFrameCount,
+                totalVideoFrames: element.webkitDroppedFrameCount + element.webkitDecodedFrameCount,
+                creationTime: new Date()
+            };
+        }
+
+        return result;
+    }
+
+    getClientWidth() {
+        return this.width;
+    }
+
+    getClientHeight() {
+        return this.height;
     }
 
     getElement() {

--- a/test/unit/streaming.controllers.AbrControllerSpec.js
+++ b/test/unit/streaming.controllers.AbrControllerSpec.js
@@ -7,6 +7,7 @@ import DashMetrics from '../../src/dash/DashMetrics';
 import DashManifestModel from '../../src/dash/models/DashManifestModel';
 import TimelineConverter from '../../src/dash/utils/TimelineConverter';
 import VideoModel from '../../src/streaming/models/VideoModel';
+import BitrateInfo from '../../src/streaming/vo/BitrateInfo';
 
 const expect = require('chai').expect;
 
@@ -193,5 +194,19 @@ describe('AbrController', function () {
         abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) - 1);
         minAllowedIndex = abrCtrl.getMinAllowedIndexFor(testType);
         expect(minAllowedIndex).to.be.equal(0);
+    });
+
+    it('should return an appropriate BitrateInfo when calling getTopQualityBitrateInfoFor', function () {
+        let bitrateInfo = abrCtrl.getTopQualityBitrateInfoFor(testType);
+        expect(bitrateInfo).to.be.an.instanceOf(BitrateInfo);
+        expect(bitrateInfo.bitrate).to.be.equal(1000000);
+        expect(bitrateInfo.qualityIndex).to.be.equal(0);
+
+        abrCtrl.setMinAllowedBitrateFor(testType, (streamProcessor.getMediaInfo().bitrateList[0].bandwidth / 1000) + 1);
+
+        bitrateInfo = abrCtrl.getTopQualityBitrateInfoFor(testType);
+        expect(bitrateInfo).to.be.an.instanceOf(BitrateInfo);
+        expect(bitrateInfo.bitrate).to.be.equal(2000000);
+        expect(bitrateInfo.qualityIndex).to.be.equal(1);
     });
 });

--- a/test/unit/streaming.controllers.AbrControllerSpec.js
+++ b/test/unit/streaming.controllers.AbrControllerSpec.js
@@ -202,16 +202,16 @@ describe('AbrController', function () {
         expect(minAllowedIndex).to.be.equal(0);
     });
 
-    it('should return an appropriate BitrateInfo when calling getTopQualityBitrateInfoFor', function () {
+    it('should return an appropriate BitrateInfo when calling getTopBitrateInfoFor', function () {
         abrCtrl.updateTopQualityIndex(dummyMediaInfo);
 
-        let bitrateInfo = abrCtrl.getTopQualityBitrateInfoFor(testType);
+        let bitrateInfo = abrCtrl.getTopBitrateInfoFor(testType);
         expect(bitrateInfo).to.be.an.instanceOf(BitrateInfo);
         expect(bitrateInfo.bitrate).to.be.equal(3000000);
         expect(bitrateInfo.qualityIndex).to.be.equal(2);
 
         abrCtrl.setLimitBitrateByPortal(true);
-        bitrateInfo = abrCtrl.getTopQualityBitrateInfoFor(testType);
+        bitrateInfo = abrCtrl.getTopBitrateInfoFor(testType);
         expect(bitrateInfo).to.be.an.instanceOf(BitrateInfo);
         expect(bitrateInfo.bitrate).to.be.equal(2000000);
         expect(bitrateInfo.qualityIndex).to.be.equal(1);


### PR DESCRIPTION
This PR adds a new method to the MediaPlayer to get the top quality BitrateInfo. It calls `getTopQualityIndexFor ` internally so portal size and max bitrate are checked. #2463 