### PR TITLE
Fix couple of race conditions when resetting while loading

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -112,6 +112,9 @@ function ManifestLoader(config) {
         httpLoader.load({
             request: request,
             success: function (data, textStatus, responseURL) {
+                // Manage situations in which success is called after calling reset
+                if (!xlinkController) return;
+
                 let actualUrl,
                     baseUri,
                     manifest;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -427,6 +427,9 @@ function StreamController() {
         let sourceUrl;
 
         function onMediaSourceOpen() {
+            // Manage situations in which a call to reset happens while MediaSource is being opened
+            if (!mediaSource) return;
+
             log('MediaSource is open!');
             window.URL.revokeObjectURL(sourceUrl);
             mediaSource.removeEventListener('sourceopen', onMediaSourceOpen);


### PR DESCRIPTION
Fix a couple of race conditions that cause exceptions when resetting dash.js player while mediaSource is being opened (Fix #2535).