### PR TITLE
Fixed stream reload when seeking

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -241,7 +241,8 @@ function StreamController() {
             preloading.deactivate(true);
         }
 
-        if (seekingStream && (seekingStream !== activeStream || !activeStream.isActive()) ) {
+        if (seekingStream && (seekingStream !== activeStream || (preloading && !activeStream.isActive()))) {
+            // If we're preloading other stream, the active one was deactivated and we need to switch back
             flushPlaylistMetrics(PlayListTrace.END_OF_PERIOD_STOP_REASON);
             switchStream(activeStream, seekingStream, e.seekTime);
         } else {


### PR DESCRIPTION
Fixed an issue causing a stream reload when seeking into the current stream but with reloaded manifest. Found on 2.8 RC1