### PR TITLE
Remove import from typings file

### DIFF
--- a/build/typings/index.d.ts
+++ b/build/typings/index.d.ts
@@ -1,5 +1,3 @@
-import ClearKeyKeySet from "./src/streaming/protection/vo/ClearKeyKeySet";
-
 export = dashjs;
 export as namespace dashjs;
 


### PR DESCRIPTION
Fix typings. An import was accidentally introduced in latest version of typings.