### PR TITLE
Update not fragmented subtitles management

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -585,14 +585,14 @@ function Stream(config) {
         let arr = [];
 
         let type,
-            controller;
+            streamProcessor;
 
         for (let i = 0; i < ln; i++) {
-            controller = streamProcessors[i];
-            type = controller.getType();
+            streamProcessor = streamProcessors[i];
+            type = streamProcessor.getType();
 
-            if (type === Constants.AUDIO || type === Constants.VIDEO || type === Constants.FRAGMENTED_TEXT) {
-                arr.push(controller);
+            if (type === Constants.AUDIO || type === Constants.VIDEO || type === Constants.FRAGMENTED_TEXT || type === Constants.TEXT) {
+                arr.push(streamProcessor);
             }
         }
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -306,7 +306,7 @@ function Stream(config) {
             trackChangedEvent = e;
             manifestUpdater.refreshManifest();
         } else {
-            processor.updateMediaInfo(mediaInfo);
+            processor.selectMediaInfo(mediaInfo);
             if (mediaInfo.type !== Constants.FRAGMENTED_TEXT) {
                 abrController.updateTopQualityIndex(mediaInfo);
                 processor.switchTrackAsked();
@@ -358,13 +358,11 @@ function Stream(config) {
                 if (allMediaForType[i].index === mediaInfo.index) {
                     idx = i;
                 }
-                streamProcessor.updateMediaInfo(allMediaForType[i]); //creates text tracks for all adaptations in one stream processor
+                streamProcessor.addMediaInfo(allMediaForType[i]); //creates text tracks for all adaptations in one stream processor
             }
-            if (mediaInfo.type === Constants.FRAGMENTED_TEXT) {
-                streamProcessor.updateMediaInfo(allMediaForType[idx]); //sets the initial media info
-            }
+            streamProcessor.selectMediaInfo(allMediaForType[idx]); //sets the initial media info
         } else {
-            streamProcessor.updateMediaInfo(mediaInfo);
+            streamProcessor.addMediaInfo(mediaInfo, true);
         }
     }
 
@@ -624,7 +622,7 @@ function Stream(config) {
             let streamProcessor = streamProcessors[i];
             let mediaInfo = adapter.getMediaInfoForType(streamInfo, streamProcessor.getType());
             abrController.updateTopQualityIndex(mediaInfo);
-            streamProcessor.updateMediaInfo(mediaInfo);
+            streamProcessor.addMediaInfo(mediaInfo, true);
         }
 
         if (trackChangedEvent) {

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -256,10 +256,6 @@ function Stream(config) {
         }
     }
 
-    function getMimeTypeOrType(mediaInfo) {
-        return mediaInfo.type === Constants.TEXT ? mediaInfo.mimeType : mediaInfo.type;
-    }
-
     function isMediaSupported(mediaInfo) {
         const type = mediaInfo.type;
         let codec,
@@ -317,7 +313,7 @@ function Stream(config) {
 
     function createStreamProcessor(mediaInfo, allMediaForType, mediaSource, optionalSettings) {
         let streamProcessor = StreamProcessor(context).create({
-            type: getMimeTypeOrType(mediaInfo),
+            type: mediaInfo.type,
             mimeType: mediaInfo.mimeType,
             timelineConverter: timelineConverter,
             adapter: adapter,

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -513,13 +513,13 @@ function Stream(config) {
 
     function getMediaInfo(type) {
         const ln = streamProcessors.length;
-        let mediaCtrl = null;
+        let streamProcessor = null;
 
         for (let i = 0; i < ln; i++) {
-            mediaCtrl = streamProcessors[i];
+            streamProcessor = streamProcessors[i];
 
-            if (mediaCtrl.getType() === type) {
-                return mediaCtrl.getMediaInfo();
+            if (streamProcessor.getType() === type) {
+                return streamProcessor.getMediaInfo();
             }
         }
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -243,14 +243,21 @@ function StreamProcessor(config) {
         return stream ? stream.getEventController() : null;
     }
 
-    function updateMediaInfo(newMediaInfo) {
+    function selectMediaInfo(newMediaInfo) {
         if (newMediaInfo !== mediaInfo && (!newMediaInfo || !mediaInfo || (newMediaInfo.type === mediaInfo.type))) {
             mediaInfo = newMediaInfo;
         }
+        adapter.updateData(this);
+    }
+
+    function addMediaInfo(newMediaInfo, selectNewMediaInfo) {
         if (mediaInfoArr.indexOf(newMediaInfo) === -1) {
             mediaInfoArr.push(newMediaInfo);
         }
-        adapter.updateData(this);
+
+        if (selectNewMediaInfo) {
+            this.selectMediaInfo(newMediaInfo);
+        }
     }
 
     function getMediaInfoArr() {
@@ -368,7 +375,8 @@ function StreamProcessor(config) {
         isBufferingCompleted: isBufferingCompleted,
         createBuffer: createBuffer,
         getStreamInfo: getStreamInfo,
-        updateMediaInfo: updateMediaInfo,
+        selectMediaInfo: selectMediaInfo,
+        addMediaInfo: addMediaInfo,
         switchTrackAsked: switchTrackAsked,
         getMediaInfoArr: getMediaInfoArr,
         getMediaInfo: getMediaInfo,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -104,6 +104,7 @@ function StreamProcessor(config) {
         bufferController = createBufferControllerForType(type);
         scheduleController = ScheduleController(context).create({
             type: type,
+            mimeType: mimeType,
             metricsModel: metricsModel,
             adapter: adapter,
             dashMetrics: dashMetrics,
@@ -339,6 +340,7 @@ function StreamProcessor(config) {
         } else {
             controller = TextBufferController(context).create({
                 type: type,
+                mimeType: mimeType,
                 metricsModel: metricsModel,
                 mediaPlayerModel: mediaPlayerModel,
                 manifestModel: manifestModel,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -106,7 +106,7 @@ function ScheduleController(config) {
             textController: textController
         });
 
-        if (dashManifestModel.getIsTextTrack(type)) {
+        if (dashManifestModel.getIsTextTrack(config.mimeType)) {
             eventBus.on(Events.TIMED_TEXT_REQUESTED, onTimedTextRequested, this);
         }
 

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -158,26 +158,36 @@ function NotFragmentedTextBufferController(config) {
             return;
         }
 
-        eventBus.trigger(Events.TIMED_TEXT_REQUESTED, {
-            index: 0,
-            sender: e.sender
-        }); //TODO make index dynamic if referring to MP?
+        const chunk = initCache.extract(streamProcessor.getStreamInfo().id, e.sender.getCurrentRepresentation().id);
+
+        if (!chunk) {
+            eventBus.trigger(Events.TIMED_TEXT_REQUESTED, {
+                index: 0,
+                sender: e.sender
+            }); //TODO make index dynamic if referring to MP?
+        }
     }
 
     function onInitFragmentLoaded(e) {
         if (e.fragmentModel !== streamProcessor.getFragmentModel() || (!e.chunk.bytes)) {
             return;
         }
+
         initCache.save(e.chunk);
         buffer.append(e.chunk);
+
+        eventBus.trigger(Events.STREAM_COMPLETED, {
+            request: e.request,
+            fragmentModel: e.fragmentModel
+        });
     }
 
     function switchInitData(streamId, representationId) {
         const chunk = initCache.extract(streamId, representationId);
-        if (chunk) {
-            buffer.append(chunk);
-        } else {
-            eventBus.trigger(Events.INIT_REQUESTED, {
+
+        if (!chunk) {
+            eventBus.trigger(Events.TIMED_TEXT_REQUESTED, {
+                index: 0,
                 sender: instance
             });
         }

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -46,6 +46,7 @@ function NotFragmentedTextBufferController(config) {
 
     let errHandler = config.errHandler;
     let type = config.type;
+    let mimeType = config.mimeType;
     let streamProcessor = config.streamProcessor;
 
     let instance,
@@ -86,7 +87,7 @@ function NotFragmentedTextBufferController(config) {
             if (!initialized) {
                 const textBuffer = buffer.getBuffer();
                 if (textBuffer.hasOwnProperty(Constants.INITIALIZE)) {
-                    textBuffer.initialize(type, streamProcessor);
+                    textBuffer.initialize(mimeType, streamProcessor);
                 }
                 initialized = true;
             }

--- a/src/streaming/text/TextBufferController.js
+++ b/src/streaming/text/TextBufferController.js
@@ -67,6 +67,7 @@ function TextBufferController(config) {
             // in this case, internal buffer controller is a not fragmented text controller object
             _BufferControllerImpl = NotFragmentedTextBufferController(context).create({
                 type: config.type,
+                mimeType: config.mimeType,
                 errHandler: config.errHandler,
                 streamProcessor: config.streamProcessor
             });

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -264,7 +264,7 @@ function TextController() {
 
                 if (streamProcessor && mediaInfosArr) {
                     for (let i = 0; i < mediaInfosArr.length; i++) {
-                        if (mediaInfosArr[i].lang === currentTrackInfo.lang) {
+                        if (mediaInfosArr[i].index === currentTrackInfo.index && mediaInfosArr[i].lang === currentTrackInfo.lang) {
                             streamProcessor.selectMediaInfo(mediaInfosArr[i]);
                             break;
                         }

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -225,6 +225,8 @@ function TextController() {
         let config = textSourceBuffer.getConfig();
         let fragmentModel = config.fragmentModel;
         let fragmentedTracks = config.fragmentedTracks;
+        let mediaInfosArr,
+            streamProcessor;
 
         let oldTrackIdx = textTracks.getCurrentTrackIdx();
         if (oldTrackIdx !== idx) {
@@ -247,6 +249,24 @@ function TextController() {
                             textTracks.deleteCuesFromTrackIdx(oldTrackIdx);
                             mediaController.setTrack(mediaInfo);
                             textSourceBuffer.setCurrentFragmentedTrackIdx(i);
+                        }
+                    }
+                }
+            } else if (currentTrackInfo && !currentTrackInfo.isFragmented) {
+                const streamProcessors = streamController.getActiveStreamProcessors();
+                for (let i = 0; i < streamProcessors.length; i++) {
+                    if (streamProcessors[i].getType() === Constants.TEXT) {
+                        streamProcessor = streamProcessors[i];
+                        mediaInfosArr = streamProcessor.getMediaInfoArr();
+                        break;
+                    }
+                }
+
+                if (streamProcessor && mediaInfosArr) {
+                    for (let i = 0; i < mediaInfosArr.length; i++) {
+                        if (mediaInfosArr[i].lang === currentTrackInfo.lang) {
+                            streamProcessor.selectMediaInfo(mediaInfosArr[i]);
+                            break;
                         }
                     }
                 }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -84,7 +84,7 @@ function TextSourceBuffer() {
         logger = Debug(context).getInstance().getLogger(instance);
     }
 
-    function initialize(type, streamProcessor) {
+    function initialize(mimeType, streamProcessor) {
         parser = null;
         fragmentModel = null;
         initializationSegmentReceived = false;
@@ -101,7 +101,7 @@ function TextSourceBuffer() {
             videoModel: videoModel
         });
         textTracks.initialize();
-        isFragmented = !dashManifestModel.getIsTextTrack(type);
+        isFragmented = !dashManifestModel.getIsTextTrack(mimeType);
         boxParser = BoxParser(context).getInstance();
         fragmentedTextBoxParser = FragmentedTextBoxParser(context).getInstance();
         fragmentedTextBoxParser.setConfig({
@@ -406,7 +406,10 @@ function TextSourceBuffer() {
 
             try {
                 result = getParser(codecType).parse(ccContent, 0);
-                createTextTrackFromMediaInfo(result, mediaInfo);
+                for (i = 0; i < mediaInfos.length; i++) {
+                    createTextTrackFromMediaInfo(null, mediaInfos[i]);
+                }
+                textTracks.addCaptions(textTracks.getCurrentTrackIdx(), 0, result);
             } catch (e) {
                 errHandler.timedTextError(e, 'parse', ccContent);
             }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -301,7 +301,7 @@ function TextSourceBuffer() {
 
             textTrackInfo.captionData = captionData;
             textTrackInfo.lang = mediaInfo.lang;
-            textTrackInfo.label = mediaInfo.id; // AdaptationSet id (an unsigned int)
+            textTrackInfo.label = mediaInfo.id ? mediaInfo.id : mediaInfo.index; // AdaptationSet id (an unsigned int) as it's optionnal parameter, use mediaInfo.index
             textTrackInfo.index = mediaInfo.index; // AdaptationSet index in manifest
             textTrackInfo.isTTML = checkTTML();
             textTrackInfo.defaultTrack = getIsDefault(mediaInfo);

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -46,6 +46,8 @@ class StreamControllerMock {
     setConfig() {}
 
     reset() {}
+
+    getActiveStreamProcessors() { return [];}
 }
 
 export default StreamControllerMock;

--- a/test/unit/streaming.text.NotFragmentedTextBufferController.js
+++ b/test/unit/streaming.text.NotFragmentedTextBufferController.js
@@ -133,7 +133,7 @@ describe('NotFragmentedTextBufferController', function () {
         });
 
         describe('Method switchInitData', function () {
-            it('should append init data to source buffer if data have been cached', function () {
+            it('should not append init data to source buffer if data have already been cached', function () {
                 let chunk = {
                     bytes: 'initData',
                     quality: 2,
@@ -148,19 +148,19 @@ describe('NotFragmentedTextBufferController', function () {
                 notFragmentedTextBufferController.createBuffer(mockMediaInfo);
                 const buffer = notFragmentedTextBufferController.getBuffer().getBuffer();
                 notFragmentedTextBufferController.switchInitData(chunk.streamId, chunk.representationId);
-                expect(buffer.chunk).to.equal(chunk.bytes);
+                expect(buffer.chunk).to.equal(null);
             });
 
-            it('should trigger INIT_REQUESTED if no init data is cached', function (done) {
+            it('should trigger TIMED_TEXT_REQUESTED if no init data is cached', function (done) {
 
                 // reset cache
                 initCache.reset();
 
                 let onInitRequest = function () {
-                    eventBus.off(Events.INIT_REQUESTED, onInitRequest);
+                    eventBus.off(Events.TIMED_TEXT_REQUESTED, onInitRequest);
                     done();
                 };
-                eventBus.on(Events.INIT_REQUESTED, onInitRequest, this);
+                eventBus.on(Events.TIMED_TEXT_REQUESTED, onInitRequest, this);
 
                 notFragmentedTextBufferController.switchInitData('streamId', 'representationId');
             });
@@ -172,7 +172,8 @@ describe('NotFragmentedTextBufferController', function () {
 
                 let event = {
                     sender: {
-                        getStreamProcessor: function () { return streamProcessorMock; }
+                        getStreamProcessor: function () { return streamProcessorMock; },
+                        getCurrentRepresentation: function () { return { id: 0}; }
                     }
                 };
 

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -6,6 +6,7 @@ import EventBus from '../../src/core/EventBus';
 import Events from '../../src/core/events/Events';
 
 import VideoModelMock from './mocks/VideoModelMock';
+import StreamControllerMock from './mocks/StreamControllerMock';
 
 const expect = require('chai').expect;
 const context = {};
@@ -16,6 +17,7 @@ const eventBus = EventBus(context).getInstance();
 describe('TextController', function () {
 
     let videoModelMock = new VideoModelMock();
+    let streamControllerMock = new StreamControllerMock();
     let textTracks;
     let textController;
 
@@ -27,7 +29,8 @@ describe('TextController', function () {
 
         textController = TextController(context).getInstance();
         textController.setConfig({
-            videoModel: videoModelMock
+            videoModel: videoModelMock,
+            streamController: streamControllerMock
         });
     });
 


### PR DESCRIPTION
Hi,

this PR has to optimize not fragmented subtitles management.

Indeed, when a stream is selected with not fragmented subtitle, like for instance https://vm2.dashif.org/dash/vod/testpic_2s/xml_subs.mpd, by default all the subtitles files are downloaded and parsed at the beginning. Then, if the user decides to seek somewhere in this content, the selected subtitle file is parsed a second time when this first seek command occurs.

So, these modifications allow to download only the selected subtitles file. Then, if the user wants to change subtitles track, the new file will be downloaded. Finally, if a seek command occurs, the useless parsing is not done.

Nico