### PR TITLE
update bandwidth replacement

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -299,7 +299,7 @@ function ScheduleController(config) {
         const request = adapter.getInitRequest(streamProcessor, quality);
         if (request) {
             setFragmentProcessState(true);
-            request.url = replaceTokenForTemplate(request.url, 'Bandwidth', currentRepresentationInfo.bandwidth);
+            request.url = replaceTokenForTemplate(request.url, 'Bandwidth', currentRepresentationInfo ? currentRepresentationInfo.bandwidth : null);
             fragmentModel.executeRequest(request);
         }
     }


### PR DESCRIPTION
Hi,

since the PR #2747, the bandwidth parameter is replaced for init fragment too. The problem is that for full subtitles file, the currentRepresentationInfo is undefined.

In order to test this issue, the stream 'TTML Sideloaded XML Subtitles' can be use.

Nico