### PR TITLE
Smooth period transition

### DIFF
--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -47,8 +47,11 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         buffer,
         isAppendingInProgress;
 
+    let callbacks = [];
+
     let appendQueue = [];
     let onAppended = onAppendedCallback;
+    let intervalId;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -64,6 +67,25 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
                 throw new Error('not really supported');
             }
             buffer = oldBuffer ? oldBuffer : mediaSource.addSourceBuffer(codec);
+
+            const CHECK_INTERVAL = 50;
+            // use updateend event if possible
+            if (typeof buffer.addEventListener === 'function') {
+                try {
+                    buffer.addEventListener('updateend', updateEndHandler, false);
+                    buffer.addEventListener('error', errHandler, false);
+                    buffer.addEventListener('abort', errHandler, false);
+
+                } catch (err) {
+                    // use setInterval to periodically check if updating has been completed
+                    intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
+                }
+            } else {
+                // use setInterval to periodically check if updating has been completed
+                intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
+            }
+
+
         } catch (ex) {
             // Note that in the following, the quotes are open to allow for extra text after stpp and wvtt
             if ((mediaInfo.isText) || (codec.indexOf('codecs="stpp') !== -1) || (codec.indexOf('codecs="wvtt') !== -1)) {
@@ -75,17 +97,23 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         }
     }
 
-    function reset() {
+    function reset(keepBuffer) {
         if (buffer) {
-            try {
-                if (!buffer.getClassName || buffer.getClassName() !== 'TextSourceBuffer') {
-                    mediaSource.removeSourceBuffer(buffer);
+            buffer.removeEventListener('updateend', updateEndHandler, false);
+            buffer.removeEventListener('error', errHandler, false);
+            buffer.removeEventListener('abort', errHandler, false);
+            clearInterval(intervalId);
+            if (!keepBuffer) {
+                try {
+                    if (!buffer.getClassName || buffer.getClassName() !== 'TextSourceBuffer') {
+                        mediaSource.removeSourceBuffer(buffer);
+                    }
+                } catch (e) {
+                    logger.error('Failed to remove source buffer from media source.');
                 }
-            } catch (e) {
-                logger.error('Failed to remove source buffer from media source.');
+                buffer = null;
             }
             isAppendingInProgress = false;
-            buffer = null;
         }
         appendQueue = [];
         onAppended = null;
@@ -241,41 +269,42 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         appendQueue = [];
     }
 
-    function waitForUpdateEnd(buffer, callback) {
-        let intervalId;
-        const CHECK_INTERVAL = 50;
-
-        const checkIsUpdateEnded = function () {
-            // if updating is still in progress do nothing and wait for the next check again.
-            if (buffer.updating) return;
-            // updating is completed, now we can stop checking and resolve the promise
-            clearInterval(intervalId);
-            callback();
-        };
-
-        const updateEndHandler = function () {
-            if (buffer.updating) return;
-
-            buffer.removeEventListener('updateend', updateEndHandler, false);
-            callback();
-        };
-
-        if (!buffer.updating) {
-            callback();
-            return;
+    function executeCallback() {
+        if (callbacks.length > 0) {
+            const cb = callbacks.shift();
+            if (buffer.updating) {
+                waitForUpdateEnd(buffer, cb);
+            } else {
+                cb();
+            }
         }
 
-        // use updateend event if possible
-        if (typeof buffer.addEventListener === 'function') {
-            try {
-                buffer.addEventListener('updateend', updateEndHandler, false);
-            } catch (err) {
-                // use setInterval to periodically check if updating has been completed
-                intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
-            }
-        } else {
-            // use setInterval to periodically check if updating has been completed
-            intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
+    }
+
+    function checkIsUpdateEnded() {
+        // if updating is still in progress do nothing and wait for the next check again.
+        if (buffer.updating) return;
+        // updating is completed, now we can stop checking and resolve the promise
+        executeCallback();
+    }
+
+
+    function updateEndHandler() {
+        if (buffer.updating) return;
+
+        executeCallback();
+    }
+
+    function errHandler() {
+        log('SourceBufferSink error', mediaInfo.type);
+    }
+
+
+    function waitForUpdateEnd(buffer, callback) {
+        callbacks.push(callback);
+
+        if (!buffer.updating) {
+            executeCallback();
         }
     }
 

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -99,9 +99,11 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
 
     function reset(keepBuffer) {
         if (buffer) {
-            buffer.removeEventListener('updateend', updateEndHandler, false);
-            buffer.removeEventListener('error', errHandler, false);
-            buffer.removeEventListener('abort', errHandler, false);
+            if (typeof buffer.removeEventListener === 'function') {
+                buffer.removeEventListener('updateend', updateEndHandler, false);
+                buffer.removeEventListener('error', errHandler, false);
+                buffer.removeEventListener('abort', errHandler, false);
+            }
             clearInterval(intervalId);
             if (!keepBuffer) {
                 try {

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -130,7 +130,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
             return buffer.buffered;
         } catch (e) {
             log('getAllBufferRanges exception: ' + e.message);
-            return [];
+            return null;
         }
     }
 

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -38,7 +38,7 @@ import TextController from './text/TextController';
  * @class SourceBufferSink
  * @implements FragmentSink
  */
-function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
+function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer) {
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
 
@@ -63,8 +63,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
             if (codec.match(/application\/mp4;\s*codecs="(stpp|wvtt).*"/i)) {
                 throw new Error('not really supported');
             }
-
-            buffer = mediaSource.addSourceBuffer(codec);
+            buffer = oldBuffer ? oldBuffer : mediaSource.addSourceBuffer(codec);
         } catch (ex) {
             // Note that in the following, the quotes are open to allow for extra text after stpp and wvtt
             if ((mediaInfo.isText) || (codec.indexOf('codecs="stpp') !== -1) || (codec.indexOf('codecs="wvtt') !== -1)) {
@@ -97,7 +96,12 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
     }
 
     function getAllBufferRanges() {
-        return buffer ? buffer.buffered : [];
+        try {
+            return buffer.buffered;
+        } catch (e) {
+            log('getAllBufferRanges exception: ' + e.message);
+            return [];
+        }
     }
 
     function append(chunk) {

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -129,7 +129,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         try {
             return buffer.buffered;
         } catch (e) {
-            log('getAllBufferRanges exception: ' + e.message);
+            logger.error('getAllBufferRanges exception: ' + e.message);
             return null;
         }
     }
@@ -298,7 +298,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
     }
 
     function errHandler() {
-        log('SourceBufferSink error', mediaInfo.type);
+        logger.error('SourceBufferSink error', mediaInfo.type);
     }
 
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -571,7 +571,7 @@ function Stream(config) {
     function createBuffers(previousBuffers) {
         const buffers = {};
         for (let i = 0, ln = streamProcessors.length; i < ln; i++) {
-            buffers[streamProcessors[i].getType()] = streamProcessors[i].createBuffer(previousBuffers);
+            buffers[streamProcessors[i].getType()] = streamProcessors[i].createBuffer(previousBuffers).getBuffer();
         }
         return buffers;
     }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -128,6 +128,7 @@ function Stream(config) {
             } else {
                 initializeAfterPreload();
                 result = previousBuffers;
+                eventBus.on(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
             }
             isStreamActivated = true;
             return result;
@@ -151,6 +152,7 @@ function Stream(config) {
         streamProcessors = [];
         isStreamActivated = false;
         isMediaInitialized = false;
+        setPreloaded(false);
         eventBus.off(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
     }
 
@@ -206,6 +208,8 @@ function Stream(config) {
         eventBus.off(Events.KEY_SYSTEM_SELECTED, onProtectionError, instance);
         eventBus.off(Events.KEY_SESSION_CREATED, onProtectionError, instance);
         eventBus.off(Events.KEY_STATUSES_CHANGED, onProtectionError, instance);
+
+        setPreloaded(false);
     }
 
     function getDuration() {
@@ -787,7 +791,8 @@ function Stream(config) {
         reset: reset,
         getProcessors: getProcessors,
         setMediaSource: setMediaSource,
-        isCompatibleWithStream: isCompatibleWithStream
+        isCompatibleWithStream: isCompatibleWithStream,
+        getPreloaded: getPreloaded
     };
 
     setup();

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -485,24 +485,8 @@ function Stream(config) {
     }
 
     function initializeAfterPreload() {
-        checkConfig();
-
-        let events;
-
-        //if initializeMedia is called from a switch period, eventController could have been already created.
-        if (!eventController) {
-            eventController = EventController(context).create();
-
-            eventController.setConfig({
-                manifestModel: manifestModel,
-                manifestUpdater: manifestUpdater,
-                playbackController: playbackController
-            });
-            events = adapter.getEventsFor(streamInfo);
-            eventController.addInlineEvents(events);
-        }
         isUpdating = true;
-
+        checkConfig();
         filterCodecs(Constants.VIDEO);
         filterCodecs(Constants.AUDIO);
 
@@ -754,6 +738,21 @@ function Stream(config) {
     }
 
     function preload(mediaSource, previousBuffers) {
+        let events;
+
+        //if initializeMedia is called from a switch period, eventController could have been already created.
+        if (!eventController) {
+            eventController = EventController(context).create();
+
+            eventController.setConfig({
+                manifestModel: manifestModel,
+                manifestUpdater: manifestUpdater,
+                playbackController: playbackController
+            });
+            events = adapter.getEventsFor(streamInfo);
+            eventController.addInlineEvents(events);
+        }
+
         initializeMediaForType(Constants.VIDEO, mediaSource);
         initializeMediaForType(Constants.AUDIO, mediaSource);
         initializeMediaForType(Constants.TEXT, mediaSource);

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -75,6 +75,17 @@ function Stream(config) {
         preloaded,
         trackChangedEvent;
 
+    const codecCompatibilityTable = [
+        {
+            'codec': 'avc1',
+            'compatibleCodecs': ['avc3']
+        },
+        {
+            'codec': 'avc3',
+            'compatibleCodecs': ['avc1']
+        }
+    ];
+
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
@@ -715,14 +726,19 @@ function Stream(config) {
             return oldCodecs.indexOf(newCodec) > -1;
         });
 
-        const partialCodecMatch = codecMatch || newCodecs.some((newCodec) => {
-            return oldCodecs.some((oldCodec) => {
-                const codecRoot = oldCodec.split('.')[0];
-                return newCodec.indexOf(codecRoot) === 0;
-            });
-        });
-
+        const partialCodecMatch = newCodecs.some((newCodec) => oldCodecs.some((oldCodec) => codecRootCompatibleWithCodec(oldCodec, newCodec)));
         return codecMatch || (partialCodecMatch && sameMimeType);
+    }
+
+    // Check if the root of the old codec is the same as the new one, or if it's declared as compatible in the compat table
+    function codecRootCompatibleWithCodec(codec1, codec2) {
+        const codecRoot = codec1.split('.')[0];
+        const compatTableCodec = codecCompatibilityTable.find((compat) => compat.codec === codecRoot);
+        const rootCompatible = codec2.indexOf(codecRoot) === 0;
+        if (compatTableCodec) {
+            return rootCompatible || compatTableCodec.compatibleCodecs.some((compatibleCodec) => codec2.indexOf(compatibleCodec) === 0);
+        }
+        return rootCompatible;
     }
 
     function setPreloaded(value) {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -156,6 +156,10 @@ function Stream(config) {
         eventBus.off(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
     }
 
+    function isActive() {
+        return isStreamActivated;
+    }
+
     function setMediaSource(mediaSource) {
         for (let i = 0; i < streamProcessors.length;) {
             if (isMediaSupported(streamProcessors[i].getMediaInfo())) {
@@ -776,6 +780,7 @@ function Stream(config) {
         initialize: initialize,
         activate: activate,
         deactivate: deactivate,
+        isActive: isActive,
         getDuration: getDuration,
         getStartTime: getStartTime,
         getId: getId,

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -499,7 +499,7 @@ function Stream(config) {
         if (streamProcessors.length === 0) {
             let msg = 'No streams to play.';
             errHandler.manifestError(msg, 'nostreams', manifestModel.getValue());
-            log(msg);
+            logger.debug(msg);
         } else {
             checkIfInitializationCompleted();
         }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -698,7 +698,8 @@ function Stream(config) {
         const currentAdaptation = dashManifestModel.getAdaptationForType(manifestModel.getValue(), currentStreamInfo.index, type, currentStreamInfo);
 
         if (!newAdaptation || !currentAdaptation) {
-            return false;
+            // If there is no adaptation for neither the old or the new stream they're compatible
+            return !newAdaptation && !currentAdaptation;
         }
 
         const sameMimeType =  newAdaptation && currentAdaptation && newAdaptation.mimeType === currentAdaptation.mimeType;

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -300,6 +300,14 @@ function StreamProcessor(config) {
         return false;
     }
 
+    function timeIsBuffered(time) {
+        if (bufferController) {
+            return bufferController.getRangeAt(time, 0) !== null;
+        }
+
+        return false;
+    }
+
     function getBufferLevel() {
         return bufferController.getBufferLevel();
     }
@@ -374,6 +382,7 @@ function StreamProcessor(config) {
         getBufferLevel: getBufferLevel,
         switchInitData: switchInitData,
         isBufferingCompleted: isBufferingCompleted,
+        timeIsBuffered: timeIsBuffered,
         createBuffer: createBuffer,
         getStreamInfo: getStreamInfo,
         selectMediaInfo: selectMediaInfo,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -161,12 +161,12 @@ function StreamProcessor(config) {
         unregisterAllExternalController();
     }
 
-    function reset(errored) {
+    function reset(errored, keepBuffers) {
 
         indexHandler.reset();
 
         if (bufferController) {
-            bufferController.reset(errored);
+            bufferController.reset(errored, keepBuffers);
             bufferController = null;
         }
 
@@ -311,8 +311,8 @@ function StreamProcessor(config) {
         }
     }
 
-    function createBuffer() {
-        return (bufferController.getBuffer() || bufferController.createBuffer(mediaInfo));
+    function createBuffer(previousBuffers) {
+        return (bufferController.getBuffer() || bufferController.createBuffer(mediaInfo, previousBuffers));
     }
 
     function switchTrackAsked() {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -83,7 +83,6 @@ function StreamProcessor(config) {
     }
 
     function initialize(mediaSource) {
-
         indexHandler = DashHandler(context).create({
             mimeType: mimeType,
             timelineConverter: timelineConverter,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -107,6 +107,8 @@ function AbrController() {
             setElementSize();
         }
         eventBus.on(Events.METRIC_ADDED, onMetricAdded, this);
+        eventBus.on(Events.PERIOD_SWITCH_COMPLETED, createAbrRulesCollection, this);
+
         throughputHistory = ThroughputHistory(context).create({
             mediaPlayerModel: mediaPlayerModel
         });
@@ -157,6 +159,7 @@ function AbrController() {
         eventBus.off(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
         eventBus.off(Events.QUALITY_CHANGE_RENDERED, onQualityChangeRendered, this);
         eventBus.off(Events.METRIC_ADDED, onMetricAdded, this);
+        eventBus.off(Events.PERIOD_SWITCH_COMPLETED, createAbrRulesCollection, this);
 
         if (abrRulesCollection) {
             abrRulesCollection.reset();

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -181,7 +181,7 @@ function BufferController(config) {
     }
 
     function isActive() {
-        return streamProcessor && streamController && streamProcessor.getStreamInfo() ? streamProcessor.getStreamInfo().id === streamController.getActiveStreamInfo().id : false;
+        return streamProcessor && streamController && streamProcessor.getStreamInfo();
     }
 
     function onInitFragmentLoaded(e) {
@@ -865,8 +865,8 @@ function BufferController(config) {
             buffer.reset();
             buffer = null;
         }
-        bufferResetInProgress = false;
 
+        bufferResetInProgress = false;
     }
 
     function reset(errored, keepBuffers) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -129,7 +129,7 @@ function BufferController(config) {
         if (mediaSource) {
             try {
                 if (oldBuffers && oldBuffers[type]) {
-                    buffer = SourceBufferSink(context).create(mediaSource, mediaInfo, onAppended.bind(this), oldBuffers[type].getBuffer());
+                    buffer = SourceBufferSink(context).create(mediaSource, mediaInfo, onAppended.bind(this), oldBuffers[type]);
                 } else {
                     buffer = SourceBufferSink(context).create(mediaSource, mediaInfo, onAppended.bind(this));
                 }
@@ -858,11 +858,11 @@ function BufferController(config) {
         wallclockTicked = 0;
         pendingPruningRanges = [];
 
-        if (buffer && !keepBuffers) {
+        if (buffer) {
             if (!errored) {
                 buffer.abort();
             }
-            buffer.reset();
+            buffer.reset(keepBuffers);
             buffer = null;
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -635,11 +635,7 @@ function PlaybackController() {
                 }
                 if (checkTimeInRanges(earliestTime, ranges)) {
                     if (!isSeeking()) {
-                        if (compatibleWithPreviousStream) {
-                            eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
-                            onPlaybackSeeking();
-                            onPlaybackSeeked();
-                        } else {
+                        if (!compatibleWithPreviousStream) {
                             seek(earliestTime, true);
                         }
                     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -634,10 +634,8 @@ function PlaybackController() {
                     ranges = bufferedRange[streamInfo.id].video;
                 }
                 if (checkTimeInRanges(earliestTime, ranges)) {
-                    if (!isSeeking()) {
-                        if (!compatibleWithPreviousStream) {
-                            seek(earliestTime, true);
-                        }
+                    if (!isSeeking() && !compatibleWithPreviousStream) {
+                        seek(earliestTime, true);
                     }
                     commonEarliestTime[streamInfo.id].started = true;
                 }
@@ -646,7 +644,7 @@ function PlaybackController() {
             //current stream has only audio or only video content
             if (commonEarliestTime[streamInfo.id][type]) {
                 earliestTime = commonEarliestTime[streamInfo.id][type] > initialStartTime ? commonEarliestTime[streamInfo.id][type] : initialStartTime;
-                if (!isSeeking()) {
+                if (!isSeeking() && !compatibleWithPreviousStream) {
                     seek(earliestTime);
                 }
                 commonEarliestTime[streamInfo.id].started = true;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -70,7 +70,8 @@ function PlaybackController() {
         lastLivePlaybackTime,
         originalPlaybackRate,
         catchingUp,
-        availabilityStartTime;
+        availabilityStartTime,
+        compatibleWithPreviousStream;
 
     let catchUpPlaybackRate = DEFAULT_CATCHUP_PLAYBACK_RATE;
 
@@ -79,11 +80,12 @@ function PlaybackController() {
         reset();
     }
 
-    function initialize(StreamInfo) {
+    function initialize(StreamInfo, compatible) {
         streamInfo = StreamInfo;
         addAllListeners();
         isDynamic = streamInfo.manifestInfo.isDynamic;
         liveStartTime = streamInfo.start;
+        compatibleWithPreviousStream = compatible;
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
         eventBus.on(Events.BYTES_APPENDED_END_FRAGMENT, onBytesAppended, this);
         eventBus.on(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
@@ -132,11 +134,11 @@ function PlaybackController() {
         return streamInfo && videoModel ? videoModel.isSeeking() : null;
     }
 
-    function seek(time) {
+    function seek(time, stickToBuffered) {
         if (streamInfo && videoModel) {
             eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
             logger.info('Requesting seek to time: ' + time);
-            videoModel.setCurrentTime(time);
+            videoModel.setCurrentTime(time, stickToBuffered);
         }
     }
 
@@ -633,7 +635,13 @@ function PlaybackController() {
                 }
                 if (checkTimeInRanges(earliestTime, ranges)) {
                     if (!isSeeking()) {
-                        seek(earliestTime);
+                        if (compatibleWithPreviousStream) {
+                            eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
+                            onPlaybackSeeking();
+                            onPlaybackSeeked();
+                        } else {
+                            seek(earliestTime, true);
+                        }
                     }
                     commonEarliestTime[streamInfo.id].started = true;
                 }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -191,7 +191,6 @@ function ScheduleController(config) {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     logger.debug('Quality has changed, get init request for representationid = ' + currentRepresentationInfo.id);
                     lastInitQuality = currentRepresentationInfo.quality;
-
                     streamProcessor.switchInitData(currentRepresentationInfo.id);
                 } else if (switchTrack) {
                     logger.debug('Switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -426,7 +426,7 @@ function StreamController() {
         compatible = false;
         if (oldStream) {
             oldStream.stopEventController();
-            compatible = activeStream.isCompatibleWithStream(newStream) && !seekTime;
+            compatible = activeStream.isCompatibleWithStream(newStream) && !seekTime || newStream.getPreloaded();
             oldStream.deactivate(compatible);
         }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -292,7 +292,7 @@ function StreamController() {
                 logger.debug('[toggleEndPeriodTimer] start-up of timer to notify PLAYBACK_ENDED event. It will be triggered in ' + delayPlaybackEnded + ' milliseconds');
                 playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED);}, delayPlaybackEnded);
                 const preloadDelay = delayPlaybackEnded < 2000 ? delayPlaybackEnded / 4 : delayPlaybackEnded - 2000;
-                log('[StreamController][toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
+                logger.info('[StreamController][toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
                 setTimeout(onStreamCanLoadNext,  preloadDelay);
             }
         }
@@ -319,7 +319,7 @@ function StreamController() {
             const newStream = getNextStream();
             compatible = activeStream.isCompatibleWithStream(newStream);
             if (compatible) {
-                log('[StreamController][onStreamCanLoadNext] Preloading next stream');
+                logger.info('[StreamController][onStreamCanLoadNext] Preloading next stream');
                 activeStream.stopEventController();
                 activeStream.deactivate(true);
                 newStream.preload(mediaSource, buffers);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -298,6 +298,7 @@ function StreamController() {
             isStreamBufferingCompleted = true;
             if (isPaused === false) {
                 toggleEndPeriodTimer();
+                preloadNextPeriod();
             }
         }
     }
@@ -417,6 +418,17 @@ function StreamController() {
 
     function preloadStream(seekTime) {
         activateStream(seekTime);
+    }
+
+    function preloadNextPeriod() {
+        log('[StreamController][onStreamBufferingCompleted] preloadNextPeriod');
+        const nextStream = getNextStream();
+        if (nextStream) {
+            let compatible = activeStream.isCompatibleWithStream(nextStream);
+            if (compatible) {
+                log('[StreamController][preloadNextPeriod] next stream is compatible');
+            }
+        }
     }
 
     function switchToVideoElement(seekTime) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -507,9 +507,11 @@ function StreamController() {
                 playbackController.seek(seekTime); //we only need to call seek here, IndexHandlerTime was set from seeking event
             } else {
                 let startTime = playbackController.getStreamStartTime(true);
-                activeStream.getProcessors().forEach(p => {
-                    adapter.setIndexHandlerTime(p, startTime);
-                });
+                if (!keepBuffers) {
+                    activeStream.getProcessors().forEach(p => {
+                        adapter.setIndexHandlerTime(p, startTime);
+                    });
+                }
             }
         }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -285,6 +285,9 @@ function StreamController() {
                 const delayPlaybackEnded = timeToEnd > 0 ? timeToEnd * 1000 : 0;
                 logger.debug('[toggleEndPeriodTimer] start-up of timer to notify PLAYBACK_ENDED event. It will be triggered in ' + delayPlaybackEnded + ' milliseconds');
                 playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED);}, delayPlaybackEnded);
+                const preloadDelay = delayPlaybackEnded < 2000 ? delayPlaybackEnded / 4 : delayPlaybackEnded - 2000;
+                log('[StreamController][toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
+                setTimeout(onStreamCanLoadNext,  preloadDelay);
             }
         }
     }
@@ -300,6 +303,23 @@ function StreamController() {
             isStreamBufferingCompleted = true;
             if (isPaused === false) {
                 toggleEndPeriodTimer();
+            }
+        }
+    }
+
+    function onStreamCanLoadNext() {
+        const isLast = getActiveStreamInfo().isLast;
+        if (mediaSource && !isLast) {
+            const newStream = getNextStream();
+            compatible = activeStream.isCompatibleWithStream(newStream);
+            if (compatible) {
+                log('[StreamController][onStreamCanLoadNext] Preloading next stream');
+                activeStream.stopEventController();
+                activeStream.deactivate(true);
+                newStream.preload(mediaSource, buffers);
+                newStream.getProcessors().forEach(p => {
+                    adapter.setIndexHandlerTime(p, newStream.getStartTime());
+                });
             }
         }
     }
@@ -463,7 +483,6 @@ function StreamController() {
             logger.debug('MediaSource attached to element.  Waiting on open...');
         } else {
             if (keepBuffers) {
-                setMediaDuration();
                 activateStream(seekTime, keepBuffers);
                 if (!oldStream) {
                     eventBus.trigger(Events.SOURCE_INITIALIZED);
@@ -480,7 +499,6 @@ function StreamController() {
 
     function activateStream(seekTime, keepBuffers) {
         buffers = activeStream.activate(mediaSource, keepBuffers ? buffers : undefined);
-
         audioTrackDetected = checkTrackPresence(Constants.AUDIO);
         videoTrackDetected = checkTrackPresence(Constants.VIDEO);
 

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -84,8 +84,18 @@ function FragmentModel(config) {
             return isNaN(req1.index) && isNaN(req2.index) && (req1.quality === req2.quality);
         };
 
+        const isInBuffer = function (req) {
+            return streamProcessor.timeIsBuffered(req.startTime + getRequestThreshold(req));
+        };
+
         const check = function (requests) {
             let isLoaded = false;
+
+            // This fixes buffer out of sync in Safari
+            if (!isInBuffer(request) && request.action !== FragmentRequest.ACTION_COMPLETE) {
+                return isLoaded;
+            }
+
             requests.some(req => {
                 if (isEqualMedia(request, req) || isEqualInit(request, req) || isEqualComplete(request, req)) {
                     isLoaded = true;

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -79,7 +79,7 @@ function VideoModel() {
     }
 
     //TODO Move the DVR window calculations from MediaPlayer to Here.
-    function setCurrentTime(currentTime) {
+    function setCurrentTime(currentTime, stickToBuffered) {
         if (element) {
             //_currentTime = currentTime;
 
@@ -93,6 +93,7 @@ function VideoModel() {
             // set currentTime even if readyState = 0.
             // setTimeout is used to workaround InvalidStateError in IE11
             try {
+                currentTime = stickToBuffered ? stickTimeToBuffered(currentTime) : currentTime;
                 element.currentTime = currentTime;
             } catch (e) {
                 if (element.readyState === 0 && e.code === e.INVALID_STATE_ERR) {
@@ -102,6 +103,35 @@ function VideoModel() {
                 }
             }
         }
+    }
+
+    function stickTimeToBuffered(time) {
+        const buffered = getBufferRange();
+        let closestTime = time;
+        let closestDistance = 9999999999;
+        if (buffered) {
+            for (let i = 0; i < buffered.length; i++) {
+                const start = buffered.start(i);
+                const end = buffered.end(i);
+                const distanceToStart = Math.abs(start - time);
+                const distanceToEnd = Math.abs(end - time);
+
+                if (time >= start && time <= end) {
+                    return time;
+                }
+
+                if (distanceToStart < closestDistance) {
+                    closestDistance = distanceToStart;
+                    closestTime = start;
+                }
+
+                if (distanceToEnd < closestDistance) {
+                    closestDistance = distanceToEnd;
+                    closestTime = end;
+                }
+            }
+        }
+        return closestTime;
     }
 
     function getElement() {

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -91,7 +91,7 @@ function NotFragmentedTextBufferController(config) {
                 }
                 initialized = true;
             }
-
+            return buffer;
         } catch (e) {
             if ((mediaInfo.isText) || (mediaInfo.codec.indexOf('codecs="stpp') !== -1) || (mediaInfo.codec.indexOf('codecs="wvtt') !== -1)) {
                 try {

--- a/test/unit/mocks/TextBufferMock.js
+++ b/test/unit/mocks/TextBufferMock.js
@@ -5,13 +5,8 @@ class TextBufferMock {
     }
 
     appendBuffer(chunk) {
-        this.updating = true;
+        this.updating = false;
         this.chunk = chunk;
-
-        let that = this;
-        setTimeout(function () {
-            that.updating = false;
-        }, 500);
     }
 }
 


### PR DESCRIPTION
This PR introduces buffer reuse for compatible codecs and preload of next periods to avoid jumps and freezes when switching periods.

It also introduces some changes to the SourceBufferSink to handle the appends and removes with a queue.

It's the same as #2575 but with clearer commit history.
Closes #1708 