### PR TITLE
Internal seek update

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -663,7 +663,7 @@ function PlaybackController() {
                     ranges = bufferedRange[streamInfo.id].video;
                 }
                 if (checkTimeInRanges(earliestTime, ranges)) {
-                    if (!isSeeking() && !compatibleWithPreviousStream) {
+                    if (!isSeeking() && !compatibleWithPreviousStream && earliestTime !== 0) {
                         seek(earliestTime, true, true);
                     }
                     commonEarliestTime[streamInfo.id].started = true;


### PR DESCRIPTION
Hi,

this PR has to fix issue #2715 : no need to do an internal seek if earliestTime (common time of video and audio types) is 0.

Nico