### PR TITLE
Fix ES5 Incompatibility in Controlbar

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -463,7 +463,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
                 availableBitrates.video = player.getBitrateInfoListFor("video") || [];
                 if (availableBitrates.audio.length > 1 || availableBitrates.video.length > 1) {
                     contentFunc = function (element, index) {
-                        let result = isNaN(index) ? " Auto Switch" : Math.floor(element.bitrate / 1000) + ' kbps';
+                        var result = isNaN(index) ? " Auto Switch" : Math.floor(element.bitrate / 1000) + ' kbps';
                         result += element && element.width && element.height ? ` (${element.width}x${element.height})` : '';
                         return result;
                     }


### PR DESCRIPTION
Fixed an ES5 incompatibility where `let` was used instead of `var`. Since this file is not compiled it needs to stay compatible with ES5 assuming that is the target. When running this file through the [uglify minifier](https://github.com/mishoo/UglifyJS), it throws an error since it thinks this is a syntax error.

I'm not entirely sure what compatibility is expected for `controlbar.js`, but this seemed like a reasonable assumption since the file is not compiled. The change was so small I went ahead and opened this PR instead of an issue first.

Thanks!

Semi-related, this is the PR where `let` came from https://github.com/Dash-Industry-Forum/dash.js/pull/2520