### PR TITLE
Fixed a bug causing a loop requesting a chunk when a gap was created after appending

### DIFF
--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -162,7 +162,7 @@ function FragmentModel(config) {
 
     function removeExecutedRequestsAfterTime(time) {
         executedRequests = executedRequests.filter(req => {
-            return isNaN(req.startTime) || (time !== undefined ? req.startTime < time : false);
+            return isNaN(req.startTime) || (time !== undefined ? req.startTime + req.duration < time : false);
         });
     }
 


### PR DESCRIPTION
After we trigger unintended removal, executedRequests will be filtered by endTime, not startTime, in case a chunk was deleted partially only.

Fixes #2690