### PR TITLE
Safari/Mac live stream fail fix

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -699,6 +699,11 @@ function BufferController(config) {
             isPruningInProgress = false;
         }
 
+        if (e.unintended) {
+            log('[BufferController][', type,'] detected unintended removal from:', e.from, 'to', e.to, 'setting index handler time to', e.from);
+            adapter.setIndexHandlerTime(streamProcessor, e.from);
+        }
+
         if (isPruningInProgress) {
             clearNextRange();
         } else {
@@ -711,7 +716,7 @@ function BufferController(config) {
                     appendToBuffer(mediaChunk);
                 }
             }
-            eventBus.trigger(Events.BUFFER_CLEARED, { sender: instance, from: e.from, to: e.to, hasEnoughSpaceToAppend: hasEnoughSpaceToAppend() });
+            eventBus.trigger(Events.BUFFER_CLEARED, { sender: instance, from: e.from, to: e.to, unintended: e.unintended,  hasEnoughSpaceToAppend: hasEnoughSpaceToAppend() });
         }
         //TODO - REMEMBER removed a timerout hack calling clearBuffer after manifestInfo.minBufferTime * 1000 if !hasEnoughSpaceToAppend() Aug 04 2016
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -493,7 +493,8 @@ function ScheduleController(config) {
 
         if (e.unintended) {
             // There was an unintended buffer remove, probably creating a gap in the buffer, remove every saved request
-            streamProcessor.getFragmentModel().syncExecutedRequestsWithBufferedRange();
+            streamProcessor.getFragmentModel().removeExecutedRequestsAfterTime(e.from,
+                streamProcessor.getStreamInfo().duration);
         } else {
             streamProcessor.getFragmentModel().syncExecutedRequestsWithBufferedRange(
                 streamProcessor.getBufferController().getBuffer().getAllBufferRanges(),

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -491,9 +491,14 @@ function ScheduleController(config) {
             return;
         }
 
-        streamProcessor.getFragmentModel().syncExecutedRequestsWithBufferedRange(
-            streamProcessor.getBufferController().getBuffer().getAllBufferRanges(),
-            streamProcessor.getStreamInfo().duration);
+        if (e.unintended) {
+            // There was an unintended buffer remove, probably creating a gap in the buffer, remove every saved request
+            streamProcessor.getFragmentModel().syncExecutedRequestsWithBufferedRange();
+        } else {
+            streamProcessor.getFragmentModel().syncExecutedRequestsWithBufferedRange(
+                streamProcessor.getBufferController().getBuffer().getAllBufferRanges(),
+                streamProcessor.getStreamInfo().duration);
+        }
 
         if (e.hasEnoughSpaceToAppend && isStopped) {
             start();

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -162,6 +162,12 @@ function FragmentModel(config) {
         });
     }
 
+    function removeExecutedRequestsAfterTime(time) {
+        executedRequests = executedRequests.filter(req => {
+            return isNaN(req.startTime) || (time !== undefined ? req.startTime <= time : false);
+        });
+    }
+
     function removeExecutedRequestsInTimeRange(start, end) {
         if (end <= start + 0.5) {
             return;
@@ -349,6 +355,7 @@ function FragmentModel(config) {
         isFragmentLoaded: isFragmentLoaded,
         isFragmentLoadedOrPending: isFragmentLoadedOrPending,
         removeExecutedRequestsBeforeTime: removeExecutedRequestsBeforeTime,
+        removeExecutedRequestsAfterTime: removeExecutedRequestsAfterTime,
         syncExecutedRequestsWithBufferedRange: syncExecutedRequestsWithBufferedRange,
         abortRequests: abortRequests,
         executeRequest: executeRequest,


### PR DESCRIPTION
This PR fixes issue #2567 it adds a check to know if safari dropped any chunk while appending, and fires an event to act accordingly.


This PR replaces #2579 but it may conflict with #2575. 