### PR TITLE
PlayReady DRM fixes for SmartTVs

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -223,8 +223,7 @@ function DashAdapter() {
             const mpd = dashManifestModel.getMpd(manifest);
 
             voLocalPeriods = dashManifestModel.getRegularPeriods(mpd);
-
-        }else {
+        } else {
             if (voPeriods.length > 0) {
                 manifest = voPeriods[0].mpd.manifest;
             } else {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -596,7 +596,7 @@ function DashManifestModel(config) {
                     voAdaptationSet.type = Constants.FRAGMENTED_TEXT;
                 } else if (getIsImage(realAdaptationSet)) {
                     voAdaptationSet.type = Constants.IMAGE;
-                }else {
+                } else {
                     voAdaptationSet.type = Constants.TEXT;
                 }
                 voAdaptations.push(voAdaptationSet);
@@ -752,7 +752,7 @@ function DashManifestModel(config) {
         } else if (isDynamic) {
             periodEnd = Number.POSITIVE_INFINITY;
         } else {
-            throw new Error('Must have @mediaPresentationDuratio on MPD or an explicit @duration on the last period.');
+            throw new Error('Must have @mediaPresentationDuration on MPD or an explicit @duration on the last period.');
         }
 
         return periodEnd;

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -97,7 +97,7 @@ function ManifestLoader(config) {
             if (mssHandler) {
                 parser = mssHandler.createMssParser();
                 mssHandler.registerEvents();
-            }else {
+            } else {
                 errHandler.manifestError('manifest type unsupported', 'createParser');
             }
             return parser;

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -286,7 +286,7 @@ function TimeSyncController() {
         if (!isNaN(dateHeaderTime)) {
             setOffsetMs(dateHeaderTime - new Date().getTime());
             completeTimeSyncSequence(false, dateHeaderTime / 1000, offsetToDeviceTimeMs);
-        }else {
+        } else {
             completeTimeSyncSequence(true);
         }
     }

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -79,26 +79,34 @@ function KeySystemPlayReady(config) {
             headers['Content-Type'] = headers.Content;
             delete headers.Content;
         }
+        // some devices (Ex: LG SmartTVs) require content-type to be defined
+        if (!headers.hasOwnProperty('Content-Type')) {
+            headers['Content-Type'] = 'text/xml; charset=' + messageFormat;
+        }
         return headers;
     }
 
     function getLicenseRequestFromMessage(message) {
-        let msg,
-            xmlDoc;
         let licenseRequest = null;
         const parser = new DOMParser();
         const dataview = (messageFormat === 'utf16') ? new Uint16Array(message) : new Uint8Array(message);
 
         checkConfig();
-        msg = String.fromCharCode.apply(null, dataview);
-        xmlDoc = parser.parseFromString(msg, 'application/xml');
+        const msg = String.fromCharCode.apply(null, dataview);
+        const xmlDoc = parser.parseFromString(msg, 'application/xml');
 
         if (xmlDoc.getElementsByTagName('Challenge')[0]) {
             const Challenge = xmlDoc.getElementsByTagName('Challenge')[0].childNodes[0].nodeValue;
             if (Challenge) {
                 licenseRequest = BASE64.decode(Challenge);
             }
+        } else if (xmlDoc.getElementsByTagName('parsererror').length) {
+            // In case it is not an XML doc, return the message itself
+            // There are CDM implementations of some devices (example: some smartTVs) that
+            // return directly the challenge without wrapping it in an xml doc
+            return message;
         }
+
         return licenseRequest;
     }
 

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -246,7 +246,11 @@ function ProtectionModel_01b(config) {
 
     function closeKeySession(sessionToken) {
         // Send our request to the CDM
-        videoElement[api.cancelKeyRequest](keySystem.systemString, sessionToken.sessionID);
+        try {
+            videoElement[api.cancelKeyRequest](keySystem.systemString, sessionToken.sessionID);
+        } catch (error) {
+            eventBus.trigger(events.KEY_SESSION_CLOSED, {data: null, error: 'Error closing session (' + sessionToken.sessionID + ') ' + error.message});
+        }
     }
 
     function setServerCertificate(/*serverCertificate*/) { /* Not supported */ }
@@ -329,6 +333,8 @@ function ProtectionModel_01b(config) {
                                 sessionToken = pendingSessions.shift();
                                 sessions.push(sessionToken);
                                 sessionToken.sessionID = event.sessionId;
+
+                                eventBus.trigger(events.KEY_SESSION_CREATED, {data: sessionToken});
                             }
                         } else if (pendingSessions.length > 0) { // SessionIDs not supported
                             sessionToken = pendingSessions.shift();

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -66,7 +66,7 @@ function BufferLevelRule(config) {
             if (abrController.isPlayingAtTopQuality(streamInfo)) {
                 const isLongFormContent = streamInfo.manifestInfo.duration >= mediaPlayerModel.getLongFormContentDurationThreshold();
                 bufferTarget = isLongFormContent ? mediaPlayerModel.getBufferTimeAtTopQualityLongForm() : mediaPlayerModel.getBufferTimeAtTopQuality();
-            }else {
+            } else {
                 bufferTarget = mediaPlayerModel.getStableBufferTime();
             }
         }

--- a/src/streaming/utils/CustomTimeRanges.js
+++ b/src/streaming/utils/CustomTimeRanges.js
@@ -68,20 +68,20 @@ function CustomTimeRanges(/*config*/) {
                 this.customTimeRangeArray.splice(i,1);
                 i--;
 
-            }else if (start > this.customTimeRangeArray[i].start && end < this.customTimeRangeArray[i].end) {
+            } else if (start > this.customTimeRangeArray[i].start && end < this.customTimeRangeArray[i].end) {
                 //|-----------------Range i----------------|
                 //        |-------Range to remove -----|
                 this.customTimeRangeArray.splice(i + 1, 0, {start: end,end: this.customTimeRangeArray[i].end});
                 this.customTimeRangeArray[i].end = start;
                 break;
-            }else if ( start > this.customTimeRangeArray[i].start && start < this.customTimeRangeArray[i].end) {
+            } else if ( start > this.customTimeRangeArray[i].start && start < this.customTimeRangeArray[i].end) {
                 //|-----------Range i----------|
                 //                    |---------Range to remove --------|
                 //    or
                 //|-----------------Range i----------------|
                 //            |-------Range to remove -----|
                 this.customTimeRangeArray[i].end = start;
-            }else if ( end > this.customTimeRangeArray[i].start && end < this.customTimeRangeArray[i].end) {
+            } else if ( end > this.customTimeRangeArray[i].start && end < this.customTimeRangeArray[i].end) {
                 //                     |-----------Range i----------|
                 //|---------Range to remove --------|
                 //            or


### PR DESCRIPTION
Add changes to KeySystemPlayReady to make it compatible with some SmartTVs that don't pass an XML doc with a challenge in the key message but the challenge itself. 

Add triggering session creation and close events for ProtectionModel01b, as we are doing for all the other models. Catch exceptions when calling closeKeySession of ProtectionModel01b, as there are some devices (ex: LG SmartTVs) which raise exceptions when trying to close a session after the source being unloaded.