### PR TITLE
Update Gap detection in NextFragmentRequestRule

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -158,7 +158,8 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         audio: null,
         video: null,
         text: null,
-        textEnabled: true
+        textEnabled: true,
+        forceTextStreaming: false
     };
     $scope.mediaSettingsCacheEnabled = true;
     $scope.metricsTimer = null;
@@ -461,6 +462,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             $scope.player.setTextDefaultLanguage($scope.initialSettings.text);
         }
         $scope.player.setTextDefaultEnabled($scope.initialSettings.textEnabled);
+        $scope.player.enableForcedTextStreaming($scope.initialSettings.forceTextStreaming);
         $scope.controlbar.enable();
     };
 

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -223,6 +223,11 @@
                         <input type="checkbox" id="enableTextAtLoading" ng-model="initialSettings.textEnabled">
                         Enable Text At Loading
                     </label>
+                    <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                           title="Force text streaming">
+                        <input type="checkbox" id="enableForceTextStreaming" ng-model="initialSettings.forceTextStreaming">
+                        Force Text Streaming
+                    </label>
 
                 </div>
             </div>

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -80,7 +80,7 @@ function NextFragmentRequestRule(config) {
             const numberOfBuffers = bufferRanges ? bufferRanges.length : 0;
             if ((range !== null || playingRange !== null) && !hasSeekTarget) {
                 if ( !range || (playingRange && playingRange.start != range.start && playingRange.end != range.end) ) {
-                    if (numberOfBuffers > 1 ) {
+                    if (numberOfBuffers > 1 && mediaType !== Constants.FRAGMENTED_TEXT) {
                         streamProcessor.getFragmentModel().removeExecutedRequestsAfterTime(playingRange.end);
                         bufferIsDivided = true;
                     }


### PR DESCRIPTION
Hi,

this PR has to solve issue detected by @dsparacio in dashjs slack channel. 

_In 2.7.0 I added enableForcedTextStreaming and it is working as expected in 2.7.0.  However in 2.9.0 it still works upfront, but on a seek the text fragment is loaded over and over again rapidly and fills the text track with duplication of captions_

The bug could also occur by doing a simple seek command.

NextFragmentRequestRule has not to detect gap in buffers for fragmented Text media type because those buffers are never deleted when, for instance, a seek command occurs.

Nico