### PR TITLE
Low latency catch up

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -123,7 +123,7 @@ declare namespace dashjs {
         isMuted(): boolean;
         setVolume(value: number): void;
         getVolume(): number;
-        time(streamId: string | undefined): number;
+        time(streamId?: string): number;
         duration(): number;
         timeAsUTC(): number;
         durationAsUTC(): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -269,6 +269,8 @@ declare namespace dashjs {
         METRIC_UPDATED: 'metricUpdated';
         PERIOD_SWITCH_COMPLETED: 'periodSwitchCompleted';
         PERIOD_SWITCH_STARTED: 'periodSwitchStarted';
+        PLAYBACK_CATCHUP_END: 'playbackCatchupEnd';
+        PLAYBACK_CATCHUP_START: 'playbackCatchupStart';
         PLAYBACK_ENDED: 'playbackEnded';
         PLAYBACK_ERROR: 'playbackError';
         PLAYBACK_METADATA_LOADED: 'playbackMetaDataLoaded';

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ declare namespace dashjs {
         isMuted(): boolean;
         setVolume(value: number): void;
         getVolume(): number;
-        time(streamId: string | undefined): number;
+        time(streamId?: string): number;
         duration(): number;
         timeAsUTC(): number;
         durationAsUTC(): number;

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -74,7 +74,7 @@
           "name": "Low Latency (Single-Rate)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 3
+            "liveDelay": 3.5
           }
         },
         {
@@ -82,7 +82,7 @@
           "name": "Low Latency (Multi-Rate)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 3
+            "liveDelay": 3.5
           }
         },
         {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -82,6 +82,7 @@ function MediaPlayer() {
     const SOURCE_NOT_ATTACHED_ERROR = 'You must first call attachSource() with a valid source before calling this method';
     const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
     const MEDIA_PLAYER_BAD_ARGUMENT_ERROR = 'MediaPlayer Invalid Arguments!';
+    const PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR = 'Playback catchup rate invalid argument! Use a number from 1 to 1.2';
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
@@ -480,6 +481,29 @@ function MediaPlayer() {
             throw ELEMENT_NOT_ATTACHED_ERROR;
         }
         return getVideoElement().playbackRate;
+    }
+
+    /**
+     * Use this method to set the playback rate that will be used when catching up with live stream. Set 1 to disable the feature.
+     * @param {number} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setCatchUpPlaybackRate(value) {
+        if (isNaN(value) || value < 1 || value > 1.20) {
+            throw PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR;
+        }
+        playbackController.setCatchUpPlaybackRate(value);
+    }
+
+    /**
+     * Returns the current catchup playback rate.
+     * @returns {number}
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getCatchUpPlaybackRate() {
+        return playbackController.getCatchUpPlaybackRate();
     }
 
     /**
@@ -2831,6 +2855,8 @@ function MediaPlayer() {
         seek: seek,
         setPlaybackRate: setPlaybackRate,
         getPlaybackRate: getPlaybackRate,
+        setCatchUpPlaybackRate: setCatchUpPlaybackRate,
+        getCatchUpPlaybackRate: getCatchUpPlaybackRate,
         setMute: setMute,
         isMuted: isMuted,
         setVolume: setVolume,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -484,13 +484,22 @@ function MediaPlayer() {
     }
 
     /**
-     * Use this method to set the playback rate that will be used when catching up with live stream. Set 1 to disable the feature.
-     * @param {number} value
+     * Use this method to set the catch up rate, as a percentage, for low latency live streams. In low latency mode,
+     * when measured latency is higher than the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
+     * dash.js increases playback rate the percentage defined with this method until target is reached.
+     *
+     * Valid values for catch up rate are in range 0-20%. Set it to 0% to turn off live catch up feature.
+     *
+     * Note: Catch-up mechanism is only applied when playing low latency live streams.
+     *
+     * @param {number} value Percentage in which playback rate is increased when live catch up mechanism is activated.
      * @memberof module:MediaPlayer
+     * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
+     * @default {number} 0.05
      * @instance
      */
     function setCatchUpPlaybackRate(value) {
-        if (isNaN(value) || value < 1 || value > 1.20) {
+        if (isNaN(value) || value < 0.0 || value > 0.20) {
             throw PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR;
         }
         playbackController.setCatchUpPlaybackRate(value);
@@ -499,6 +508,7 @@ function MediaPlayer() {
     /**
      * Returns the current catchup playback rate.
      * @returns {number}
+     * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
      * @memberof module:MediaPlayer
      * @instance
      */

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -214,6 +214,19 @@ class MediaPlayerEvents extends EventsBase {
          */
         this.CAN_PLAY = 'canPlay';
 
+
+        /**
+         * Sent live catch up stops and playback rate goes back to normal
+         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_END
+         */
+        this.PLAYBACK_CATCHUP_END = 'playbackCatchupEnd';
+
+        /**
+         * Sent when playing live and buffer is too long, the player starts catching up by accelerating.
+         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_START
+         */
+        this.PLAYBACK_CATCHUP_START = 'playbackCatchupStart';
+
         /**
          * Sent when playback completes.
          * @event MediaPlayerEvents#PLAYBACK_ENDED

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -214,18 +214,22 @@ class MediaPlayerEvents extends EventsBase {
          */
         this.CAN_PLAY = 'canPlay';
 
-
         /**
-         * Sent live catch up stops and playback rate goes back to normal
-         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_END
-         */
-        this.PLAYBACK_CATCHUP_END = 'playbackCatchupEnd';
-
-        /**
-         * Sent when playing live and buffer is too long, the player starts catching up by accelerating.
+         * Sent when live catch mechanism has been activated, which implies the measured latency of the low latency
+         * stream that is been played has gone beyond the target one.
+         * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
+         * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
          * @event MediaPlayerEvents#PLAYBACK_CATCHUP_START
          */
         this.PLAYBACK_CATCHUP_START = 'playbackCatchupStart';
+
+        /**
+         * Sent live catch up mechanism has been deactivated.
+         * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
+         * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
+         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_END
+         */
+        this.PLAYBACK_CATCHUP_END = 'playbackCatchupEnd';
 
         /**
          * Sent when playback completes.

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -69,7 +69,6 @@ function BufferLevelRule(config) {
                 bufferTarget = mediaPlayerModel.getStableBufferTime();
             }
         }
-
         return bufferTarget;
     }
 

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -9,7 +9,7 @@ class PlaybackControllerMock {
         this.playing = false;
         this.seeking = false;
         this.isDynamic = false;
-        this.catchUpPlaybackRate = 1.05;
+        this.catchUpPlaybackRate = 0.05;
     }
 
     initialize() {}

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -9,6 +9,7 @@ class PlaybackControllerMock {
         this.playing = false;
         this.seeking = false;
         this.isDynamic = false;
+        this.catchUpPlaybackRate = 1.05;
     }
 
     initialize() {}
@@ -96,6 +97,14 @@ class PlaybackControllerMock {
 
     getStreamStartTime() {
         return 0;
+    }
+
+    setCatchUpPlaybackRate(value) {
+        this.catchUpPlaybackRate = value;
+    }
+
+    getCatchUpPlaybackRate() {
+        return this.catchUpPlaybackRate;
     }
 }
 

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -247,7 +247,7 @@ describe('MediaPlayer', function () {
                 expect(playbackRate).to.equal(newPlaybackRate);
             });
 
-            it('Method setPlaybackRate should return video element playback rate', function () {
+            it('Method getPlaybackRate should return video element playback rate', function () {
                 const elementPlayBackRate = videoElementMock.playbackRate;
                 const playerPlayBackRate = player.getPlaybackRate();
                 expect(playerPlayBackRate).to.equal(elementPlayBackRate);
@@ -329,6 +329,25 @@ describe('MediaPlayer', function () {
                 videoElementMock.duration = 4;
                 duration = player.duration();
                 expect(duration).to.equal(4);
+            });
+
+            it('Method setCatchUpPlaybackRate should change catchUpPlaybackRate', function () {
+                let rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(1.05);
+
+                player.setCatchUpPlaybackRate(1.2);
+                rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(1.2);
+
+                player.setCatchUpPlaybackRate(1);
+                rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(1);
+            });
+
+            it('Method setCatchUpPlaybackRate should throw an exception if given bad values', function () {
+                expect(() => {player.setCatchUpPlaybackRate(0.9);}).to.throw(MediaPlayer.PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setCatchUpPlaybackRate(13);}).to.throw(MediaPlayer.PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setCatchUpPlaybackRate('string');}).to.throw(MediaPlayer.PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
             });
         });
     });

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -333,15 +333,15 @@ describe('MediaPlayer', function () {
 
             it('Method setCatchUpPlaybackRate should change catchUpPlaybackRate', function () {
                 let rate = player.getCatchUpPlaybackRate();
-                expect(rate).to.equal(1.05);
+                expect(rate).to.equal(0.05);
 
-                player.setCatchUpPlaybackRate(1.2);
+                player.setCatchUpPlaybackRate(0.2);
                 rate = player.getCatchUpPlaybackRate();
-                expect(rate).to.equal(1.2);
+                expect(rate).to.equal(0.2);
 
-                player.setCatchUpPlaybackRate(1);
+                player.setCatchUpPlaybackRate(0.0);
                 rate = player.getCatchUpPlaybackRate();
-                expect(rate).to.equal(1);
+                expect(rate).to.equal(0.0);
             });
 
             it('Method setCatchUpPlaybackRate should throw an exception if given bad values', function () {


### PR DESCRIPTION
Checking the buffer level and target live delay, if it's behind the playback rate will be increased by 5% by default, configurable from 0% to 20%

Fixes #2600