### PR TITLE
[mss] do not process segment when onSegmentMediaLoaded gets an error

### DIFF
--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -113,6 +113,9 @@ function MssHandler(config) {
     }
 
     function onSegmentMediaLoaded(e) {
+        if (e.error) {
+            return;
+        }
         // Process moof to transcode it from MSS to DASH
         let streamProcessor = e.sender.getStreamProcessor();
         mssFragmentProcessor.processFragment(e, streamProcessor);


### PR DESCRIPTION
This avoids errors in processFragment and subsequent problems of not having managed the error at this level.