### PR TITLE
Change type and text of bleeding live edge message

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -217,12 +217,12 @@ function ScheduleController(config) {
                         if (!streamProcessor.getBufferController().getIsPruningInProgress()) {
                             request = nextFragmentRequestRule.execute(streamProcessor, replacement);
                             if (!request && streamInfo.manifestInfo && streamInfo.manifestInfo.isDynamic) {
-                                logger.info('Playing at the bleeding live edge and frag is not available yet');
+                                logger.debug('Next fragment seems to be at the bleeding live edge and is not available yet. Rescheduling.');
                             }
                         }
 
                         if (request) {
-                            logger.debug('getNextFragment - request is ' + request.url);
+                            logger.debug('Next fragment request url is ' + request.url);
                             fragmentModel.executeRequest(request);
                         } else { // Use case - Playing at the bleeding live edge and frag is not available yet. Cycle back around.
                             setFragmentProcessState(false);


### PR DESCRIPTION
Change the "Playing at bleeding live edge" message to be a DEBUG one. I have also change the text of the message to avoid further confusions. It is not really playhead is close to live edge, but the end of the play buffer is. There are some cases in which this message was interpreted by users as an issue.

This is an internal message that just notifies about a regular situation that happens quite frequently while managing requests/fragments for live streams: playback buffer is still not full and there are no more fragments available. 