### PR TITLE
Allow easy testing of player API in Ref Player

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -223,7 +223,8 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     ////////////////////////////////////////
 
     $scope.video = document.querySelector('.dash-video-player video');
-    $scope.player = dashjs.MediaPlayer().create(); /* jshint ignore:line */
+    // store a ref in window.player to provide an easy way to play with dash.js API
+    window.player = $scope.player = dashjs.MediaPlayer().create(); /* jshint ignore:line */
 
     $scope.player.on(dashjs.MediaPlayer.events.ERROR, function (e) { /* jshint ignore:line */
         //use the new error callback


### PR DESCRIPTION
In reference player, add a player reference to window object so developers can easily play with dash.js API. This also make easier some debug tasks in which methods/config parameters not exposed in the GUI are required to be call/modified.

Related with #2634