### PR TITLE
Don't log messages when browser report playback stalled

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -688,7 +688,6 @@ function PlaybackController() {
     }
 
     function onPlaybackStalled(e) {
-        logger.info('Native video element event: stalled', e);
         eventBus.trigger(Events.PLAYBACK_STALLED, {
             e: e
         });


### PR DESCRIPTION
Fix #2660. Given how media element stalled event works in browsers (Chrome), they are not useful anymore and reporting them in dash.js logging system could cause confusion in user side.