### PR TITLE
Fix redundant segment download when setQualityfor() is invoked many times

### DIFF
--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -79,7 +79,7 @@ function FragmentModel(config) {
         };
 
         const isEqualMedia = function (req1, req2) {
-            return !isNaN(req1.index) && (req1.startTime === req2.startTime) && (req1.adaptationIndex === req2.adaptationIndex);
+            return !isNaN(req1.index) && (req1.startTime === req2.startTime) && (req1.adaptationIndex === req2.adaptationIndex) && (req1.type === req2.type);
         };
 
         const isEqualInit = function (req1, req2) {

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -71,7 +71,7 @@ function FragmentModel(config) {
 
     function isFragmentLoaded(request) {
         const isEqualUrl = function (req1, req2) {
-            return req1.url.replace(req1.representationId, '') === req2.url.replace(req2.representationId, '');
+            return (req1.url === req2.url);
         };
 
         const isEqualComplete = function (req1, req2) {
@@ -89,7 +89,7 @@ function FragmentModel(config) {
         const check = function (requests) {
             let isLoaded = false;
             requests.some(req => {
-                if ( isEqualUrl(request,req) && (isEqualMedia(request, req) || isEqualInit(request, req) || isEqualComplete(request, req))) {
+                if ( isEqualUrl(request, req) || isEqualMedia(request, req) || isEqualInit(request, req) || isEqualComplete(request, req)) {
                     isLoaded = true;
                     return isLoaded;
                 }

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -71,7 +71,7 @@ function FragmentModel(config) {
 
     function isFragmentLoaded(request) {
         const isEqualUrl = function (req1, req2) {
-            return (req1.url === req2.url);
+            return req1.url.replace(req1.representationId, '') === req2.url.replace(req2.representationId, '');
         };
 
         const isEqualComplete = function (req1, req2) {


### PR DESCRIPTION
Changed isFragmentLoaded method to ignore the track representation when comparing URL, this caused redundant segment downloads when quality changed.

This comparison was added at https://github.com/Dash-Industry-Forum/dash.js/pull/2252, the logic should still be valid for that case.

Fixes #2434 