### PR TITLE
add accessibility to TextTrackInfo

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -305,6 +305,7 @@ function TextSourceBuffer() {
             textTrackInfo.isEmbedded = mediaInfo.isEmbedded ? true : false;
             textTrackInfo.kind = getKind();
             textTrackInfo.roles = mediaInfo.roles;
+            textTrackInfo.roles = mediaInfo.accessibility;
             let totalNrTracks = (mediaInfos ? mediaInfos.length : 0) + embeddedTracks.length;
             textTracks.addTextTrack(textTrackInfo, totalNrTracks);
         }


### PR DESCRIPTION
Hi,

this PR adds accessibility information in order to be able to know if the track is, for instance, a hard of hearing one. 

According to the [spec](http://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.01.01_60/ts_103285v010101p.pdf) page 28, a main roles with an accessibility of 2 define a Hoh subtitle track.

Nico