### PR TITLE
Default text language for subtitles bug fix

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -122,13 +122,13 @@ function Stream(config) {
     function activate(mediaSource, previousBuffers) {
         if (!isStreamActivated) {
             let result;
+            eventBus.on(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
             if (!getPreloaded()) {
                 result = initializeMedia(mediaSource, previousBuffers);
             } else {
                 initializeAfterPreload();
                 result = previousBuffers;
             }
-            eventBus.on(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
             isStreamActivated = true;
             return result;
         }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -133,7 +133,7 @@ function TextSourceBuffer() {
                 const currFragTrack = mediaController.getCurrentTrackFor(Constants.FRAGMENTED_TEXT, streamController.getActiveStreamInfo());
                 for (let i = 0; i < fragmentedTracks.length; i++) {
                     if (fragmentedTracks[i] === currFragTrack) {
-                        currFragmentedTrackIdx = i;
+                        setCurrentFragmentedTrackIdx(i);
                         break;
                     }
                 }


### PR DESCRIPTION
Hi,

this PR has to solve issue ##2766 by registering CURRENT_TRACK_CHANGED in Stream before to build different StreamProcessors. By doing so, the currentRepresentationInfo of ScheduleController is correctly updated when the default text language is set.

Nico