### PR TITLE
Fix stalling after seeking

### DIFF
--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -278,6 +278,8 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
                 waitForUpdateEnd(buffer, cb);
             } else {
                 cb();
+                // Try to execute next callback if still not updating
+                executeCallback();
             }
         }
 


### PR DESCRIPTION
Executing all possible callbacks after appending to the buffer to avoid some of them getting stuck until next append / remove.

This fixes a random stall after seeking.