### PR TITLE
Low latency stuck on start fix

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -620,6 +620,9 @@ function BufferController(config) {
         if (currentTimeRequest) {
             rangeToKeep.start = Math.min(currentTimeRequest.startTime, rangeToKeep.start);
             rangeToKeep.end = Math.max(currentTimeRequest.startTime + currentTimeRequest.duration, rangeToKeep.end);
+        } else if (currentTime === 0 && playbackController.getIsDynamic()) {
+            // Don't prune before the live stream starts, it messes with low latency
+            return [];
         }
 
         if (ranges.start(0) <= rangeToKeep.start) {


### PR DESCRIPTION
This PR fixes the stream getting stuck in low latency mode if a buffer prune was called before it started playing, the index handler time went down to 0 and no fragments were downloaded.