### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -687,6 +687,7 @@ declare namespace dashjs {
          * @param periodIdx Make sure this is the period index not id
          */
         getMaxIndexForBufferType(bufferType: 'video' | 'audio', periodIdx: number): number;
+        getBandwidthForRepresentation(representationId: string, periodIdx: number): number;
         getCurrentRepresentationSwitch(metrics: MetricsList): any[];
         getLatestBufferLevelVO(metrics: MetricsList): any[];
         getCurrentBufferLevel(metrics: MetricsList): number;


### PR DESCRIPTION
`getBandwidthForRepresentation` from `DashMetrics` was missing from the type definitions.