### PR TITLE
Fixed an edge issue causing text track to stop working when seeking back

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -348,6 +348,8 @@ function TextSourceBuffer() {
                             result = parser.parse(ccContent, offsetTime, sampleStart / timescale, (sampleStart + sample.duration) / timescale, images);
                             textTracks.addCaptions(currFragmentedTrackIdx, firstSubtitleStart / timescale, result);
                         } catch (e) {
+                            fragmentModel.removeExecutedRequestsBeforeTime(Date.now());
+                            this.remove();
                             log('TTML parser error: ' + e.message);
                         }
                     }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -348,7 +348,7 @@ function TextSourceBuffer() {
                             result = parser.parse(ccContent, offsetTime, sampleStart / timescale, (sampleStart + sample.duration) / timescale, images);
                             textTracks.addCaptions(currFragmentedTrackIdx, firstSubtitleStart / timescale, result);
                         } catch (e) {
-                            fragmentModel.removeExecutedRequestsBeforeTime(Date.now());
+                            fragmentModel.removeExecutedRequestsBeforeTime();
                             this.remove();
                             log('TTML parser error: ' + e.message);
                         }

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -466,8 +466,13 @@ function TextTracks() {
                     }
                 }
             }
-
-            track.addCue(cue);
+            try {
+                track.addCue(cue);
+            } catch (e) {
+                // Edge crash, delete everything and start adding again
+                deleteTrackCues(track);
+                track.addCue(cue);
+            }
         }
     }
 

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -470,8 +470,10 @@ function TextTracks() {
                 track.addCue(cue);
             } catch (e) {
                 // Edge crash, delete everything and start adding again
+                // @see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11979877/
                 deleteTrackCues(track);
                 track.addCue(cue);
+                throw e;
             }
         }
     }


### PR DESCRIPTION
`addCue` method crashed with `Invalid argument` after seeking back, a simple track reset if the exception happens fixes this. #2524 