### PR TITLE
Introduce new API enableForcedTextStreaming

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1967,6 +1967,25 @@ function MediaPlayer() {
         textController.enableText(enable);
     }
 
+
+    /**
+     * Enable/disable text
+     * When enabling dash will keep downloading and process fragmented text tracks even if all tracks are in mode "hidden"
+     *
+     * @param {boolean} enable - true to enable text streaming even if all text tracks are hidden.
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function enableForcedTextStreaming(enable) {
+        if (textController === undefined) {
+            textController = TextController(context).getInstance();
+        }
+
+        textController.enableForcedTextStreaming(enable);
+    }
+
+
+
     /**
      * Return if text is enabled
      *
@@ -2865,6 +2884,7 @@ function MediaPlayer() {
         setTextDefaultEnabled: setTextDefaultEnabled,
         getTextDefaultEnabled: getTextDefaultEnabled,
         enableText: enableText,
+        enableForcedTextStreaming: enableForcedTextStreaming,
         isTextEnabled: isTextEnabled,
         setTextTrack: setTextTrack,
         getBitrateInfoListFor: getBitrateInfoListFor,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -553,7 +553,7 @@ function BufferController(config) {
     }
 
     function notifyBufferStateChanged(state) {
-        if (bufferState === state || (type === Constants.FRAGMENTED_TEXT && textController.getAllTracksAreDisabled())) return;
+        if (bufferState === state || (type === Constants.FRAGMENTED_TEXT && !textController.isTextEnabled())) return;
         bufferState = state;
         addBufferMetrics();
 

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -52,7 +52,7 @@ function BufferLevelRule(config) {
         let bufferTarget = NaN;
         const representationInfo = streamProcessor.getCurrentRepresentationInfo();
         if (type === Constants.FRAGMENTED_TEXT) {
-            bufferTarget = textController.getAllTracksAreDisabled() ? 0 : representationInfo.fragmentDuration;
+            bufferTarget = textController.isTextEnabled() ? representationInfo.fragmentDuration : 0;
         } else if (type === Constants.AUDIO && videoTrackPresent) {
             const videoBufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(Constants.VIDEO));
             if (isNaN(representationInfo.fragmentDuration)) {

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -53,7 +53,7 @@ function NextFragmentRequestRule(config) {
 
         let time = hasSeekTarget ? seekTarget : adapter.getIndexHandlerTime(streamProcessor);
 
-        if (isNaN(time) || (mediaType === Constants.FRAGMENTED_TEXT && textController.getAllTracksAreDisabled())) {
+        if (isNaN(time) || (mediaType === Constants.FRAGMENTED_TEXT && !textController.isTextEnabled())) {
             return null;
         }
 


### PR DESCRIPTION
When enabling dash will keep downloading and process fragmented text tracks even if all tracks are in mode "hidden"