### PR TITLE
Make more robust the period parsing. Add unit tests

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -46,21 +46,27 @@ import Debug from '../../core/Debug';
 function DashManifestModel(config) {
 
     config = config || {};
-    let instance;
-    const context = this.context;
-    const log = Debug(context).getInstance().log;
 
+    let instance,
+        logger;
+
+    const context = this.context;
     const urlUtils = URLUtils(context).getInstance();
     const mediaController = config.mediaController;
     const timelineConverter = config.timelineConverter;
     const adapter = config.adapter;
 
     const PROFILE_DVB = 'urn:dvb:dash:profile:dvb-dash:2014';
+
     const isInteger = Number.isInteger || function (value) {
         return typeof value === 'number' &&
             isFinite(value) &&
             Math.floor(value) === value;
     };
+
+    function setup () {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
 
     function getIsTypeOf(adaptation, type) {
 
@@ -653,7 +659,7 @@ function DashManifestModel(config) {
                 if (voPeriod !== null) {
                     voPreviousPeriod.duration = parseFloat((voPeriod.start - voPreviousPeriod.start).toFixed(5));
                 } else {
-                    log('Warning - First period duration could not be calculated because lack of start and duration period properties. This will cause timing issues during playback');
+                    logger.warn('First period duration could not be calculated because lack of start and duration period properties. This will cause timing issues during playback');
                 }
             }
 
@@ -1049,6 +1055,8 @@ function DashManifestModel(config) {
         getLocation: getLocation,
         getUseCalculatedLiveEdgeTimeForAdaptation: getUseCalculatedLiveEdgeTimeForAdaptation
     };
+
+    setup();
 
     return instance;
 }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -563,7 +563,7 @@ function MediaPlayer() {
                 const buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));
                 return buffer ? buffer : NaN;
             } else {
-                logger.warn('Warning  - getBufferLength requested for invalid type');
+                logger.warn('getBufferLength requested for invalid type');
                 return NaN;
             }
         }
@@ -1239,7 +1239,7 @@ function MediaPlayer() {
         if (value === Constants.ABR_STRATEGY_DYNAMIC || value === Constants.ABR_STRATEGY_BOLA || value === Constants.ABR_STRATEGY_THROUGHPUT) {
             mediaPlayerModel.setABRStrategy(value);
         } else {
-            logger.warn('Warning: Ignoring setABRStrategy(' + value + ') - unknown value.');
+            logger.warn('Ignoring setABRStrategy(' + value + ') - unknown value.');
         }
     }
 

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -70,7 +70,7 @@ function KeySystemW3CClearKey(config) {
             }
             clearkeySet = new ClearKeyKeySet(keyPairs);
 
-            debug.warn('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
+            debug.warn('ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
         }
         return clearkeySet;
     }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -206,7 +206,7 @@ function TextSourceBuffer() {
             }
             embeddedTracks.push(mediaInfo);
         } else {
-            logger.warn('Warning: Embedded track ' + mediaInfo.id + ' not supported!');
+            logger.warn('Embedded track ' + mediaInfo.id + ' not supported!');
         }
     }
 

--- a/src/streaming/utils/DOMStorage.js
+++ b/src/streaming/utils/DOMStorage.js
@@ -76,7 +76,7 @@ function DOMStorage(config) {
                 storage = window[type];
             }
         } catch (error) {
-            logger.warn('Warning: DOMStorage access denied: ' + error.message);
+            logger.warn('DOMStorage access denied: ' + error.message);
             return supported;
         }
 
@@ -94,7 +94,7 @@ function DOMStorage(config) {
             storage.removeItem(testKey);
             supported = true;
         } catch (error) {
-            logger.warn('Warning: DOMStorage is supported, but cannot be used: ' + error.message);
+            logger.warn('DOMStorage is supported, but cannot be used: ' + error.message);
         }
 
         return supported;

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -85,7 +85,7 @@ function TTMLParser() {
             onOpenTag: function (ns, name, attrs) {
                 if (name === 'image' && ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt') {
                     if (!attrs[' imagetype'] || attrs[' imagetype'].value !== 'PNG') {
-                        logger.warn('Warning: smpte-tt imagetype != PNG. Discarded');
+                        logger.warn('smpte-tt imagetype != PNG. Discarded');
                         return;
                     }
                     currentImageId = attrs['http://www.w3.org/XML/1998/namespace id'].value;

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -390,10 +390,13 @@ describe('DashManifestModel', function () {
             'maxSegmentDuration': 4.5,
             'mediaPresentationDuration': 300.0
         };
+
         const periodsArray = dashManifestModel.getRegularPeriods(manifest);
 
         expect(periodsArray).to.be.instanceOf(Array);    // jshint ignore:line
         expect(periodsArray).to.have.lengthOf(1);        // jshint ignore:line
+        expect(periodsArray[0].start).to.equals(0);
+        expect(periodsArray[0].duration).to.equals(300);
     });
 
     it('should calculate period start and duration properties of periods when duration properties are provided for all but the latest', () => {

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -96,14 +96,14 @@ describe('DashManifestModel', function () {
     });
 
     it('should return null when getAdaptationForId is called and id is undefined and periodIndex = 0', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0 } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
         const adaptation = dashManifestModel.getAdaptationForId(undefined, manifest, 0);
 
         expect(adaptation).to.be.null;    // jshint ignore:line
     });
 
     it('should return valid value when getAdaptationForId is called and id is 0 and periodIndex = 0', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0 } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
         const adaptation = dashManifestModel.getAdaptationForId(0, manifest, 0);
 
         expect(adaptation.id).to.equal(0); // jshint ignore:line
@@ -130,14 +130,14 @@ describe('DashManifestModel', function () {
     });
 
     it('should return null when getAdaptationForIndex is called and id is undefined and periodIndex = 0', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0 } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
         const adaptation = dashManifestModel.getAdaptationForIndex(undefined, manifest, 0);
 
         expect(adaptation).to.be.null;    // jshint ignore:line
     });
 
     it('should return valid value when getAdaptationForIndex is called and id is 0 and periodIndex = 0', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0 } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
         const adaptation = dashManifestModel.getAdaptationForIndex(0, manifest, 0);
 
         expect(adaptation.id).to.equal(0); // jshint ignore:line
@@ -180,27 +180,27 @@ describe('DashManifestModel', function () {
     });
 
     it('should return an empty array when getAdaptationsForType is called and type is undefined', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0 } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
 
         expect(dashManifestModel.getAdaptationsForType.bind(dashManifestModel, manifest, 0, undefined)).to.throw('type is not defined');
     });
 
     it('should return an empty array when getAdaptationForType is called and streamInfo is undefined', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: 0, mimeType: 'video' } ] }] };
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0, mimeType: 'video' }] }] };
         const adaptation = dashManifestModel.getAdaptationForType(manifest, 0, 'video', undefined);
 
         expect(adaptation.id).to.equal(0); // jshint ignore:line
     });
 
     it('should return the correct adaptation when getAdaptationForType is called', () => {
-        const manifest = { Period_asArray: [ { AdaptationSet_asArray: [ { id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{value: 'main'}] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{value: 'main'}] }] }]};
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{ value: 'main' }] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{ value: 'main' }] }] }] };
 
         const streamInfo = {
             id: 'id'
         };
 
-        const track1 = {codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 0, isText: false, lang: 'eng',mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo};
-        const track2 = {codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 1, isText: false, lang: 'deu',mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo};
+        const track1 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 0, isText: false, lang: 'eng', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
+        const track2 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 1, isText: false, lang: 'deu', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
 
         mediaControllerMock.addTrack(track1);
         mediaControllerMock.addTrack(track2);
@@ -226,7 +226,7 @@ describe('DashManifestModel', function () {
     });
 
     it('should return null when getCodec is called and adaptation.Representation_asArray.length is -1', () => {
-        const codec = dashManifestModel.getCodec({Representation_asArray: {length: -1}});
+        const codec = dashManifestModel.getCodec({ Representation_asArray: { length: -1 } });
 
         expect(codec).to.be.null;    // jshint ignore:line
     });
@@ -244,7 +244,7 @@ describe('DashManifestModel', function () {
     });
 
     it('should return null when getMimeType is called and adaptation.Representation_asArray.length is -1', () => {
-        const mimeType = dashManifestModel.getMimeType({Representation_asArray: {length: -1}});
+        const mimeType = dashManifestModel.getMimeType({ Representation_asArray: { length: -1 } });
 
         expect(mimeType).to.be.null;    // jshint ignore:line
     });
@@ -363,6 +363,137 @@ describe('DashManifestModel', function () {
 
         expect(periodsArray).to.be.instanceOf(Array);    // jshint ignore:line
         expect(periodsArray).to.be.empty;                // jshint ignore:line
+    });
+
+    it('should return just the first period when type is static and neither start nor duration period attributes are provided', () => {
+        const manifest = {
+            'manifest': {
+                'Period': [
+                    {
+                        'id': '153199'
+                    },
+                    {
+                        'id': '153202'
+                    }
+                ],
+                'Period_asArray': [
+                    {
+                        'id': '153199'
+                    },
+                    {
+                        'id': '153202'
+                    }
+                ],
+                'type': 'static',
+                'mediaPresentationDuration': 300.0
+            },
+            'maxSegmentDuration': 4.5,
+            'mediaPresentationDuration': 300.0
+        };
+        const periodsArray = dashManifestModel.getRegularPeriods(manifest);
+
+        expect(periodsArray).to.be.instanceOf(Array);    // jshint ignore:line
+        expect(periodsArray).to.have.lengthOf(1);        // jshint ignore:line
+    });
+
+    it('should calculate period start and duration properties of periods when duration properties are provided for all but the latest', () => {
+        const manifest = {
+            'manifest': {
+                'Period': [
+                    {
+                        'id': '153199',
+                        'duration': 100
+                    },
+                    {
+                        'id': '153200',
+                        'duration': 50
+                    },
+                    {
+                        'id': '153201'
+                    }
+                ],
+                'Period_asArray': [
+                    {
+                        'id': '153199',
+                        'duration': 100
+                    },
+                    {
+                        'id': '153200',
+                        'duration': 50
+                    },
+                    {
+                        'id': '153201'
+                    }
+                ],
+                'type': 'static',
+                'mediaPresentationDuration': 320.0
+            },
+            'maxSegmentDuration': 4.5,
+            'mediaPresentationDuration': 320.0
+        };
+        const periodsArray = dashManifestModel.getRegularPeriods(manifest);
+
+        expect(periodsArray).to.be.instanceOf(Array);    // jshint ignore:line
+        expect(periodsArray).to.have.lengthOf(3);        // jshint ignore:line
+
+        expect(periodsArray[0].start).to.equals(0);
+        expect(periodsArray[0].duration).to.equals(100);
+
+        expect(periodsArray[1].start).to.equals(100);
+        expect(periodsArray[1].duration).to.equals(50);
+
+        expect(periodsArray[2].start).to.equals(150);
+        expect(periodsArray[2].duration).to.equals(170);
+    });
+
+    it('should calculate period start and duration properties of periods when start properties are provided for all but the first', () => {
+        const manifest = {
+            'manifest': {
+                'Period': [
+                    {
+                        'id': '153199'
+                    },
+                    {
+                        'id': '153200',
+                        'start': 80
+                    },
+                    {
+                        'id': '153201',
+                        'start': 120
+                    }
+                ],
+                'Period_asArray': [
+                    {
+                        'id': '153199'
+                    },
+                    {
+                        'id': '153200',
+                        'start': 80
+                    },
+                    {
+                        'id': '153201',
+                        'start': 120
+                    }
+                ],
+                'type': 'static',
+                'mediaPresentationDuration': 300.0
+            },
+            'maxSegmentDuration': 4.5,
+            'mediaPresentationDuration': 300.0
+        };
+        const periodsArray = dashManifestModel.getRegularPeriods(manifest);
+
+        expect(periodsArray).to.be.instanceOf(Array);    // jshint ignore:line
+        expect(periodsArray).to.have.lengthOf(3);        // jshint ignore:line
+
+        expect(periodsArray[0].start).to.equals(0);
+        expect(periodsArray[0].duration).to.equals(80);
+
+        expect(periodsArray[1].start).to.equals(80);
+        expect(periodsArray[1].duration).to.equals(40);
+
+        expect(periodsArray[2].start).to.equals(120);
+        expect(periodsArray[2].duration).to.equals(180);
     });
 
     it('should return an empty array when getAdaptationsForPeriod is called and period is undefined', () => {
@@ -552,9 +683,9 @@ describe('DashManifestModel', function () {
             const TEST_WEIGHT = 2;
             const node = {
                 BaseURL_asArray: [{
-                    __text:         TEST_URL,
+                    __text: TEST_URL,
                     'dvb:priority': TEST_PRIORITY,
-                    'dvb:weight':   TEST_WEIGHT
+                    'dvb:weight': TEST_WEIGHT
                 }]
             };
 

--- a/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
+++ b/test/unit/streaming.protection.drm.KeySystemW3CClearKey.js
@@ -40,7 +40,7 @@ describe('KeySystemW3CClearKey', function () {
     it('should warn when using this system', function () {
         keySystem = KeySystemW3CClearKey(context).getInstance(config);
         keySystem.getClearKeysFromProtectionData(protData, message);
-        expect(debug.warn).to.have.been.called.with('Warning: ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
+        expect(debug.warn).to.have.been.called.with('ClearKey schemeIdURI is using W3C Common PSSH systemID (1077efec-c0b2-4d02-ace3-3c1e52e2fb4b) in Content Protection. See DASH-IF IOP v4.1 section 7.6.2.4');
     });
 
     it('returns clearkey pair', function () {


### PR DESCRIPTION
Partial refactor of getRegularPeriods method of DashManifestModel. Added a new check to cover situations in which multi period streams, for static assets, are not defining start and duration attributes of any of their periods. This avoids dash.js to throw exceptions, and logs a warning message to notify the user about the issue. 

Note: Having this situation implies a wrong mpd and that, even with this fix, there will be timing inconsistencies after the first period. However, IMHO, I prefer dash.js to play something whenever is possible. Once we add the flag to dash.js to allow/disallow playback of streams/assets out of DASH IOP guidelines, I will revisit this.

Added unit tests to cover this and regular situations (multiple combinations of period with combinations of start and duration attributes).