### PR TITLE
pass distinctiveIdentifier and persistentState through to CDM

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -337,6 +337,8 @@ function ProtectionController(config) {
         const audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
         const videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
         const ksSessionType = getSessionType(keySystem);
+        const distinctiveIdentifier = (protData && protData.distinctiveIdentifier) ? protData.distinctiveIdentifier : 'optional';
+        const persistentState = (protData && protData.persistentState) ? protData.persistentState : (ksSessionType === 'temporary') ? 'optional' : 'required';
 
         mediaInfoArr.forEach((media) => {
             if (media.type === constants.AUDIO) {
@@ -347,8 +349,8 @@ function ProtectionController(config) {
         });
 
         return new KeySystemConfiguration(
-            audioCapabilities, videoCapabilities, 'optional',
-            (ksSessionType === 'temporary') ? 'optional' : 'required',
+            audioCapabilities, videoCapabilities, distinctiveIdentifier,
+            persistentState,
             [ksSessionType]);
     }
 


### PR DESCRIPTION
It's needed for our DRM provider for Chrome, perhaps others will as well.

If there are tests / documentation to update please let me know and I will update them.