### PR TITLE
send proper field to Cea608Parser

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -468,7 +468,7 @@ function TextSourceBuffer() {
                             return;
                         }
                         handler = makeCueAdderForIndex(this, trackIdx);
-                        embeddedCea608FieldParsers[i] = new cea608parser.Cea608Parser(i, {
+                        embeddedCea608FieldParsers[i] = new cea608parser.Cea608Parser(i + 1, {
                             'newCue': handler
                         }, null);
                     }


### PR DESCRIPTION
This is just a minor fix. The `Cea608Parser` expects fields to be 1 or 2, not 0 or 1. This is made worse by [a `0 || 1` error in the parser](https://github.com/Dash-Industry-Forum/cea608.js/blob/master/lib/cea608-parser.js#L804), so its field will always be 1.

Note that the parser doesn't ever actually use the value of `this.field`, which is why this hasn't caused any bugs.