### PR TITLE
Support URI schema for thumbnails as defined in IOP

### DIFF
--- a/samples/thumbnails/thumbnails.html
+++ b/samples/thumbnails/thumbnails.html
@@ -30,7 +30,7 @@
         }
     </script>
 
-    <style class="code">
+    <style>
         .dash-video-player {
             position: relative;  /* This position relative is needed to position the thumbnails */
             width: 640px;
@@ -71,9 +71,6 @@
                         <span class="icon-caption"></span>
                     </div>
                     <span id="videoDuration" class="duration-display">00:00:00</span>
-                    <!--<div class="seekContainer">--> <!-- Traditional range bar, lacks the buffered bar -->
-                        <!--<input type="range" id="seekbar" value="0" class="seekbar seekbar-complete" min="0" step="0.01"/>-->
-                    <!--</div>-->
                     <div class="seekContainer">
                         <div id="seekbar" class="seekbar seekbar-complete">
                             <div id="seekbar-buffer" class="seekbar seekbar-buffer"></div>

--- a/src/streaming/thumbnail/ThumbnailTracks.js
+++ b/src/streaming/thumbnail/ThumbnailTracks.js
@@ -35,7 +35,8 @@ import ThumbnailTrackInfo from '../vo/ThumbnailTrackInfo';
 import URLUtils from '../../streaming/utils/URLUtils';
 import {replaceIDForTemplate} from '../../dash/utils/SegmentsUtils';
 
-const THUMBNAILS_SCHEME_ID_URI = 'http://dashif.org/thumbnail_tile';
+const THUMBNAILS_SCHEME_ID_URIS = ['http://dashif.org/thumbnail_tile',
+                                   'http://dashif.org/guidelines/thumbnail_tile'];
 
 function ThumbnailTracks(config) {
 
@@ -107,7 +108,7 @@ function ThumbnailTracks(config) {
 
         if (representation.essentialProperties) {
             representation.essentialProperties.forEach((p) => {
-                if (p.schemeIdUri === THUMBNAILS_SCHEME_ID_URI && p.value) {
+                if (THUMBNAILS_SCHEME_ID_URIS.indexOf(p.schemeIdUri) >= 0 && p.value) {
                     const vars = p.value.split('x');
                     if (vars.length === 2 && !isNaN(vars[0]) && !isNaN(vars[1])) {
                         track.tilesHor = parseInt(vars[0], 10);

--- a/test/unit/streaming.thumbnail.ThumbnailController.js
+++ b/test/unit/streaming.thumbnail.ThumbnailController.js
@@ -20,7 +20,7 @@ const sampleRepresentation = {
     timescale: 1,
     media: 'http://media/$RepresentationID$/$Number$.jpg',
     essentialProperties: [{
-        schemeIdUri: 'http://dashif.org/thumbnail_tile',
+        schemeIdUri: 'http://dashif.org/guidelines/thumbnail_tile',
         value: '10x1'
     }]
 };
@@ -36,8 +36,24 @@ const sampleRepresentation2 = {
     timescale: 1,
     media: 'http://media/$RepresentationID$/$Number$.jpg',
     essentialProperties: [{
-        schemeIdUri: 'http://dashif.org/thumbnail_tile',
+        schemeIdUri: 'http://dashif.org/guidelines/thumbnail_tile',
         value: '10x20'
+    }]
+};
+
+const sampleRepresentation3 = {
+    id: 'rep_id',
+    segmentInfoType: 'SegmentTemplate',
+    bandwidth: 2000,
+    width: 1024,
+    height: 1152,
+    startNumber: 1,
+    segmentDuration: 634.566,
+    timescale: 1,
+    media: 'http://media/$RepresentationID$/$Number$.jpg',
+    essentialProperties: [{
+        schemeIdUri: 'http://dashif.org/thumbnail_tile',
+        value: '50x10'
     }]
 };
 
@@ -274,6 +290,42 @@ describe('Thumbnails', function () {
             expect(thumbnailTracks.getCurrentTrackIndex()).to.equal(-1);
             thumbnailTracks.setTrackByIndex(100);
             expect(thumbnailTracks.getCurrentTrackIndex()).to.equal(0);
+        });
+    });
+
+    describe('CR URI schema', function () {
+        const objectsHelper = new ObjectsHelper();
+        const dashManifestModel = new DashManifestModelMock();
+        let thumbnailController;
+        let thumbnailTracks;
+
+        beforeEach(function () {
+            thumbnailTracks = ThumbnailTracks(context).create({
+                dashManifestModel: dashManifestModel,
+                adapter: new AdapterMock(),
+                baseURLController: objectsHelper.getDummyBaseURLController(),
+                stream: new StreamMock()
+            });
+        });
+
+        afterEach(function () {
+            thumbnailTracks.reset();
+        });
+
+        it('should support CR URI schema', function () {
+            dashManifestModel.setRepresentation(sampleRepresentation3);
+            thumbnailController = ThumbnailController(context).create({
+                dashManifestModel: dashManifestModel,
+                adapter: new AdapterMock(),
+                baseURLController: objectsHelper.getDummyBaseURLController(),
+                stream: new StreamMock()
+            });
+
+            thumbnailTracks.initialize();
+            const tracks = thumbnailTracks.getTracks();
+
+            expect(tracks[0].tilesHor).to.equal(50);
+            expect(tracks[0].tilesVert).to.equal(10);
         });
     });
 });


### PR DESCRIPTION
Fix #2740

Support Thumbnails URI schema as defined in IOP 4.1 -> http://dashif.org/guidelines/thumbnail_tile

The previous URI schema, defined in the CR corresponding to thumbnails support, is also supported to ensure backward compatibility.

I took advantage of this PR to also clean up thumbnail sample.