### PR TITLE
Fix ProtectionModel_21Jan2015

### DIFF
--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -341,7 +341,6 @@ function ProtectionModel_21Jan2015(config) {
         for (let i = 0; i < sessions.length; i++) {
             if (sessions[i] === token) {
                 sessions.splice(i,1);
-                logger.debug('DRM: Session removed.  SessionID = ' + token.getSessionID());
                 break;
             }
         }

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -116,8 +116,9 @@ function ProtectionModel_21Jan2015(config) {
         for (let i = 0; i < sessions.length; i++) {
             session = sessions[i];
             if (!session.getUsable()) {
-                removeSession(session);
-                closeKeySessionInternal(session);
+                closeKeySessionInternal(session).catch(function () {
+                    removeSession(session);
+                });
             }
         }
     }


### PR DESCRIPTION
This PR fixes potential uncaught exception in stop() method.
Closing MediaKeySession may throw an exception if MediaKeySession is not callable.