### PR TITLE
Bug with clear next range

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -661,7 +661,11 @@ function BufferController(config) {
     }
 
     function clearNextRange() {
+        // If there's nothing to prune reset state
         if (pendingPruningRanges.length === 0 || !buffer) {
+            log('Nothing to prune, halt pruning');
+            pendingPruningRanges = [];
+            isPruningInProgress = false;
             return;
         }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -664,8 +664,13 @@ function BufferController(config) {
         if (pendingPruningRanges.length === 0 || !buffer) {
             return;
         }
+
         const sourceBuffer = buffer.getBuffer();
+        // If there's nothing buffered any pruning is invalid, so reset our state
         if (!sourceBuffer || !sourceBuffer.buffered || sourceBuffer.buffered.length === 0) {
+            log('SourceBuffer is empty (or does not exist), halt pruning');
+            pendingPruningRanges = [];
+            isPruningInProgress = false;
             return;
         }
 


### PR DESCRIPTION
There appears to be a race condition that occurs sometimes in the `BufferController` where the controller thinks that it needs to prune some ranges, but it's not possible to do so. The `BufferController` already has checks to catch these scenarios, but the pruning state isn't flipped back to "not pruning", which causes the player to get stuck in a pruning state. This has the side effect of effectively halting playback since the `ScheduleController` will not executes requests while pruning.

This PR resets the pruning state if it is discovered that pruning cannot continue.