### PR TITLE
Fix clearNextRange so it checks buffer properly

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -74,7 +74,7 @@
           "name": "Low Latency (Single-Rate)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 2
+            "liveDelay": 3
           }
         },
         {
@@ -82,7 +82,7 @@
           "name": "Low Latency (Multi-Rate)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 2
+            "liveDelay": 3
           }
         },
         {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -661,7 +661,13 @@ function BufferController(config) {
     }
 
     function clearNextRange() {
-        if (pendingPruningRanges.length === 0 || !buffer || !buffer.buffered || buffer.buffered.length === 0) return;
+        if (pendingPruningRanges.length === 0 || !buffer) {
+            return;
+        }
+        const sourceBuffer = buffer.getBuffer();
+        if (!sourceBuffer || !sourceBuffer.buffered || sourceBuffer.buffered.length === 0) {
+            return;
+        }
 
         const range = pendingPruningRanges.shift();
         log('Removing', type, 'buffer from:', range.start, 'to', range.end);


### PR DESCRIPTION
Fix a regression detected in clearNextRange (BufferController). First "if", responsible of checking whether there is a buffer and ranges to clear, was wrong and always returned false what caused inconsistencies in the Media Buffer.

This is a fix for #2556. @bbert, @nicosang, could you please let me know if you can still reproduce any issue in your end? Your opinion and feedback is highly appreciated.