### PR TITLE
Fixed crash when calling attachView on an already initialized player

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -420,8 +420,10 @@ function StreamController() {
     }
 
     function switchToVideoElement(seekTime) {
-        playbackController.initialize(activeStream.getStreamInfo());
-        openMediaSource(seekTime, null, true);
+        if (activeStream) {
+            playbackController.initialize(activeStream.getStreamInfo());
+            openMediaSource(seekTime, null, true);
+        }
     }
 
     function openMediaSource(seekTime, oldStream, streamActivated) {


### PR DESCRIPTION
Fixes a crash by checking if there is an active stream in the `StreamController` before trying to initialize `PlaybackController`

Fixes #2637