### PR TITLE
Fixed error in index.d.ts.

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -390,6 +390,7 @@ declare namespace dashjs {
         type: MediaPlayerEvents['CAPTION_RENDERED'];
         captionDiv: HTMLDivElement;
         currentTrackIdx: number;
+    }
 
     export interface CaptionContainerResizeEvent extends Event {
         type: MediaPlayerEvents['CAPTION_CONTAINER_RESIZE'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -390,6 +390,7 @@ declare namespace dashjs {
         type: MediaPlayerEvents['CAPTION_RENDERED'];
         captionDiv: HTMLDivElement;
         currentTrackIdx: number;
+    }
 
     export interface CaptionContainerResizeEvent extends Event {
         type: MediaPlayerEvents['CAPTION_CONTAINER_RESIZE'];


### PR DESCRIPTION
Fixed missing closing curly brace at the end of CaptionRenderedEvent in index.d.ts that prevented TypeScript projects from building.