### PR TITLE
Add CAPTION_RENDERED event

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -76,6 +76,7 @@ declare namespace dashjs {
         initialize(view?: HTMLElement, source?: string, autoPlay?: boolean): void;
         on(type: AstInFutureEvent['type'], listener: (e: AstInFutureEvent) => void, scope?: object): void;
         on(type: BufferEvent['type'], listener: (e: BufferEvent) => void, scope?: object): void;
+        on(type: CaptionRenderedEvent['type'], listener: (e: CaptionRenderedEvent) => void, scope?: object): void;
         on(type: ErrorEvent['type'], listener: (e: ErrorEvent) => void, scope?: object): void;
         on(type: FragmentLoadingCompletedEvent['type'], listener: (e: FragmentLoadingCompletedEvent) => void, scope?: object): void;
         on(type: FragmentLoadingAbandonedEvent['type'], listener: (e: FragmentLoadingAbandonedEvent) => void, scope?: object): void;
@@ -248,6 +249,7 @@ declare namespace dashjs {
         BUFFER_LEVEL_STATE_CHANGED: 'bufferStateChanged';
         BUFFER_LOADED: 'bufferLoaded';
         CAN_PLAY: 'canPlay';
+        CAPTION_RENDERED: 'captionRendered';
         ERROR: 'error';
         FRAGMENT_LOADING_ABANDONED: 'fragmentLoadingAbandoned';
         FRAGMENT_LOADING_COMPLETED: 'fragmentLoadingCompleted';
@@ -356,6 +358,12 @@ declare namespace dashjs {
     }
 
     export type ErrorEvent = GenericErrorEvent | DownloadErrorEvent | ManifestErrorEvent | TimedTextErrorEvent;
+
+    export interface CaptionRenderedEvent extends Event {
+        type: MediaPlayerEvents['CAPTION_RENDERED'];
+        captionDiv: HTMLDivElement;
+        currentTrackIdx: number;
+    }
 
     export interface FragmentLoadingCompletedEvent extends Event {
         type: MediaPlayerEvents['FRAGMENT_LOADING_COMPLETED'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ declare namespace dashjs {
         initialize(view?: HTMLElement, source?: string, autoPlay?: boolean): void;
         on(type: AstInFutureEvent['type'], listener: (e: AstInFutureEvent) => void, scope?: object): void;
         on(type: BufferEvent['type'], listener: (e: BufferEvent) => void, scope?: object): void;
+        on(type: CaptionRenderedEvent['type'], listener: (e: CaptionRenderedEvent) => void, scope?: object): void;
         on(type: ErrorEvent['type'], listener: (e: ErrorEvent) => void, scope?: object): void;
         on(type: FragmentLoadingCompletedEvent['type'], listener: (e: FragmentLoadingCompletedEvent) => void, scope?: object): void;
         on(type: FragmentLoadingAbandonedEvent['type'], listener: (e: FragmentLoadingAbandonedEvent) => void, scope?: object): void;
@@ -248,6 +249,7 @@ declare namespace dashjs {
         BUFFER_LEVEL_STATE_CHANGED: 'bufferStateChanged';
         BUFFER_LOADED: 'bufferLoaded';
         CAN_PLAY: 'canPlay';
+        CAPTION_RENDERED: 'captionRendered';
         ERROR: 'error';
         FRAGMENT_LOADING_ABANDONED: 'fragmentLoadingAbandoned';
         FRAGMENT_LOADING_COMPLETED: 'fragmentLoadingCompleted';
@@ -356,6 +358,12 @@ declare namespace dashjs {
     }
 
     export type ErrorEvent = GenericErrorEvent | DownloadErrorEvent | ManifestErrorEvent | TimedTextErrorEvent;
+
+    export interface CaptionRenderedEvent extends Event {
+        type: MediaPlayerEvents['CAPTION_RENDERED'];
+        captionDiv: HTMLDivElement;
+        currentTrackIdx: number;
+    }
 
     export interface FragmentLoadingCompletedEvent extends Event {
         type: MediaPlayerEvents['FRAGMENT_LOADING_COMPLETED'];

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -207,6 +207,12 @@ class MediaPlayerEvents extends EventsBase {
         this.TTML_TO_PARSE = 'ttmlToParse';
 
         /**
+         * Triggered when a caption is rendered.
+         * @event MediaPlayerEvents#CAPTION_RENDERED
+         */
+        this.CAPTION_RENDERED = 'captionRendered';
+
+        /**
          * Sent when enough data is available that the media can be played,
          * at least for a couple of frames.  This corresponds to the
          * HAVE_ENOUGH_DATA readyState.

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -386,6 +386,7 @@ function TextTracks() {
                 //TODO add ErrorHandler management
             }, previousISDState, true /*enableRollUp*/);
             finalCue.id = cue.cueID;
+            eventBus.trigger(Events.CAPTION_RENDERED, {captionDiv: finalCue, currentTrackIdx});
         }
     }
 


### PR DESCRIPTION
Adds a new CAPTION_RENDERED event that is triggered every time a caption is rendered on screen or when a caption is re-rendered due to a video resize.