### PR TITLE
reset BlacklistController after url resolution failed

### DIFF
--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -114,7 +114,7 @@ function BaseURLSelector() {
                     )
                 }
             );
-
+            reset();
             return;
         }
 

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -114,7 +114,9 @@ function BaseURLSelector() {
                     )
                 }
             );
-            reset();
+            if (selector === basicSelector) {
+                reset();
+            }
             return;
         }
 


### PR DESCRIPTION
The use case is to be able to seek after a segment download has failed. At the moment, when this happens,  an event Events.URL_RESOLUTION_FAILED is fired and stops the schedule controller.
If we want to seek further to bypass a missing segment, we can not start the playing again because the base url of the segment that failed is stored in the black list controller.
By resetting it after the event firing, it allows to try seeking further. Without this PR we can not seek at all after this event. So the only thing this PR changes is to at least let the client to jump over a missing segment.
If needed we can add a configuration to enable/disable this feature. What do you think ?