### PR TITLE
Fix BUFFER_EMPTY never fired

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -257,6 +257,7 @@ declare namespace dashjs {
         PLAYBACK_RATE_CHANGED: 'playbackRateChanged';
         PLAYBACK_SEEKED: 'playbackSeeked';
         PLAYBACK_SEEKING: 'playbackSeeking';
+        PLAYBACK_STALLED: 'playbackStalled';
         PLAYBACK_STARTED: 'playbackStarted';
         PLAYBACK_TIME_UPDATED: 'playbackTimeUpdated';
         PLAYBACK_WAITING: 'playbackWaiting';

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -286,6 +286,12 @@ class MediaPlayerEvents extends EventsBase {
         this.PLAYBACK_SEEK_ASKED = 'playbackSeekAsked';
 
         /**
+         * Sent when the video element reports stalled
+         * @event MediaPlayerEvents#PLAYBACK_STALLED
+         */
+        this.PLAYBACK_STALLED = 'playbackStalled';
+
+        /**
          * Sent when playback of the media starts after having been paused;
          * that is, when playback is resumed after a prior pause event.
          *

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -580,6 +580,13 @@ function PlaybackController() {
         videoModel.setStallState(e.mediaType, e.state === BufferController.BUFFER_EMPTY);
     }
 
+    function onPlaybackStalled(e) {
+        log('Native video element event: stalled', e);
+        eventBus.trigger(Events.PLAYBACK_STALLED, {
+            e: e
+        });
+    }
+
     function addAllListeners() {
         videoModel.addEventListener('canplay', onCanPlay);
         videoModel.addEventListener('play', onPlaybackStart);
@@ -594,6 +601,7 @@ function PlaybackController() {
         videoModel.addEventListener('ratechange', onPlaybackRateChanged);
         videoModel.addEventListener('loadedmetadata', onPlaybackMetaDataLoaded);
         videoModel.addEventListener('ended', onPlaybackEnded);
+        videoModel.addEventListener('stalled', onPlaybackStalled);
     }
 
     function removeAllListeners() {
@@ -610,6 +618,8 @@ function PlaybackController() {
         videoModel.removeEventListener('ratechange', onPlaybackRateChanged);
         videoModel.removeEventListener('loadedmetadata', onPlaybackMetaDataLoaded);
         videoModel.removeEventListener('ended', onPlaybackEnded);
+        videoModel.removeEventListener('stalled', onPlaybackStalled);
+
     }
 
     instance = {


### PR DESCRIPTION
Fix BUFFER_EMPTY never firing if buffer level never went above safe distance, also will check buffer when native video element triggers stalled or playing.

Fixes #2607