### PR TITLE
don't double-add caption parsers on period switch

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -195,6 +195,11 @@ function TextSourceBuffer() {
             initEmbedded();
         }
         if (mediaInfo.id === Constants.CC1 || mediaInfo.id === Constants.CC3) {
+            for (let i = 0; i < embeddedTracks.length; i++) {
+                if (embeddedTracks[i].id === mediaInfo.id) {
+                    return;
+                }
+            }
             embeddedTracks.push(mediaInfo);
         } else {
             log('Warning: Embedded track ' + mediaInfo.id + ' not supported!');


### PR DESCRIPTION
Caption parsers are added for every `mediaInfo` that's processed in the MPD. This causes a problem for multi-period feeds, as you'll get duplicate captions pushed out. 