### PR TITLE
Seeking will remove preload timer

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -95,6 +95,7 @@ function StreamController() {
         audioTrackDetected,
         isStreamBufferingCompleted,
         playbackEndedTimerId,
+        preloadTimerId,
         wallclockTicked,
         buffers,
         compatible,
@@ -236,6 +237,10 @@ function StreamController() {
             isStreamBufferingCompleted = false;
         }
 
+        if (preloadTimerId) {
+            stopPreloadTimer();
+        }
+
         if ( seekingStream === activeStream && preloading ) {
             // Seeking to the current period was requested while preloading the next one, deactivate preloading one
             preloading.deactivate(true);
@@ -281,6 +286,12 @@ function StreamController() {
         playbackEndedTimerId = undefined;
     }
 
+    function stopPreloadTimer() {
+        logger.debug('[PreloadTimer] stop period preload timer.');
+        clearTimeout(preloadTimerId);
+        preloadTimerId = undefined;
+    }
+
     function toggleEndPeriodTimer() {
         //stream buffering completed has not been detected, nothing to do....
         if (isStreamBufferingCompleted) {
@@ -294,7 +305,7 @@ function StreamController() {
                 playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED, {'isLast': getActiveStreamInfo().isLast});}, delayPlaybackEnded);
                 const preloadDelay = delayPlaybackEnded < 2000 ? delayPlaybackEnded / 4 : delayPlaybackEnded - 2000;
                 logger.info('[StreamController][toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
-                setTimeout(onStreamCanLoadNext,  preloadDelay);
+                preloadTimerId = setTimeout(onStreamCanLoadNext,  preloadDelay);
             }
         }
     }


### PR DESCRIPTION
When the stream is fully loaded, we set a timeout to preload the next stream in the future. This timeout was not cleared when seeking, so the stream could be preloaded several times causing weird behavior.

This PR fixes it.