### PR TITLE
BUGFIX: Clean-up CDM key sessions when videoelement unref'ed.

### DIFF
--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -182,6 +182,14 @@ function ProtectionModel_01b(config) {
         // Replacing the previous element
         if (videoElement) {
             removeEventListeners();
+
+            // VUDU Rik - close any open sessions
+            if (sessions) {
+                for (var i = 0; i < sessions.length; i++) {
+                    closeKeySession(sessions[i]);
+                }
+                sessions = [];
+            }
         }
 
         videoElement = mediaElement;


### PR DESCRIPTION
Seems like a bug was introduced to DASH-JS in the refactor of
ProtectionController/ProtectionModel.  The old "teardown()" code
was removed (see dashjs1.6) and now StreamController::reset() calls
ProtectionController::reset().

ProtectionController::reset() nulls out the videoElement reference in
the ProtectionModel, so ProtectionModel::reset() is not able to call
cancelKeyRequest().

Add code in ProtectionModel::setMediaElement() to close the keysessions
on the de-referenced videoElement.