### PR TITLE
Protection Controller onNeedKey will be delayed until initializeForMedia is called

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -33,6 +33,9 @@ import CommonEncryption from '../CommonEncryption';
 import MediaCapability from '../vo/MediaCapability';
 import KeySystemConfiguration from '../vo/KeySystemConfiguration';
 
+const NEEDKEY_BEFORE_INITIALIZE_RETRIES = 5;
+const NEEDKEY_BEFORE_INITIALIZE_TIMEOUT = 500;
+
 /**
  * @module ProtectionController
  * @description Provides access to media protection information and functionality.  Each
@@ -57,6 +60,7 @@ function ProtectionController(config) {
     const debug = config.debug;
     const BASE64 = config.BASE64;
     const constants = config.constants;
+    let needkeyRetries = [];
 
     let instance,
         logger,
@@ -312,6 +316,9 @@ function ProtectionController(config) {
             protectionModel.reset();
             protectionModel = null;
         }
+
+        needkeyRetries.forEach( retryTimeout => clearTimeout(retryTimeout));
+        needkeyRetries = [];
 
         mediaInfoArr = [];
     }
@@ -605,12 +612,24 @@ function ProtectionController(config) {
         xhr.send(keySystem.getLicenseRequestFromMessage(message));
     }
 
-    function onNeedKey(event) {
+    function onNeedKey(event, retry) {
         logger.debug('DRM: onNeedKey');
         // Ignore non-cenc initData
         if (event.key.initDataType !== 'cenc') {
             logger.warn('DRM:  Only \'cenc\' initData is supported!  Ignoring initData of type: ' + event.key.initDataType);
             return;
+        }
+
+        if (mediaInfoArr.length === 0) {
+            logger.warn('DRM: onNeedKey called before initializeForMedia, wait until initialized');
+            retry = typeof retry === 'undefined' ? 1 : retry + 1;
+            if (retry < NEEDKEY_BEFORE_INITIALIZE_RETRIES) {
+                needkeyRetries.push(setTimeout(() => {
+                    onNeedKey(event, retry);
+                }, NEEDKEY_BEFORE_INITIALIZE_TIMEOUT));
+                return;
+            }
+
         }
 
         // Some browsers return initData as Uint8Array (IE), some as ArrayBuffer (Chrome).


### PR DESCRIPTION
This PR prevents a rare player crash when a NeedKey event was fired before initializeForMedia was called, now it will retry a few times.