### PR TITLE
Change error codes

### DIFF
--- a/src/core/errors/Errors.js
+++ b/src/core/errors/Errors.js
@@ -37,53 +37,53 @@ import ErrorsBase from './ErrorsBase';
 class Errors extends ErrorsBase {
     constructor () {
         super();
-        this.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE = 1;
-        this.MANIFEST_LOADER_LOADING_FAILURE_ERROR_CODE = 2;
-        this.XLINK_LOADER_LOADING_FAILURE_ERROR_CODE = 3;
-        this.SEGMENTS_UPDATE_FAILED_ERROR_CODE = 4;
-        this.SEGMENTS_UNAVAILABLE_ERROR_CODE = 5;
-        this.SEGMENT_BASE_LOADER_ERROR_CODE = 6;
-        this.TIME_SYNC_FAILED_ERROR_CODE = 7;
-        this.FRAGMENT_LOADER_LOADING_FAILURE_ERROR_CODE = 8;
-        this.FRAGMENT_LOADER_NULL_REQUEST_ERROR_CODE = 9;
-        this.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = 10;
-        this.APPEND_ERROR_CODE = 11;
-        this.REMOVE_ERROR_CODE = 12;
-        this.DATA_UPDATE_FAILED_ERROR_CODE = 13;
+        this.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE = 10;
+        this.MANIFEST_LOADER_LOADING_FAILURE_ERROR_CODE = 12;
+        this.XLINK_LOADER_LOADING_FAILURE_ERROR_CODE = 13;
+        this.SEGMENTS_UPDATE_FAILED_ERROR_CODE = 14;
+        this.SEGMENTS_UNAVAILABLE_ERROR_CODE = 15;
+        this.SEGMENT_BASE_LOADER_ERROR_CODE = 16;
+        this.TIME_SYNC_FAILED_ERROR_CODE = 17;
+        this.FRAGMENT_LOADER_LOADING_FAILURE_ERROR_CODE = 18;
+        this.FRAGMENT_LOADER_NULL_REQUEST_ERROR_CODE = 19;
+        this.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE = 20;
+        this.APPEND_ERROR_CODE = 21;
+        this.REMOVE_ERROR_CODE = 22;
+        this.DATA_UPDATE_FAILED_ERROR_CODE = 23;
 
-        this.CAPABILITY_MEDIASOURCE_ERROR_CODE = 14;
-        this.CAPABILITY_MEDIAKEYS_ERROR_CODE   = 15;
+        this.CAPABILITY_MEDIASOURCE_ERROR_CODE = 24;
+        this.CAPABILITY_MEDIAKEYS_ERROR_CODE   = 25;
 
-        this.DOWNLOAD_ERROR_ID_MANIFEST_CODE        = 16;
+        this.DOWNLOAD_ERROR_ID_MANIFEST_CODE   = 26;
         /*
          *@deprecated
          */
         this.DOWNLOAD_ERROR_ID_MANIFEST        = 'manifest';
-        this.DOWNLOAD_ERROR_ID_SIDX_CODE            = 17;
-        this.DOWNLOAD_ERROR_ID_CONTENT_CODE         = 18;
+        this.DOWNLOAD_ERROR_ID_SIDX_CODE            = 27;
+        this.DOWNLOAD_ERROR_ID_CONTENT_CODE         = 28;
         /*
          *@deprecated
          */
         this.DOWNLOAD_ERROR_ID_CONTENT         = 'content';
-        this.DOWNLOAD_ERROR_ID_INITIALIZATION_CODE  = 19;
+        this.DOWNLOAD_ERROR_ID_INITIALIZATION_CODE  = 29;
         /*
          *@deprecated
          */
         this.DOWNLOAD_ERROR_ID_INITIALIZATION  = 'initialization';
-        this.DOWNLOAD_ERROR_ID_XLINK_CODE           = 20;
+        this.DOWNLOAD_ERROR_ID_XLINK_CODE           = 30;
         /*
          *@deprecated
          */
         this.DOWNLOAD_ERROR_ID_XLINK           = 'xlink';
 
-        this.MANIFEST_ERROR_ID_CODEC_CODE           = 21;
-        this.MANIFEST_ERROR_ID_PARSE_CODE           = 22;
-        this.MANIFEST_ERROR_ID_NOSTREAMS_CODE       = 23;
+        this.MANIFEST_ERROR_ID_CODEC_CODE           = 31;
+        this.MANIFEST_ERROR_ID_PARSE_CODE           = 32;
+        this.MANIFEST_ERROR_ID_NOSTREAMS_CODE       = 33;
 
-        this.TIMED_TEXT_ERROR_ID_PARSE_CODE         = 24;
+        this.TIMED_TEXT_ERROR_ID_PARSE_CODE         = 34;
 
-        this.MANIFEST_ERROR_ID_MULTIPLEXED_CODE     = 25;
-        this.MEDIASOURCE_TYPE_UNSUPPORTED_CODE = 26;
+        this.MANIFEST_ERROR_ID_MULTIPLEXED_CODE     = 35;
+        this.MEDIASOURCE_TYPE_UNSUPPORTED_CODE = 36;
 
         this.MANIFEST_LOADER_PARSING_FAILURE_ERROR_MESSAGE = 'parsing failed for ';
         this.MANIFEST_LOADER_LOADING_FAILURE_ERROR_MESSAGE = 'Failed loading manifest: ';

--- a/test/unit/core.errors.Errors.js
+++ b/test/unit/core.errors.Errors.js
@@ -5,32 +5,32 @@ const expect = require('chai').expect;
 describe('Errors', function () {
     it('Errors code should exist', () => {
         expect(Errors).to.exist; // jshint ignore:line
-        expect(Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE).to.equal(1);
-        expect(Errors.MANIFEST_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(2);
-        expect(Errors.XLINK_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(3);
-        expect(Errors.SEGMENTS_UPDATE_FAILED_ERROR_CODE).to.equal(4);
-        expect(Errors.SEGMENTS_UNAVAILABLE_ERROR_CODE).to.equal(5);
-        expect(Errors.SEGMENT_BASE_LOADER_ERROR_CODE).to.equal(6);
-        expect(Errors.TIME_SYNC_FAILED_ERROR_CODE).to.equal(7);
-        expect(Errors.FRAGMENT_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(8);
-        expect(Errors.FRAGMENT_LOADER_NULL_REQUEST_ERROR_CODE).to.equal(9);
-        expect(Errors.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE).to.equal(10);
-        expect(Errors.APPEND_ERROR_CODE).to.equal(11);
-        expect(Errors.REMOVE_ERROR_CODE).to.equal(12);
-        expect(Errors.DATA_UPDATE_FAILED_ERROR_CODE).to.equal(13);
-        expect(Errors.CAPABILITY_MEDIASOURCE_ERROR_CODE).to.equal(14);
-        expect(Errors.CAPABILITY_MEDIAKEYS_ERROR_CODE).to.equal(15);
-        expect(Errors.DOWNLOAD_ERROR_ID_MANIFEST_CODE).to.equal(16);
-        expect(Errors.DOWNLOAD_ERROR_ID_SIDX_CODE).to.equal(17);
-        expect(Errors.DOWNLOAD_ERROR_ID_CONTENT_CODE).to.equal(18);
-        expect(Errors.DOWNLOAD_ERROR_ID_INITIALIZATION_CODE).to.equal(19);
-        expect(Errors.DOWNLOAD_ERROR_ID_XLINK_CODE).to.equal(20);
-        expect(Errors.MANIFEST_ERROR_ID_CODEC_CODE).to.equal(21);
-        expect(Errors.MANIFEST_ERROR_ID_PARSE_CODE).to.equal(22);
-        expect(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE).to.equal(23);
-        expect(Errors.TIMED_TEXT_ERROR_ID_PARSE_CODE).to.equal(24);
-        expect(Errors.MANIFEST_ERROR_ID_MULTIPLEXED_CODE).to.equal(25);
-        expect(Errors.MEDIASOURCE_TYPE_UNSUPPORTED_CODE).to.equal(26);
+        expect(Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE).to.equal(10);
+        expect(Errors.MANIFEST_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(12);
+        expect(Errors.XLINK_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(13);
+        expect(Errors.SEGMENTS_UPDATE_FAILED_ERROR_CODE).to.equal(14);
+        expect(Errors.SEGMENTS_UNAVAILABLE_ERROR_CODE).to.equal(15);
+        expect(Errors.SEGMENT_BASE_LOADER_ERROR_CODE).to.equal(16);
+        expect(Errors.TIME_SYNC_FAILED_ERROR_CODE).to.equal(17);
+        expect(Errors.FRAGMENT_LOADER_LOADING_FAILURE_ERROR_CODE).to.equal(18);
+        expect(Errors.FRAGMENT_LOADER_NULL_REQUEST_ERROR_CODE).to.equal(19);
+        expect(Errors.URL_RESOLUTION_FAILED_GENERIC_ERROR_CODE).to.equal(20);
+        expect(Errors.APPEND_ERROR_CODE).to.equal(21);
+        expect(Errors.REMOVE_ERROR_CODE).to.equal(22);
+        expect(Errors.DATA_UPDATE_FAILED_ERROR_CODE).to.equal(23);
+        expect(Errors.CAPABILITY_MEDIASOURCE_ERROR_CODE).to.equal(24);
+        expect(Errors.CAPABILITY_MEDIAKEYS_ERROR_CODE).to.equal(25);
+        expect(Errors.DOWNLOAD_ERROR_ID_MANIFEST_CODE).to.equal(26);
+        expect(Errors.DOWNLOAD_ERROR_ID_SIDX_CODE).to.equal(27);
+        expect(Errors.DOWNLOAD_ERROR_ID_CONTENT_CODE).to.equal(28);
+        expect(Errors.DOWNLOAD_ERROR_ID_INITIALIZATION_CODE).to.equal(29);
+        expect(Errors.DOWNLOAD_ERROR_ID_XLINK_CODE).to.equal(30);
+        expect(Errors.MANIFEST_ERROR_ID_CODEC_CODE).to.equal(31);
+        expect(Errors.MANIFEST_ERROR_ID_PARSE_CODE).to.equal(32);
+        expect(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE).to.equal(33);
+        expect(Errors.TIMED_TEXT_ERROR_ID_PARSE_CODE).to.equal(34);
+        expect(Errors.MANIFEST_ERROR_ID_MULTIPLEXED_CODE).to.equal(35);
+        expect(Errors.MEDIASOURCE_TYPE_UNSUPPORTED_CODE).to.equal(36);
     });
 
     it('Errors should return the correct error message', () => {

--- a/test/unit/streaming.controllers.SourceBufferSink.js
+++ b/test/unit/streaming.controllers.SourceBufferSink.js
@@ -2,6 +2,7 @@ import SourceBufferSink from '../../src/streaming/SourceBufferSink';
 import Events from '../../src/core/events/Events';
 import EventBus from '../../src/core/EventBus';
 import FactoryMaker from '../../src/core/FactoryMaker.js';
+import Errors from '../../src/core/errors/Errors';
 
 import TextBufferMock from './mocks/TextBufferMock';
 import TextControllerMock from './mocks/TextControllerMock';
@@ -190,7 +191,7 @@ describe('SourceBufferSink', function () {
             };
             let mediaSource = new MediaSourceMock();
             function onAppend(e) {
-                expect(e.error.code).to.equal(11);
+                expect(e.error.code).to.equal(Errors.APPEND_ERROR_CODE);
                 expect(e.error.message).to.equal('chunk is not defined');
                 done();
             }

--- a/test/unit/streaming.text.TextSourceBuffer.js
+++ b/test/unit/streaming.text.TextSourceBuffer.js
@@ -1,5 +1,6 @@
 import TextSourceBuffer from '../../src/streaming/text/TextSourceBuffer';
 import TTMLParser from '../../src/streaming/utils/TTMLParser';
+import Errors from '../../src/core/errors/Errors';
 
 import StreamControllerMock from './mocks/StreamControllerMock';
 import DashManifestModelMock from './mocks/DashManifestModelMock';
@@ -33,6 +34,6 @@ describe('TextSourceBuffer', function () {
     it('call to append function with invalid tttml data should triggered a parse error', function () {
         const buffer = new ArrayBuffer(8);
         textSourceBuffer.append(buffer, {mediaInfo: {type: 'text', mimeType: 'application/ttml+xml', codec: 'application/ttml+xml;codecs=\'undefined\''}});
-        expect(errorHandlerMock.errorCode).to.equal(24);
+        expect(errorHandlerMock.errorCode).to.equal(Errors.TIMED_TEXT_ERROR_ID_PARSE_CODE);
     });
 });


### PR DESCRIPTION
Hi,

this PR has to modify error codes in order to be unique. Indeed, html5 video element returns error codes :
- 1 = MEDIA_ERR_ABORTED - fetching process aborted by user
- 2 = MEDIA_ERR_NETWORK - error occurred when downloading
- 3 = MEDIA_ERR_DECODE - error occurred when decoding
- 4 = MEDIA_ERR_SRC_NOT_SUPPORTED - audio/video not supported
- 5 = MEDIA_ERR_ENCRYPTED

So, dash.js error codes need to be shift to start at 10 value.

Nico