### PR TITLE
Keep media keys

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -256,6 +256,7 @@ declare namespace dashjs {
         setManifestUpdateRetryInterval(value: number): void;        
         getManifestUpdateRetryInterval(): number;
         setSegmentOverlapToleranceTime(value: number): void;
+        keepProtectionMediaKeys(value: boolean): void;
     }
 
     export interface MediaPlayerFactory {

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,6 +256,7 @@ declare namespace dashjs {
         setManifestUpdateRetryInterval(value: number): void;        
         getManifestUpdateRetryInterval(): number;
         setSegmentOverlapToleranceTime(value: number): void;
+        keepProtectionMediaKeys(value: boolean): void;
     }
 
     export interface MediaPlayerFactory {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2670,9 +2670,13 @@ function MediaPlayer() {
         mediaController.reset();
         textController.reset();
         if (protectionController) {
-            protectionController.reset();
-            protectionController = null;
-            detectProtection();
+            if (mediaPlayerModel.getKeepProtectionMediaKeys()) {
+                protectionController.stop();
+            } else {
+                protectionController.reset();
+                protectionController = null;
+                detectProtection();
+            }
         }
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2487,6 +2487,28 @@ function MediaPlayer() {
     /*
     ---------------------------------------------------------------------------
 
+        PROTECTION CONTROLLER MANAGEMENT
+
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Set the value for the ProtectionController and MediaKeys life cycle. If true, the
+     * ProtectionController and then created MediaKeys and MediaKeySessions will be preserved during
+     * the MediaPlayer lifetime.
+     *
+     * @param {boolean=} value - True or false flag.
+     *
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function keepProtectionMediaKeys(value) {
+        mediaPlayerModel.setKeepProtectionMediaKeys(value);
+    }
+
+    /*
+    ---------------------------------------------------------------------------
+
         TOOLS AND OTHERS FUNCTIONS
 
     ---------------------------------------------------------------------------
@@ -3006,6 +3028,7 @@ function MediaPlayer() {
         getUseDeadTimeLatencyForAbr: getUseDeadTimeLatencyForAbr,
         setUseDeadTimeLatencyForAbr: setUseDeadTimeLatencyForAbr,
         getThumbnail: getThumbnail,
+        keepProtectionMediaKeys: keepProtectionMediaKeys,
         reset: reset
     };
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -114,7 +114,8 @@ function MediaPlayerModel() {
         jumpGaps,
         smallGapLimit,
         lowLatencyEnabled,
-        manifestUpdateRetryInterval;
+        manifestUpdateRetryInterval,
+        keepProtectionMediaKeys;
 
     function setup() {
         UTCTimingSources = [];
@@ -533,6 +534,14 @@ function MediaPlayerModel() {
         return manifestUpdateRetryInterval;
     }
 
+    function setKeepProtectionMediaKeys(value) {
+        keepProtectionMediaKeys = value;
+    }
+
+    function getKeepProtectionMediaKeys() {
+        return keepProtectionMediaKeys;
+    }
+
     function reset() {
         //TODO need to figure out what props to persist across sessions and which to reset if any.
         //setup();
@@ -613,6 +622,8 @@ function MediaPlayerModel() {
         setLowLatencyEnabled: setLowLatencyEnabled,
         setManifestUpdateRetryInterval: setManifestUpdateRetryInterval,
         getManifestUpdateRetryInterval: getManifestUpdateRetryInterval,
+        setKeepProtectionMediaKeys: setKeepProtectionMediaKeys,
+        getKeepProtectionMediaKeys: getKeepProtectionMediaKeys,
         reset: reset
     };
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -179,6 +179,8 @@ function MediaPlayerModel() {
         cacheLoadThresholds = {};
         cacheLoadThresholds[Constants.VIDEO] = CACHE_LOAD_THRESHOLD_VIDEO;
         cacheLoadThresholds[Constants.AUDIO] = CACHE_LOAD_THRESHOLD_AUDIO;
+
+        keepProtectionMediaKeys = false;
     }
 
     //TODO Should we use Object.define to have setters/getters? makes more readable code on other side.

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -291,8 +291,21 @@ function ProtectionController(config) {
     }
 
     /**
+     * Stop method is called when current playback is stopped/resetted.
+     *
+     * @memberof module:ProtectionController
+     * @instance
+     */    
+    function stop() {
+        if (protectionModel) {
+            protectionModel.stop();
+        }
+    }
+
+
+    /**
      * Destroys all protection data associated with this protection set.  This includes
-     * deleting all key sessions.  In the case of persistent key sessions, the sessions
+     * deleting all key sessions. In the case of persistent key sessions, the sessions
      * will simply be unloaded and not deleted.  Additionally, if this protection set is
      * associated with a HTMLMediaElement, it will be detached from that element.
      *
@@ -666,6 +679,7 @@ function ProtectionController(config) {
         setProtectionData: setProtectionData,
         getSupportedKeySystemsFromContentProtection: getSupportedKeySystemsFromContentProtection,
         getKeySystems: getKeySystems,
+        stop: stop,
         reset: reset
     };
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -295,7 +295,7 @@ function ProtectionController(config) {
      *
      * @memberof module:ProtectionController
      * @instance
-     */    
+     */
     function stop() {
         if (protectionModel) {
             protectionModel.stop();
@@ -442,6 +442,9 @@ function ProtectionController(config) {
                 eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
                 eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
                 if (!event.error) {
+                    if (!protectionModel) {
+                        return;
+                    }
                     keySystem = protectionModel.getKeySystem();
                     eventBus.trigger(events.KEY_SYSTEM_SELECTED, {data: keySystemAccess});
                     // Set server certificate from protData
@@ -577,6 +580,9 @@ function ProtectionController(config) {
         xhr.open(licenseServerData.getHTTPMethod(messageType), url, true);
         xhr.responseType = licenseServerData.getResponseType(keySystemString, messageType);
         xhr.onload = function () {
+            if (!protectionModel) {
+                return;
+            }
             if (this.status == 200) {
                 const licenseMessage = licenseServerData.getLicenseMessage(this.response, keySystemString, messageType);
                 if (licenseMessage !== null) {

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -407,6 +407,7 @@ function ProtectionModel_01b(config) {
         setServerCertificate: setServerCertificate,
         loadKeySession: loadKeySession,
         removeKeySession: removeKeySession,
+        stop: reset,
         reset: reset
     };
 

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -370,6 +370,7 @@ function ProtectionModel_3Feb2014(config) {
         setServerCertificate: setServerCertificate,
         loadKeySession: loadKeySession,
         removeKeySession: removeKeySession,
+        stop: reset,
         reset: reset
     };
 


### PR DESCRIPTION
The goal of this PR to enable maintining the MediaKeys instance and all valid MediaKeySessions during the MediaPlayer lifetime.

The use case is a live service for which you instantiate a MediaPlayer to playback all the streams.
Then you can specify the keep the MediaKeys instance when one zaps over all the streams/channels.
The benefits are:
- only 1 license request per channel during the MediaPlayer lifetime
- zapping time is reduced since you do request media key system access only at 1st playback, and do not need to request license if channel has been already played

By default, this option is disabled.

The condition before enabling this option is to ensure that the key system configuration (license type, audio/video robustness levels...) is the same for all streams/channels