### PR TITLE
Fix #2547 - do not reject empty TTML docs as invalid

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -115,8 +115,8 @@ function TTMLParser() {
 
         let imsc1doc = fromXML(content.data, function (msg) {
             errorMsg = msg;
-        },
-            metadataHandler);
+        }, metadataHandler);
+
         eventBus.trigger(Events.TTML_PARSED, {ttmlString: content.data, ttmlDoc: imsc1doc});
 
         let mediaTimeEvents = imsc1doc.getMediaTimeEvents();
@@ -148,13 +148,10 @@ function TTMLParser() {
 
         if (errorMsg !== '') {
             log(errorMsg);
-        }
-
-        if (captionArray.length > 0) {
-            return captionArray;
-        } else { // This seems too strong given that there are segments with no TTML subtitles
             throw new Error(errorMsg);
         }
+
+        return captionArray;
     }
 
     function setup() {


### PR DESCRIPTION
Have TTMLParser return an empty array of captions when the TTML document is valid but contains nothing to display (ie empty samples to maintain the timeline). Still throw an error if there was one.

I have not tested that it does not regress #2527 as I do not have access to Edge.

IMO this should be included in the upcoming release as it is a serious regression.