### PR TITLE
Fixed a bug in playbackController causing multiple wallclockTime intervals

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -222,7 +222,6 @@ function PlaybackController() {
     function reset() {
         currentTime = 0;
         liveStartTime = NaN;
-        wallclockTimeIntervalId = null;
         playOnceInitialized = false;
         commonEarliestTime = {};
         liveDelay = 0;
@@ -236,6 +235,7 @@ function PlaybackController() {
             stopUpdatingWallclockTime();
             removeAllListeners();
         }
+        wallclockTimeIntervalId = null;
         videoModel = null;
         streamInfo = null;
         isDynamic = null;


### PR DESCRIPTION
`wallclockTimeIntervalId` was set to `null` before stopping the interval.

May be related to #2593