### PR TITLE
Fix LOADING_PROGRESS event not being fired

### DIFF
--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -98,14 +98,14 @@ function FragmentLoader(config) {
         if (request) {
             httpLoader.load({
                 request: request,
-                progress: function (data) {
+                progress: function (event) {
                     eventBus.trigger(Events.LOADING_PROGRESS, {
                         request: request
                     });
-                    if (data) {
+                    if (event.data) {
                         eventBus.trigger(Events.LOADING_DATA_PROGRESS, {
                             request: request,
-                            response: data || null,
+                            response: event.data || null,
                             error: null,
                             sender: instance
                         });

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -175,8 +175,8 @@ function HTTPLoader(cfg) {
                 lastTraceReceivedCount = event.loaded;
             }
 
-            if (config.progress && event.data) {
-                config.progress(event.data);
+            if (config.progress && event) {
+                config.progress(event);
             }
         };
 


### PR DESCRIPTION
Fixes LOADING_PROGRESS event, an event required to be able to abandon requests and make the ABR algorithm work. Fixes #2632