### PR TITLE
Added checks in nextFragmentRule to see if the buffer was split (safari bug)

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -358,6 +358,10 @@ function StreamProcessor(config) {
         return controller;
     }
 
+    function getPlaybackController() {
+        return playbackController;
+    }
+
     instance = {
         initialize: initialize,
         isUpdating: isUpdating,
@@ -370,6 +374,7 @@ function StreamProcessor(config) {
         getFragmentController: getFragmentController,
         getRepresentationController: getRepresentationController,
         getIndexHandler: getIndexHandler,
+        getPlaybackController: getPlaybackController,
         getCurrentRepresentationInfo: getCurrentRepresentationInfo,
         getRepresentationInfoForQuality: getRepresentationInfoForQuality,
         getBufferLevel: getBufferLevel,

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -161,7 +161,7 @@ function FragmentModel(config) {
 
     function removeExecutedRequestsAfterTime(time) {
         executedRequests = executedRequests.filter(req => {
-            return isNaN(req.startTime) || (time !== undefined ? req.startTime <= time : false);
+            return isNaN(req.startTime) || (time !== undefined ? req.startTime < time : false);
         });
     }
 

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -55,8 +55,9 @@ function NextFragmentRequestRule(config) {
         const seekTarget = scheduleController.getSeekTarget();
         const hasSeekTarget = !isNaN(seekTarget);
         const bufferController = streamProcessor.getBufferController();
-
+        const currentTime = streamProcessor.getPlaybackController().getTime();
         let time = hasSeekTarget ? seekTarget : adapter.getIndexHandlerTime(streamProcessor);
+        let bufferIsDivided = false;
 
         if (isNaN(time) || (mediaType === Constants.FRAGMENTED_TEXT && !textController.isTextEnabled())) {
             return null;
@@ -70,8 +71,18 @@ function NextFragmentRequestRule(config) {
          * This is critical for IE/Safari/EDGE
          * */
         if (bufferController) {
-            const range = bufferController.getRangeAt(time);
-            if (range !== null && !hasSeekTarget) {
+            let range = bufferController.getRangeAt(time);
+            const playingRange = bufferController.getRangeAt(currentTime);
+            const bufferRanges = bufferController.getBuffer().getAllBufferRanges();
+            const numberOfBuffers = bufferRanges ? bufferRanges.length : 0;
+            if ((range !== null || playingRange !== null) && !hasSeekTarget) {
+                if ( !range || (playingRange && playingRange.start != range.start && playingRange.end != range.end) ) {
+                    if (numberOfBuffers > 1 ) {
+                        streamProcessor.getFragmentModel().removeExecutedRequestsAfterTime(playingRange.end);
+                        bufferIsDivided = true;
+                    }
+                    range = playingRange;
+                }
                 logger.debug('Prior to making a request for time, NextFragmentRequestRule is aligning index handler\'s currentTime with bufferedRange.end for', mediaType, '.', time, 'was changed to', range.end);
                 time = range.end;
             }
@@ -86,7 +97,7 @@ function NextFragmentRequestRule(config) {
             });
         } else {
             request = adapter.getFragmentRequestForTime(streamProcessor, representationInfo, time, {
-                keepIdx: !hasSeekTarget
+                keepIdx: !hasSeekTarget && !bufferIsDivided
             });
 
             // Then, check if this request was downloaded or not


### PR DESCRIPTION
This PR adds a check in NextFragmentRule to see if the buffer is divided (IE, when appending out of order in safari) and react to that by downloading chunks for the active buffer.

Fixes #2588 