### PR TITLE
[MSS] Live subtitles bug fix

### DIFF
--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -111,11 +111,11 @@ function MssFragmentMoofProcessor(config) {
             t = segment.t;
 
             // Determine the segments' availability start time
-            availabilityStartTime = t - (manifest.timeShiftBufferDepth * timescale);
+            availabilityStartTime = Math.round((t - (manifest.timeShiftBufferDepth * timescale)) / timescale);
 
             // Remove segments prior to availability start time
             segment = segments[0];
-            while (segment.t < availabilityStartTime) {
+            while (Math.round(segment.t / timescale) < availabilityStartTime) {
                 logger.debug('Remove segment  - t = ' + (segment.t / timescale));
                 segments.splice(0, 1);
                 segment = segments[0];


### PR DESCRIPTION
Hi,

this PR has to solve an issue about subitles in mss live stream. To reproduce it, in development branch, you just have to select mss Prince Of Persia - Live stream. After few or more seconds, subtitles will disappear. The origin of this issue is the removal of two segments in MssFragmentMoofProcessor instead of only one. The source code is modified by using precision of the second in this removal.

Nico