### PR TITLE
[Definitions] Mark values in protection data as optional.

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -627,17 +627,17 @@ declare namespace dashjs {
          * type with the corresponding property value being the URL to use for
          * messages of that type
          */
-        serverURL: string | { [P in MediaKeyMessageType]: string };
+        serverURL?: string | { [P in MediaKeyMessageType]: string };
 
         /** headers to add to the http request */
-        httpRequestHeaders: object;
+        httpRequestHeaders?: object;
 
         /**
          * Defines a set of clear keys that are available to the key system.
          * Object properties are base64-encoded keyIDs (with no padding).
          * Corresponding property values are keys, base64-encoded (no padding).
          */
-        clearkeys: { [key: string]: string };
+        clearkeys?: { [key: string]: string };
     }
 
     export class MetricsList {

--- a/index.d.ts
+++ b/index.d.ts
@@ -627,17 +627,17 @@ declare namespace dashjs {
          * type with the corresponding property value being the URL to use for
          * messages of that type
          */
-        serverURL: string | { [P in MediaKeyMessageType]: string };
+        serverURL?: string | { [P in MediaKeyMessageType]: string };
 
         /** headers to add to the http request */
-        httpRequestHeaders: object;
+        httpRequestHeaders?: object;
 
         /**
          * Defines a set of clear keys that are available to the key system.
          * Object properties are base64-encoded keyIDs (with no padding).
          * Corresponding property values are keys, base64-encoded (no padding).
          */
-        clearkeys: { [key: string]: string };
+        clearkeys?: { [key: string]: string };
     }
 
     export class MetricsList {


### PR DESCRIPTION
Not all values are required when setting protection data but not passing them all throws a TypeScript error.