### PR TITLE
log events are sent regardless of log level

### DIFF
--- a/src/core/Debug.js
+++ b/src/core/Debug.js
@@ -205,10 +205,6 @@ function Debug() {
     }
 
     function doLog(level, _this, ...params) {
-        if (logLevel < level) {
-            return;
-        }
-
         let message = '';
         let logTime = null;
 
@@ -232,12 +228,13 @@ function Debug() {
             message += item + ' ';
         });
 
-        if (logFn[level]) {
+        // log to console if the log level is high enough
+        if (logFn[level] && logLevel >= level) {
             logFn[level](message);
         }
 
-        // TODO: To be removed
-        eventBus.trigger(Events.LOG, {message: message});
+        // send log event regardless of log level
+        eventBus.trigger(Events.LOG, {message: message, level: level});
     }
 
     instance = {

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -99,7 +99,6 @@ class MediaPlayerEvents extends EventsBase {
         /**
          * Triggered when {@link module:Debug} logger methods are called.
          * @event MediaPlayerEvents#LOG
-         * @deprecated
          */
         this.LOG = 'log';
 


### PR DESCRIPTION
This change makes it so that log events are sent regardless of log level. The log level only controls whether or not logs should be sent to the console.

This allows users to have the console logs off but still use the log messages for debugging in the case that an error occurred. In my app I store the log messages and send them to my own error reporting tool in the event that the player fails for some reason.

Fixes https://github.com/Dash-Industry-Forum/dash.js/issues/2749
