### PR TITLE
Fix to update liveEdge in every segment list update

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -223,7 +223,7 @@ function DashHandler(config) {
         voRepresentation.segments = segments;
         if (segments && segments.length > 0) {
             earliestTime = isNaN(earliestTime) ? segments[0].presentationStartTime : Math.min(segments[0].presentationStartTime,  earliestTime);
-            if (isDynamic && isNaN(timelineConverter.getExpectedLiveEdge())) {
+            if (isDynamic) {
                 const lastSegment = segments[segments.length - 1];
                 const liveEdge = lastSegment.presentationStartTime;
                 const metrics = metricsModel.getMetricsFor(Constants.STREAM);


### PR DESCRIPTION
**Use-case** : In a multi-period dynamic content with SegmentTimeline in MPD, the playback stops after first period. 
**Root-Cause**: The start time of second period is not available and playback fails. While starting the playback of the second period, start time calculation uses live edge. Live edge is not updated and it has the value of first period last segment. 
**Analysis** :  liveEdge is assigned only at the beginning of playback, when it NaN. It is not updated when the second period and segments added to the manifest. This value is used in calculation of start time in setLiveEdgeSeekTarget (ScheduleController.js).  

Fix for Issue #2639