### PR TITLE
Fix Another ES5 Incompatibility in ControlBar.js

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -468,7 +468,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
                 if (availableBitrates.audio.length > 1 || availableBitrates.video.length > 1) {
                     contentFunc = function (element, index) {
                         var result = isNaN(index) ? " Auto Switch" : Math.floor(element.bitrate / 1000) + ' kbps';
-                        result += element && element.width && element.height ? ` (${element.width}x${element.height})` : '';
+                        result += element && element.width && element.height ? ' (' + element.width + 'x' + element.height + ')' : '';
                         return result;
                     }
 


### PR DESCRIPTION
Fixed an ES5 incompatibility where a template string was used. Since ControlBar.js is an external module and is not compiled it should remain compatible with ES5.

Side note: ES6 will break uglifyjs since it expects ES5, there is a separate project uglify-es that has the ability to minify ES6.

Related: https://github.com/Dash-Industry-Forum/dash.js/pull/2576