### PR TITLE
Add log level feature

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -2,9 +2,31 @@ export = dashjs;
 export as namespace dashjs;
 
 declare namespace dashjs {
+    interface Logger {
+        debug(...params): void;
+        info(...params): void;
+        warn(...params): void;
+        error(...params): void;
+        fatal(...params): void;
+    }
+
+    enum LogLevel {
+        LOG_LEVEL_NONE = 0,
+        LOG_LEVEL_FATAL = 1,
+        LOG_LEVEL_ERROR = 2,
+        LOG_LEVEL_WARNING = 3,
+        LOG_LEVEL_INFO = 4,
+        LOG_LEVEL_DEBUG = 5
+    }
+
     interface Debug {
+        getLogger(): Logger;
+        setLogTimestampVisible(flag: boolean): void;
+        setCalleeNameVisible(flag: boolean): void;
         getLogToBrowserConsole(): boolean;
         setLogToBrowserConsole(flag: boolean): void;
+        setLogLevel(level: LogLevel): void;
+        getLogLevel(): LogLevel;
     }
 
     interface VideoModel { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,31 @@ export = dashjs;
 export as namespace dashjs;
 
 declare namespace dashjs {
+    interface Logger {
+        debug(...params): void;
+        info(...params): void;
+        warn(...params): void;
+        error(...params): void;
+        fatal(...params): void;
+    }
+
+    enum LogLevel {
+        LOG_LEVEL_NONE = 0,
+        LOG_LEVEL_FATAL = 1,
+        LOG_LEVEL_ERROR = 2,
+        LOG_LEVEL_WARNING = 3,
+        LOG_LEVEL_INFO = 4,
+        LOG_LEVEL_DEBUG = 5
+    }
+
     interface Debug {
+        getLogger(): Logger;
+        setLogTimestampVisible(flag: boolean): void;
+        setCalleeNameVisible(flag: boolean): void;
         getLogToBrowserConsole(): boolean;
         setLogToBrowserConsole(flag: boolean): void;
+        setLogLevel(level: LogLevel): void;
+        getLogLevel(): LogLevel;
     }
 
     interface VideoModel { }

--- a/index.js
+++ b/index.js
@@ -34,10 +34,12 @@ import { MediaPlayer } from './index_mediaplayerOnly';
 import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import Protection from './src/streaming/protection/Protection';
 import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
+import Debug from './src/core/Debug';
 
 dashjs.Protection = Protection;
 dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
+dashjs.Debug = Debug;
 
 export default dashjs;
-export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory};
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, Debug};

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -41,7 +41,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     sources.query(function (data) {
         $scope.availableStreams = data.items;
         // if no mss package, remove mss samples.
-        let MssHandler = dashjs.MssHandler; /* jshint ignore:line */
+        var MssHandler = dashjs.MssHandler; /* jshint ignore:line */
         if (typeof MssHandler !== 'function') {
             for (var i = $scope.availableStreams.length - 1; i >= 0; i--) {
                 if ($scope.availableStreams[i].name === 'Smooth Streaming') {
@@ -233,6 +233,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         $("#errorModal").modal('show');
     }, $scope);
 
+    $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_INFO);
     $scope.player.initialize($scope.video, null, $scope.autoPlaySelected);
     $scope.player.setFastSwitchEnabled($scope.fastSwitchSelected);
     $scope.player.setJumpGaps($scope.jumpGapsSelected);
@@ -472,6 +473,35 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.changeTrackSwitchMode = function (mode, type) {
         $scope.player.setTrackSwitchModeFor(type, mode);
     };
+
+    $scope.setLogLevel = function (mode) {
+        var level = $("input[name='log-level']:checked").val();
+        switch(level) {
+            case 'none':
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_NONE);
+            break;
+
+            case 'fatal':
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_FATAL);
+            break;
+
+            case 'error':
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_ERROR);
+            break;
+
+            case 'warning':
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_WARNING);
+            break;
+
+            case 'info':
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_INFO);
+            break;
+
+            default:
+            $scope.player.getDebug().setLogLevel(dashjs.Debug.LOG_LEVEL_DEBUG);
+        }
+
+    }
 
     $scope.hasLogo = function (item) {
         return (item.hasOwnProperty('logo') && item.logo);

--- a/samples/dash-if-reference-player/app/rules/ThroughputRule.js
+++ b/samples/dash-if-reference-player/app/rules/ThroughputRule.js
@@ -37,10 +37,17 @@ function CustomThroughputRuleClass() {
     let SwitchRequest = factory.getClassFactoryByName('SwitchRequest');
     let MetricsModel = factory.getSingletonFactoryByName('MetricsModel');
 
+    let Debug = factory.getSingletonFactoryByName('Debug');
+
     let context = this.context;
+    let instance,
+        logger;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function getMaxIndex(rulesContext) {
-
         // here you can get some informations aboit metrics for example, to implement the rule
         let metricsModel = MetricsModel(context).getInstance();
         var mediaType = rulesContext.getMediaInfo().type;
@@ -52,9 +59,12 @@ function CustomThroughputRuleClass() {
         return SwitchRequest(context).create();
     }
 
-    const instance = {
+    instance = {
         getMaxIndex: getMaxIndex
     };
+
+    setup();
+
     return instance;
 }
 

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -253,6 +253,42 @@
                     </label>
                 </div>
             </div>
+            <div class="options-item">
+                <div class="options-item-title">Debug</div>
+                <div class="options-item-body">
+                    <label class="options-label">Log Level:</label>
+                    <label data-toggle="tooltip" data-placement="right"
+                           title="Don't write any log message in browser console">
+                        <input  type="radio" id="log-none" value="none" autocomplete="off" name="log-level" ng-click="setLogLevel()" >
+                        NONE
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                           title="Sets log level of to LOG_LEVEL_FATAL">
+                           <input  type="radio" id="log-fatal" value="fatal" autocomplete="off" name="log-level" ng-click="setLogLevel()" >
+                        FATAL
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                           title="Sets log level of to LOG_LEVEL_ERROR">
+                           <input  type="radio" id="log-error" value="error" autocomplete="off" name="log-level" ng-click="setLogLevel()" >
+                        ERROR
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                            title="Sets log level of to LOG_LEVEL_WARNING">
+                           <input  type="radio" id="log-warning" value="warning" autocomplete="off" name="log-level" ng-click="setLogLevel()" >
+                        WARNING
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                            title="Sets log level of to LOG_LEVEL_INFO">
+                           <input  type="radio" id="log-info" value="info" autocomplete="off" name="log-level" checked="checked" ng-click="setLogLevel()" >
+                        INFO
+                    </label>
+                    <label data-toggle="tooltip" data-placement="right"
+                            title="Sets log level of to LOG_LEVEL_DEBUG">
+                           <input  type="radio" id="log-debug" value="debug" autocomplete="off" name="log-level" ng-click="setLogLevel()" >
+                        DEBUG
+                    </label>
+                </div>
+            </div>
 
         </div>
 

--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -32,31 +32,115 @@ import EventBus from './EventBus';
 import Events from './events/Events';
 import FactoryMaker from './FactoryMaker';
 
+const LOG_LEVEL_NONE = 0;
+const LOG_LEVEL_FATAL = 1;
+const LOG_LEVEL_ERROR = 2;
+const LOG_LEVEL_WARNING = 3;
+const LOG_LEVEL_INFO = 4;
+const LOG_LEVEL_DEBUG = 5;
+
 /**
  * @module Debug
  */
 function Debug() {
 
-    let context = this.context;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+
+    const logFn = [];
 
     let instance,
-        logToBrowserConsole,
         showLogTimestamp,
         showCalleeName,
-        startTime;
+        startTime,
+        logLevel;
 
     function setup() {
-        logToBrowserConsole = true;
         showLogTimestamp = true;
-        showCalleeName = false;
+        showCalleeName = true;
+        logLevel = LOG_LEVEL_WARNING;
         startTime = new Date().getTime();
+
+        if (typeof window !== 'undefined' && window.console) {
+            logFn[LOG_LEVEL_FATAL] = getLogFn(window.console.error);
+            logFn[LOG_LEVEL_ERROR] = getLogFn(window.console.error);
+            logFn[LOG_LEVEL_WARNING] = getLogFn(window.console.warn);
+            logFn[LOG_LEVEL_INFO] = getLogFn(window.console.info);
+            logFn[LOG_LEVEL_DEBUG] = getLogFn(window.console.debug);
+        }
+    }
+
+    function getLogFn(fn) {
+        if (fn && fn.bind) {
+            return fn.bind(window.console);
+        }
+        // if not define, return the default function for reporting logs
+        return window.console.log.bind(window.console);
+    }
+
+    /**
+     * Retrieves a logger which can be used to write logging information in browser console.
+     * @param {object} instance Object for which the logger is created. It is used
+     * to include calle object information in log messages.
+     * @memberof module:Debug
+     * @returns {Logger}
+     * @instance
+     */
+    function getLogger(instance) {
+        return {
+            fatal: fatal.bind(instance),
+            error: error.bind(instance),
+            warn: warn.bind(instance),
+            info: info.bind(instance),
+            debug: debug.bind(instance)
+        };
+    }
+
+    /**
+     * Sets up the log level. The levels are cumulative. For example, if you set the log level
+     * to dashjs.Debug.LOG_LEVEL_WARNING all warnings, errors and fatals will be logged. Possible values
+     *
+     * <ul>
+     * <li>dashjs.Debug.LOG_LEVEL_NONE<br/>
+     * No message is written in the browser console.
+     *
+     * <li>dashjs.Debug.LOG_LEVEL_FATAL<br/>
+     * Log fatal errors. An error is considered fatal when it causes playback to fail completely.
+     *
+     * <li>dashjs.Debug.LOG_LEVEL_ERROR<br/>
+     * Log error messages.
+     *
+     * <li>dashjs.Debug.LOG_LEVEL_WARNING<br/>
+     * Log warning messages.
+     *
+     * <li>dashjs.Debug.LOG_LEVEL_INFO<br/>
+     * Log info messages.
+     *
+     * <li>dashjs.Debug.LOG_LEVEL_DEBUG<br/>
+     * Log debug messages.
+     * </ul>
+     * @param {number} value Log level
+     * @default true
+     * @memberof module:Debug
+     * @instance
+     */
+    function setLogLevel(value) {
+        logLevel = value;
+    }
+
+    /**
+     * Use this method to get the current log level.
+     * @memberof module:Debug
+     * @instance
+     */
+    function getLogLevel() {
+        return logLevel;
     }
 
     /**
      * Prepends a timestamp in milliseconds to each log message.
      * @param {boolean} value Set to true if you want to see a timestamp in each log message.
-     * @default false
+     * @default LOG_LEVEL_WARNING
      * @memberof module:Debug
      * @instance
      */
@@ -66,7 +150,7 @@ function Debug() {
     /**
      * Prepends the callee object name, and media type if available, to each log message.
      * @param {boolean} value Set to true if you want to see the callee object name and media type in each log message.
-     * @default false
+     * @default true
      * @memberof module:Debug
      * @instance
      */
@@ -79,26 +163,51 @@ function Debug() {
      * @default true
      * @memberof module:Debug
      * @instance
+     * @deprecated
      */
     function setLogToBrowserConsole(value) {
-        logToBrowserConsole = value;
+        // Replicate functionality previous to log levels feature
+        if (value) {
+            logLevel = LOG_LEVEL_DEBUG;
+        } else {
+            logLevel = LOG_LEVEL_NONE;
+        }
     }
     /**
      * Use this method to get the state of logToBrowserConsole.
      * @returns {boolean} The current value of logToBrowserConsole
      * @memberof module:Debug
      * @instance
+     * @deprecated
      */
     function getLogToBrowserConsole() {
-        return logToBrowserConsole;
+        return logLevel !== LOG_LEVEL_NONE;
     }
-    /**
-     * This method will allow you send log messages to either the browser's console and/or dispatch an event to capture at the media player level.
-     * @param {...*} arguments The message you want to log. The Arguments object is supported for this method so you can send in comma separated logging items.
-     * @memberof module:Debug
-     * @instance
-     */
-    function log() {
+
+    function fatal(...params) {
+        doLog(LOG_LEVEL_FATAL, this, ...params);
+    }
+
+    function error(...params) {
+        doLog(LOG_LEVEL_ERROR, this, ...params);
+    }
+
+    function warn(...params) {
+        doLog(LOG_LEVEL_WARNING, this, ...params);
+    }
+
+    function info(...params) {
+        doLog(LOG_LEVEL_INFO, this, ...params);
+    }
+
+    function debug(...params) {
+        doLog(LOG_LEVEL_DEBUG, this, ...params);
+    }
+
+    function doLog(level, _this, ...params) {
+        if (logLevel < level) {
+            return;
+        }
 
         let message = '';
         let logTime = null;
@@ -108,10 +217,10 @@ function Debug() {
             message += '[' + (logTime - startTime) + ']';
         }
 
-        if (showCalleeName && this && this.getClassName) {
-            message += '[' + this.getClassName() + ']';
-            if (this.getType) {
-                message += '[' + this.getType() + ']';
+        if (showCalleeName && _this && _this.getClassName) {
+            message += '[' + _this.getClassName() + ']';
+            if (_this.getType) {
+                message += '[' + _this.getType() + ']';
             }
         }
 
@@ -119,23 +228,26 @@ function Debug() {
             message += ' ';
         }
 
-        Array.apply(null, arguments).forEach(function (item) {
+        Array.apply(null, params).forEach(function (item) {
             message += item + ' ';
         });
 
-        if (logToBrowserConsole) {
-            console.log(message);
+        if (logFn[level]) {
+            logFn[level](message);
         }
 
+        // TODO: To be removed
         eventBus.trigger(Events.LOG, {message: message});
     }
 
     instance = {
-        log: log,
+        getLogger: getLogger,
         setLogTimestampVisible: setLogTimestampVisible,
         setCalleeNameVisible: setCalleeNameVisible,
         setLogToBrowserConsole: setLogToBrowserConsole,
-        getLogToBrowserConsole: getLogToBrowserConsole
+        getLogToBrowserConsole: getLogToBrowserConsole,
+        setLogLevel: setLogLevel,
+        getLogLevel: getLogLevel
     };
 
     setup();
@@ -144,4 +256,13 @@ function Debug() {
 }
 
 Debug.__dashjs_factory_name = 'Debug';
-export default FactoryMaker.getSingletonFactory(Debug);
+
+const factory = FactoryMaker.getSingletonFactory(Debug);
+factory.LOG_LEVEL_NONE = LOG_LEVEL_NONE;
+factory.LOG_LEVEL_FATAL = LOG_LEVEL_FATAL;
+factory.LOG_LEVEL_ERROR = LOG_LEVEL_ERROR;
+factory.LOG_LEVEL_WARNING = LOG_LEVEL_WARNING;
+factory.LOG_LEVEL_INFO = LOG_LEVEL_INFO;
+factory.LOG_LEVEL_DEBUG = LOG_LEVEL_DEBUG;
+FactoryMaker.updateSingletonFactory(Debug.__dashjs_factory_name, factory);
+export default factory;

--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -31,7 +31,7 @@
 /**
  * @module FactoryMaker
  */
-let FactoryMaker = (function () {
+const FactoryMaker = (function () {
 
     let instance;
     const singletonContexts = [];

--- a/src/core/Logger.js
+++ b/src/core/Logger.js
@@ -29,23 +29,37 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-import MediaPlayer from './src/streaming/MediaPlayer';
-import FactoryMaker from './src/core/FactoryMaker';
-import Debug from './src/core/Debug';
-import {getVersionString} from './src/core/Version';
+/**
+ * The an end place to put fragments after they have been fetched.
+ * @interface Logger
+ */
 
-// Shove both of these into the global scope
-var context = (typeof window !== 'undefined' && window) || global;
+/**
+* This method allows you to send fatal error messages (fatal errors implies playback interruption) to the browser's console.
+* @param {...*} arguments The message you want to debug. The Arguments object is supported for this method so you can send in comma separated logging items.
+* @function Logger#fatal
+*/
 
-var dashjs = context.dashjs;
-if (!dashjs) {
-    dashjs = context.dashjs = {};
-}
+/**
+ * This method allows you to send error messages to the browser's console.
+ * @param {...*} arguments The message you want to debug. The Arguments object is supported for this method so you can send in comma separated logging items.
+ * @function Logger#error
+ */
 
-dashjs.MediaPlayer = MediaPlayer;
-dashjs.FactoryMaker = FactoryMaker;
-dashjs.Debug = Debug;
-dashjs.Version = getVersionString();
+/**
+ * This method allows you to send warning messages to the browser's console.
+ * @param {...*} arguments The message you want to debug. The Arguments object is supported for this method so you can send in comma separated logging items.
+ * @function Logger#warning
+ */
 
-export default dashjs;
-export { MediaPlayer, FactoryMaker, Debug};
+/**
+ * This method allows you to send info messages to the browser's console.
+ * @param {...*} arguments The message you want to debug. The Arguments object is supported for this method so you can send in comma separated logging items.
+ * @function Logger#info
+ */
+
+/**
+ * This method allows you to send debug messages to the browser's console.
+ * @param {...*} arguments The message you want to debug. The Arguments object is supported for this method so you can send in comma separated logging items.
+ * @function Logger#debug
+ */

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -69,7 +69,7 @@ function DashHandler(config) {
     const baseURLController = config.baseURLController;
 
     let instance,
-        log,
+        logger,
         index,
         requestedTime,
         currentTime,
@@ -78,8 +78,7 @@ function DashHandler(config) {
         segmentsGetter;
 
     function setup() {
-        log = Debug(context).getInstance().log.bind(instance);
-
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
         segmentBaseLoader = isWebM(config.mimeType) ? WebmSegmentBaseLoader(context).getInstance() : SegmentBaseLoader(context).getInstance();
@@ -205,10 +204,10 @@ function DashHandler(config) {
             if (seg) {
                 const time = parseFloat((seg.presentationStartTime - representation.adaptation.period.start).toFixed(5));
                 const duration = representation.adaptation.period.duration;
-                log(representation.segmentInfoType + ': ' + time + ' / ' + duration);
+                logger.debug(representation.segmentInfoType + ': ' + time + ' / ' + duration);
                 isFinished = representation.segmentInfoType === DashConstants.SEGMENT_TIMELINE && isDynamic ? false : time >= duration;
             } else {
-                log('isMediaFinished - no segment found');
+                logger.debug('isMediaFinished - no segment found');
             }
         }
 
@@ -372,7 +371,7 @@ function DashHandler(config) {
 
         if (requestedTime !== time) { // When playing at live edge with 0 delay we may loop back with same time and index until it is available. Reduces verboseness of logs.
             requestedTime = time;
-            log('Getting the request for ' + type + ' time : ' + time);
+            logger.debug('Getting the request for ' + type + ' time : ' + time);
         }
 
         updateSegments(representation);
@@ -385,7 +384,7 @@ function DashHandler(config) {
         }
 
         if (index > 0) {
-            log('Index for ' + type + ' time ' + time + ' is ' + index );
+            logger.debug('Index for ' + type + ' time ' + time + ' is ' + index );
         }
 
         finished = !ignoreIsFinished ? isMediaFinished(representation) : false;
@@ -395,7 +394,7 @@ function DashHandler(config) {
             request.index = index;
             request.mediaType = type;
             request.mediaInfo = streamProcessor.getMediaInfo();
-            log('Signal complete in getSegmentRequestForTime -', type);
+            logger.debug('Signal complete in getSegmentRequestForTime -', type);
         } else {
             segment = getSegmentByIndex(index, representation);
             request = getRequestForSegment(segment);
@@ -431,12 +430,12 @@ function DashHandler(config) {
         requestedTime = null;
         index++;
 
-        log('Getting the next request at index: ' + index + ', type: ' + type);
+        logger.debug('Getting the next request at index: ' + index + ', type: ' + type);
 
         // check that there is a segment in this index. If none, update segments and wait for next time loop is called
         const seg = getSegmentByIndex(index, representation);
         if (!seg && isDynamic) {
-            log('No segment found at index: ' + index + '. Wait for next loop');
+            logger.debug('No segment found at index: ' + index + '. Wait for next loop');
             updateSegments(representation);
             index--;
             return null;
@@ -449,7 +448,7 @@ function DashHandler(config) {
             request.index = index;
             request.mediaType = type;
             request.mediaInfo = streamProcessor.getMediaInfo();
-            log('Signal complete -', type);
+            logger.debug('Signal complete -', type);
         } else {
             updateSegments(representation);
             segment = getSegmentByIndex(index, representation);

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -43,10 +43,10 @@ import HTTPLoader from '../streaming/net/HTTPLoader';
 function SegmentBaseLoader() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         errHandler,
         boxParser,
         requestModifier,
@@ -54,6 +54,10 @@ function SegmentBaseLoader() {
         mediaPlayerModel,
         httpLoader,
         baseURLController;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function initialize() {
         boxParser = BoxParser(context).getInstance();
@@ -107,7 +111,7 @@ function SegmentBaseLoader() {
             bytesToLoad: 1500
         };
 
-        log('Start searching for initialization.');
+        logger.debug('Start searching for initialization.');
 
         const request = getFragmentRequest(info);
 
@@ -134,7 +138,7 @@ function SegmentBaseLoader() {
 
         httpLoader.load({request: request, success: onload, error: onerror});
 
-        log('Perform init search: ' + info.url);
+        logger.debug('Perform init search: ' + info.url);
     }
 
     function loadSegments(representation, type, range, loadingInfo, callback) {
@@ -197,7 +201,7 @@ function SegmentBaseLoader() {
                 }
 
                 if (loadMultiSidx) {
-                    log('Initiate multiple SIDX load.');
+                    logger.debug('Initiate multiple SIDX load.');
                     info.range.end = info.range.start + sidx.size;
 
                     let j, len, ss, se, r;
@@ -226,7 +230,7 @@ function SegmentBaseLoader() {
                     }
 
                 } else {
-                    log('Parsing segments from SIDX.');
+                    logger.debug('Parsing segments from SIDX.');
                     segments = getSegmentsForSidx(sidx, info);
                     callback(segments, representation, type);
                 }
@@ -238,7 +242,7 @@ function SegmentBaseLoader() {
         };
 
         httpLoader.load({request: request, success: onload, error: onerror});
-        log('Perform SIDX load: ' + info.url);
+        logger.debug('Perform SIDX load: ' + info.url);
     }
 
     function reset() {
@@ -289,14 +293,14 @@ function SegmentBaseLoader() {
         let start,
             end;
 
-        log('Searching for initialization.');
+        logger.debug('Searching for initialization.');
 
         if (moov && moov.isComplete) {
             start = ftyp ? ftyp.offset : moov.offset;
             end = moov.offset + moov.size - 1;
             initRange = start + '-' + end;
 
-            log('Found the initialization.  Range: ' + initRange);
+            logger.debug('Found the initialization.  Range: ' + initRange);
         }
 
         return initRange;
@@ -330,6 +334,8 @@ function SegmentBaseLoader() {
         loadSegments: loadSegments,
         reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/dash/WebmSegmentBaseLoader.js
+++ b/src/dash/WebmSegmentBaseLoader.js
@@ -13,11 +13,11 @@ import HTTPLoader from '../streaming/net/HTTPLoader';
 
 function WebmSegmentBaseLoader() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         WebM,
         errHandler,
         requestModifier,
@@ -27,6 +27,7 @@ function WebmSegmentBaseLoader() {
         baseURLController;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         WebM = {
             EBML: {
                 tag: 0x1A45DFA3,
@@ -204,7 +205,7 @@ function WebmSegmentBaseLoader() {
             segments.push(segment);
         }
 
-        log('Parsed cues: ' + segments.length + ' cues.');
+        logger.debug('Parsed cues: ' + segments.length + ' cues.');
 
         return segments;
     }
@@ -228,7 +229,7 @@ function WebmSegmentBaseLoader() {
         let segmentEnd;
         let segmentStart;
 
-        log('Parse EBML header: ' + info.url);
+        logger.debug('Parse EBML header: ' + info.url);
 
         // skip over the header itself
         ebmlParser.skipOverElement(WebM.EBML);
@@ -276,7 +277,7 @@ function WebmSegmentBaseLoader() {
         };
 
         const onloadend = function () {
-            log('Download Error: Cues ' + info.url);
+            logger.error('Download Error: Cues ' + info.url);
             callback(null);
         };
 
@@ -286,7 +287,7 @@ function WebmSegmentBaseLoader() {
             error: onloadend
         });
 
-        log('Perform cues load: ' + info.url + ' bytes=' + info.range.start + '-' + info.range.end);
+        logger.debug('Perform cues load: ' + info.url + ' bytes=' + info.range.start + '-' + info.range.end);
     }
 
     function checkSetConfigCall() {
@@ -311,7 +312,7 @@ function WebmSegmentBaseLoader() {
             init: true
         };
 
-        log('Start loading initialization.');
+        logger.info('Start loading initialization.');
 
         request = getFragmentRequest(info);
 
@@ -335,7 +336,7 @@ function WebmSegmentBaseLoader() {
             error: onloadend
         });
 
-        log('Perform init load: ' + info.url);
+        logger.debug('Perform init load: ' + info.url);
     }
 
     function loadSegments(representation, type, theRange, callback) {
@@ -362,7 +363,7 @@ function WebmSegmentBaseLoader() {
         // first load the header, but preserve the manifest range so we can
         // load the cues after parsing the header
         // NOTE: we expect segment info to appear in the first 8192 bytes
-        log('Parsing ebml header');
+        logger.debug('Parsing ebml header');
 
         const onload = function (response) {
             parseEbmlHeader(response, media, theRange, function (segments) {
@@ -411,7 +412,6 @@ function WebmSegmentBaseLoader() {
     function reset() {
         errHandler = null;
         requestModifier = null;
-        log = null;
     }
 
     instance = {

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -42,14 +42,15 @@ import SegmentValuesMap from './maps/SegmentValuesMap';
 function DashParser() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
 
     let instance,
+        logger,
         matchers,
         converter,
         objectIron;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         matchers = [
             new DurationMatcher(),
             new DateTimeMatcher(),
@@ -84,7 +85,6 @@ function DashParser() {
 
     function parse(data) {
         let manifest;
-
         const startTime = window.performance.now();
 
         manifest = converter.xml_str2json(data);
@@ -94,12 +94,10 @@ function DashParser() {
         }
 
         const jsonTime = window.performance.now();
-
         objectIron.run(manifest);
 
         const ironedTime = window.performance.now();
-
-        log('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
+        logger.info('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
 
         return manifest;
     }

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -116,8 +116,6 @@ export function replaceTokenForTemplate(url, token, value) {
                     paddedValue = zeroPadToLength(value.toString(8), width);
                     break;
                 default:
-                    //TODO: commented out logging to supress jshint warning -- `log` is undefined here
-                    //log('Unsupported/invalid IEEE 1003.1 format identifier string in URL');
                     return url;
             }
         } else {

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -59,7 +59,7 @@ function MssFragmentInfoController(config) {
     const controllerType = 'MssFragmentInfoController';
 
     function setup() {
-        logger = Debug(context).getInstance().getLogger(instance);
+        logger = debug.getLogger(instance);
     }
 
     function initialize() {

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -252,6 +252,10 @@ function MssFragmentInfoController(config) {
         startTimeStampValue = null;
     }
 
+    function getType() {
+        return type;
+    }
+
     function reset() {
         doStop();
         streamProcessor.unregisterExternalController(instance);
@@ -261,6 +265,7 @@ function MssFragmentInfoController(config) {
         initialize: initialize,
         controllerType: controllerType,
         start: doStart,
+        getType: getType,
         reset: reset
     };
 

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -35,9 +35,10 @@ import MSSFragmentMoofProcessor from './MssFragmentMoofProcessor';
 function MssFragmentInfoController(config) {
 
     config = config || {};
-    let context = this.context;
+    const context = this.context;
 
     let instance;
+    let logger;
     let fragmentModel;
     let indexHandler;
     let started;
@@ -49,16 +50,16 @@ function MssFragmentInfoController(config) {
     let deltaTime;
     let segmentDuration;
 
-    let streamProcessor = config.streamProcessor;
-    let eventBus = config.eventBus;
-    let metricsModel = config.metricsModel;
-    let playbackController = config.playbackController;
+    const streamProcessor = config.streamProcessor;
+    const eventBus = config.eventBus;
+    const metricsModel = config.metricsModel;
+    const playbackController = config.playbackController;
     const ISOBoxer = config.ISOBoxer;
-    const log = config.log;
-
+    const debug = config.debug;
     const controllerType = 'MssFragmentInfoController';
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
     }
 
     function initialize() {
@@ -77,8 +78,8 @@ function MssFragmentInfoController(config) {
     }
 
     function getCurrentRepresentation() {
-        let representationController = streamProcessor.getRepresentationController();
-        let representation = representationController.getCurrentRepresentation();
+        const representationController = streamProcessor.getRepresentationController();
+        const representation = representationController.getCurrentRepresentation();
 
         return representation;
     }
@@ -97,7 +98,6 @@ function MssFragmentInfoController(config) {
     }
 
     function onFragmentRequest(request) {
-
         // Check if current request signals end of stream
         if ((request !== null) && (request.action === request.ACTION_COMPLETE)) {
             doStop();
@@ -114,40 +114,40 @@ function MssFragmentInfoController(config) {
                 return;
             }
 
-            log('[FragmentInfoController][' + type + '] onFragmentRequest ' + request.url);
+            logger.debug('onFragmentRequest ' + request.url);
 
             // Download the fragment info segment
             sendRequest(request);
         } else {
             // No more fragment in current list
-            log('[FragmentInfoController][' + type + '] bufferFragmentInfo failed');
+            logger.debug('bufferFragmentInfo failed');
         }
     }
 
     function bufferFragmentInfo() {
-        var segmentTime;
+        let segmentTime;
 
         // Check if running state
         if (!started) {
             return;
         }
 
-        log('[FragmentInfoController][' + type + '] Start buffering process...');
+        logger.debug('Start buffering process...');
 
         // Get next segment time
         segmentTime = _fragmentInfoTime;
 
-        log('[FragmentInfoController][' + type + '] loadNextFragment for time: ' + segmentTime);
+        logger.debug('LoadNextFragment for time: ' + segmentTime);
 
-        let representation = getCurrentRepresentation();
-        let request = indexHandler.getSegmentRequestForTime(representation, segmentTime);
+        const representation = getCurrentRepresentation();
+        const request = indexHandler.getSegmentRequestForTime(representation, segmentTime);
         onFragmentRequest(request);
     }
 
     function delayLoadNextFragmentInfo(delay) {
-        var delayMs = Math.round(Math.min((delay * 1000), 2000));
+        const delayMs = Math.round(Math.min((delay * 1000), 2000));
 
-        log('[FragmentInfoController][' + type + '] Check buffer delta = ' + delayMs + ' ms');
+        logger.debug('Check buffer delta = ' + delayMs + ' ms');
 
         clearTimeout(bufferTimeout);
         bufferTimeout = setTimeout(function () {
@@ -161,26 +161,25 @@ function MssFragmentInfoController(config) {
             return;
         }
 
-        let request = e.fragmentInfo.request;
+        const request = e.fragmentInfo.request;
         let deltaDate,
             deltaTimeStamp;
 
 
         if (!e.fragmentInfo.response) {
-            log('[FragmentInfoController][' + type + '] ERROR loading ', request.url);
+            logger.error('Load error', request.url);
             return;
         }
 
         segmentDuration = request.duration;
-        log('[FragmentInfoController][' + type + '] FragmentInfo loaded ', request.url);
+        logger.debug('FragmentInfo loaded ', request.url);
         try {
-
             // update segment list
-            let mssFragmentMoofProcessor = MSSFragmentMoofProcessor(context).create({
+            const mssFragmentMoofProcessor = MSSFragmentMoofProcessor(context).create({
                 metricsModel: metricsModel,
                 playbackController: playbackController,
                 ISOBoxer: ISOBoxer,
-                log: log
+                debug: debug
             });
             mssFragmentMoofProcessor.updateSegmentList(e.fragmentInfo, streamProcessor);
 
@@ -189,7 +188,7 @@ function MssFragmentInfoController(config) {
             deltaTime = (deltaTimeStamp - deltaDate) > 0 ? (deltaTimeStamp - deltaDate) : 0;
             delayLoadNextFragmentInfo(deltaTime);
         } catch (e) {
-            log('[FragmentInfoController][' + type + '] ERROR - Internal error while processing fragment info segment ');
+            logger.fatal('Internal error while processing fragment info segment ');
         }
     }
 
@@ -201,14 +200,13 @@ function MssFragmentInfoController(config) {
         startFragmentInfoDate = new Date().getTime();
         startTimeStampValue = _fragmentInfoTime;
 
-        log('[FragmentInfoController][' + type + '] startPlayback');
+        logger.debug('startPlayback');
 
         // Start buffering process
         bufferFragmentInfo.call(this);
     }
 
     function doStart() {
-
         let segments;
 
         if (started === true) {
@@ -218,7 +216,7 @@ function MssFragmentInfoController(config) {
         eventBus.on(MssEvents.FRAGMENT_INFO_LOADING_COMPLETED, onFragmentInfoLoadedCompleted, instance);
 
         started = true;
-        log('[FragmentInfoController][' + type + '] START');
+        logger.debug('Do start');
 
         let representation = getCurrentRepresentation();
         segments = representation.segments;
@@ -242,7 +240,7 @@ function MssFragmentInfoController(config) {
         if (!started) {
             return;
         }
-        log('[FragmentInfoController][' + type + '] STOP');
+        logger.debug('Do stop');
 
         eventBus.off(MssEvents.FRAGMENT_INFO_LOADING_COMPLETED, onFragmentInfoLoadedCompleted, instance);
 

--- a/src/mss/MssFragmentProcessor.js
+++ b/src/mss/MssFragmentProcessor.js
@@ -120,13 +120,13 @@ function uuidProcessor() {
 function MssFragmentProcessor(config) {
 
     config = config || {};
-    let context = this.context;
-    let metricsModel = config.metricsModel;
-    let playbackController = config.playbackController;
-    let eventBus = config.eventBus;
-    let protectionController = config.protectionController;
+    const context = this.context;
+    const metricsModel = config.metricsModel;
+    const playbackController = config.playbackController;
+    const eventBus = config.eventBus;
+    const protectionController = config.protectionController;
     const ISOBoxer = config.ISOBoxer;
-    const log = config.log;
+    const debug = config.debug;
     let instance;
 
     function setup() {
@@ -137,7 +137,8 @@ function MssFragmentProcessor(config) {
     }
 
     function generateMoov(rep) {
-        let mssFragmentMoovProcessor = MSSFragmentMoovProcessor(context).create({protectionController: protectionController, constants: config.constants, ISOBoxer: config.ISOBoxer});
+        let mssFragmentMoovProcessor = MSSFragmentMoovProcessor(context).create({protectionController: protectionController,
+            constants: config.constants, ISOBoxer: config.ISOBoxer});
         return mssFragmentMoovProcessor.generateMoov(rep);
     }
 
@@ -155,7 +156,7 @@ function MssFragmentProcessor(config) {
                 metricsModel: metricsModel,
                 playbackController: playbackController,
                 ISOBoxer: ISOBoxer,
-                log: log,
+                debug: debug,
                 errHandler: config.errHandler
             });
             mssFragmentMoofProcessor.convertFragment(e, sp);

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -53,7 +53,7 @@ function MssHandler(config) {
         eventBus: eventBus,
         constants: constants,
         ISOBoxer: config.ISOBoxer,
-        log: config.log,
+        debug: config.debug,
         errHandler: config.errHandler
     });
     let mssParser;
@@ -152,7 +152,7 @@ function MssHandler(config) {
                                 metricsModel: metricsModel,
                                 playbackController: playbackController,
                                 ISOBoxer: config.ISOBoxer,
-                                log: config.log
+                                debug: config.debug
                             });
                             fragmentInfoController.initialize();
                             fragmentInfoController.start();

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -51,10 +51,9 @@ function ManifestLoader(config) {
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
     const urlUtils = URLUtils(context).getInstance();
-    const debug = Debug(context).getInstance();
-    const log = debug.log;
 
     let instance,
+        logger,
         httpLoader,
         xlinkController,
         parser;
@@ -62,6 +61,7 @@ function ManifestLoader(config) {
     let errHandler = config.errHandler;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         eventBus.on(Events.XLINK_READY, onXlinkReady, instance);
 
         httpLoader = HTTPLoader(context).create({
@@ -184,7 +184,7 @@ function ManifestLoader(config) {
                     // Compare with ManifestUpdater/DashManifestModel
                     if (manifest.hasOwnProperty(Constants.LOCATION)) {
                         baseUri = urlUtils.parseBaseUrl(manifest.Location_asArray[0]);
-                        log('BaseURI set by Location to: ' + baseUri);
+                        logger.debug('BaseURI set by Location to: ' + baseUri);
                     }
 
                     manifest.baseUri = baseUri;

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -36,10 +36,10 @@ import Debug from '../core/Debug';
 function ManifestUpdater() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         refreshDelay,
         refreshTimer,
         isPaused,
@@ -49,6 +49,10 @@ function ManifestUpdater() {
         dashManifestModel,
         mediaPlayerModel,
         errHandler;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function setConfig(config) {
         if (!config) return;
@@ -115,7 +119,7 @@ function ManifestUpdater() {
         }
 
         if (!isNaN(delay)) {
-            log('Refresh manifest in ' + delay + ' milliseconds.');
+            logger.debug('Refresh manifest in ' + delay + ' milliseconds.');
             refreshTimer = setTimeout(onRefreshTimer, delay);
         }
     }
@@ -144,7 +148,7 @@ function ManifestUpdater() {
             refreshDelay = 0x7FFFFFFF / 1000;
         }
         eventBus.trigger(Events.MANIFEST_UPDATED, {manifest: manifest});
-        log('Manifest has been refreshed at ' + date + '[' + date.getTime() / 1000 + '] ');
+        logger.info('Manifest has been refreshed at ' + date + '[' + date.getTime() / 1000 + '] ');
 
         if (!isPaused) {
             startManifestRefreshTimer();
@@ -193,6 +197,7 @@ function ManifestUpdater() {
         reset: reset
     };
 
+    setup();
     return instance;
 }
 ManifestUpdater.__dashjs_factory_name = 'ManifestUpdater';

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -83,12 +83,12 @@ function MediaPlayer() {
     const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
     const MEDIA_PLAYER_BAD_ARGUMENT_ERROR = 'MediaPlayer Invalid Arguments!';
 
-    let context = this.context;
-    let eventBus = EventBus(context).getInstance();
-    let debug = Debug(context).getInstance();
-    let log = debug.log;
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+    const debug = Debug(context).getInstance();
 
     let instance,
+        logger,
         source,
         protectionData,
         mediaPlayerInitialized,
@@ -123,6 +123,7 @@ function MediaPlayer() {
     ---------------------------------------------------------------------------
     */
     function setup() {
+        logger = debug.getLogger(instance);
         mediaPlayerInitialized = false;
         playbackInitialized = false;
         streamingInitialized = false;
@@ -184,7 +185,6 @@ function MediaPlayer() {
      * @instance
      */
     function initialize(view, source, AutoPlay) {
-
         if (!capabilities) {
             capabilities = Capabilities(context).getInstance();
         }
@@ -248,7 +248,7 @@ function MediaPlayer() {
             attachSource(source);
         }
 
-        log('[dash.js ' + getVersion() + '] ' + 'MediaPlayer has been initialized');
+        logger.info('[dash.js ' + getVersion() + '] ' + 'MediaPlayer has been initialized');
     }
 
     /**
@@ -563,7 +563,7 @@ function MediaPlayer() {
                 const buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));
                 return buffer ? buffer : NaN;
             } else {
-                log('Warning  - getBufferLength requested for invalid type');
+                logger.warn('Warning  - getBufferLength requested for invalid type');
                 return NaN;
             }
         }
@@ -1239,7 +1239,7 @@ function MediaPlayer() {
         if (value === Constants.ABR_STRATEGY_DYNAMIC || value === Constants.ABR_STRATEGY_BOLA || value === Constants.ABR_STRATEGY_THROUGHPUT) {
             mediaPlayerModel.setABRStrategy(value);
         } else {
-            log('Warning: Ignoring setABRStrategy(' + value + ') - unknown value.');
+            logger.warn('Warning: Ignoring setABRStrategy(' + value + ') - unknown value.');
         }
     }
 
@@ -1321,7 +1321,7 @@ function MediaPlayer() {
         if (value === Constants.MOVING_AVERAGE_SLIDING_WINDOW || value === Constants.MOVING_AVERAGE_EWMA) {
             mediaPlayerModel.setMovingAverageMethod(value);
         } else {
-            log('Warning: Ignoring setMovingAverageMethod(' + value + ') - unknown value.');
+            logger.warn('Warning: Ignoring setMovingAverageMethod(' + value + ') - unknown value.');
         }
     }
 
@@ -2611,9 +2611,8 @@ function MediaPlayer() {
     }
 
     function createPlaybackControllers() {
-
         // creates or get objects instances
-        let manifestLoader = createManifestLoader();
+        const manifestLoader = createManifestLoader();
 
         if (!streamController) {
             streamController = StreamController(context).getInstance();
@@ -2708,7 +2707,7 @@ function MediaPlayer() {
                 capabilities = Capabilities(context).getInstance();
             }
             protectionController = protection.createProtectionSystem({
-                log: log,
+                debug: debug,
                 errHandler: errHandler,
                 videoModel: videoModel,
                 capabilities: capabilities,
@@ -2733,7 +2732,7 @@ function MediaPlayer() {
             let metricsReporting = MetricsReporting(context).create();
 
             metricsReportingController = metricsReporting.createMetricsReporting({
-                log: log,
+                debug: debug,
                 eventBus: eventBus,
                 mediaElement: getVideoElement(),
                 dashManifestModel: dashManifestModel,
@@ -2761,7 +2760,7 @@ function MediaPlayer() {
                 errHandler: errHandler,
                 events: Events,
                 constants: Constants,
-                log: log,
+                debug: debug,
                 initSegmentType: HTTPRequest.INIT_SEGMENT_TYPE,
                 BASE64: BASE64,
                 ISOBoxer: ISOBoxer
@@ -2798,7 +2797,7 @@ function MediaPlayer() {
     function initializePlayback() {
         if (!streamingInitialized && source) {
             streamingInitialized = true;
-            log('Streaming Initialized');
+            logger.info('Streaming Initialized');
             createPlaybackControllers();
 
             if (typeof source === 'string') {
@@ -2810,7 +2809,7 @@ function MediaPlayer() {
 
         if (!playbackInitialized && isReady()) {
             playbackInitialized = true;
-            log('Playback Initialized');
+            logger.info('Playback Initialized');
         }
     }
 
@@ -2970,7 +2969,7 @@ function MediaPlayer() {
 }
 
 MediaPlayer.__dashjs_factory_name = 'MediaPlayer';
-let factory = FactoryMaker.getClassFactory(MediaPlayer);
+const factory = FactoryMaker.getClassFactory(MediaPlayer);
 factory.events = MediaPlayerEvents;
 FactoryMaker.updateClassFactory(MediaPlayer.__dashjs_factory_name, factory);
 

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -97,8 +97,9 @@ class MediaPlayerEvents extends EventsBase {
         this.FRAGMENT_LOADING_ABANDONED = 'fragmentLoadingAbandoned';
 
         /**
-         * Triggered when {@link module:Debug} log method is called.
+         * Triggered when {@link module:Debug} logger methods are called.
          * @event MediaPlayerEvents#LOG
+         * @deprecated
          */
         this.LOG = 'log';
 

--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -39,7 +39,7 @@ function MediaPlayerFactory() {
         context = context || {};
         player = MediaPlayer(context).create();
         player.initialize(video, source.src, video.autoplay);
-        player.getDebug().log('Converted ' + videoID + ' to dash.js player and added content: ' + source.src);
+        player.getDebug().debug.info('Converted ' + videoID + ' to dash.js player and added content: ' + source.src);
 
         // Store a reference to the player on the video element so it can be gotten at for debugging and so we know its
         // already been setup.

--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -40,11 +40,16 @@ import FactoryMaker from '../core/FactoryMaker';
  */
 function PreBufferSink(onAppendedCallback) {
     const context = this.context;
-    const log = Debug(context).getInstance().log;
 
+    let instance,
+        logger;
     let chunks = [];
     let outstandingInit;
     let onAppended = onAppendedCallback;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function reset() {
         chunks = [];
@@ -61,7 +66,7 @@ function PreBufferSink(onAppendedCallback) {
             outstandingInit = chunk;
         }
 
-        log('PreBufferSink appended chunk s: ' + chunk.start + '; e: ' + chunk.end);
+        logger.debug('PreBufferSink appended chunk s: ' + chunk.start + '; e: ' + chunk.end);
         if (onAppended) {
             onAppended({
                 chunk: chunk
@@ -133,7 +138,7 @@ function PreBufferSink(onAppendedCallback) {
         return chunks.filter( a => ((isNaN(end) || a.start < end) && (isNaN(start) || a.end > start)) );
     }
 
-    const instance = {
+    instance = {
         getAllBufferRanges: getAllBufferRanges,
         append: append,
         remove: remove,
@@ -141,6 +146,8 @@ function PreBufferSink(onAppendedCallback) {
         discharge: discharge,
         reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -40,16 +40,18 @@ import TextController from './text/TextController';
  */
 function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
 
-    let buffer,
+    let instance,
+        logger,
+        buffer,
         isAppendingInProgress;
 
     let appendQueue = [];
     let onAppended = onAppendedCallback;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         isAppendingInProgress = false;
 
         const codec = mediaInfo.codec;
@@ -79,7 +81,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
             try {
                 mediaSource.removeSourceBuffer(buffer);
             } catch (e) {
-                log('Failed to remove source buffer from media source.');
+                logger.error('Failed to remove source buffer from media source.');
             }
             isAppendingInProgress = false;
             buffer = null;
@@ -170,7 +172,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
                     waitForUpdateEnd(buffer, afterSuccess.bind(this));
                 }
             } catch (err) {
-                log('SourceBuffer append failed "' + err + '"');
+                logger.fatal('SourceBuffer append failed "' + err + '"');
                 if (appendQueue.length > 0) {
                     appendNextInQueue();
                 } else {
@@ -219,7 +221,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
                 buffer.abort(); //The cues need to be removed from the TextSourceBuffer via a call to abort()
             }
         } catch (ex) {
-            log('SourceBuffer append abort failed: "' + ex + '"');
+            logger.error('SourceBuffer append abort failed: "' + ex + '"');
         }
 
         appendQueue = [];
@@ -263,7 +265,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback) {
         }
     }
 
-    const instance = {
+    instance = {
         getAllBufferRanges: getAllBufferRanges,
         getBuffer: getBuffer,
         append: append,

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -42,26 +42,26 @@ function Stream(config) {
 
     const DATA_UPDATE_FAILED_ERROR_CODE = 1;
     config = config || {};
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
-    let manifestModel = config.manifestModel;
-    let dashManifestModel = config.dashManifestModel;
-    let mediaPlayerModel = config.mediaPlayerModel;
-    let manifestUpdater = config.manifestUpdater;
-    let adapter = config.adapter;
-    let capabilities = config.capabilities;
-    let errHandler = config.errHandler;
-    let timelineConverter = config.timelineConverter;
-    let metricsModel = config.metricsModel;
-    let abrController = config.abrController;
-    let playbackController = config.playbackController;
-    let mediaController = config.mediaController;
-    let textController = config.textController;
-    let videoModel = config.videoModel;
+    const manifestModel = config.manifestModel;
+    const dashManifestModel = config.dashManifestModel;
+    const mediaPlayerModel = config.mediaPlayerModel;
+    const manifestUpdater = config.manifestUpdater;
+    const adapter = config.adapter;
+    const capabilities = config.capabilities;
+    const errHandler = config.errHandler;
+    const timelineConverter = config.timelineConverter;
+    const metricsModel = config.metricsModel;
+    const abrController = config.abrController;
+    const playbackController = config.playbackController;
+    const mediaController = config.mediaController;
+    const textController = config.textController;
+    const videoModel = config.videoModel;
 
     let instance,
+        logger,
         streamProcessors,
         isStreamActivated,
         isMediaInitialized,
@@ -75,6 +75,7 @@ function Stream(config) {
         trackChangedEvent;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
         fragmentController = FragmentController(context).create({
@@ -150,7 +151,7 @@ function Stream(config) {
         if (streamProcessors.length === 0) {
             let msg = 'No streams to play.';
             errHandler.manifestError(msg, 'nostreams', manifestModel.getValue());
-            log(msg);
+            logger.fatal(msg);
         }
     }
 
@@ -173,8 +174,6 @@ function Stream(config) {
         }
 
         resetInitialSettings();
-
-        log = null;
 
         eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, instance);
         eventBus.off(Events.BUFFERING_COMPLETED, onBufferingCompleted, instance);
@@ -252,7 +251,7 @@ function Stream(config) {
     function onProtectionError(event) {
         if (event.error) {
             errHandler.mediaKeySessionError(event.error);
-            log(event.error);
+            logger.fatal(event.error);
             reset();
         }
     }
@@ -268,7 +267,7 @@ function Stream(config) {
 
         if (type === Constants.MUXED && mediaInfo) {
             msg = 'Multiplexed representations are intentionally not supported, as they are not compliant with the DASH-AVC/264 guidelines';
-            log(msg);
+            logger.fatal(msg);
             errHandler.manifestError(msg, 'multiplexedrep', manifestModel.getValue());
             return false;
         }
@@ -277,13 +276,13 @@ function Stream(config) {
             return true;
         }
         codec = mediaInfo.codec;
-        log(type + ' codec: ' + codec);
+        logger.debug(type + ' codec: ' + codec);
 
         if (!!mediaInfo.contentProtection && !capabilities.supportsEncryptedMedia()) {
             errHandler.capabilityError('encryptedmedia');
         } else if (!capabilities.supportsCodec(codec)) {
             msg = type + 'Codec (' + codec + ') is not supported.';
-            log(msg);
+            logger.error(msg);
             return false;
         }
 
@@ -297,13 +296,13 @@ function Stream(config) {
         if (!processor) return;
 
         let currentTime = playbackController.getTime();
-        log('Stream -  Process track changed at current time ' + currentTime);
+        logger.info('Stream -  Process track changed at current time ' + currentTime);
         let mediaInfo = e.newMediaInfo;
         let manifest = manifestModel.getValue();
 
-        log('Stream -  Update stream controller');
+        logger.debug('Stream -  Update stream controller');
         if (manifest.refreshManifestOnSwitchTrack) {
-            log('Stream -  Refreshing manifest for switch track');
+            logger.debug('Stream -  Refreshing manifest for switch track');
             trackChangedEvent = e;
             manifestUpdater.refreshManifest();
         } else {
@@ -376,7 +375,7 @@ function Stream(config) {
         let initialMediaInfo;
 
         if (!allMediaForType || allMediaForType.length === 0) {
-            log('No ' + type + ' data.');
+            logger.info('No ' + type + ' data.');
             return;
         }
 
@@ -455,11 +454,10 @@ function Stream(config) {
         isUpdating = false;
 
         if (streamProcessors.length === 0) {
-            let msg = 'No streams to play.';
+            const msg = 'No streams to play.';
             errHandler.manifestError(msg, 'nostreams', manifestModel.getValue());
-            log(msg);
+            logger.fatal(msg);
         } else {
-            //log("Playback initialized!");
             checkIfInitializationCompleted();
         }
     }
@@ -476,7 +474,7 @@ function Stream(config) {
 
             const codec = dashManifestModel.getCodec(realAdaptation, i, true);
             if (!capabilities.supportsCodec(codec)) {
-                log('[Stream] codec not supported: ' + codec);
+                logger.error('[Stream] codec not supported: ' + codec);
                 return false;
             }
             return true;
@@ -545,7 +543,7 @@ function Stream(config) {
         const ln = processors.length;
 
         if (ln === 0) {
-            log('[Stream] onBufferingCompleted - can\'t trigger STREAM_BUFFERING_COMPLETED because no streamProcessor is defined');
+            logger.warn('onBufferingCompleted - can\'t trigger STREAM_BUFFERING_COMPLETED because no streamProcessor is defined');
             return;
         }
 
@@ -553,12 +551,12 @@ function Stream(config) {
         for (let i = 0; i < ln; i++) {
             //if audio or video buffer is not buffering completed state, do not send STREAM_BUFFERING_COMPLETED
             if (!processors[i].isBufferingCompleted() && (processors[i].getType() === Constants.AUDIO || processors[i].getType() === Constants.VIDEO)) {
-                log('[Stream] onBufferingCompleted - can\'t trigger STREAM_BUFFERING_COMPLETED because streamProcessor ' + processors[i].getType() + ' is not buffering completed');
+                logger.warn('onBufferingCompleted - can\'t trigger STREAM_BUFFERING_COMPLETED because streamProcessor ' + processors[i].getType() + ' is not buffering completed');
                 return;
             }
         }
 
-        log('[Stream] onBufferingCompleted - trigger STREAM_BUFFERING_COMPLETED');
+        logger.debug('onBufferingCompleted - trigger STREAM_BUFFERING_COMPLETED');
 
         eventBus.trigger(Events.STREAM_BUFFERING_COMPLETED, {
             streamInfo: streamInfo
@@ -608,8 +606,7 @@ function Stream(config) {
     }
 
     function updateData(updatedStreamInfo) {
-
-        log('Manifest updated... updating data system wide.');
+        logger.info('Manifest updated... updating data system wide.');
 
         isStreamActivated = false;
         isUpdating = true;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -58,7 +58,7 @@ function AbrController() {
     const eventBus = EventBus(context).getInstance();
 
     let instance,
-        log,
+        logger,
         abrRulesCollection,
         streamController,
         autoSwitchBitrate,
@@ -90,8 +90,7 @@ function AbrController() {
         useDeadTimeLatency;
 
     function setup() {
-        log = debug.log.bind(instance);
-
+        logger = debug.getLogger(instance);
         resetInitialSettings();
     }
 
@@ -428,7 +427,7 @@ function AbrController() {
                     }
                 } else if (debug.getLogToBrowserConsole()) {
                     const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
-                    log('AbrController (' + type + ') stay on ' + oldQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')');
+                    logger.debug('AbrController (' + type + ') stay on ' + oldQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')');
                 }
             }
         }
@@ -453,7 +452,7 @@ function AbrController() {
             const id = streamInfo ? streamInfo.id : null;
             if (debug.getLogToBrowserConsole()) {
                 const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
-                log('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
+                logger.info('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
             }
             setQualityFor(type, id, newQuality);
             eventBus.trigger(Events.QUALITY_CHANGE_REQUESTED, {mediaType: type, streamInfo: streamInfo, oldQuality: oldQuality, newQuality: newQuality, reason: reason});
@@ -551,9 +550,9 @@ function AbrController() {
 
         if (newUseBufferABR !== useBufferABR) {
             if (newUseBufferABR) {
-                log('AbrController (' + mediaType + ') switching from throughput to buffer occupancy ABR rule (buffer: ' + bufferLevel.toFixed(3) + ').');
+                logger.info('AbrController (' + mediaType + ') switching from throughput to buffer occupancy ABR rule (buffer: ' + bufferLevel.toFixed(3) + ').');
             } else {
-                log('AbrController (' + mediaType + ') switching from buffer occupancy to throughput ABR rule (buffer: ' + bufferLevel.toFixed(3) + ').');
+                logger.info('AbrController (' + mediaType + ') switching from buffer occupancy to throughput ABR rule (buffer: ' + bufferLevel.toFixed(3) + ').');
             }
         }
     }
@@ -642,7 +641,7 @@ function AbrController() {
         if (isNaN(maxRepresentationRatio) || maxRepresentationRatio >= 1 || maxRepresentationRatio < 0) {
             return idx;
         }
-        return Math.min( idx , Math.round(maxIdx * maxRepresentationRatio) );
+        return Math.min(idx , Math.round(maxIdx * maxRepresentationRatio) );
     }
 
     function setWindowResizeEventCalled(value) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -70,7 +70,7 @@ function BufferController(config) {
     const streamProcessor = config.streamProcessor;
 
     let instance,
-        log,
+        logger,
         requiredQuality,
         isBufferingCompleted,
         bufferLevel,
@@ -95,7 +95,7 @@ function BufferController(config) {
 
 
     function setup() {
-        log = Debug(context).getInstance().log.bind(instance);
+        logger = Debug(context).getInstance().getLogger(instance);
         initCache = InitCache(context).getInstance();
         chunksToAppend = [];
 
@@ -135,7 +135,7 @@ function BufferController(config) {
                     buffer.getBuffer().initialize(type, streamProcessor);
                 }
             } catch (e) {
-                log('Caught error on create SourceBuffer: ' + e);
+                logger.fatal('Caught error on create SourceBuffer: ' + e);
                 errHandler.mediaSourceError('Error creating ' + type + ' source buffer.');
             }
         } else {
@@ -153,9 +153,9 @@ function BufferController(config) {
                 for (let i = 0; i < ranges.length; i++) {
                     rangeStr += ' start: ' + ranges.start(i) + ', end: ' + ranges.end(i) + ';';
                 }
-                log(rangeStr);
+                logger.debug(rangeStr);
             } else {
-                log('PreBuffer discharge requested, but there were no media segments in the PreBuffer.');
+                logger.debug('PreBuffer discharge requested, but there were no media segments in the PreBuffer.');
             }
 
             let chunks = dischargeBuffer.discharge();
@@ -183,9 +183,9 @@ function BufferController(config) {
 
     function onInitFragmentLoaded(e) {
         if (e.fragmentModel !== streamProcessor.getFragmentModel()) return;
-        log('Init fragment finished loading saving to', type + '\'s init cache');
+        logger.info('Init fragment finished loading saving to', type + '\'s init cache');
         initCache.save(e.chunk);
-        log('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality);
+        logger.debug('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality);
         appendToBuffer(e.chunk);
     }
 
@@ -193,7 +193,7 @@ function BufferController(config) {
         const chunk = initCache.extract(streamId, representationId);
         bufferResetInProgress = bufferResetEnabled === true ? bufferResetEnabled : false;
         if (chunk) {
-            log('Append Init fragment', type, ' with representationId:', chunk.representationId, ' and quality:', chunk.quality);
+            logger.info('Append Init fragment', type, ' with representationId:', chunk.representationId, ' and quality:', chunk.quality);
             appendToBuffer(chunk);
         } else {
             eventBus.trigger(Events.INIT_REQUESTED, { sender: instance });
@@ -225,7 +225,7 @@ function BufferController(config) {
             mediaChunk = chunk;
             const ranges = buffer && buffer.getAllBufferRanges();
             if (ranges && ranges.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
-                log('Clearing buffer because track changed - ' + (ranges.end(ranges.length - 1) + BUFFER_END_THRESHOLD));
+                logger.debug('Clearing buffer because track changed - ' + (ranges.end(ranges.length - 1) + BUFFER_END_THRESHOLD));
                 clearBuffers([{
                     start: 0,
                     end: ranges.end(ranges.length - 1) + BUFFER_END_THRESHOLD,
@@ -251,21 +251,19 @@ function BufferController(config) {
         }
     }
 
-    /*
     function showBufferRanges(ranges) {
         if (ranges && ranges.length > 0) {
             for (let i = 0, len = ranges.length; i < len; i++) {
-                log('Buffered Range for type:', type, ':', ranges.start(i), ' - ', ranges.end(i), ' currentTime = ', playbackController.getTime());
+                logger.debug('Buffered Range for type:', type, ':', ranges.start(i), ' - ', ranges.end(i), ' currentTime = ', playbackController.getTime());
             }
         }
     }
-    */
 
     function onAppended(e) {
         if (e.error) {
             if (e.error.code === QUOTA_EXCEEDED_ERROR_CODE) {
                 criticalBufferLevel = getTotalBufferedTime() * 0.8;
-                log('Quota exceeded for type: ' + type + ', Critical Buffer: ' + criticalBufferLevel);
+                logger.warn('Quota exceeded for type: ' + type + ', Critical Buffer: ' + criticalBufferLevel);
 
                 if (criticalBufferLevel > 0) {
                     // recalculate buffer lengths to keep (bufferToKeep, bufferAheadToKeep, bufferTimeAtTopQuality) according to criticalBufferLevel
@@ -276,7 +274,7 @@ function BufferController(config) {
                 }
             }
             if (e.error.code === QUOTA_EXCEEDED_ERROR_CODE || !hasEnoughSpaceToAppend()) {
-                log('Clearing playback buffer to overcome quota exceed situation for type: ' + type);
+                logger.warn('Clearing playback buffer to overcome quota exceed situation for type: ' + type);
                 eventBus.trigger(Events.QUOTA_EXCEEDED, { sender: instance, criticalBufferLevel: criticalBufferLevel }); //Tells ScheduleController to stop scheduling.
                 pruneAllSafely(); // Then we clear the buffer and onCleared event will tell ScheduleController to start scheduling again.
             }
@@ -291,12 +289,12 @@ function BufferController(config) {
 
         const ranges = buffer.getAllBufferRanges();
         if (appendedBytesInfo.segmentType === HTTPRequest.MEDIA_SEGMENT_TYPE) {
-            // showBufferRanges(ranges);
+            showBufferRanges(ranges);
             onPlaybackProgression();
         } else {
             if (bufferResetInProgress) {
                 const currentTime = playbackController.getTime();
-                log('[BufferController][', type,'] appendToBuffer seek target should be ' + currentTime);
+                logger.debug('AppendToBuffer seek target should be ' + currentTime);
                 streamProcessor.getScheduleController().setSeekTarget(currentTime);
                 adapter.setIndexHandlerTime(streamProcessor, currentTime);
             }
@@ -379,7 +377,7 @@ function BufferController(config) {
 
         // There is no request in current time position yet. Let's remove everything
         if (!currentTimeRequest) {
-            log('getAllRangesWithSafetyFactor for', type, '- No request found in current time position, removing full buffer 0 -', endOfBuffer);
+            logger.debug('getAllRangesWithSafetyFactor for', type, '- No request found in current time position, removing full buffer 0 -', endOfBuffer);
             clearRanges.push({
                 start: 0,
                 end: endOfBuffer
@@ -528,7 +526,7 @@ function BufferController(config) {
         const isLastIdxAppended = maxAppendedIndex >= lastIndex - 1; // Handles 0 and non 0 based request index
         if (isLastIdxAppended && !isBufferingCompleted && buffer.discharge === undefined) {
             isBufferingCompleted = true;
-            log('[BufferController][' + type + '] checkIfBufferingCompleted trigger BUFFERING_COMPLETED');
+            logger.debug('checkIfBufferingCompleted trigger BUFFERING_COMPLETED');
             eventBus.trigger(Events.BUFFERING_COMPLETED, { sender: instance, streamInfo: streamProcessor.getStreamInfo() });
         }
     }
@@ -540,7 +538,7 @@ function BufferController(config) {
         if (seekClearedBufferingCompleted && !isBufferingCompleted && playbackController && playbackController.getTimeToStreamEnd() - bufferLevel < STALL_THRESHOLD) {
             seekClearedBufferingCompleted = false;
             isBufferingCompleted = true;
-            log('[BufferController][' + type + '] checkIfSufficientBuffer trigger BUFFERING_COMPLETED');
+            logger.debug('checkIfSufficientBuffer trigger BUFFERING_COMPLETED');
             eventBus.trigger(Events.BUFFERING_COMPLETED, { sender: instance, streamInfo: streamProcessor.getStreamInfo() });
         }
         if (bufferLevel < STALL_THRESHOLD && !isBufferingCompleted) {
@@ -559,7 +557,7 @@ function BufferController(config) {
 
         eventBus.trigger(Events.BUFFER_LEVEL_STATE_CHANGED, { sender: instance, state: state, mediaType: type, streamInfo: streamProcessor.getStreamInfo() });
         eventBus.trigger(state === BUFFER_LOADED ? Events.BUFFER_LOADED : Events.BUFFER_EMPTY, { mediaType: type });
-        log(state === BUFFER_LOADED ? 'Got enough buffer to start for ' + type : 'Waiting for more buffer before starting playback for ' + type);
+        logger.debug(state === BUFFER_LOADED ? 'Got enough buffer to start for ' + type : 'Waiting for more buffer before starting playback for ' + type);
     }
 
 
@@ -666,7 +664,7 @@ function BufferController(config) {
     function clearNextRange() {
         // If there's nothing to prune reset state
         if (pendingPruningRanges.length === 0 || !buffer) {
-            log('Nothing to prune, halt pruning');
+            logger.debug('Nothing to prune, halt pruning');
             pendingPruningRanges = [];
             isPruningInProgress = false;
             return;
@@ -675,14 +673,14 @@ function BufferController(config) {
         const sourceBuffer = buffer.getBuffer();
         // If there's nothing buffered any pruning is invalid, so reset our state
         if (!sourceBuffer || !sourceBuffer.buffered || sourceBuffer.buffered.length === 0) {
-            log('SourceBuffer is empty (or does not exist), halt pruning');
+            logger.debug('SourceBuffer is empty (or does not exist), halt pruning');
             pendingPruningRanges = [];
             isPruningInProgress = false;
             return;
         }
 
         const range = pendingPruningRanges.shift();
-        log('Removing', type, 'buffer from:', range.start, 'to', range.end);
+        logger.debug('Removing', type, 'buffer from:', range.start, 'to', range.end);
         isPruningInProgress = true;
 
         // If removing buffer ahead current playback position, update maxAppendedIndex
@@ -702,17 +700,17 @@ function BufferController(config) {
     function onRemoved(e) {
         if (buffer !== e.buffer) return;
 
-        log('[BufferController][', type,'] onRemoved buffer from:', e.from, 'to', e.to);
+        logger.debug('onRemoved buffer from:', e.from, 'to', e.to);
 
-        // const ranges = buffer.getAllBufferRanges();
-        // showBufferRanges(ranges);
+        const ranges = buffer.getAllBufferRanges();
+        showBufferRanges(ranges);
 
         if (pendingPruningRanges.length === 0) {
             isPruningInProgress = false;
         }
 
         if (e.unintended) {
-            log('[BufferController][', type,'] detected unintended removal from:', e.from, 'to', e.to, 'setting index handler time to', e.from);
+            logger.warn('Detected unintended removal from:', e.from, 'to', e.to, 'setting index handler time to', e.from);
             adapter.setIndexHandlerTime(streamProcessor, e.from);
         }
 
@@ -720,7 +718,7 @@ function BufferController(config) {
             clearNextRange();
         } else {
             if (!bufferResetInProgress) {
-                log('onRemoved : call updateBufferLevel');
+                logger.debug('onRemoved : call updateBufferLevel');
                 updateBufferLevel();
             } else {
                 bufferResetInProgress = false;
@@ -757,7 +755,7 @@ function BufferController(config) {
         const ranges = buffer && buffer.getAllBufferRanges();
         if (!ranges || (e.newMediaInfo.type !== type) || (e.newMediaInfo.streamInfo.id !== streamProcessor.getStreamInfo().id)) return;
 
-        log('[BufferController][' + type + '] track change asked');
+        logger.info('Track change asked');
         if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
             if (ranges && ranges.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
                 isBufferingCompleted = false;

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -39,11 +39,11 @@ function EventController() {
     const MPD_RELOAD_SCHEME = 'urn:mpeg:dash:event:2012';
     const MPD_RELOAD_VALUE = 1;
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         inlineEvents, // Holds all Inline Events not triggered yet
         inbandEvents, // Holds all Inband Events not triggered yet
         activeEvents, // Holds all Events currently running
@@ -56,6 +56,7 @@ function EventController() {
         isStarted;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
     }
 
@@ -85,7 +86,7 @@ function EventController() {
 
     function start() {
         checkSetConfigCall();
-        log('Start Event Controller');
+        logger.debug('Start Event Controller');
         if (!isStarted && !isNaN(refreshDelay)) {
             isStarted = true;
             eventInterval = setInterval(onEventTimer, refreshDelay);
@@ -105,10 +106,10 @@ function EventController() {
             for (var i = 0; i < values.length; i++) {
                 var event = values[i];
                 inlineEvents[event.id] = event;
-                log('Add inline event with id ' + event.id);
+                logger.debug('Add inline event with id ' + event.id);
             }
         }
-        log('Added ' + values.length + ' inline events');
+        logger.debug('Added ' + values.length + ' inline events');
     }
 
     /**
@@ -125,9 +126,9 @@ function EventController() {
                     handleManifestReloadEvent(event);
                 }
                 inbandEvents[event.id] = event;
-                log('Add inband event with id ' + event.id);
+                logger.debug('Add inband event with id ' + event.id);
             } else {
-                log('Repeated event with id ' + event.id);
+                logger.debug('Repeated event with id ' + event.id);
             }
         }
     }
@@ -142,7 +143,7 @@ function EventController() {
             } else {
                 newDuration = (event.presentationTime + event.duration) / timescale;
             }
-            log('Manifest validity changed: Valid until: ' + validUntil + '; remaining duration: ' + newDuration);
+            logger.info('Manifest validity changed: Valid until: ' + validUntil + '; remaining duration: ' + newDuration);
             eventBus.trigger(Events.MANIFEST_VALIDITY_CHANGED, {
                 id: event.id,
                 validUntil: validUntil,
@@ -164,7 +165,7 @@ function EventController() {
                 var eventId = eventIds[i];
                 var curr = activeEvents[eventId];
                 if (curr !== null && (curr.duration + curr.presentationTime) / curr.eventStream.timescale < currentVideoTime) {
-                    log('Remove Event ' + eventId + ' at time ' + currentVideoTime);
+                    logger.debug('Remove Event ' + eventId + ' at time ' + currentVideoTime);
                     curr = null;
                     delete activeEvents[eventId];
                 }
@@ -200,7 +201,7 @@ function EventController() {
                 if (curr !== undefined) {
                     presentationTime = curr.presentationTime / curr.eventStream.timescale;
                     if (presentationTime === 0 || (presentationTime <= currentVideoTime && presentationTime + presentationTimeThreshold > currentVideoTime)) {
-                        log('Start Event ' + eventId + ' at ' + currentVideoTime);
+                        logger.debug('Start Event ' + eventId + ' at ' + currentVideoTime);
                         if (curr.duration > 0) {
                             activeEvents[eventId] = curr;
                         }

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -43,7 +43,6 @@ function FragmentController( config ) {
 
     config = config || {};
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
 
     const errHandler = config.errHandler;
@@ -51,9 +50,11 @@ function FragmentController( config ) {
     const metricsModel = config.metricsModel;
 
     let instance,
+        logger,
         fragmentModels;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
         eventBus.on(Events.FRAGMENT_LOADING_COMPLETED, onFragmentLoadingCompleted, instance);
         eventBus.on(Events.FRAGMENT_LOADING_PROGRESS, onFragmentLoadingCompleted, instance);
@@ -131,7 +132,7 @@ function FragmentController( config ) {
         }
 
         if (!bytes || !streamInfo) {
-            log('No ' + request.mediaType + ' bytes to push or stream is inactive.');
+            logger.warn('No ' + request.mediaType + ' bytes to push or stream is inactive.');
             return;
         }
         const chunk = createDataChunk(bytes, request, streamInfo.id, e.type !== Events.FRAGMENT_LOADING_PROGRESS);

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -42,11 +42,11 @@ const DEFAULT_INIT_TRACK_SELECTION_MODE = TRACK_SELECTION_MODE_HIGHEST_BITRATE;
 
 function MediaController() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         tracks,
         initialSettings,
         selectionMode,
@@ -65,6 +65,7 @@ function MediaController() {
     ];
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         reset();
     }
 
@@ -75,8 +76,8 @@ function MediaController() {
      */
     function checkInitialMediaSettingsForType(type, streamInfo) {
         let settings = getInitialSettings(type);
-        let tracksForType = getTracksFor(type, streamInfo);
-        let tracks = [];
+        const tracksForType = getTracksFor(type, streamInfo);
+        const tracks = [];
 
         if (type === Constants.FRAGMENTED_TEXT) {
             // Choose the first track
@@ -117,7 +118,7 @@ function MediaController() {
     function addTrack(track) {
         if (!track) return;
 
-        let mediaType = track.type;
+        const mediaType = track.type;
         if (!isMultiTrackSupportedByType(mediaType)) return;
 
         let streamId = track.streamInfo.id;
@@ -150,7 +151,7 @@ function MediaController() {
     function getTracksFor(type, streamInfo) {
         if (!type || !streamInfo) return [];
 
-        let id = streamInfo.id;
+        const id = streamInfo.id;
 
         if (!tracks[id] || !tracks[id][type]) return [];
 
@@ -174,8 +175,8 @@ function MediaController() {
      * @memberof MediaController#
      */
     function isCurrentTrack(track) {
-        let type = track.type;
-        let id = track.streamInfo.id;
+        const type = track.type;
+        const id = track.streamInfo.id;
 
         return (tracks[id] && tracks[id][type] && isTracksEqual(tracks[id][type].current, track));
     }
@@ -187,10 +188,10 @@ function MediaController() {
     function setTrack(track) {
         if (!track) return;
 
-        let type = track.type;
-        let streamInfo = track.streamInfo;
-        let id = streamInfo.id;
-        let current = getCurrentTrackFor(type, streamInfo);
+        const type = track.type;
+        const streamInfo = track.streamInfo;
+        const id = streamInfo.id;
+        const current = getCurrentTrackFor(type, streamInfo);
 
         if (!tracks[id] || !tracks[id][type] || (current && isTracksEqual(track, current))) return;
 
@@ -251,7 +252,7 @@ function MediaController() {
         const isModeSupported = (validTrackSwitchModes.indexOf(mode) !== -1);
 
         if (!isModeSupported) {
-            log('track switch mode is not supported: ' + mode);
+            logger.warn('Track switch mode is not supported: ' + mode);
             return;
         }
 
@@ -275,7 +276,7 @@ function MediaController() {
         const isModeSupported = (validTrackSelectionModes.indexOf(mode) !== -1);
 
         if (!isModeSupported) {
-            log('track selection mode is not supported: ' + mode);
+            logger.warn('Track selection mode is not supported: ' + mode);
             return;
         }
         selectionMode = mode;
@@ -306,12 +307,12 @@ function MediaController() {
      * @memberof MediaController#
      */
     function isTracksEqual(t1, t2) {
-        let sameId = t1.id === t2.id;
-        let sameViewpoint = t1.viewpoint === t2.viewpoint;
-        let sameLang = t1.lang === t2.lang;
-        let sameRoles = t1.roles.toString() === t2.roles.toString();
-        let sameAccessibility = t1.accessibility.toString() === t2.accessibility.toString();
-        let sameAudioChannelConfiguration = t1.audioChannelConfiguration.toString() === t2.audioChannelConfiguration.toString();
+        const sameId = t1.id === t2.id;
+        const sameViewpoint = t1.viewpoint === t2.viewpoint;
+        const sameLang = t1.lang === t2.lang;
+        const sameRoles = t1.roles.toString() === t2.roles.toString();
+        const sameAccessibility = t1.accessibility.toString() === t2.accessibility.toString();
+        const sameAudioChannelConfiguration = t1.audioChannelConfiguration.toString() === t2.audioChannelConfiguration.toString();
 
         return (sameId && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
     }
@@ -338,7 +339,7 @@ function MediaController() {
     }
 
     function extractSettings(mediaInfo) {
-        let settings = {
+        const settings = {
             lang: mediaInfo.lang,
             viewpoint: mediaInfo.viewpoint,
             roles: mediaInfo.roles,
@@ -352,9 +353,9 @@ function MediaController() {
     }
 
     function matchSettings(settings, track) {
-        let matchLang = !settings.lang || (settings.lang === track.lang);
-        let matchViewPoint = !settings.viewpoint || (settings.viewpoint === track.viewpoint);
-        let matchRole = !settings.role || !!track.roles.filter(function (item) {
+        const matchLang = !settings.lang || (settings.lang === track.lang);
+        const matchViewPoint = !settings.viewpoint || (settings.viewpoint === track.viewpoint);
+        const matchRole = !settings.role || !!track.roles.filter(function (item) {
             return item === settings.role;
         })[0];
         let matchAccessibility = !settings.accessibility || !!track.accessibility.filter(function (item) {
@@ -437,7 +438,7 @@ function MediaController() {
                 }
                 break;
             default:
-                log('track selection mode is not supported: ' + mode);
+                logger.warn('Track selection mode is not supported: ' + mode);
                 break;
         }
 
@@ -499,7 +500,7 @@ function MediaController() {
 }
 
 MediaController.__dashjs_factory_name = 'MediaController';
-let factory = FactoryMaker.getSingletonFactory(MediaController);
+const factory = FactoryMaker.getSingletonFactory(MediaController);
 factory.TRACK_SWITCH_MODE_NEVER_REPLACE = TRACK_SWITCH_MODE_NEVER_REPLACE;
 factory.TRACK_SWITCH_MODE_ALWAYS_REPLACE = TRACK_SWITCH_MODE_ALWAYS_REPLACE;
 factory.TRACK_SELECTION_MODE_HIGHEST_BITRATE = TRACK_SELECTION_MODE_HIGHEST_BITRATE;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -41,10 +41,10 @@ const LIVE_UPDATE_PLAYBACK_TIME_INTERVAL_MS = 500;
 function PlaybackController() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         streamController,
         metricsModel,
         dashMetrics,
@@ -66,6 +66,7 @@ function PlaybackController() {
         availabilityStartTime;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         reset();
     }
 
@@ -123,7 +124,7 @@ function PlaybackController() {
     function seek(time) {
         if (streamInfo && videoModel) {
             eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
-            log('Requesting seek to time: ' + time);
+            logger.info('Requesting seek to time: ' + time);
             videoModel.setCurrentTime(time);
         }
     }
@@ -393,7 +394,7 @@ function PlaybackController() {
     }
 
     function onPlaybackStart() {
-        log('Native video element event: play');
+        logger.info('Native video element event: play');
         updateCurrentTime();
         startUpdatingWallclockTime();
         eventBus.trigger(Events.PLAYBACK_STARTED, {
@@ -402,21 +403,21 @@ function PlaybackController() {
     }
 
     function onPlaybackWaiting() {
-        log('Native video element event: waiting');
+        logger.info('Native video element event: waiting');
         eventBus.trigger(Events.PLAYBACK_WAITING, {
             playingTime: getTime()
         });
     }
 
     function onPlaybackPlaying() {
-        log('Native video element event: playing');
+        logger.info('Native video element event: playing');
         eventBus.trigger(Events.PLAYBACK_PLAYING, {
             playingTime: getTime()
         });
     }
 
     function onPlaybackPaused() {
-        log('Native video element event: pause');
+        logger.info('Native video element event: pause');
         eventBus.trigger(Events.PLAYBACK_PAUSED, {
             ended: getEnded()
         });
@@ -424,7 +425,7 @@ function PlaybackController() {
 
     function onPlaybackSeeking() {
         const seekTime = getTime();
-        log('Seeking to: ' + seekTime);
+        logger.info('Seeking to: ' + seekTime);
         startUpdatingWallclockTime();
         eventBus.trigger(Events.PLAYBACK_SEEKING, {
             seekTime: seekTime
@@ -432,7 +433,7 @@ function PlaybackController() {
     }
 
     function onPlaybackSeeked() {
-        log('Native video element event: seeked');
+        logger.info('Native video element event: seeked');
         eventBus.trigger(Events.PLAYBACK_SEEKED);
     }
 
@@ -459,20 +460,20 @@ function PlaybackController() {
 
     function onPlaybackRateChanged() {
         const rate = getPlaybackRate();
-        log('Native video element event: ratechange: ', rate);
+        logger.info('Native video element event: ratechange: ', rate);
         eventBus.trigger(Events.PLAYBACK_RATE_CHANGED, {
             playbackRate: rate
         });
     }
 
     function onPlaybackMetaDataLoaded() {
-        log('Native video element event: loadedmetadata');
+        logger.info('Native video element event: loadedmetadata');
         eventBus.trigger(Events.PLAYBACK_METADATA_LOADED);
         startUpdatingWallclockTime();
     }
 
     function onPlaybackEnded() {
-        log('Native video element event: ended');
+        logger.info('Native video element event: ended');
         pause();
         stopUpdatingWallclockTime();
         eventBus.trigger(Events.PLAYBACK_ENDED);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -430,7 +430,7 @@ function ScheduleController(config) {
         if (e.sender !== fragmentModel) {
             return;
         }
-        logger.info('OnFragmentLoadingCompleted - Type:', type, ', Url:', e.request ? e.request.url : 'undefined');
+        logger.info('OnFragmentLoadingCompleted - Url:', e.request ? e.request.url : 'undefined');
         if (dashManifestModel.getIsTextTrack(type)) {
             setFragmentProcessState(false);
         }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -61,7 +61,7 @@ function ScheduleController(config) {
     const mediaController = config.mediaController;
 
     let instance,
-        log,
+        logger,
         fragmentModel,
         currentRepresentationInfo,
         initialRequest,
@@ -85,8 +85,7 @@ function ScheduleController(config) {
         mediaRequest;
 
     function setup() {
-        log = Debug(context).getInstance().log.bind(instance);
-
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
     }
 
@@ -137,10 +136,10 @@ function ScheduleController(config) {
 
     function start() {
         if (!currentRepresentationInfo || streamProcessor.isBufferingCompleted()) {
-            log('[ScheduleController][', type,'] start denied');
+            logger.warn('Start denied to Schedule Controller');
             return;
         }
-        log('[ScheduleController][', type,'] start');
+        logger.debug('Schedule Controller starts');
         addPlaylistTraceMetrics();
         isStopped = false;
 
@@ -155,7 +154,7 @@ function ScheduleController(config) {
         if (isStopped) {
             return;
         }
-        log('[ScheduleController][', type,'] stop');
+        logger.debug('Schedule Controller stops');
         isStopped = true;
         clearTimeout(scheduleTimeout);
     }
@@ -165,7 +164,7 @@ function ScheduleController(config) {
         const newTopQualityIndex = abrController.getTopQualityIndexFor(type, id);
 
         if (topQualityIndex[id][type] != newTopQualityIndex) {
-            log('Top quality ' + type + ' index has changed from ' + topQualityIndex[id][type] + ' to ' + newTopQualityIndex);
+            logger.info('Top quality ' + type + ' index has changed from ' + topQualityIndex[id][type] + ' to ' + newTopQualityIndex);
             topQualityIndex[id][type] = newTopQualityIndex;
             return true;
         }
@@ -175,7 +174,7 @@ function ScheduleController(config) {
 
     function schedule() {
         if (isStopped || isFragmentProcessingInProgress || !streamProcessor.getBufferController() || playbackController.isPaused() && !scheduleWhilePaused) {
-            log('[ScheduleController][', type,'] - schedule stop!');
+            logger.debug('Schedule stop!');
             return;
         }
 
@@ -190,12 +189,12 @@ function ScheduleController(config) {
             const getNextFragment = function () {
                 const fragmentController = streamProcessor.getFragmentController();
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
-                    log('ScheduleController - ' + type + ' - quality has changed, get init request for representationid = ' + currentRepresentationInfo.id);
+                    logger.debug('Quality has changed, get init request for representationid = ' + currentRepresentationInfo.id);
                     lastInitQuality = currentRepresentationInfo.quality;
 
                     streamProcessor.switchInitData(currentRepresentationInfo.id);
                 } else if (switchTrack) {
-                    log('ScheduleController - ' + type + ' - switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
+                    logger.debug('Switch track has been asked, get init request for ' + type + ' with representationid = ' + currentRepresentationInfo.id);
                     bufferResetInProgress = mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE ? true : false;
                     streamProcessor.switchInitData(currentRepresentationInfo.id, bufferResetInProgress);
                     lastInitQuality = currentRepresentationInfo.quality;
@@ -212,12 +211,12 @@ function ScheduleController(config) {
                         if (!streamProcessor.getBufferController().getIsPruningInProgress()) {
                             request = nextFragmentRequestRule.execute(streamProcessor, replacement);
                             if (!request && streamInfo.manifestInfo && streamInfo.manifestInfo.isDynamic) {
-                                log('getNextFragment - ' + type + ' - Playing at the bleeding live edge and frag is not available yet');
+                                logger.info('Playing at the bleeding live edge and frag is not available yet');
                             }
                         }
 
                         if (request) {
-                            log('ScheduleController - ' + type + ' - getNextFragment - request is ' + request.url);
+                            logger.debug('getNextFragment - request is ' + request.url);
                             fragmentModel.executeRequest(request);
                         } else { // Use case - Playing at the bleeding live edge and frag is not available yet. Cycle back around.
                             setFragmentProcessState(false);
@@ -260,7 +259,7 @@ function ScheduleController(config) {
 
             if (fastSwitchModeEnabled && (trackChanged || qualityChanged) && bufferLevel >= safeBufferLevel && abandonmentState !== AbrController.ABANDON_LOAD) {
                 replaceRequest(request);
-                log('Reloading outdated fragment at index: ', request.index);
+                logger.debug('Reloading outdated fragment at index: ', request.index);
             } else if (request.quality > currentRepresentationInfo.quality) {
                 // The buffer has better quality it in then what we would request so set append point to end of buffer!!
                 setSeekTarget(playbackController.getTime() + streamProcessor.getBufferLevel());
@@ -285,7 +284,7 @@ function ScheduleController(config) {
         if (isFragmentProcessingInProgress !== state ) {
             isFragmentProcessingInProgress = state;
         } else {
-            log('[ScheduleController][', type, '] isFragmentProcessingInProgress is already equal to', state);
+            logger.debug('isFragmentProcessingInProgress is already equal to', state);
         }
     }
 
@@ -424,14 +423,14 @@ function ScheduleController(config) {
 
         stop();
         setFragmentProcessState(false);
-        log('[ScheduleController] Stream is complete');
+        logger.info('Stream is complete');
     }
 
     function onFragmentLoadingCompleted(e) {
         if (e.sender !== fragmentModel) {
             return;
         }
-        log('[ScheduleController][', type,'] - onFragmentLoadingCompleted');
+        logger.info('OnFragmentLoadingCompleted - Type:', type, ', Url:', e.request ? e.request.url : 'undefined');
         if (dashManifestModel.getIsTextTrack(type)) {
             setFragmentProcessState(false);
         }
@@ -469,9 +468,9 @@ function ScheduleController(config) {
         if (e.streamProcessor !== streamProcessor) {
             return;
         }
-        log('[ScheduleController][onFragmentLoadingAbandoned] for ' + type + ', request: ' + e.request.url + ' has been aborted');
+        logger.info('onFragmentLoadingAbandoned for ' + type + ', request: ' + e.request.url + ' has been aborted');
         if (!playbackController.isSeeking() && !switchTrack) {
-            log('[ScheduleController][onFragmentLoadingAbandoned] for ' + type + ', request: ' + e.request.url + ' has to be downloaded again, origin is not seeking process or switch track call');
+            logger.info('onFragmentLoadingAbandoned for ' + type + ', request: ' + e.request.url + ' has to be downloaded again, origin is not seeking process or switch track call');
             replaceRequest(e.request);
         }
         setFragmentProcessState(false);
@@ -508,7 +507,7 @@ function ScheduleController(config) {
 
     function onBufferLevelStateChanged(e) {
         if ((e.sender.getStreamProcessor() === streamProcessor) && e.state === BufferController.BUFFER_EMPTY && !playbackController.isSeeking()) {
-            log('[ScheduleController][', type,'] - Buffer is empty! Stalling!');
+            logger.info('Buffer is empty! Stalling!');
             clearPlayListTraceMetrics(new Date(), PlayListTrace.REBUFFERING_REASON);
         }
     }
@@ -559,7 +558,7 @@ function ScheduleController(config) {
         if (!isFragmentProcessingInProgress) {
             startScheduleTimer(0);
         } else {
-            log('[ScheduleController][onPlaybackSeeking] for ' + type + ', call fragmentModel.abortRequests in order to seek quicker');
+            logger.debug('onPlaybackSeeking for ' + type + ', call fragmentModel.abortRequests in order to seek quicker');
             fragmentModel.abortRequests();
         }
     }

--- a/src/streaming/controllers/SourceBufferController.js
+++ b/src/streaming/controllers/SourceBufferController.js
@@ -421,7 +421,7 @@ function SourceBufferController(config) {
 }
 
 SourceBufferController.__dashjs_factory_name = 'SourceBufferController';
-let factory = FactoryMaker.getSingletonFactory(SourceBufferController);
+const factory = FactoryMaker.getSingletonFactory(SourceBufferController);
 factory.QUOTA_EXCEEDED_ERROR_CODE = QUOTA_EXCEEDED_ERROR_CODE;
 FactoryMaker.updateSingletonFactory(SourceBufferController.__dashjs_factory_name, factory);
 export default factory;

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -42,13 +42,12 @@ const HTTP_TIMEOUT_MS = 5000;
 
 function TimeSyncController() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
-
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
     const urlUtils = URLUtils(context).getInstance();
 
     let instance,
+        logger,
         offsetToDeviceTimeMs,
         isSynchronizing,
         isInitialised,
@@ -57,6 +56,10 @@ function TimeSyncController() {
         metricsModel,
         dashMetrics,
         baseURLController;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function initialize(timingSources, useManifestDateHeader) {
         useManifestDateHeaderTimeSource = useManifestDateHeader;
@@ -332,9 +335,9 @@ function TimeSyncController() {
 
                         setOffsetMs(offset);
 
-                        log('Local time:      ' + new Date(deviceTime));
-                        log('Server time:     ' + new Date(serverTime));
-                        log('Difference (ms): ' + offset);
+                        logger.debug('Local time: ' + new Date(deviceTime));
+                        logger.debug('Server time: ' + new Date(serverTime));
+                        logger.info('Server Time - Local Time (ms): ' + offset);
 
                         onComplete(serverTime, offset);
                     },
@@ -369,11 +372,13 @@ function TimeSyncController() {
         reset: reset
     };
 
+    setup();
+
     return instance;
 }
 
 TimeSyncController.__dashjs_factory_name = 'TimeSyncController';
-let factory = FactoryMaker.getSingletonFactory(TimeSyncController);
+const factory = FactoryMaker.getSingletonFactory(TimeSyncController);
 factory.TIME_SYNC_FAILED_ERROR_CODE = TIME_SYNC_FAILED_ERROR_CODE;
 factory.HTTP_TIMEOUT_MS = HTTP_TIMEOUT_MS;
 FactoryMaker.updateSingletonFactory(TimeSyncController.__dashjs_factory_name, factory);

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -84,7 +84,7 @@ function MetricsReporting() {
 }
 
 MetricsReporting.__dashjs_factory_name = 'MetricsReporting';
-let factory = dashjs.FactoryMaker.getClassFactory(MetricsReporting); /* jshint ignore:line */
+const factory = dashjs.FactoryMaker.getClassFactory(MetricsReporting); /* jshint ignore:line */
 factory.events = MetricsReportingEvents;
 dashjs.FactoryMaker.updateClassFactory(MetricsReporting.__dashjs_factory_name, factory); /* jshint ignore:line */
 export default factory;

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -52,14 +52,14 @@ function MetricsController(config) {
             rangeController.initialize(metricsEntry.Range);
 
             reportingController = ReportingController(context).create({
-                log: config.log,
+                debug: config.debug,
                 metricsConstants: config.metricsConstants
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);
 
             metricsHandlersController = MetricsHandlersController(context).create({
-                log: config.log,
+                debug: config.debug,
                 eventBus: config.eventBus,
                 metricsConstants: config.metricsConstants,
                 events: config.events

--- a/src/streaming/metrics/controllers/MetricsHandlersController.js
+++ b/src/streaming/metrics/controllers/MetricsHandlersController.js
@@ -37,12 +37,12 @@ function MetricsHandlersController(config) {
     let handlers = [];
 
     let instance;
-    let context = this.context;
-    let eventBus = config.eventBus;
+    const context = this.context;
+    const eventBus = config.eventBus;
     const Events = config.events;
 
     let metricsHandlerFactory = MetricsHandlerFactory(context).getInstance({
-        log: config.log,
+        debug: config.debug,
         eventBus: config.eventBus,
         metricsConstants: config.metricsConstants
     });

--- a/src/streaming/metrics/metrics/MetricsHandlerFactory.js
+++ b/src/streaming/metrics/metrics/MetricsHandlerFactory.js
@@ -38,12 +38,12 @@ function MetricsHandlerFactory(config) {
 
     config = config || {};
     let instance;
-    let log = config.log;
+    const debug = config.debug;
 
     // group 1: key, [group 3: n [, group 5: type]]
     let keyRegex = /([a-zA-Z]*)(\(([0-9]*)(\,\s*([a-zA-Z]*))?\))?/;
 
-    let context = this.context;
+    const context = this.context;
     let knownFactoryProducts = {
         BufferLevel:    BufferLevel,
         DVBErrors:      DVBErrors,
@@ -75,8 +75,7 @@ function MetricsHandlerFactory(config) {
             );
         } catch (e) {
             handler = null;
-
-            log(`MetricsHandlerFactory: Could not create handler for type ${matches[1]} with args ${matches[3]}, ${matches[5]} (${e.message})`);
+            debug.error(`MetricsHandlerFactory: Could not create handler for type ${matches[1]} with args ${matches[3]}, ${matches[5]} (${e.message})`);
         }
 
         return handler;

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -39,7 +39,7 @@ function ReportingFactory(config) {
     };
 
     const context = this.context;
-    const log = config.log;
+    const debug = config.debug;
     const metricsConstants = config.metricsConstants;
 
     let instance;
@@ -55,8 +55,7 @@ function ReportingFactory(config) {
             reporting.initialize(entry, rangeController);
         } catch (e) {
             reporting = null;
-
-            log(`ReportingFactory: could not create Reporting with schemeIdUri ${entry.schemeIdUri} (${e.message})`);
+            debug.error(`ReportingFactory: could not create Reporting with schemeIdUri ${entry.schemeIdUri} (${e.message})`);
         }
 
         return reporting;

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -54,7 +54,6 @@ function ManifestParsing (config) {
                 if (metric.hasOwnProperty('metrics')) {
                     metricEntry.metrics = metric.metrics;
                 } else {
-                    //console.log("Invalid Metrics. metrics must be set. Ignoring.");
                     return;
                 }
 

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -45,17 +45,18 @@ function FragmentModel(config) {
 
     config = config || {};
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const eventBus = EventBus(context).getInstance();
     const metricsModel = config.metricsModel;
     const fragmentLoader = config.fragmentLoader;
 
     let instance,
+        logger,
         streamProcessor,
         executedRequests,
         loadingRequests;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
         eventBus.on(Events.LOADING_COMPLETED, onLoadingCompleted, instance);
         eventBus.on(Events.LOADING_DATA_PROGRESS, onLoadingInProgress, instance);
@@ -203,7 +204,7 @@ function FragmentModel(config) {
             case FragmentRequest.ACTION_COMPLETE:
                 executedRequests.push(request);
                 addSchedulingInfoMetrics(request, FRAGMENT_MODEL_EXECUTED);
-                log('[FragmentModel] executeRequest trigger STREAM_COMPLETED');
+                logger.debug('executeRequest trigger STREAM_COMPLETED');
                 eventBus.trigger(Events.STREAM_COMPLETED, {
                     request: request,
                     fragmentModel: this
@@ -215,7 +216,7 @@ function FragmentModel(config) {
                 loadCurrentFragment(request);
                 break;
             default:
-                log('Unknown request action.');
+                logger.warn('Unknown request action.');
         }
     }
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -614,7 +614,7 @@ function MediaPlayerModel() {
 
 //TODO see if you can move this and not export and just getter to get default value.
 MediaPlayerModel.__dashjs_factory_name = 'MediaPlayerModel';
-let factory = FactoryMaker.getSingletonFactory(MediaPlayerModel);
+const factory = FactoryMaker.getSingletonFactory(MediaPlayerModel);
 factory.DEFAULT_UTC_TIMING_SOURCE = DEFAULT_UTC_TIMING_SOURCE;
 FactoryMaker.updateSingletonFactory(MediaPlayerModel.__dashjs_factory_name, factory);
 export default factory;

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -37,6 +37,7 @@ import Debug from '../../core/Debug';
 function VideoModel() {
 
     let instance,
+        logger,
         element,
         TTMLRenderingDiv,
         videoContainer,
@@ -44,10 +45,13 @@ function VideoModel() {
 
     const VIDEO_MODEL_WRONG_ELEMENT_TYPE = 'element is not video or audio DOM type!';
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
     const stalledStreams = [];
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function initialize() {
         eventBus.on(Events.PLAYBACK_PLAYING, onPlaying, this);
@@ -249,7 +253,7 @@ function VideoModel() {
                     if (e.name === 'NotAllowedError') {
                         eventBus.trigger(Events.PLAYBACK_NOT_ALLOWED);
                     }
-                    log(`Caught pending play exception - continuing (${e})`);
+                    logger.warn(`Caught pending play exception - continuing (${e})`);
                 });
             }
         }
@@ -411,6 +415,8 @@ function VideoModel() {
         getVideoRelativeOffsetLeft: getVideoRelativeOffsetLeft,
         reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -100,9 +100,8 @@ const APIS_ProtectionModel_3Feb2014 = [
 ];
 
 function Protection() {
-
     let instance;
-    let context = this.context;
+    const context = this.context;
 
     /**
      * Create a ProtectionController and associated ProtectionModel for use with
@@ -113,11 +112,10 @@ function Protection() {
      *
      */
     function createProtectionSystem(config) {
-
         let controller = null;
 
-        let protectionKeyController = ProtectionKeyController(context).getInstance();
-        protectionKeyController.setConfig({log: config.log, BASE64: config.BASE64});
+        const protectionKeyController = ProtectionKeyController(context).getInstance();
+        protectionKeyController.setConfig({ debug: config.debug, BASE64: config.BASE64 });
         protectionKeyController.initialize();
 
         let protectionModel =  getProtectionModel(config);
@@ -127,7 +125,7 @@ function Protection() {
                 protectionModel: protectionModel,
                 protectionKeyController: protectionKeyController,
                 eventBus: config.eventBus,
-                log: config.log,
+                debug: config.debug,
                 events: config.events,
                 BASE64: config.BASE64,
                 constants: config.constants
@@ -138,39 +136,31 @@ function Protection() {
     }
 
     function getProtectionModel(config) {
-
-        let log = config.log;
-        let eventBus = config.eventBus;
-        let errHandler = config.errHandler;
-        let videoElement = config.videoModel ? config.videoModel.getElement() : null;
+        const debug = config.debug;
+        const logger = debug.getLogger(instance);
+        const eventBus = config.eventBus;
+        const errHandler = config.errHandler;
+        const videoElement = config.videoModel ? config.videoModel.getElement() : null;
 
         if ((!videoElement || videoElement.onencrypted !== undefined) &&
             (!videoElement || videoElement.mediaKeys !== undefined)) {
-            log('EME detected on this user agent! (ProtectionModel_21Jan2015)');
-            return ProtectionModel_21Jan2015(context).create({log: log, eventBus: eventBus, events: config.events});
-
+            logger.info('EME detected on this user agent! (ProtectionModel_21Jan2015)');
+            return ProtectionModel_21Jan2015(context).create({ debug: debug, eventBus: eventBus, events: config.events });
         } else if (getAPI(videoElement, APIS_ProtectionModel_3Feb2014)) {
-
-            log('EME detected on this user agent! (ProtectionModel_3Feb2014)');
-            return ProtectionModel_3Feb2014(context).create({log: log, eventBus: eventBus, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_3Feb2014)});
-
+            logger.info('EME detected on this user agent! (ProtectionModel_3Feb2014)');
+            return ProtectionModel_3Feb2014(context).create({ debug: debug, eventBus: eventBus, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_3Feb2014) });
         } else if (getAPI(videoElement, APIS_ProtectionModel_01b)) {
-
-            log('EME detected on this user agent! (ProtectionModel_01b)');
-            return ProtectionModel_01b(context).create({log: log, eventBus: eventBus, errHandler: errHandler, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_01b)});
-
+            logger.info('EME detected on this user agent! (ProtectionModel_01b)');
+            return ProtectionModel_01b(context).create({ debug: debug, eventBus: eventBus, errHandler: errHandler, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_01b) });
         } else {
-
-            log('No supported version of EME detected on this user agent! - Attempts to play encrypted content will fail!');
+            logger.warn('No supported version of EME detected on this user agent! - Attempts to play encrypted content will fail!');
             return null;
-
         }
     }
 
     function getAPI(videoElement, apis) {
-
         for (let i = 0; i < apis.length; i++) {
-            let api = apis[i];
+            const api = apis[i];
             // detect if api is supported by browser
             // check only first function in api -> should be fine
             if (typeof videoElement[api[Object.keys(api)[0]]] !== 'function') {
@@ -191,7 +181,7 @@ function Protection() {
 }
 
 Protection.__dashjs_factory_name = 'Protection';
-let factory = dashjs.FactoryMaker.getClassFactory(Protection); /* jshint ignore:line */
+const factory = dashjs.FactoryMaker.getClassFactory(Protection); /* jshint ignore:line */
 factory.events = ProtectionEvents;
 dashjs.FactoryMaker.updateClassFactory(Protection.__dashjs_factory_name, factory); /* jshint ignore:line */
 export default factory;

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -48,7 +48,8 @@ function ProtectionKeyController() {
     let context = this.context;
 
     let instance,
-        log,
+        debug,
+        logger,
         keySystems,
         BASE64,
         clearkeyKeySystem,
@@ -57,8 +58,9 @@ function ProtectionKeyController() {
     function setConfig(config) {
         if (!config) return;
 
-        if (config.log) {
-            log = config.log;
+        if (config.debug) {
+            debug = config.debug;
+            logger = debug.getLogger(instance);
         }
 
         if (config.BASE64) {
@@ -85,7 +87,7 @@ function ProtectionKeyController() {
         clearkeyKeySystem = keySystem;
 
         // W3C ClearKey
-        keySystem = KeySystemW3CClearKey(context).getInstance({ BASE64: BASE64, log: log });
+        keySystem = KeySystemW3CClearKey(context).getInstance({ BASE64: BASE64, debug: debug });
         keySystems.push(keySystem);
         clearkeyW3CKeySystem = keySystem;
     }
@@ -298,7 +300,7 @@ function ProtectionKeyController() {
         try {
             return clearkeyKeySystem.getClearKeysFromProtectionData(protData, message);
         } catch (error) {
-            log('Failed to retrieve clearkeys from ProtectionData');
+            logger.error('Failed to retrieve clearkeys from ProtectionData');
             return null;
         }
     }

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -41,7 +41,7 @@ const schemeIdURI = 'urn:uuid:' + uuid;
 function KeySystemW3CClearKey(config) {
     let instance;
     const BASE64 = config.BASE64;
-    const log = config.log;
+    const debug = config.debug;
     /**
      * Returns desired clearkeys (as specified in the CDM message) from protection data
      *
@@ -70,7 +70,7 @@ function KeySystemW3CClearKey(config) {
             }
             clearkeySet = new ClearKeyKeySet(keyPairs);
 
-            log('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
+            debug.warn('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
         }
         return clearkeySet;
     }

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -50,11 +50,12 @@ function ProtectionModel_01b(config) {
     const context = this.context;
     const eventBus = config.eventBus;//Need to pass in here so we can use same instance since this is optional module
     const events = config.events;
-    const log = config.log;
+    const debug = config.debug;
     const api = config.api;
     const errHandler = config.errHandler;
 
     let instance,
+        logger,
         videoElement,
         keySystem,
         protectionKeyController,
@@ -83,6 +84,7 @@ function ProtectionModel_01b(config) {
         eventHandler;
 
     function setup() {
+        logger = debug.getLogger(instance);
         videoElement = null;
         keySystem = null;
         pendingSessions = [];
@@ -299,7 +301,7 @@ function ProtectionModel_01b(config) {
                             // TODO: Build error string based on key error
                             eventBus.trigger(events.KEY_ERROR, {data: new KeyError(sessionToken, msg)});
                         } else {
-                            log('No session token found for key error');
+                            logger.error('No session token found for key error');
                         }
                         break;
 
@@ -310,10 +312,10 @@ function ProtectionModel_01b(config) {
                         }
 
                         if (sessionToken) {
-                            log('DRM: Key added.');
+                            logger.debug('DRM: Key added.');
                             eventBus.trigger(events.KEY_ADDED, {data: sessionToken});//TODO not sure anything is using sessionToken? why there?
                         } else {
-                            log('No session token found for key added');
+                            logger.debug('No session token found for key added');
                         }
                         break;
 
@@ -355,7 +357,7 @@ function ProtectionModel_01b(config) {
                             eventBus.trigger(events.INTERNAL_KEY_MESSAGE, {data: new KeyMessage(sessionToken, message, event.defaultURL)});
 
                         } else {
-                            log('No session token found for key message');
+                            logger.warn('No session token found for key message');
                         }
                         break;
                 }

--- a/src/streaming/rules/DroppedFramesHistory.js
+++ b/src/streaming/rules/DroppedFramesHistory.js
@@ -46,5 +46,5 @@ function DroppedFramesHistory() {
 }
 
 DroppedFramesHistory.__dashjs_factory_name = 'DroppedFramesHistory';
-let factory = FactoryMaker.getClassFactory(DroppedFramesHistory);
+const factory = FactoryMaker.getClassFactory(DroppedFramesHistory);
 export default factory;

--- a/src/streaming/rules/SwitchRequest.js
+++ b/src/streaming/rules/SwitchRequest.js
@@ -71,7 +71,7 @@ function SwitchRequest(q, r, p) {
 }
 
 SwitchRequest.__dashjs_factory_name = 'SwitchRequest';
-let factory = FactoryMaker.getClassFactory(SwitchRequest);
+const factory = FactoryMaker.getClassFactory(SwitchRequest);
 factory.NO_CHANGE = NO_CHANGE;
 factory.PRIORITY = PRIORITY;
 FactoryMaker.updateClassFactory(SwitchRequest.__dashjs_factory_name, factory);

--- a/src/streaming/rules/SwitchRequestHistory.js
+++ b/src/streaming/rules/SwitchRequestHistory.js
@@ -86,5 +86,5 @@ function SwitchRequestHistory() {
 }
 
 SwitchRequestHistory.__dashjs_factory_name = 'SwitchRequestHistory';
-let factory = FactoryMaker.getClassFactory(SwitchRequestHistory);
+const factory = FactoryMaker.getClassFactory(SwitchRequestHistory);
 export default factory;

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -40,17 +40,18 @@ function AbandonRequestsRule(config) {
     const MIN_LENGTH_TO_AVERAGE = 5;
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
-
     const mediaPlayerModel = config.mediaPlayerModel;
     const metricsModel = config.metricsModel;
     const dashMetrics = config.dashMetrics;
 
-    let fragmentDict,
+    let instance,
+        logger,
+        fragmentDict,
         abandonDict,
         throughputArray;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         reset();
     }
 
@@ -128,7 +129,7 @@ function AbandonRequestsRule(config) {
                         switchRequest.reason.throughput = fragmentInfo.measuredBandwidthInKbps;
                         switchRequest.reason.fragmentID = fragmentInfo.id;
                         abandonDict[fragmentInfo.id] = fragmentInfo;
-                        log('AbandonRequestsRule ( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
+                        logger.debug('AbandonRequestsRule ( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
                         delete fragmentDict[mediaType][fragmentInfo.id];
                     }
                 }
@@ -146,7 +147,7 @@ function AbandonRequestsRule(config) {
         throughputArray = [];
     }
 
-    const instance = {
+    instance = {
         shouldAbandon: shouldAbandon,
         reset: reset
     };

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -129,7 +129,7 @@ function AbandonRequestsRule(config) {
                         switchRequest.reason.throughput = fragmentInfo.measuredBandwidthInKbps;
                         switchRequest.reason.fragmentID = fragmentInfo.id;
                         abandonDict[fragmentInfo.id] = fragmentInfo;
-                        logger.debug('AbandonRequestsRule ( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
+                        logger.debug('( ', mediaType, 'frag id',fragmentInfo.id,') is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
                         delete fragmentDict[mediaType][fragmentInfo.id];
                     }
                 }

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -58,7 +58,6 @@ function BolaRule(config) {
 
     config = config || {};
     const context = this.context;
-    const log = Debug(context).getInstance().log;
 
     const dashMetrics = config.dashMetrics;
     const metricsModel = config.metricsModel;
@@ -66,9 +65,11 @@ function BolaRule(config) {
     const eventBus = EventBus(context).getInstance();
 
     let instance,
+        logger,
         bolaStateDict;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
         eventBus.on(Events.BUFFER_EMPTY, onBufferEmpty, instance);
@@ -494,7 +495,7 @@ function BolaRule(config) {
                 break; // BOLA_STATE_STEADY
 
             default:
-                log('BOLA ABR rule invoked in bad state.');
+                logger.debug('BOLA ABR rule invoked in bad state.');
                 // should not arrive here, try to recover
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, safeThroughput, latency);
                 switchRequest.reason.state = bolaState.state;

--- a/src/streaming/rules/abr/DroppedFramesRule.js
+++ b/src/streaming/rules/abr/DroppedFramesRule.js
@@ -30,7 +30,7 @@ function DroppedFramesRule() {
 
                     if (totalFrames > GOOD_SAMPLE_SIZE && droppedFrames / totalFrames > DROPPED_PERCENTAGE_FORBID) {
                         maxIndex = i - 1;
-                        logger.debug('DroppedFramesRule, index: ' + maxIndex + ' Dropped Frames: ' + droppedFrames + ' Total Frames: ' + totalFrames);
+                        logger.debug('index: ' + maxIndex + ' Dropped Frames: ' + droppedFrames + ' Total Frames: ' + totalFrames);
                         break;
                     }
                 }

--- a/src/streaming/rules/abr/DroppedFramesRule.js
+++ b/src/streaming/rules/abr/DroppedFramesRule.js
@@ -6,11 +6,15 @@ import Debug from '../../../core/Debug';
 function DroppedFramesRule() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
+    let instance,
+        logger;
 
     const DROPPED_PERCENTAGE_FORBID = 0.15;
     const GOOD_SAMPLE_SIZE = 375; //Don't apply the rule until this many frames have been rendered(and counted under those indices).
 
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function getMaxIndex(rulesContext) {
         const droppedFramesHistory = rulesContext.getDroppedFramesHistory();
@@ -26,7 +30,7 @@ function DroppedFramesRule() {
 
                     if (totalFrames > GOOD_SAMPLE_SIZE && droppedFrames / totalFrames > DROPPED_PERCENTAGE_FORBID) {
                         maxIndex = i - 1;
-                        log('DroppedFramesRule, index: ' + maxIndex + ' Dropped Frames: ' + droppedFrames + ' Total Frames: ' + totalFrames);
+                        logger.debug('DroppedFramesRule, index: ' + maxIndex + ' Dropped Frames: ' + droppedFrames + ' Total Frames: ' + totalFrames);
                         break;
                     }
                 }
@@ -37,9 +41,13 @@ function DroppedFramesRule() {
         return SwitchRequest(context).create();
     }
 
-    return {
+    instance = {
         getMaxIndex: getMaxIndex
     };
+
+    setup();
+
+    return instance;
 }
 
 DroppedFramesRule.__dashjs_factory_name = 'DroppedFramesRule';

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -41,16 +41,17 @@ function InsufficientBufferRule(config) {
     const INSUFFICIENT_BUFFER_SAFETY_FACTOR = 0.5;
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
 
     const eventBus = EventBus(context).getInstance();
     const metricsModel = config.metricsModel;
     const dashMetrics = config.dashMetrics;
 
     let instance,
+        logger,
         bufferStateDict;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
         eventBus.on(Events.PLAYBACK_SEEKING, onPlaybackSeeking, instance);
     }
@@ -91,7 +92,7 @@ function InsufficientBufferRule(config) {
         }
 
         if (lastBufferStateVO.state === BufferController.BUFFER_EMPTY) {
-            log('Switch to index 0; buffer is empty.');
+            logger.info('Switch to index 0; buffer is empty.');
             switchRequest.quality = 0;
             switchRequest.reason = 'InsufficientBufferRule: Buffer is empty';
         } else {

--- a/src/streaming/rules/abr/SwitchHistoryRule.js
+++ b/src/streaming/rules/abr/SwitchHistoryRule.js
@@ -6,7 +6,9 @@ import SwitchRequest from '../SwitchRequest';
 function SwitchHistoryRule() {
 
     const context = this.context;
-    const log = Debug(context).getInstance().log;
+
+    let instance,
+        logger;
 
     //MAX_SWITCH is the number of drops made. It doesn't consider the size of the drop.
     const MAX_SWITCH = 0.075;
@@ -15,6 +17,9 @@ function SwitchHistoryRule() {
     //must be < SwitchRequestHistory SWITCH_REQUEST_HISTORY_DEPTH to enable rule
     const SAMPLE_SIZE = 6;
 
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function getMaxIndex(rulesContext) {
         const switchRequestHistory = rulesContext ? rulesContext.getSwitchHistory() : null;
@@ -33,7 +38,7 @@ function SwitchHistoryRule() {
                 if (drops + noDrops >= SAMPLE_SIZE && (drops / noDrops > MAX_SWITCH)) {
                     switchRequest.quality = (i > 0 && switchRequests[i].drops > 0) ? i - 1 : i;
                     switchRequest.reason = {index: switchRequest.quality, drops: drops, noDrops: noDrops, dropSize: dropSize};
-                    log('Switch history rule index: ' + switchRequest.quality + ' samples: ' + (drops + noDrops) + ' drops: ' + drops);
+                    logger.info('Switch history rule index: ' + switchRequest.quality + ' samples: ' + (drops + noDrops) + ' drops: ' + drops);
                     break;
                 }
             }
@@ -42,9 +47,13 @@ function SwitchHistoryRule() {
         return switchRequest;
     }
 
-    return {
+    instance = {
         getMaxIndex: getMaxIndex
     };
+
+    setup();
+
+    return instance;
 }
 
 

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -84,7 +84,7 @@ function ThroughputRule(config) {
             if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
                 streamProcessor.getScheduleController().setTimeToLoadDelay(0);
-                logger.info('ThroughputRule requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
+                logger.info('requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
                 switchRequest.reason = {throughput: throughput, latency: latency};
             }
         }

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -38,9 +38,14 @@ function ThroughputRule(config) {
 
     config = config || {};
     const context = this.context;
-    const log = Debug(context).getInstance().log;
-
     const metricsModel = config.metricsModel;
+
+    let instance,
+        logger;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function checkConfig() {
         if (!metricsModel || !metricsModel.hasOwnProperty('getReadOnlyMetricsFor')) {
@@ -79,7 +84,7 @@ function ThroughputRule(config) {
             if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
                 streamProcessor.getScheduleController().setTimeToLoadDelay(0);
-                log('ThroughputRule requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
+                logger.info('ThroughputRule requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
                 switchRequest.reason = {throughput: throughput, latency: latency};
             }
         }
@@ -91,10 +96,12 @@ function ThroughputRule(config) {
         // no persistent information to reset
     }
 
-    const instance = {
+    instance = {
         getMaxIndex: getMaxIndex,
         reset: reset
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -60,7 +60,6 @@ function BufferLevelRule(config) {
             } else {
                 bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
             }
-            // console.log('videoBufferLevel  - ' + videoBufferLevel + ' target : ' + bufferTarget);
         } else {
             const streamInfo = representationInfo.mediaInfo.streamInfo;
             if (abrController.isPlayingAtTopQuality(streamInfo)) {

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -37,12 +37,17 @@ function NextFragmentRequestRule(config) {
 
     config = config || {};
     const context = this.context;
-    const log = Debug(context).getInstance().log;
     const adapter = config.adapter;
     const textController = config.textController;
 
-    function execute(streamProcessor, requestToReplace) {
+    let instance,
+        logger;
 
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
+
+    function execute(streamProcessor, requestToReplace) {
         const representationInfo = streamProcessor.getCurrentRepresentationInfo();
         const mediaInfo = representationInfo.mediaInfo;
         const mediaType = mediaInfo.type;
@@ -67,7 +72,7 @@ function NextFragmentRequestRule(config) {
         if (bufferController) {
             const range = bufferController.getRangeAt(time);
             if (range !== null && !hasSeekTarget) {
-                log('Prior to making a request for time, NextFragmentRequestRule is aligning index handler\'s currentTime with bufferedRange.end for', mediaType, '.', time, 'was changed to', range.end);
+                logger.debug('Prior to making a request for time, NextFragmentRequestRule is aligning index handler\'s currentTime with bufferedRange.end for', mediaType, '.', time, 'was changed to', range.end);
                 time = range.end;
             }
         }
@@ -101,9 +106,11 @@ function NextFragmentRequestRule(config) {
         return request;
     }
 
-    const instance = {
+    instance = {
         execute: execute
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/text/EmbeddedTextHtmlRender.js
+++ b/src/streaming/text/EmbeddedTextHtmlRender.js
@@ -40,12 +40,12 @@ function EmbeddedTextHtmlRender() {
         let line = '';
 
         for (let c = 0; c < chars.length; ++c) {
-            let uc = chars[c];
+            const uc = chars[c];
             line += uc.uchar;
         }
 
-        let l = line.length;
-        let ll = line.replace(/^\s+/,'').length;
+        const l = line.length;
+        const ll = line.replace(/^\s+/,'').length;
         return l - ll;
     }
 
@@ -84,30 +84,27 @@ function EmbeddedTextHtmlRender() {
     }
 
     function ltrim(s) {
-        let trimmed = s.replace(/^\s+/g, '');
-        return trimmed;
+        return s.replace(/^\s+/g, '');
     }
     function rtrim(s) {
-        let trimmed = s.replace(/\s+$/g, '');
-        return trimmed;
+        return s.replace(/\s+$/g, '');
     }
 
 
     function createHTMLCaptionsFromScreen(videoElement, startTime, endTime, captionScreen) {
-
         let currRegion = null;
         let existingRegion = null;
         let lastRowHasText = false;
         let lastRowIndentL = -1;
-        let currP = { start: startTime, end: endTime, spans: [] };
+        let currP = {start: startTime, end: endTime, spans: []};
         let currentStyle = 'style_cea608_white_black';
-        let seenRegions = { };
-        let styleStates = { };
-        let regions = [];
+        const seenRegions = {};
+        const styleStates = {};
+        const regions = [];
         let r, s;
 
         for (r = 0; r < 15; ++r) {
-            let row = captionScreen.rows[r];
+            const row = captionScreen.rows[r];
             let line = '';
             let prevPenState = null;
 
@@ -115,7 +112,7 @@ function EmbeddedTextHtmlRender() {
                 /* Row is not empty */
 
                 /* Get indentation of this row */
-                let rowIndent = checkIndent(row.chars);
+                const rowIndent = checkIndent(row.chars);
 
                 /* Create a new region is there is none */
                 if (currRegion === null) {
@@ -140,8 +137,8 @@ function EmbeddedTextHtmlRender() {
                 }
 
                 for (let c = 0; c < row.chars.length; ++c) {
-                    let uc = row.chars[c];
-                    let currPenState = uc.penState;
+                    const uc = row.chars[c];
+                    const currPenState = uc.penState;
                     if ((prevPenState === null) || (!currPenState.equals(prevPenState))) {
                         if (line.trim().length > 0) {
                             currP.spans.push({ name: currentStyle, line: line, row: r });
@@ -213,37 +210,34 @@ function EmbeddedTextHtmlRender() {
             currRegion = null;
         }
 
-        //log(styleStates);
-        //log(regions);
-
-        let captionsArray = [];
+        const captionsArray = [];
 
         /* Loop thru regions */
         for (r = 0; r < regions.length; ++r) {
-            let region = regions[r];
+            const region = regions[r];
 
-            let cueID = 'sub_cea608_' + (captionId++);
-            let finalDiv = document.createElement('div');
+            const cueID = 'sub_cea608_' + (captionId++);
+            const finalDiv = document.createElement('div');
             finalDiv.id = cueID;
-            let cueRegionProperties = getRegionProperties(region);
+            const cueRegionProperties = getRegionProperties(region);
             finalDiv.style.cssText = 'position: absolute; margin: 0; display: flex; box-sizing: border-box; pointer-events: none;' + cueRegionProperties;
 
-            let bodyDiv = document.createElement('div');
+            const bodyDiv = document.createElement('div');
             bodyDiv.className = 'paragraph bodyStyle';
             bodyDiv.style.cssText = getStyle(videoElement);
 
-            let cueUniWrapper = document.createElement('div');
+            const cueUniWrapper = document.createElement('div');
             cueUniWrapper.className = 'cueUniWrapper';
             cueUniWrapper.style.cssText = 'unicode-bidi: normal; direction: ltr;';
 
             for (let p = 0; p < region.p.length; ++p) {
-                let ptag = region.p[p];
+                const ptag = region.p[p];
                 let lastSpanRow = 0;
                 for (s = 0; s < ptag.spans.length; ++s) {
                     let span = ptag.spans[s];
                     if (span.line.length > 0) {
                         if ((s !== 0) && lastSpanRow != span.row) {
-                            let brElement = document.createElement('br');
+                            const brElement = document.createElement('br');
                             brElement.className = 'lineBreak';
                             cueUniWrapper.appendChild(brElement);
                         }
@@ -252,8 +246,8 @@ function EmbeddedTextHtmlRender() {
                             sameRow = true;
                         }
                         lastSpanRow = span.row;
-                        let spanStyle = styleStates[span.name];
-                        let spanElement = document.createElement('span');
+                        const spanStyle = styleStates[span.name];
+                        const spanElement = document.createElement('span');
                         spanElement.className = 'spanPadding ' + span.name + ' customSpanColor';
                         spanElement.style.cssText = getStyle(videoElement, spanStyle);
                         /* If this is not the first span, and it's on the same
@@ -288,11 +282,10 @@ function EmbeddedTextHtmlRender() {
             }
 
             bodyDiv.appendChild(cueUniWrapper);
-
             finalDiv.appendChild(bodyDiv);
 
-            let fontSize = { 'bodyStyle': ['%', 90] };
-            for (s in styleStates) {
+            const fontSize = { 'bodyStyle': ['%', 90] };
+            for (const s in styleStates) {
                 if (styleStates.hasOwnProperty(s)) {
                     fontSize[s] = ['%', 90];
                 }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -45,12 +45,12 @@ import Events from '../../core/events/Events';
 
 function TextSourceBuffer() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
+    const context = this.context;
     const eventBus = EventBus(context).getInstance();
     let embeddedInitialized = false;
 
     let instance,
+        logger,
         boxParser,
         errHandler,
         dashManifestModel,
@@ -79,6 +79,10 @@ function TextSourceBuffer() {
         embeddedCea608FieldParsers,
         embeddedTextHtmlRender,
         mseTimeOffset;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function initialize(type, streamProcessor) {
         parser = null;
@@ -168,7 +172,7 @@ function TextSourceBuffer() {
         embeddedTextHtmlRender = EmbeddedTextHtmlRender(context).getInstance();
 
         const streamProcessors = streamController.getActiveStreamProcessors();
-        for (let i in streamProcessors) {
+        for (const i in streamProcessors) {
             if (streamProcessors[i].getType() === 'video') {
                 mseTimeOffset = streamProcessors[i].getCurrentRepresentationInfo().MSETimeOffset;
                 break;
@@ -202,7 +206,7 @@ function TextSourceBuffer() {
             }
             embeddedTracks.push(mediaInfo);
         } else {
-            log('Warning: Embedded track ' + mediaInfo.id + ' not supported!');
+            logger.warn('Warning: Embedded track ' + mediaInfo.id + ' not supported!');
         }
     }
 
@@ -240,7 +244,7 @@ function TextSourceBuffer() {
     }
 
     function getConfig() {
-        let config = {
+        const config = {
             errHandler: errHandler,
             dashManifestModel: dashManifestModel,
             mediaController: mediaController,
@@ -266,18 +270,18 @@ function TextSourceBuffer() {
             i, j, k,
             samplesInfo,
             ccContent;
-        let mediaInfo = chunk.mediaInfo;
-        let mediaType = mediaInfo.type;
-        let mimeType = mediaInfo.mimeType;
-        let codecType = mediaInfo.codec || mimeType;
+        const mediaInfo = chunk.mediaInfo;
+        const mediaType = mediaInfo.type;
+        const mimeType = mediaInfo.mimeType;
+        const codecType = mediaInfo.codec || mimeType;
         if (!codecType) {
-            log('No text type defined');
+            logger.error('No text type defined');
             return;
         }
 
         function createTextTrackFromMediaInfo(captionData, mediaInfo) {
-            let textTrackInfo = new TextTrackInfo();
-            let trackKindMap = { subtitle: 'subtitles', caption: 'captions' }; //Dash Spec has no "s" on end of KIND but HTML needs plural.
+            const textTrackInfo = new TextTrackInfo();
+            const trackKindMap = { subtitle: 'subtitles', caption: 'captions' }; //Dash Spec has no "s" on end of KIND but HTML needs plural.
             const getKind = function () {
                 let kind = (mediaInfo.roles.length > 0) ? trackKindMap[mediaInfo.roles[0]] : trackKindMap.caption;
                 kind = (kind === trackKindMap.caption || kind === trackKindMap.subtitle) ? kind : trackKindMap.caption;
@@ -305,7 +309,7 @@ function TextSourceBuffer() {
             textTrackInfo.isEmbedded = mediaInfo.isEmbedded ? true : false;
             textTrackInfo.kind = getKind();
             textTrackInfo.roles = mediaInfo.roles;
-            let totalNrTracks = (mediaInfos ? mediaInfos.length : 0) + embeddedTracks.length;
+            const totalNrTracks = (mediaInfos ? mediaInfos.length : 0) + embeddedTracks.length;
             textTracks.addTextTrack(textTrackInfo, totalNrTracks);
         }
 
@@ -325,66 +329,66 @@ function TextSourceBuffer() {
                 if (codecType.search(Constants.STPP) >= 0) {
                     parser = parser !== null ? parser : getParser(codecType);
                     for (i = 0; i < sampleList.length; i++) {
-                        let sample = sampleList[i];
-                        let sampleStart = sample.cts;
-                        let sampleRelStart = sampleStart - firstSubtitleStart;
+                        const sample = sampleList[i];
+                        const sampleStart = sample.cts;
+                        const sampleRelStart = sampleStart - firstSubtitleStart;
                         this.buffered.add(sampleRelStart / timescale, (sampleRelStart + sample.duration) / timescale);
-                        let dataView = new DataView(bytes, sample.offset, sample.subSizes[0]);
+                        const dataView = new DataView(bytes, sample.offset, sample.subSizes[0]);
                         ccContent = ISOBoxer.Utils.dataViewToString(dataView, Constants.UTF8);
-                        let images = [];
+                        const images = [];
                         let subOffset = sample.offset + sample.subSizes[0];
                         for (j = 1; j < sample.subSizes.length; j++) {
-                            let inData = new Uint8Array(bytes, subOffset, sample.subSizes[j]);
-                            let raw = String.fromCharCode.apply(null, inData);
+                            const inData = new Uint8Array(bytes, subOffset, sample.subSizes[j]);
+                            const raw = String.fromCharCode.apply(null, inData);
                             images.push(raw);
                             subOffset += sample.subSizes[j];
                         }
                         try {
                             // Only used for Miscrosoft Smooth Streaming support - caption time is relative to sample time. In this case, we apply an offset.
-                            let manifest = manifestModel.getValue();
-                            let offsetTime = manifest.ttmlTimeIsRelative ? sampleStart / timescale : 0;
+                            const manifest = manifestModel.getValue();
+                            const offsetTime = manifest.ttmlTimeIsRelative ? sampleStart / timescale : 0;
                             result = parser.parse(ccContent, offsetTime, sampleStart / timescale, (sampleStart + sample.duration) / timescale, images);
                             textTracks.addCaptions(currFragmentedTrackIdx, firstSubtitleStart / timescale, result);
                         } catch (e) {
                             fragmentModel.removeExecutedRequestsBeforeTime();
                             this.remove();
-                            log('TTML parser error: ' + e.message);
+                            logger.error('TTML parser error: ' + e.message);
                         }
                     }
                 } else {
                     // WebVTT case
-                    let captionArray = [];
+                    const captionArray = [];
                     for (i = 0 ; i < sampleList.length; i++) {
-                        let sample = sampleList[i];
+                        const sample = sampleList[i];
                         sample.cts -= firstSubtitleStart;
                         this.buffered.add(sample.cts / timescale, (sample.cts + sample.duration) / timescale);
-                        let sampleData = bytes.slice(sample.offset, sample.offset + sample.size);
+                        const sampleData = bytes.slice(sample.offset, sample.offset + sample.size);
                         // There are boxes inside the sampleData, so we need a ISOBoxer to get at it.
-                        let sampleBoxes = ISOBoxer.parseBuffer(sampleData);
+                        const sampleBoxes = ISOBoxer.parseBuffer(sampleData);
 
                         for (j = 0 ; j < sampleBoxes.boxes.length; j++) {
-                            let box1 = sampleBoxes.boxes[j];
-                            log('VTT box1: ' + box1.type);
+                            const box1 = sampleBoxes.boxes[j];
+                            logger.debug('VTT box1: ' + box1.type);
                             if (box1.type === 'vtte') {
                                 continue; //Empty box
                             }
                             if (box1.type === 'vttc') {
-                                log('VTT vttc boxes.length = ' + box1.boxes.length);
+                                logger.debug('VTT vttc boxes.length = ' + box1.boxes.length);
                                 for (k = 0 ; k < box1.boxes.length; k++) {
-                                    let box2 = box1.boxes[k];
-                                    log('VTT box2: ' + box2.type);
+                                    const box2 = box1.boxes[k];
+                                    logger.debug('VTT box2: ' + box2.type);
                                     if (box2.type === 'payl') {
-                                        let cue_text = box2.cue_text;
-                                        log('VTT cue_text = ' + cue_text);
-                                        let start_time = sample.cts / timescale;
-                                        let end_time = (sample.cts + sample.duration) / timescale;
+                                        const cue_text = box2.cue_text;
+                                        logger.debug('VTT cue_text = ' + cue_text);
+                                        const start_time = sample.cts / timescale;
+                                        const end_time = (sample.cts + sample.duration) / timescale;
                                         captionArray.push({
                                             start: start_time,
                                             end: end_time,
                                             data: cue_text,
                                             styles: {}
                                         });
-                                        log('VTT ' + start_time + '-' + end_time + ' : ' + cue_text);
+                                        logger.debug('VTT ' + start_time + '-' + end_time + ' : ' + cue_text);
                                     }
                                 }
                             }
@@ -396,7 +400,7 @@ function TextSourceBuffer() {
                 }
             }
         } else if (mediaType === Constants.TEXT) {
-            let dataView = new DataView(bytes, 0, bytes.byteLength);
+            const dataView = new DataView(bytes, 0, bytes.byteLength);
             ccContent = ISOBoxer.Utils.dataViewToString(dataView, Constants.UTF8);
 
             try {
@@ -415,7 +419,7 @@ function TextSourceBuffer() {
                 }
             } else { // MediaSegment
                 if (embeddedTimescale === 0) {
-                    log('CEA-608: No timescale for embeddedTextTrack yet');
+                    logger.warn('CEA-608: No timescale for embeddedTextTrack yet');
                     return;
                 }
                 const makeCueAdderForIndex = function (self, trackIndex) {
@@ -424,8 +428,7 @@ function TextSourceBuffer() {
                         if (videoModel.getTTMLRenderingDiv()) {
                             captionsArray = embeddedTextHtmlRender.createHTMLCaptionsFromScreen(videoModel.getElement(), startTime, endTime, captionScreen);
                         } else {
-                            let text = captionScreen.getDisplayText();
-                            //log("CEA text: " + startTime + "-" + endTime + "  '" + text + "'");
+                            const text = captionScreen.getDisplayText();
                             captionsArray = [{
                                 start: startTime,
                                 end: endTime,
@@ -440,10 +443,9 @@ function TextSourceBuffer() {
                     return newCue;
                 };
 
-
                 samplesInfo = fragmentedTextBoxParser.getSamplesInfo(bytes);
 
-                let sequenceNumber = samplesInfo.lastSequenceNumber;
+                const sequenceNumber = samplesInfo.lastSequenceNumber;
 
                 if (!embeddedCea608FieldParsers[0] && !embeddedCea608FieldParsers[1]) {
                     // Time to setup the CEA-608 parsing
@@ -457,7 +459,7 @@ function TextSourceBuffer() {
                             trackIdx = textTracks.getTrackIdxForId(Constants.CC3);
                         }
                         if (trackIdx === -1) {
-                            log('CEA-608: data before track is ready.');
+                            logger.warn('CEA-608: data before track is ready.');
                             return;
                         }
                         handler = makeCueAdderForIndex(this, trackIdx);
@@ -476,15 +478,12 @@ function TextSourceBuffer() {
                         }
                     }
 
-                    let allCcData = extractCea608Data(bytes, samplesInfo.sampleList);
+                    const allCcData = extractCea608Data(bytes, samplesInfo.sampleList);
 
                     for (let fieldNr = 0; fieldNr < embeddedCea608FieldParsers.length; fieldNr++) {
-                        let ccData = allCcData.fields[fieldNr];
-                        let fieldParser = embeddedCea608FieldParsers[fieldNr];
+                        const ccData = allCcData.fields[fieldNr];
+                        const fieldParser = embeddedCea608FieldParsers[fieldNr];
                         if (fieldParser) {
-                            /*if (ccData.length > 0 ) {
-                                log("CEA-608 adding Data to field " + fieldNr + " " + ccData.length + "bytes");
-                            }*/
                             for (i = 0; i < ccData.length; i++) {
                                 fieldParser.addData(ccData[i][0] / embeddedTimescale, ccData[i][1]);
                             }
@@ -503,23 +502,22 @@ function TextSourceBuffer() {
      * @returns {Object|null} ccData corresponding to one segment.
      */
     function extractCea608Data(data, samples) {
-
         if (samples.length === 0) {
             return null;
         }
 
-        let allCcData = {
+        const allCcData = {
             splits: [],
             fields: [[], []]
         };
-        let raw = new DataView(data);
+        const raw = new DataView(data);
         for (let i = 0; i < samples.length; i++) {
-            let sample = samples[i];
-            let cea608Ranges = cea608parser.findCea608Nalus(raw, sample.offset, sample.size);
+            const sample = samples[i];
+            const cea608Ranges = cea608parser.findCea608Nalus(raw, sample.offset, sample.size);
             let lastSampleTime = null;
             let idx = 0;
             for (let j = 0; j < cea608Ranges.length; j++) {
-                let ccData = cea608parser.extractCea608DataFromRange(raw, cea608Ranges[j]);
+                const ccData = cea608parser.extractCea608DataFromRange(raw, cea608Ranges[j]);
                 for (let k = 0; k < 2; k++) {
                     if (ccData[k].length > 0) {
                         if (sample.cts !== lastSampleTime) {
@@ -596,6 +594,8 @@ function TextSourceBuffer() {
         setCurrentFragmentedTrackIdx: setCurrentFragmentedTrackIdx,
         remove: remove
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -376,7 +376,7 @@ function TextTracks() {
                 return null;
             }
         }, captionContainer.clientHeight, captionContainer.clientWidth, false/*displayForcedOnlyMode*/, function (err) {
-            logger.info('[TextTracks][renderCaption]', err);
+            logger.info('renderCaption :', err);
             //TODO add ErrorHandler management
         }, previousISDState, true /*enableRollUp*/);
         finalCue.id = cue.cueID;

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -39,9 +39,9 @@ function TextTracks() {
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
-    const log = Debug(context).getInstance().log;
 
     let instance,
+        logger,
         Cue,
         videoModel,
         textTrackQueue,
@@ -58,6 +58,10 @@ function TextTracks() {
         displayCCOnTop,
         previousISDState,
         topZIndex;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function initialize() {
         if (typeof window === 'undefined' || typeof navigator === 'undefined') {
@@ -121,7 +125,7 @@ function TextTracks() {
 
     function addTextTrack(textTrackInfoVO, totalTextTracks) {
         if (textTrackQueue.length === totalTextTracks) {
-            log('Trying to add too many tracks.');
+            logger.error('Trying to add too many tracks.');
             return;
         }
 
@@ -372,7 +376,7 @@ function TextTracks() {
                 return null;
             }
         }, captionContainer.clientHeight, captionContainer.clientWidth, false/*displayForcedOnlyMode*/, function (err) {
-            log('[TextTracks][renderCaption]', err);
+            logger.info('[TextTracks][renderCaption]', err);
             //TODO add ErrorHandler management
         }, previousISDState, true /*enableRollUp*/);
         finalCue.id = cue.cueID;
@@ -423,7 +427,7 @@ function TextTracks() {
                     if (track.mode === Constants.TEXT_SHOWING) {
                         if (this.isd) {
                             renderCaption(this);
-                            log('Cue enter id:' + this.cueID);
+                            logger.debug('Cue enter id:' + this.cueID);
                         } else {
                             captionContainer.appendChild(this.cueHTMLElement);
                             scaleCue.call(self, this);
@@ -435,7 +439,7 @@ function TextTracks() {
                     const divs = captionContainer.childNodes;
                     for (let i = 0; i < divs.length; ++i) {
                         if (divs[i].id === this.cueID) {
-                            log('Cue exit id:' + divs[i].id);
+                            logger.debug('Cue exit id:' + divs[i].id);
                             captionContainer.removeChild(divs[i]);
                         }
                     }
@@ -644,6 +648,8 @@ function TextTracks() {
         deleteTextTrack: deleteTextTrack,
         setConfig: setConfig
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -142,7 +142,7 @@ function BaseURLSelector() {
 }
 
 BaseURLSelector.__dashjs_factory_name = 'BaseURLSelector';
-let factory = FactoryMaker.getClassFactory(BaseURLSelector);
+const factory = FactoryMaker.getClassFactory(BaseURLSelector);
 factory.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE;
 factory.URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE = URL_RESOLUTION_FAILED_GENERIC_ERROR_MESSAGE;
 FactoryMaker.updateClassFactory(BaseURLSelector.__dashjs_factory_name, factory);

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -49,12 +49,17 @@ const LAST_MEDIA_SETTINGS = 'LastMediaSettings';
 function DOMStorage(config) {
 
     config = config || {};
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let mediaPlayerModel = config.mediaPlayerModel;
+    const context = this.context;
+    const mediaPlayerModel = config.mediaPlayerModel;
 
     let instance,
+        logger,
         supported;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+        translateLegacyKeys();
+    }
 
     //type can be local, session
     function isSupported(type) {
@@ -62,8 +67,8 @@ function DOMStorage(config) {
 
         supported = false;
 
-        let testKey = '1';
-        let testValue = '1';
+        const testKey = '1';
+        const testValue = '1';
         let storage;
 
         try {
@@ -71,7 +76,7 @@ function DOMStorage(config) {
                 storage = window[type];
             }
         } catch (error) {
-            log('Warning: DOMStorage access denied: ' + error.message);
+            logger.warn('Warning: DOMStorage access denied: ' + error.message);
             return supported;
         }
 
@@ -89,7 +94,7 @@ function DOMStorage(config) {
             storage.removeItem(testKey);
             supported = true;
         } catch (error) {
-            log('Warning: DOMStorage is supported, but cannot be used: ' + error.message);
+            logger.warn('Warning: DOMStorage is supported, but cannot be used: ' + error.message);
         }
 
         return supported;
@@ -106,20 +111,16 @@ function DOMStorage(config) {
                     try {
                         localStorage.setItem(entry.newKey, value);
                     } catch (e) {
-                        log(e.message);
+                        logger.error(e.message);
                     }
                 }
             });
         }
     }
 
-    function setup() {
-        translateLegacyKeys();
-    }
-
     // Return current epoch time, ms, rounded to the nearest 10m to avoid fingerprinting user
     function getTimestamp() {
-        let ten_minutes_ms = 60 * 1000 * 10;
+        const ten_minutes_ms = 60 * 1000 * 10;
         return Math.round(new Date().getTime() / ten_minutes_ms) * ten_minutes_ms;
     }
 
@@ -171,7 +172,7 @@ function DOMStorage(config) {
 
                 if (!isNaN(bitrate) && !isExpired) {
                     savedBitrate = bitrate;
-                    log('Last saved bitrate for ' + type + ' was ' + bitrate);
+                    logger.debug('Last saved bitrate for ' + type + ' was ' + bitrate);
                 } else if (isExpired) {
                     localStorage.removeItem(key);
                 }
@@ -184,22 +185,22 @@ function DOMStorage(config) {
 
     function setSavedMediaSettings(type, value) {
         if (canStore(STORAGE_TYPE_LOCAL, LAST_MEDIA_SETTINGS)) {
-            let key = LOCAL_STORAGE_SETTINGS_KEY_TEMPLATE.replace(/\?/, type);
+            const key = LOCAL_STORAGE_SETTINGS_KEY_TEMPLATE.replace(/\?/, type);
             try {
                 localStorage.setItem(key, JSON.stringify({settings: value, timestamp: getTimestamp()}));
             } catch (e) {
-                log(e.message);
+                logger.error(e.message);
             }
         }
     }
 
     function setSavedBitrateSettings(type, bitrate) {
         if (canStore(STORAGE_TYPE_LOCAL, LAST_BITRATE) && bitrate) {
-            let key = LOCAL_STORAGE_BITRATE_KEY_TEMPLATE.replace(/\?/, type);
+            const key = LOCAL_STORAGE_BITRATE_KEY_TEMPLATE.replace(/\?/, type);
             try {
                 localStorage.setItem(key, JSON.stringify({bitrate: bitrate.toFixed(3), timestamp: getTimestamp()}));
             } catch (e) {
-                log(e.message);
+                logger.error(e.message);
             }
         }
     }
@@ -216,5 +217,5 @@ function DOMStorage(config) {
 }
 
 DOMStorage.__dashjs_factory_name = 'DOMStorage';
-let factory = FactoryMaker.getSingletonFactory(DOMStorage);
+const factory = FactoryMaker.getSingletonFactory(DOMStorage);
 export default factory;

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -36,19 +36,23 @@ import { fromXML, generateISD } from 'imsc';
 
 function TTMLParser() {
 
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
-    let eventBus = EventBus(context).getInstance();
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
     /*
      * This TTML parser follows "EBU-TT-D SUBTITLING DISTRIBUTION FORMAT - tech3380" spec - https://tech.ebu.ch/docs/tech/tech3380.pdf.
      * */
-    let instance;
+    let instance,
+        logger;
 
     let cueCounter = 0; // Used to give every cue a unique ID.
 
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
+
     function getCueID() {
-        let id = 'cue_TTML_' + cueCounter;
+        const id = 'cue_TTML_' + cueCounter;
         cueCounter++;
         return id;
     }
@@ -67,13 +71,13 @@ function TTMLParser() {
         let i;
 
         let errorMsg = '';
-        let captionArray = [];
+        const captionArray = [];
         let startTime,
             endTime;
 
-        let content = {};
+        const content = {};
 
-        let embeddedImages = {};
+        const embeddedImages = {};
         let currentImageId = '';
         let accumulated_image_data = '';
         let metadataHandler = {
@@ -81,7 +85,7 @@ function TTMLParser() {
             onOpenTag: function (ns, name, attrs) {
                 if (name === 'image' && ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt') {
                     if (!attrs[' imagetype'] || attrs[' imagetype'].value !== 'PNG') {
-                        log('Warning: smpte-tt imagetype != PNG. Discarded');
+                        logger.warn('Warning: smpte-tt imagetype != PNG. Discarded');
                         return;
                     }
                     currentImageId = attrs['http://www.w3.org/XML/1998/namespace id'].value;
@@ -112,13 +116,13 @@ function TTMLParser() {
 
         eventBus.trigger(Events.TTML_TO_PARSE, content);
 
-        let imsc1doc = fromXML(content.data, function (msg) {
+        const imsc1doc = fromXML(content.data, function (msg) {
             errorMsg = msg;
         }, metadataHandler);
 
         eventBus.trigger(Events.TTML_PARSED, {ttmlString: content.data, ttmlDoc: imsc1doc});
 
-        let mediaTimeEvents = imsc1doc.getMediaTimeEvents();
+        const mediaTimeEvents = imsc1doc.getMediaTimeEvents();
 
         for (i = 0; i < mediaTimeEvents.length; i++) {
             let isd = generateISD(imsc1doc, mediaTimeEvents[i], function (error) {
@@ -145,14 +149,11 @@ function TTMLParser() {
         }
 
         if (errorMsg !== '') {
-            log(errorMsg);
+            logger.error(errorMsg);
             throw new Error(errorMsg);
         }
 
         return captionArray;
-    }
-
-    function setup() {
     }
 
     instance = {

--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -34,16 +34,17 @@ import Debug from '../../core/Debug';
 const WEBVTT = 'WEBVTT';
 
 function VTTParser() {
-    let context = this.context;
-    let log = Debug(context).getInstance().log;
+    const context = this.context;
 
     let instance,
+        logger,
         regExNewLine,
         regExToken,
         regExWhiteSpace,
         regExWhiteSpaceWordBoundary;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         regExNewLine = /(?:\r\n|\r|\n)/gm;
         regExToken = /-->/;
         regExWhiteSpace = /(^[\s]+|[\s]+$)/g;
@@ -51,7 +52,7 @@ function VTTParser() {
     }
 
     function parse(data) {
-        let captionArray = [];
+        const captionArray = [];
         let len,
             lastStartTime;
 
@@ -63,20 +64,17 @@ function VTTParser() {
         len = data.length;
         lastStartTime = -1;
 
-        for (let i = 0 ; i < len; i++)
-        {
+        for (let i = 0 ; i < len; i++) {
             let item = data[i];
 
-            if (item.length > 0 && item !== WEBVTT)
-            {
-                if (item.match(regExToken))
-                {
-                    let attributes = parseItemAttributes(item);
-                    let cuePoints = attributes.cuePoints;
-                    let styles = attributes.styles;
-                    let text = getSublines(data, i + 1);
-                    let startTime = convertCuePointTimes(cuePoints[0].replace(regExWhiteSpace, ''));
-                    let endTime = convertCuePointTimes(cuePoints[1].replace(regExWhiteSpace, ''));
+            if (item.length > 0 && item !== WEBVTT) {
+                if (item.match(regExToken)) {
+                    const attributes = parseItemAttributes(item);
+                    const cuePoints = attributes.cuePoints;
+                    const styles = attributes.styles;
+                    const text = getSublines(data, i + 1);
+                    const startTime = convertCuePointTimes(cuePoints[0].replace(regExWhiteSpace, ''));
+                    const endTime = convertCuePointTimes(cuePoints[1].replace(regExWhiteSpace, ''));
 
                     if ((!isNaN(startTime) && !isNaN(endTime)) && startTime >= lastStartTime && endTime > startTime) {
                         if (text !== '') {
@@ -90,11 +88,11 @@ function VTTParser() {
                             });
                         }
                         else {
-                            log('Skipping cue due to empty/malformed cue text');
+                            logger.error('Skipping cue due to empty/malformed cue text');
                         }
                     }
                     else {
-                        log('Skipping cue due to incorrect cue timing');
+                        logger.error('Skipping cue due to incorrect cue timing');
                     }
                 }
             }
@@ -104,7 +102,7 @@ function VTTParser() {
     }
 
     function convertCuePointTimes(time) {
-        let timeArray = time.split(':');
+        const timeArray = time.split(':');
         const len = timeArray.length - 1;
 
         time = parseInt( timeArray[len - 1], 10 ) * 60 + parseFloat( timeArray[len]);
@@ -117,8 +115,8 @@ function VTTParser() {
     }
 
     function parseItemAttributes(data) {
-        let vttCuePoints = data.split(regExToken);
-        let arr = vttCuePoints[1].split(regExWhiteSpaceWordBoundary);
+        const vttCuePoints = data.split(regExToken);
+        const arr = vttCuePoints[1].split(regExWhiteSpaceWordBoundary);
         arr.shift(); //remove first array index it is empty...
         vttCuePoints[1] = arr[0];
         arr.shift();
@@ -126,7 +124,7 @@ function VTTParser() {
     }
 
     function getCaptionStyles(arr) {
-        let styleObject = {};
+        const styleObject = {};
         arr.forEach(function (element) {
             if (element.split(/:/).length > 1) {
                 let val = element.split(/:/)[1];

--- a/test/unit/core.Debug.js
+++ b/test/unit/core.Debug.js
@@ -1,0 +1,99 @@
+import Debug from '../../src/core/Debug';
+
+const chai = require('chai');
+const expect = chai.expect;
+const spies = require('chai-spies');
+
+chai.use(spies);
+
+const context = {};
+let debug;
+
+describe('Debug', function () {
+    before(function () {
+        if (typeof window === 'undefined') {
+            global.window = {
+                console: {
+                    log: chai.spy(),
+                    debug: chai.spy(),
+                    info: chai.spy(),
+                    warn: chai.spy(),
+                    error: chai.spy()
+                }
+            };
+        }
+    });
+
+    after(function () {
+        delete global.window;
+    });
+
+    beforeEach(function () {
+        debug = Debug(context).getInstance();
+    });
+
+    afterEach(function () {
+    });
+
+    it('Default values', function () {
+        var logLevel = debug.getLogLevel();
+        expect(logLevel).to.equal(Debug.LOG_LEVEL_WARNING);
+    });
+
+    it('should set log level', function () {
+        debug.setLogLevel(Debug.LOG_LEVEL_NONE);
+        var logLevel = debug.getLogLevel();
+        expect(logLevel).to.equal(Debug.LOG_LEVEL_NONE);
+    });
+
+    describe('Log Levels', function () {
+        it('should return a logger with the right interface', function () {
+            var logger = debug.getLogger();
+            expect(logger.debug).to.be.instanceOf(Function);
+            expect(logger.info).to.be.instanceOf(Function);
+            expect(logger.warn).to.be.instanceOf(Function);
+            expect(logger.error).to.be.instanceOf(Function);
+            expect(logger.fatal).to.be.instanceOf(Function);
+        });
+
+        it('shouldnt write logs when LOG_LEVEL_NONE level is set', function () {
+            var logger = debug.getLogger();
+
+            debug.setLogLevel(Debug.LOG_LEVEL_NONE);
+            logger.fatal('Fatal error');
+            expect(global.window.console.error).not.to.have.been.called; // jshint ignore:line
+            logger.error('Error');
+            expect(global.window.console.error).not.to.have.been.called; // jshint ignore:line
+            logger.warn('Warning');
+            expect(global.window.console.warn).not.to.have.been.called; // jshint ignore:line
+            logger.info('Info');
+            expect(global.window.console.info).not.to.have.been.called; // jshint ignore:line
+            logger.debug('debug');
+            expect(global.window.console.debug).not.to.have.been.called; // jshint ignore:line
+        });
+
+        it('should manage log levels correctly', function () {
+            var logger = debug.getLogger();
+            // Debug
+            debug.setLogLevel(Debug.LOG_LEVEL_DEBUG);
+
+            logger.debug('debug message');
+            expect(global.window.console.debug).to.have.been.called.once; // jshint ignore:line
+
+            logger.fatal('Fatal error');
+            expect(global.window.console.error).to.have.been.called.once; // jshint ignore:line
+
+            // Warning
+            debug.setLogLevel(Debug.LOG_LEVEL_WARNING);
+
+            logger.debug('debug');
+            expect(global.window.console.debug).not.to.have.been.called; // jshint ignore:line
+
+            logger.warn('Warning');
+            expect(global.window.console.warn).to.have.been.called.once; // jshint ignore:line
+
+            logger.error('Error');
+            expect(global.window.console.warn).to.have.been.called.once; // jshint ignore:line
+        });
+    });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -31,6 +31,7 @@
 
 import FactoryMaker from '../../src/core/FactoryMaker';
 
+
 // Shove both of these into the global scope
 var context = (typeof window !== 'undefined' && window) || global;
 

--- a/test/unit/mocks/DebugMock
+++ b/test/unit/mocks/DebugMock
@@ -1,0 +1,14 @@
+class DebugMock {
+    getLogger() {
+        const nop = function () {};
+        return {
+            fatal: nop,
+            error: nop,
+            warning: nop,
+            info: nop,
+            debug: nop
+        };
+    }
+}
+
+export default DebugMock;

--- a/test/unit/mss.MssFragmentProcessor.js
+++ b/test/unit/mss.MssFragmentProcessor.js
@@ -4,6 +4,7 @@ import PlaybackController from '../../src/streaming/controllers/PlaybackControll
 import EventBus from '../../src/core/EventBus';
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 import StreamProcessorMock from './mocks/StreamProcessorMock';
+import DebugMock from './mocks/DebugMock';
 import ISOBoxer from 'codem-isoboxer';
 
 const expect = require('chai').expect;
@@ -14,10 +15,11 @@ const metricsModel = MetricsModel(context).getInstance();
 const playbackController = PlaybackController(context).getInstance();
 const eventBus = EventBus(context).getInstance();
 const errorHandlerMock = new ErrorHandlerMock();
-const mssFragmentProcessor = MssFragmentProcessor(context).create({metricsModel: metricsModel, playbackController: playbackController, eventBus: eventBus, ISOBoxer: ISOBoxer, errHandler: errorHandlerMock});
+const mssFragmentProcessor = MssFragmentProcessor(context).create({metricsModel: metricsModel,
+    playbackController: playbackController, eventBus: eventBus, ISOBoxer: ISOBoxer,
+    errHandler: errorHandlerMock, debug: new DebugMock()});
 
 describe('MssFragmentProcessor', function () {
-
     const testType = 'video';
     const streamInfo = {
         id: 'id'

--- a/test/unit/mss.parser.MssParser.js
+++ b/test/unit/mss.parser.MssParser.js
@@ -1,11 +1,10 @@
 import MssParser from '../../src/mss/parser/MssParser';
 import MediaPlayerModel from '../../src/streaming/models/MediaPlayerModel';
-import Debug from '../../src/core/Debug';
+import DebugMock from './mocks/DebugMock';
 
 const expect = require('chai').expect;
 const fs = require('fs');
 const jsdom = require('jsdom').JSDOM;
-const context = {};
 
 describe('MssParser', function () {
 
@@ -32,7 +31,7 @@ describe('MssParser', function () {
     beforeEach(function () {
         mssParser = MssParser().create({
             mediaPlayerModel: mediaPlayerModel,
-            log: Debug(context).getInstance().log
+            debug: new DebugMock()
         });
 
         expect(mssParser).to.exist; // jshint ignore:line
@@ -46,7 +45,6 @@ describe('MssParser', function () {
 
         let adaptation;
         for (let i = 0; i < manifest.Period.AdaptationSet_asArray.length; i++) {
-
             adaptation = manifest.Period.AdaptationSet_asArray[i];
             expect(adaptation.id).to.exist; // jshint ignore:line
             expect(adaptation.id).not.to.be.empty; // jshint ignore:line

--- a/test/unit/streaming.controllers.TimeSyncController.js
+++ b/test/unit/streaming.controllers.TimeSyncController.js
@@ -46,7 +46,6 @@ describe('TimeSyncController', function () {
 
 
     it('should synchronize time when time source is defined', function (done) {
-
         let self = this;
         let date = new Date();
 

--- a/test/unit/streaming.protection.controllers.ProtectionController.js
+++ b/test/unit/streaming.protection.controllers.ProtectionController.js
@@ -1,7 +1,7 @@
 import ProtectionController from '../../src/streaming/protection/controllers/ProtectionController';
 import ProtectionEvents from '../../src/streaming/protection/ProtectionEvents';
 import EventBus from '../../src/core/EventBus';
-import Debug from '../../src/core/Debug';
+import DebugMock from './mocks/DebugMock';
 
 import ProtectionKeyControllerMock from './mocks/ProtectionKeyControllerMock';
 
@@ -11,7 +11,7 @@ const eventBus = EventBus(context).getInstance();
 
 describe('ProtectionController', function () {
     describe('Not well initialized', function () {
-        let protectionController = ProtectionController(context).create({});
+        let protectionController = ProtectionController(context).create({debug: new DebugMock()});
 
         it('should throw an exception when attempting to call initializeForMedia function without mediaInfo parameter', function () {
             expect(protectionController.initializeForMedia.bind(protectionController)).to.throw('mediaInfo can not be null or undefined');
@@ -27,7 +27,7 @@ describe('ProtectionController', function () {
             const protectionKeyControllerMock = new ProtectionKeyControllerMock();
             let protectionController = ProtectionController(context).create({protectionKeyController: protectionKeyControllerMock,
                                                                              events: ProtectionEvents,
-                                                                             log: Debug(context).getInstance().log,
+                                                                             debug: new DebugMock(),
                                                                              eventBus: eventBus});
 
             let onDRMError = function (data) {

--- a/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
+++ b/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
@@ -2,7 +2,7 @@
 
 import KeySystemW3CClearKey from '../../src/streaming/protection/drm/KeySystemW3CClearKey';
 import BASE64 from '../../externals/base64';
-
+import DebugMock from './mocks/DebugMock';
 const chai = require('chai');
 const expect = chai.expect;
 const spies = require('chai-spies');
@@ -15,7 +15,7 @@ describe('KeySystemW3CClearKey', function () {
     let config;
     let keySystem;
     let message = new Uint8Array([123,34,107,105,100,115,34,58,91,34,97,75,69,114,88,72,78,71,98,51,103,97,68,98,89,98,95,114,111,99,112,119,34,93,44,34,116,121,112,101,34,58,34,116,101,109,112,111,114,97,114,121,34,125]);
-
+    let debug = new DebugMock();
     const protData = {
         'clearkeys': {
             'aKErXHNGb3gaDbYb_rocpw': 'FmY0xnWCPCNaSpRG-tUuTQ'
@@ -23,7 +23,8 @@ describe('KeySystemW3CClearKey', function () {
     };
 
     beforeEach(function () {
-        config = { BASE64, log: chai.spy() };
+        debug.warn = chai.spy();
+        config = { BASE64, debug: debug };
         context = {};
     });
 
@@ -39,7 +40,7 @@ describe('KeySystemW3CClearKey', function () {
     it('should warn when using this system', function () {
         keySystem = KeySystemW3CClearKey(context).getInstance(config);
         keySystem.getClearKeysFromProtectionData(protData, message);
-        expect(config.log).to.have.been.called.with('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
+        expect(debug.warn).to.have.been.called.with('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
     });
 
     it('returns clearkey pair', function () {


### PR DESCRIPTION
Improves the logging system so it works with log levels (as requested in #2601).

A couple of methods have been created in Debug class to allow developers to set/retrieve the log level:
  * `Debug.setLogLevel`
  * `Debug.getLogLevel`

The following log levels are supported:
- `dashjs.Debug.LOG_LEVEL_DEBUG`: what we have today. Everything.
- `dashjs.Debug.LOG_LEVEL_INFO`: key events (ex: segment loaded, bitrate changes).
- `dashjs.Debug.LOG_LEVEL_WARNING`: (ex: timecode jumping, fetch is not available, EME not available, adaptations set that are not supported, semantic problems with the mpd that dont avoid playback to start).
- `dashjs.Debug.LOG_LEVEL_ERROR`: errors that don't stop playback (ex: segment 404, codec errors - fallback).
- `dashjs.Debug.LOG_LEVEL_FATAL`: Playback fails completely (codecs not supported).

With the new approach, any dash.js class that wants to use the new Logger has to create its own Logger instance. Example: 
```
logger = Debug(context).getInstance().getLogger(instance);
logger.warn('This is a warning message');
```

Additionally:
  * Method `Debug.setLogToBrowserConsole` has been deprecated and will be removed two versions after current one (v2.7.0)
  * Method `Debug.getLogToBrowserConsole` has been deprecated and will be removed two versions after current one (v2.7.0)
  * `Event Events.LOG` has been deprecated and will be removed two versions after current one (v2.7.0)

Documentation, definition file and unit tests updated.