### PR TITLE
Update manifest parsing error

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -224,6 +224,15 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.video = document.querySelector('.dash-video-player video');
     $scope.player = dashjs.MediaPlayer().create(); /* jshint ignore:line */
 
+    $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) { /* jshint ignore:line */
+        var message = e.event.message ? e.event.message : typeof e.event === 'string' ? e.event: e.event.url ? e.event.url : '';
+        $scope.$apply(function () {
+            $scope.error = message;
+            $scope.errorType = e.error;
+        });
+        $("#errorModal").modal('show');
+    }, $scope);
+
     $scope.player.initialize($scope.video, null, $scope.autoPlaySelected);
     $scope.player.setFastSwitchEnabled($scope.fastSwitchSelected);
     $scope.player.setJumpGaps($scope.jumpGapsSelected);
@@ -260,15 +269,6 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.controlbar.initialize();
     $scope.controlbar.disable();
     $scope.version = $scope.player.getVersion();
-
-    $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) { /* jshint ignore:line */
-        var message = e.event.message ? e.event.message : typeof e.event === 'string' ? e.event: e.event.url ? e.event.url : '';
-        $scope.$apply(function () {
-            $scope.error = message;
-            $scope.errorType = e.error;
-        });
-        $("#errorModal").modal('show');
-    }, $scope);
 
     $scope.player.on(dashjs.MediaPlayer.events.MANIFEST_LOADED, function (e) { /* jshint ignore:line */
         $scope.isDynamic = e.data.type === 'dynamic';

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -39,12 +39,10 @@ import NumericMatcher from './matchers/NumericMatcher';
 import RepresentationBaseValuesMap from './maps/RepresentationBaseValuesMap';
 import SegmentValuesMap from './maps/SegmentValuesMap';
 
-function DashParser(config) {
+function DashParser() {
 
-    config = config || {};
     const context = this.context;
     const log = Debug(context).getInstance().log;
-    const errorHandler = config.errorHandler;
 
     let instance,
         matchers,
@@ -76,12 +74,6 @@ function DashParser(config) {
         });
     }
 
-    function checkConfig() {
-        if (!errorHandler || !errorHandler.hasOwnProperty('manifestError')) {
-            throw new Error('Missing config parameter(s)');
-        }
-    }
-
     function getMatchers() {
         return matchers;
     }
@@ -93,28 +85,21 @@ function DashParser(config) {
     function parse(data) {
         let manifest;
 
-        checkConfig();
+        const startTime = window.performance.now();
 
-        try {
-            const startTime = window.performance.now();
+        manifest = converter.xml_str2json(data);
 
-            manifest = converter.xml_str2json(data);
-
-            if (!manifest) {
-                throw new Error('parser error');
-            }
-
-            const jsonTime = window.performance.now();
-
-            objectIron.run(manifest);
-
-            const ironedTime = window.performance.now();
-
-            log('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
-        } catch (err) {
-            errorHandler.manifestError('parsing the manifest failed', 'parse', data, err);
-            return null;
+        if (!manifest) {
+            throw new Error('parsing the manifest failed');
         }
+
+        const jsonTime = window.performance.now();
+
+        objectIron.run(manifest);
+
+        const ironedTime = window.performance.now();
+
+        log('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
 
         return manifest;
     }

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -37,7 +37,6 @@ function MssParser(config) {
     config = config || {};
     const BASE64 = config.BASE64;
     const log = config.log;
-    const errorHandler = config.errHandler;
     const constants = config.constants;
 
     const DEFAULT_TIME_SCALE = 10000000.0;
@@ -704,16 +703,11 @@ function MssParser(config) {
         let xmlDoc = null;
 
         if (window.DOMParser) {
-            try {
-                let parser = new window.DOMParser();
+            let parser = new window.DOMParser();
 
-                xmlDoc = parser.parseFromString(data, 'text/xml');
-                if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
-                    throw new Error('Error parsing XML');
-                }
-            } catch (e) {
-                errorHandler.manifestError('parsing the manifest failed', 'parse', data, e);
-                xmlDoc = null;
+            xmlDoc = parser.parseFromString(data, 'text/xml');
+            if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
+                throw new Error('parsing the manifest failed');
             }
         }
 

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -97,14 +97,10 @@ function ManifestLoader(config) {
             if (mssHandler) {
                 parser = mssHandler.createMssParser();
                 mssHandler.registerEvents();
-            } else {
-                errHandler.manifestError('manifest type unsupported', 'createParser');
             }
             return parser;
         } else if (data.indexOf('MPD') > -1) {
-            return DashParser(context).create({
-                errorHandler: errHandler
-            });
+            return DashParser(context).create();
         } else {
             return parser;
         }
@@ -117,7 +113,8 @@ function ManifestLoader(config) {
             request: request,
             success: function (data, textStatus, responseURL) {
                 let actualUrl,
-                    baseUri;
+                    baseUri,
+                    manifest;
 
                 // Handle redirects for the MPD - as per RFC3986 Section 5.1.3
                 // also handily resolves relative MPD URLs to absolute
@@ -146,7 +143,7 @@ function ManifestLoader(config) {
                             manifest: null,
                             error: new DashJSError(
                                 MANIFEST_LOADER_ERROR_PARSING_FAILURE,
-                                `Failed detecting manifest type: ${url}`
+                                `Failed detecting manifest type or manifest type unsupported : ${url}`
                             )
                         }
                     );
@@ -157,7 +154,20 @@ function ManifestLoader(config) {
                 xlinkController.setMatchers(parser.getMatchers());
                 xlinkController.setIron(parser.getIron());
 
-                const manifest = parser.parse(data);
+                try {
+                    manifest = parser.parse(data);
+                } catch (e) {
+                    eventBus.trigger(
+                        Events.INTERNAL_MANIFEST_LOADED, {
+                            manifest: null,
+                            error: new DashJSError(
+                               MANIFEST_LOADER_ERROR_PARSING_FAILURE,
+                                `Failed parsing manifest : ${url}`
+                           )
+                        }
+                    );
+                    return;
+                }
 
                 if (manifest) {
                     manifest.url = actualUrl || url;

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -47,7 +47,8 @@ function ManifestUpdater() {
         manifestLoader,
         manifestModel,
         dashManifestModel,
-        mediaPlayerModel;
+        mediaPlayerModel,
+        errHandler;
 
     function setConfig(config) {
         if (!config) return;
@@ -63,6 +64,9 @@ function ManifestUpdater() {
         }
         if (config.manifestLoader) {
             manifestLoader = config.manifestLoader;
+        }
+        if (config.errHandler) {
+            errHandler = config.errHandler;
         }
     }
 

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -165,6 +165,8 @@ function ManifestUpdater() {
     function onManifestLoaded(e) {
         if (!e.error) {
             update(e.manifest);
+        } else {
+            errHandler.manifestError(e.error.message, e.error.code);
         }
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -120,7 +120,8 @@ function StreamController() {
             manifestModel: manifestModel,
             dashManifestModel: dashManifestModel,
             mediaPlayerModel: mediaPlayerModel,
-            manifestLoader: manifestLoader
+            manifestLoader: manifestLoader,
+            errHandler: errHandler
         });
         manifestUpdater.initialize();
 

--- a/test/unit/dash.DashParser.js
+++ b/test/unit/dash.DashParser.js
@@ -1,13 +1,13 @@
 import DashParser from '../../src/dash/parser/DashParser';
-import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 
 const expect = require('chai').expect;
 const jsdom = require('jsdom').JSDOM;
 
 const context = {};
 
+let dashParser = DashParser(context).create();
+
 describe('DashParser', function () {
-    let dashParser;
 
     beforeEach(function () {
         if (typeof window === 'undefined') {
@@ -26,27 +26,11 @@ describe('DashParser', function () {
         delete global.window;
     });
 
-    it('should throw an error when parse is called and config object is not defined', function () {
-        dashParser = DashParser(context).create();
-        expect(dashParser.parse.bind('')).to.be.throw('Missing config parameter(s)');
-    });
-
-    it('should throw an error when parse is called and config object has not been set properly', function () {
-        dashParser = DashParser(context).create({});
-        expect(dashParser.parse.bind('')).to.be.throw('Missing config parameter(s)');
-    });
-
     it('should throw an error when parse is called without data and config object has been set properly', function () {
-        const errorHandlerMock = new ErrorHandlerMock();
-        dashParser = DashParser(context).create({errorHandler: errorHandlerMock});
-        dashParser.parse();
-        expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
+        expect(dashParser.parse.bind('')).to.be.throw('parsing the manifest failed');
     });
 
     it('should throw an error when parse is called with invalid data', function () {
-        const errorHandlerMock = new ErrorHandlerMock();
-        dashParser = DashParser(context).create({errorHandler: errorHandlerMock});
-        dashParser.parse('<MPD');
-        expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
+        expect(dashParser.parse.bind('<MPD')).to.be.throw('parsing the manifest failed');
     });
 });

--- a/test/unit/mss.parser.MssParser.js
+++ b/test/unit/mss.parser.MssParser.js
@@ -2,8 +2,6 @@ import MssParser from '../../src/mss/parser/MssParser';
 import MediaPlayerModel from '../../src/streaming/models/MediaPlayerModel';
 import Debug from '../../src/core/Debug';
 
-import ErrorHandlerMock from './mocks/ErrorHandlerMock';
-
 const expect = require('chai').expect;
 const fs = require('fs');
 const jsdom = require('jsdom').JSDOM;
@@ -11,8 +9,7 @@ const context = {};
 
 describe('MssParser', function () {
 
-    let mssParser,
-        errorHandlerMock;
+    let mssParser;
     const mediaPlayerModel = MediaPlayerModel().getInstance();
 
     beforeEach(function () {
@@ -33,11 +30,9 @@ describe('MssParser', function () {
     });
 
     beforeEach(function () {
-        errorHandlerMock = new ErrorHandlerMock();
         mssParser = MssParser().create({
             mediaPlayerModel: mediaPlayerModel,
-            log: Debug(context).getInstance().log,
-            errHandler: errorHandlerMock
+            log: Debug(context).getInstance().log
         });
 
         expect(mssParser).to.exist; // jshint ignore:line
@@ -78,7 +73,6 @@ describe('MssParser', function () {
         expect(adaptations[0].contentType).to.equal('audio');
     });
     it('should throw an error when parse is called with invalid smooth data', function () {
-        mssParser.parse('<SmoothStreamingMedia');
-        expect(errorHandlerMock.error).to.equal('parsing the manifest failed');
+        expect(mssParser.parse.bind('<SmoothStreamingMedia')).to.be.throw('parsing the manifest failed');
     });
 });

--- a/test/unit/streaming.ManifestUpdater.js
+++ b/test/unit/streaming.ManifestUpdater.js
@@ -1,0 +1,43 @@
+import ManifestUpdater from './../../src/streaming/ManifestUpdater';
+import Events from '../../src/core/events/Events';
+import EventBus from '../../src/core/EventBus';
+
+import ManifestModelMock from './mocks/ManifestModelMock';
+import DashManifestModelMock from './mocks/DashManifestModelMock';
+import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
+import ManifestLoaderMock from './mocks/ManifestLoaderMock';
+import ErrorHandlerMock from './mocks/ErrorHandlerMock';
+
+const expect = require('chai').expect;
+
+describe('ManifestUpdater', function () {
+    const context = {};
+    const eventBus = EventBus(context).getInstance();
+    let manifestUpdater = ManifestUpdater(context).create();
+
+    // init mock
+    const manifestModelMock = new ManifestModelMock();
+    const dashManifestModelMock = new DashManifestModelMock();
+    const mediaPlayerModelMock = new MediaPlayerModelMock();
+    const manifestLoaderMock = new ManifestLoaderMock();
+    const errHandlerMock = new ErrorHandlerMock();
+
+    const manifestErrorMockText = `Mock Failed detecting manifest type or manifest type unsupported`;
+
+    manifestUpdater.setConfig({
+        manifestModel: manifestModelMock,
+        dashManifestModel: dashManifestModelMock,
+        mediaPlayerModel: mediaPlayerModelMock,
+        manifestLoader: manifestLoaderMock,
+        errHandler: errHandlerMock
+    });
+
+    manifestUpdater.initialize();
+
+    it('should return an error when parsing error occurs', function () {
+        eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+            error: {message: manifestErrorMockText}
+        });
+        expect(errHandlerMock.error).to.equal(manifestErrorMockText);
+    });
+});


### PR DESCRIPTION
Hi,

this PR has to update manifest parsing error. The main idea is that each parser (dash or mss) has to throw an error if needed. This error is caught by the ManifestLoader class which has to trigger a INTERNAL_MANIFEST_LOADED event.
Finally, ManifestUpdater has to analyze error attribute of this event, and if needed, call manifestError function of ErrorHandler class. Thus, the call to manifestError function is centralized in ManifestUpdater only during parsing process.

A first version of ManifestUpdater unit test has also been added.

Nico