### PR TITLE
Correct audio segments scheduling in live mode

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -398,6 +398,7 @@ function ScheduleController(config) {
                 playbackController.setLiveStartTime(request.startTime);
             }
             seekTarget = playbackController.getStreamStartTime(false, liveEdge);
+            streamProcessor.getBufferController().setSeekStartTime(seekTarget);
 
             //special use case for multi period stream. If the startTime is out of the current period, send a seek command.
             //in onPlaybackSeeking callback (StreamController), the detection of switch stream is done.


### PR DESCRIPTION
In live mode, until the first video segment is appended, the audio scheduling (via the BufferLevelRule) was considering audio buffer level always equal to 0.
Then in case 1st video segment takes some time to be downloaded, this can lead scheduler to request audio segments at live edge before they are available.

With this PR audio scheduler is correctly aligned with video scheduler. 