### PR TITLE
Edge licenses persistence

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -458,6 +458,12 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         // Check if persistent license session ID is stored for current stream
         var sessionId = $scope.persistentSessionId[$scope.selectedItem.url];
         if (sessionId) {
+            if (!protData) {
+                protData = {};
+            }
+            if (!protData[$scope.selectedKeySystem]) {
+                protData[$scope.selectedKeySystem] = {};
+            }
             protData[$scope.selectedKeySystem].sessionId = sessionId;
         }
 

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -778,6 +778,16 @@
           }
         },
         {
+          "name": "Microsoft AZURE MEDIA SERVICES ON DEMAND H264 AAC 4K CENC PLAYREADY 2.0 (persistent)",
+          "url": "https://profficialsite.origin.mediaservices.windows.net/c51358ea-9a5e-4322-8951-897d640fdfd7/tearsofsteel_4k.ism/manifest(format=mpd-time-csf)",
+          "protData": {
+            "com.microsoft.playready": {
+              "serverURL": "http://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:true,sl:150)",
+              "sessionType": "persistent-license"
+            }
+          }
+        },
+        {
           "name": "Source: XBox One commercial video",
           "url": "https://profficialsite.origin.mediaservices.windows.net/9cc5e871-68ec-42c2-9fc7-fda95521f17d/dayoneplayready.ism/manifest(format=mpd-time-csf)",
           "protData": {
@@ -940,9 +950,14 @@
         },
         {
           "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
-          "name": "Super Speedway + PlayReady DRM",
+          "name": "Super Speedway + PlayReady DRM"
+        },
+        {
+          "url": "http://test.playready.microsoft.com/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
+          "name": "Super Speedway + PlayReady DRM (persistent)",
           "protData": {
             "com.microsoft.playready": {
+                "serverURL": "http://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:true,sl:150)",                
                 "sessionType": "persistent-license"
               }
           }

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -940,7 +940,12 @@
         },
         {
           "url": "http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
-          "name": "Super Speedway + PlayReady DRM"
+          "name": "Super Speedway + PlayReady DRM",
+          "protData": {
+            "com.microsoft.playready": {
+                "sessionType": "persistent-license"
+              }
+          }
         }
       ]
     }

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -281,7 +281,13 @@ function KeySystemPlayReady(config) {
         return null;
     }
 
-    function getSessionId(/*cp*/) {
+    function getSessionId(cp) {
+        // Get sessionId from protectionData or from manifest
+        if (protData && protData.sessionId) {
+            return protData.sessionId;
+        } else if (cp && cp.sessionId) {
+            return cp.sessionId;
+        }
         return null;
     }
 

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -290,7 +290,14 @@ function ProtectionModel_21Jan2015(config) {
         (function (i) {
             const keySystem = ksConfigurations[i].ks;
             const configs = ksConfigurations[i].configs;
-            navigator.requestMediaKeySystemAccess(keySystem.systemString, configs).then(function (mediaKeySystemAccess) {
+            let systemString = keySystem.systemString;
+
+            // PATCH to support persistent licenses on Edge browser (see issue #2658)
+            if (systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING && configs[0].persistentState === 'required') {
+                systemString += '.recommendation';
+            }
+
+            navigator.requestMediaKeySystemAccess(systemString, configs).then(function (mediaKeySystemAccess) {
                 // Chrome 40 does not currently implement MediaKeySystemAccess.getConfiguration()
                 const configuration = (typeof mediaKeySystemAccess.getConfiguration === 'function') ?
                         mediaKeySystemAccess.getConfiguration() : null;


### PR DESCRIPTION
This PR enables license persistence on Edge browser using 'com.microsoft.playready.recommendation' key system, as discussed in issue #2658.

Waiting for DASH test streams to be added in sample to validate this PR.