### PR TITLE
[MSS] Update timescale support

### DIFF
--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -53,6 +53,7 @@ function MssFragmentMoofProcessor(config) {
 
         let manifest = representation.adaptation.period.mpd.manifest;
         let adaptation = manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index];
+        let timescale = adaptation.SegmentTemplate.timescale;
 
         if (manifest.type !== 'dynamic') {
             return;
@@ -98,7 +99,7 @@ function MssFragmentMoofProcessor(config) {
             return;
         }
 
-        log('[MssFragmentMoofProcessor][', type,'] Add new segment - t = ', (entry.fragment_absolute_time /  10000000.0));
+        log('[MssFragmentMoofProcessor][', type,'] Add new segment - t = ', (entry.fragment_absolute_time / timescale));
         segment = {};
         segment.t = entry.fragment_absolute_time;
         segment.d = entry.fragment_duration;
@@ -111,12 +112,12 @@ function MssFragmentMoofProcessor(config) {
             t = segment.t;
 
             // Determine the segments' availability start time
-            availabilityStartTime = t - (manifest.timeShiftBufferDepth * 10000000);
+            availabilityStartTime = t - (manifest.timeShiftBufferDepth * timescale);
 
             // Remove segments prior to availability start time
             segment = segments[0];
             while (segment.t < availabilityStartTime) {
-                log('[MssFragmentMoofProcessor]Remove segment  - t = ' + (segment.t / 10000000.0));
+                log('[MssFragmentMoofProcessor]Remove segment  - t = ' + (segment.t / timescale));
                 segments.splice(0, 1);
                 segment = segments[0];
             }

--- a/src/mss/MssFragmentMoovProcessor.js
+++ b/src/mss/MssFragmentMoovProcessor.js
@@ -35,7 +35,6 @@
  */
 function MssFragmentMoovProcessor(config) {
     config = config || {};
-    const TIME_SCALE = 10000000;
     const NALUTYPE_SPS = 7;
     const NALUTYPE_PPS = 8;
     const constants = config.constants;
@@ -47,6 +46,7 @@ function MssFragmentMoovProcessor(config) {
         adaptationSet,
         representation,
         contentProtection,
+        timescale,
         trackId;
 
     function createFtypBox(isoFile) {
@@ -151,8 +151,8 @@ function MssFragmentMoovProcessor(config) {
 
         mvhd.creation_time = 0; // the creation time of the presentation => ignore (set to 0)
         mvhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
-        mvhd.timescale = TIME_SCALE; // the time-scale for the entire presentation => 10000000 for MSS
-        mvhd.duration = Math.round(period.duration * TIME_SCALE); // the length of the presentation (in the indicated timescale) =>  take duration of period
+        mvhd.timescale = timescale; // the time-scale for the entire presentation => 10000000 for MSS
+        mvhd.duration = Math.round(period.duration * timescale); // the length of the presentation (in the indicated timescale) =>  take duration of period
         mvhd.rate = 1.0; // 16.16 number, '1.0' = normal playback
         mvhd.volume = 1.0; // 8.8 number, '1.0' = full volume
         mvhd.reserved1 = 0;
@@ -181,7 +181,7 @@ function MssFragmentMoovProcessor(config) {
         tkhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
         tkhd.track_ID = trackId; // uniquely identifies this track over the entire life-time of this presentation
         tkhd.reserved1 = 0;
-        tkhd.duration = Math.round(period.duration * TIME_SCALE); // the duration of this track (in the timescale indicated in the Movie Header Box) =>  take duration of period
+        tkhd.duration = Math.round(period.duration * timescale); // the duration of this track (in the timescale indicated in the Movie Header Box) =>  take duration of period
         tkhd.reserved2 = [0x0, 0x0];
         tkhd.layer = 0; // specifies the front-to-back ordering of video tracks; tracks with lower numbers are closer to the viewer => 0 since only one video track
         tkhd.alternate_group = 0; // specifies a group or collection of tracks => ignore
@@ -206,8 +206,8 @@ function MssFragmentMoovProcessor(config) {
 
         mdhd.creation_time = 0; // the creation time of the presentation => ignore (set to 0)
         mdhd.modification_time = 0; // the most recent time the presentation was modified => ignore (set to 0)
-        mdhd.timescale = TIME_SCALE; // the time-scale for the entire presentation
-        mdhd.duration = Math.round(period.duration * TIME_SCALE); // the duration of this media (in the scale of the timescale). If the duration cannot be determined then duration is set to all 1s.
+        mdhd.timescale = timescale; // the time-scale for the entire presentation
+        mdhd.duration = Math.round(period.duration * timescale); // the duration of this media (in the scale of the timescale). If the duration cannot be determined then duration is set to all 1s.
         mdhd.language = adaptationSet.lang || 'und'; // declares the language code for this media (see getLanguageCode())
         mdhd.pre_defined = 0;
 
@@ -631,6 +631,8 @@ function MssFragmentMoovProcessor(config) {
         period = adaptationSet.period;
         trackId = adaptationSet.index + 1;
         contentProtection = period.mpd.manifest.Period_asArray[period.index].AdaptationSet_asArray[adaptationSet.index].ContentProtection;
+
+        timescale = period.mpd.manifest.Period_asArray[period.index].AdaptationSet_asArray[adaptationSet.index].SegmentTemplate.timescale;
 
         isoFile = ISOBoxer.createFile();
         createFtypBox(isoFile);

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -385,6 +385,23 @@ function MssParser(config) {
 
             // Create new segment
             segments.push(segment);
+
+            // Support for 'r' attribute (i.e. "repeat" as in MPEG-DASH)
+            r = parseFloat(chunks[i].getAttribute('r'));
+            if (r) {
+
+                for (j = 0; j < (r - 1); j++) {
+                    prevSegment = segments[segments.length - 1];
+                    segment = {};
+                    segment.t = prevSegment.t + prevSegment.d;
+                    segment.d = prevSegment.d;
+                    if (prevSegment.tManifest) {
+                        segment.tManifest  = parseFloat(prevSegment.tManifest) + prevSegment.d;
+                    }
+                    duration += segment.d;
+                    segments.push(segment);
+                }
+            }
         }
 
         segmentTimeline.S = segments;

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -40,7 +40,7 @@ function MssParser(config) {
     const errorHandler = config.errHandler;
     const constants = config.constants;
 
-    const TIME_SCALE_100_NANOSECOND_UNIT = 10000000.0;
+    const DEFAULT_TIME_SCALE = 10000000.0;
     const SUPPORTED_CODECS = ['AAC', 'AACL', 'AVC1', 'H264', 'TTML', 'DFXP'];
     // MPEG-DASH Role and accessibility mapping according to ETSI TS 103 285 v1.1.1 (section 7.1.2)
     const ROLE = {
@@ -80,18 +80,16 @@ function MssParser(config) {
         mediaPlayerModel = config.mediaPlayerModel;
     }
 
-    function mapPeriod(smoothStreamingMedia) {
+    function mapPeriod(smoothStreamingMedia, timescale) {
         let period = {};
         let streams,
             adaptation;
-
-        period.duration = (parseFloat(smoothStreamingMedia.getAttribute('Duration')) === 0) ? Infinity : parseFloat(smoothStreamingMedia.getAttribute('Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
 
         // For each StreamIndex node, create an AdaptationSet element
         period.AdaptationSet_asArray = [];
         streams = smoothStreamingMedia.getElementsByTagName('StreamIndex');
         for (let i = 0; i < streams.length; i++) {
-            adaptation = mapAdaptationSet(streams[i]);
+            adaptation = mapAdaptationSet(streams[i], timescale);
             if (adaptation !== null) {
                 period.AdaptationSet_asArray.push(adaptation);
             }
@@ -104,7 +102,7 @@ function MssParser(config) {
         return period;
     }
 
-    function mapAdaptationSet(streamIndex) {
+    function mapAdaptationSet(streamIndex, timescale) {
 
         let adaptationSet = {};
         let representations = [];
@@ -143,7 +141,7 @@ function MssParser(config) {
         }
 
         // Create a SegmentTemplate with a SegmentTimeline
-        segmentTemplate = mapSegmentTemplate(streamIndex);
+        segmentTemplate = mapSegmentTemplate(streamIndex, timescale);
 
         qualityLevels = streamIndex.getElementsByTagName('QualityLevel');
         // For each QualityLevel node, create a Representation element
@@ -314,23 +312,27 @@ function MssParser(config) {
         return 'mp4a.40.' + objectType;
     }
 
-    function mapSegmentTemplate(streamIndex) {
+    function mapSegmentTemplate(streamIndex, timescale) {
 
         let segmentTemplate = {};
-        let mediaUrl;
+        let mediaUrl,
+            streamIndexTimeScale;
 
         mediaUrl = streamIndex.getAttribute('Url').replace('{bitrate}', '$Bandwidth$');
         mediaUrl = mediaUrl.replace('{start time}', '$Time$');
 
-        segmentTemplate.media = mediaUrl;
-        segmentTemplate.timescale = TIME_SCALE_100_NANOSECOND_UNIT;
+        streamIndexTimeScale = streamIndex.getAttribute('TimeScale');
+        streamIndexTimeScale = streamIndexTimeScale ? parseFloat(streamIndexTimeScale) : timescale;
 
-        segmentTemplate.SegmentTimeline = mapSegmentTimeline(streamIndex);
+        segmentTemplate.media = mediaUrl;
+        segmentTemplate.timescale = streamIndexTimeScale;
+
+        segmentTemplate.SegmentTimeline = mapSegmentTimeline(streamIndex, segmentTemplate.timescale);
 
         return segmentTemplate;
     }
 
-    function mapSegmentTimeline(streamIndex) {
+    function mapSegmentTimeline(streamIndex, timescale) {
 
         let segmentTimeline = {};
         let chunks = streamIndex.getElementsByTagName('c');
@@ -338,7 +340,7 @@ function MssParser(config) {
         let segment;
         let prevSegment;
         let tManifest;
-        let i;
+        let i,j,r;
         let duration = 0;
 
         for (i = 0; i < chunks.length; i++) {
@@ -406,7 +408,7 @@ function MssParser(config) {
 
         segmentTimeline.S = segments;
         segmentTimeline.S_asArray = segments;
-        segmentTimeline.duration = duration / TIME_SCALE_100_NANOSECOND_UNIT;
+        segmentTimeline.duration = duration / timescale;
 
         return segmentTimeline;
     }
@@ -571,14 +573,17 @@ function MssParser(config) {
             timestampOffset,
             startTime,
             segments,
+            timescale,
             i, j;
 
         // Set manifest node properties
         manifest.protocol = 'MSS';
         manifest.profiles = 'urn:mpeg:dash:profile:isoff-live:2011';
         manifest.type = smoothStreamingMedia.getAttribute('IsLive') === 'TRUE' ? 'dynamic' : 'static';
-        manifest.timeShiftBufferDepth = parseFloat(smoothStreamingMedia.getAttribute('DVRWindowLength')) / TIME_SCALE_100_NANOSECOND_UNIT;
-        manifest.mediaPresentationDuration = (parseFloat(smoothStreamingMedia.getAttribute('Duration')) === 0) ? Infinity : parseFloat(smoothStreamingMedia.getAttribute('Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        timescale =  smoothStreamingMedia.getAttribute('TimeScale');
+        manifest.timescale = timescale ? parseFloat(timescale) : DEFAULT_TIME_SCALE;
+        manifest.timeShiftBufferDepth = parseFloat(smoothStreamingMedia.getAttribute('DVRWindowLength')) / manifest.timescale;
+        manifest.mediaPresentationDuration = (parseFloat(smoothStreamingMedia.getAttribute('Duration')) === 0) ? Infinity : parseFloat(smoothStreamingMedia.getAttribute('Duration')) / manifest.timescale;
         manifest.minBufferTime = mediaPlayerModel.getStableBufferTime();
         manifest.ttmlTimeIsRelative = true;
 
@@ -591,7 +596,7 @@ function MssParser(config) {
         }
 
         // Map period node to manifest root node
-        manifest.Period = mapPeriod(smoothStreamingMedia);
+        manifest.Period = mapPeriod(smoothStreamingMedia, manifest.timescale);
         manifest.Period_asArray = [manifest.Period];
 
         // Initialize period start time
@@ -658,14 +663,14 @@ function MssParser(config) {
             for (i = 0; i < adaptations.length; i++) {
                 if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {
                     segments = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray;
-                    startTime = segments[0].t;
+                    startTime = segments[0].t / adaptations[i].SegmentTemplate.timescale;
                     if (timestampOffset === undefined) {
                         timestampOffset = startTime;
                     }
                     timestampOffset = Math.min(timestampOffset, startTime);
                     // Correct content duration according to minimum adaptation's segments duration
                     // in order to force <video> element sending 'ended' event
-                    manifest.mediaPresentationDuration = Math.min(manifest.mediaPresentationDuration, ((segments[segments.length - 1].t + segments[segments.length - 1].d) / TIME_SCALE_100_NANOSECOND_UNIT).toFixed(3));
+                    manifest.mediaPresentationDuration = Math.min(manifest.mediaPresentationDuration, adaptations[i].SegmentTemplate.SegmentTimeline.duration);
                 }
             }
 
@@ -677,16 +682,17 @@ function MssParser(config) {
                         if (!segments[j].tManifest) {
                             segments[j].tManifest = segments[j].t;
                         }
-                        segments[j].t -= timestampOffset;
+                        segments[j].t -= (timestampOffset * adaptations[i].SegmentTemplate.timescale);
                     }
                     if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {
                         period.start = Math.max(segments[0].t, period.start);
                     }
                 }
-                period.start /= TIME_SCALE_100_NANOSECOND_UNIT;
+                period.start /= manifest.timescale;
             }
         }
 
+        manifest.mediaPresentationDuration = Math.floor(manifest.mediaPresentationDuration * 1000) / 1000;
         period.duration = manifest.mediaPresentationDuration;
 
         return manifest;

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -112,7 +112,6 @@ function MssParser(config) {
         let qualityLevels,
             representation,
             segments,
-            range,
             i;
 
         adaptationSet.id = streamIndex.getAttribute('Name') ? streamIndex.getAttribute('Name') : streamIndex.getAttribute('Type');
@@ -178,11 +177,6 @@ function MssParser(config) {
         adaptationSet.SegmentTemplate = segmentTemplate;
 
         segments = segmentTemplate.SegmentTimeline.S_asArray;
-
-        range = {
-            start: segments[0].t / segmentTemplate.timescale,
-            end: (segments[segments.length - 1].t + segments[segments.length - 1].d) / segmentTemplate.timescale
-        };
 
         return adaptationSet;
     }

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -686,6 +686,7 @@ function MssParser(config) {
                     }
                     if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {
                         period.start = Math.max(segments[0].t, period.start);
+                        adaptations[i].SegmentTemplate.presentationTimeOffset = period.start;
                     }
                 }
                 period.start /= manifest.timescale;

--- a/test/unit/mocks/StreamProcessorMock.js
+++ b/test/unit/mocks/StreamProcessorMock.js
@@ -26,7 +26,7 @@ class RepresentationControllerMock {
     constructor() {}
 
     getCurrentRepresentation() {
-        return {adaptation: {period: {mpd: {manifest: {type: 'dynamic', Period_asArray: [{AdaptationSet_asArray: []}]}}, index: 0}, index: 0}};
+        return {adaptation: {period: {mpd: {manifest: {type: 'dynamic', Period_asArray: [{AdaptationSet_asArray: [{SegmentTemplate: {timescale: 10000000}}]}]}}, index: 0}, index: 0}};
     }
 }
 


### PR DESCRIPTION
Hi,

This PR adds : 

- support for MSS manifests with a TimeScale different from default one.
- support for MSS manifests with a TimeScale different from audio and video streamIndex.

Sample streams to test are available [here](http://icostreaming.streaming.mediaservices.windows.net/8c8dc03f-caa7-49d2-89a9-9087263f389a/4b901fdc-1884-4d3a-8e7a-9ed941197abb.ism/manifest) and [here](http://icostreaming.streaming.mediaservices.windows.net/39616a5a-83eb-470b-a5b6-048fa003dec4/fb198532-f5ed-422f-af4a-1f9690ad7560.ism/manifest)

Nico