### PR TITLE
Fix issue with captions and subs atom box

### DIFF
--- a/src/dash/utils/FragmentedTextBoxParser.js
+++ b/src/dash/utils/FragmentedTextBoxParser.js
@@ -114,7 +114,7 @@ function FragmentedTextBoxParser() {
                         if (subsBoxes) {
                             for (m = 0; m < subsBoxes.length; m++) {
                                 let subsBox = subsBoxes[m];
-                                if (subsIndex < subsBox.entry_count && i > nextSubsSample) {
+                                if (subsIndex < (subsBox.entry_count - 1) && i > nextSubsSample) {
                                     subsIndex++;
                                     nextSubsSample += subsBox.entries[subsIndex].sample_delta;
                                 }

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -339,7 +339,7 @@ function TextSourceBuffer() {
             } else {
                 samplesInfo = fragmentedTextBoxParser.getSamplesInfo(bytes);
                 sampleList = samplesInfo.sampleList;
-                if (!firstFragmentedSubtitleStart && sampleList.length > 0) {
+                if (firstFragmentedSubtitleStart === null && sampleList.length > 0) {
                     firstFragmentedSubtitleStart = sampleList[0].cts - chunk.start * timescale;
                 }
                 if (codecType.search(Constants.STPP) >= 0) {


### PR DESCRIPTION
This PR fixes an issue reported by @Gontran-Molotov and related with captioning. Couple of changes included:

- Fix in FragmentTextBoxParser when using subs atoms. Some times, when samples length was higher than subsamples one, an exception was raised because we were trying to read out of subsamples array bounds. 

- Fix the way we calculate firstFragmentedSubtitleStart. If first timestamp was exactly 0 we were not initializing first timestamp correctly and then the time offset used for deciding when to show each caption was wrong.