### PR TITLE
fix cues for IE and Edge

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -402,7 +402,7 @@ function TextTracks() {
             return;
         }
 
-        for (let item in captionData) {
+        for (let item = 0; item < captionData.length; item++) {
             let cue;
             const currentItem = captionData[item];
 


### PR DESCRIPTION
Using `for (item in Object)` is a bad idea in Microsoft browsers, as it'll pick up extraneous object properties. This causes some cues to be dropped, as it tries to create a new `Cue` from a function, which of course fails.

Corrected to C-style `for` loop.

You can test this by removing the call to `attachTTMLRenderingDiv` in the reference player.