### PR TITLE
Don't listen to events coming from aborted XmlHTTPRequests

### DIFF
--- a/src/streaming/net/XHRLoader.js
+++ b/src/streaming/net/XHRLoader.js
@@ -86,7 +86,9 @@ function XHRLoader(cfg) {
     }
 
     function abort(request) {
-        request.response.abort();
+        const x = request.response;
+        x.onloadend = x.onerror = x.onprogress = undefined; //Ignore events from aborted requests.
+        x.abort();
     }
 
     instance = {

--- a/test/unit/streaming.net.XHRLoader.js
+++ b/test/unit/streaming.net.XHRLoader.js
@@ -113,7 +113,7 @@ describe('XHRLoader', function () {
         sinon.assert.notCalled(callbackError);
         sinon.assert.notCalled(callbackSucceeded);
         // abort triggers both onloadend and onabort
-        sinon.assert.calledOnce(callbackCompleted);
+        sinon.assert.notCalled(callbackCompleted);
         sinon.assert.calledOnce(callbackAbort);
     });
 


### PR DESCRIPTION
After aborting an event, the onloadend event fires still. This causes the aborted segment to look like an error and will be retried, and this causes a second scheduling loop to start up, leading to segments being downloaded multiple times concurrently (an example is in the logs in #2588 , but this occurs on all platforms).