### PR TITLE
Low latency improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ jsdoc
 dist
 build/temp
 build/es5
+build/typings
 coverage
 
 #################

--- a/index.d.ts
+++ b/index.d.ts
@@ -243,8 +243,11 @@ declare namespace dashjs {
         removeAllABRCustomRule(): void;
         getLowLatencyEnabled(): boolean;
         setLowLatencyEnabled(value: boolean): void;
-        getCatchUpPlaybackRate(): number;
-        setCatchUpPlaybackRate(value: number): void;
+        enableLowLatencyCatchUp(value: boolean): void;
+        getLowLatencyMinDrift(): number;
+        setLowLatencyMinDrift(value: number): void;
+        getLowLatencyMaxDriftBeforeSeeking(): number;
+        setLowLatencyMaxDriftBeforeSeeking(value: number): void;
         getUseDeadTimeLatencyForAbr(): boolean;
         setUseDeadTimeLatencyForAbr(value: boolean): void;
         getCurrentLiveLatency(): number;
@@ -307,8 +310,6 @@ declare namespace dashjs {
         METRIC_UPDATED: 'metricUpdated';
         PERIOD_SWITCH_COMPLETED: 'periodSwitchCompleted';
         PERIOD_SWITCH_STARTED: 'periodSwitchStarted';
-        PLAYBACK_CATCHUP_END: 'playbackCatchupEnd';
-        PLAYBACK_CATCHUP_START: 'playbackCatchupStart';
         PLAYBACK_ENDED: 'playbackEnded';
         PLAYBACK_ERROR: 'playbackError';
         PLAYBACK_METADATA_LOADED: 'playbackMetaDataLoaded';

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -320,14 +320,14 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     $scope.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, function (e) { /* jshint ignore:line */
         $scope[e.mediaType + 'Index'] = e.oldQuality + 1;
         $scope[e.mediaType + 'PendingIndex'] = e.newQuality + 1;
-        $scope.plotPoint('pendingIndex', e.mediaType, e.newQuality + 1);
+        $scope.plotPoint('pendingIndex', e.mediaType, e.newQuality + 1, getTimeForPlot());
         $scope.safeApply();
     }, $scope);
 
     $scope.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) { /* jshint ignore:line */
         $scope[e.mediaType + 'Index'] = e.newQuality + 1;
         $scope[e.mediaType + 'PendingIndex'] = e.newQuality + 1;
-        $scope.plotPoint('index', e.mediaType, e.newQuality + 1);
+        $scope.plotPoint('index', e.mediaType, e.newQuality + 1, getTimeForPlot());
         $scope.safeApply();
     }, $scope);
 
@@ -660,12 +660,12 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         }
     };
 
-    $scope.plotPoint = function (name, type, value) {
+    $scope.plotPoint = function (name, type, value, time) {
         if ($scope.chartEnabled) {
             var specificChart = $scope.chartState[type];
             if (specificChart) {
                 var data = specificChart[name].data;
-                data.push([$scope.video.currentTime, value]);
+                data.push([time, value]);
                 if (data.length > $scope.maxPointsToChart) {
                     data.splice(0, 1);
                 }
@@ -710,6 +710,11 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         $scope.chartOptions.legend.noColumns = Math.min($scope.chartData.length, 5);
     };
 
+    function getTimeForPlot() {
+        var now = new Date().getTime() / 1000;
+        return Math.max(now - $scope.sessionStartTime, 0);
+    }
+
     function updateMetrics(type) {
         var metrics = $scope.player.getMetricsFor(type);
         var dashMetrics = $scope.player.getDashMetrics();
@@ -741,16 +746,17 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             }
 
             if ($scope.chartCount % 2 === 0) {
-                $scope.plotPoint('buffer', type, bufferLevel);
-                $scope.plotPoint('index', type, index);
-                $scope.plotPoint('bitrate', type, bitrate);
-                $scope.plotPoint('droppedFPS', type, droppedFPS);
-                $scope.plotPoint('liveLatency', type, liveLatency);
+                var time = getTimeForPlot();
+                $scope.plotPoint('buffer', type, bufferLevel, time);
+                $scope.plotPoint('index', type, index, time);
+                $scope.plotPoint('bitrate', type, bitrate, time);
+                $scope.plotPoint('droppedFPS', type, droppedFPS, time);
+                $scope.plotPoint('liveLatency', type, liveLatency, time);
 
                 if (httpMetrics) {
-                    $scope.plotPoint('download', type, httpMetrics.download[type].average.toFixed(2));
-                    $scope.plotPoint('latency', type, httpMetrics.latency[type].average.toFixed(2));
-                    $scope.plotPoint('ratio', type, httpMetrics.ratio[type].average.toFixed(2));
+                    $scope.plotPoint('download', type, httpMetrics.download[type].average.toFixed(2), time);
+                    $scope.plotPoint('latency', type, httpMetrics.latency[type].average.toFixed(2), time);
+                    $scope.plotPoint('ratio', type, httpMetrics.ratio[type].average.toFixed(2), time);
                 }
                 $scope.safeApply();
             }
@@ -830,6 +836,19 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             try {
                 item = JSON.parse(atob(vars.stream));
             } catch (e) {}
+        }
+
+
+        if (vars && vars.hasOwnProperty('targetLatency')) {
+            let targetLatency = parseInt(vars.targetLatency, 10);
+            if (!isNaN(targetLatency)) {
+                item.bufferConfig = {
+                    lowLatencyMode: true,
+                    liveDelay: targetLatency / 1000
+                };
+
+                $scope.lowLatencyModeSelected = true;
+            }
         }
 
         if (item.url) {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -74,7 +74,7 @@
           "name": "Low Latency (Single-Rate) (livesim-chunked)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 2.8
+            "liveDelay": 4
           }
         },
         {
@@ -82,7 +82,7 @@
           "name": "Low Latency (Multi-Rate) (livesim-chunked)",
           "bufferConfig" : {
             "lowLatencyMode": true,
-            "liveDelay": 2.8
+            "liveDelay": 4
           }
         },
         {

--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -86,6 +86,14 @@
           }
         },
         {
+          "url": "https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd",
+          "name": "Akamai Low Latency Stream",
+          "bufferConfig" : {
+            "lowLatencyMode": true,
+            "liveDelay": 3
+          }
+        },
+        {
           "url": "http://24x7dash-i.akamaihd.net/dash/live/900080/dash-demo/dash.mpd",
           "name": "Akamai 24x7 reference stream - segmentTemplate"
         },

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -68,7 +68,6 @@ function TemplateSegmentsGetter(config, isDynamic) {
         endIdx = segmentRange.end;
 
         for (periodSegIdx = startIdx; periodSegIdx <= endIdx; periodSegIdx++) {
-
             seg = getIndexBasedSegment(timelineConverter, isDynamic, representation, periodSegIdx);
             seg.replacementTime = (start + periodSegIdx - 1) * representation.segmentDuration;
             url = template.media;

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -173,7 +173,6 @@ function TimelineConverter() {
         if (isClientServerTimeSyncCompleted) return;
 
         if (e.offset !== undefined) {
-
             setClientTimeOffset(e.offset / 1000);
             isClientServerTimeSyncCompleted = true;
 

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -100,7 +100,8 @@ function FragmentLoader(config) {
                 request: request,
                 progress: function (event) {
                     eventBus.trigger(Events.LOADING_PROGRESS, {
-                        request: request
+                        request: request,
+                        stream: event.stream
                     });
                     if (event.data) {
                         eventBus.trigger(Events.LOADING_DATA_PROGRESS, {

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -32,6 +32,7 @@ import HTTPLoader from './net/HTTPLoader';
 import HeadRequest from './vo/HeadRequest';
 import DashJSError from './vo/DashJSError';
 import EventBus from './../core/EventBus';
+import BoxParser from '../streaming/utils/BoxParser';
 import Events from './../core/events/Events';
 import Errors from './../core/errors/Errors';
 import FactoryMaker from '../core/FactoryMaker';
@@ -46,11 +47,13 @@ function FragmentLoader(config) {
         httpLoader;
 
     function setup() {
+        const boxParser = BoxParser(context).getInstance();
         httpLoader = HTTPLoader(context).create({
             errHandler: config.errHandler,
             metricsModel: config.metricsModel,
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier,
+            boxParser: boxParser,
             useFetch: config.mediaPlayerModel.getLowLatencyEnabled()
         });
     }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -533,7 +533,7 @@ function MediaPlayer() {
     }
 
     /**
-     * Use this method to set the maxium latency deviation allowed before dash.js to do a seeking to live position. In low latency mode,
+     * Use this method to set the maximum latency deviation allowed before dash.js to do a seeking to live position. In low latency mode,
      * when the difference between the measured latency and the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
      * as an absolute number, is higher than the one sets with this method, then dash.js does a seek to live edge position minus
      * the target live delay.

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -485,18 +485,35 @@ function MediaPlayer() {
     }
 
     /**
-     * Set to false if you would like to disable the catch-up mechanism applied to low latency live streams
-     * when estimated latency minus target one is higher than a defined limit (({@link module:MediaPlayer#setLowLatencyMinDrift setLowLatencyMinDrift()}))
+     * Use this method to set the maximum catch up rate, as a percentage, for low latency live streams. In low latency mode,
+     * when measured latency is higher/lower than the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
+     * dash.js increases/decreases playback rate respectively up to (+/-) the percentage defined with this method until target is reached.
      *
-     * @param {boolean} enable - Will toggle if feature is enabled. True to enable, False to disable.
-     * @default enable = True
+     * Valid values for catch up rate are in range 0-0.5 (0-50%). Set it to 0 to turn off live catch up feature.
+     *
+     * Note: Catch-up mechanism is only applied when playing low latency live streams.
+     *
+     * @param {number} value Percentage in which playback rate is increased/decreased when live catch up mechanism is activated.
+     * @memberof module:MediaPlayer
+     * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
+     * @default {number} 0.5
+     * @instance
+     */
+    function setCatchUpPlaybackRate(value) {
+        mediaPlayerModel.setCatchUpPlaybackRate(value);
+    }
+
+    /**
+     * Returns the current catchup playback rate.
+     * @returns {number}
+     * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
      * @memberof module:MediaPlayer
      * @instance
-     *
      */
-    function enableLowLatencyCatchUp(enable) {
-        mediaPlayerModel.setUseLowLatencyCatchUp(enable);
+    function getCatchUpPlaybackRate() {
+        return mediaPlayerModel.getCatchUpPlaybackRate();
     }
+
 
     /**
      * Use this method to set the minimum latency deviation allowed before activating catch-up mechanism. In low latency mode,
@@ -3026,7 +3043,8 @@ function MediaPlayer() {
         getSmallGapLimit: getSmallGapLimit,
         setLowLatencyEnabled: setLowLatencyEnabled,
         getLowLatencyEnabled: getLowLatencyEnabled,
-        enableLowLatencyCatchUp: enableLowLatencyCatchUp,
+        setCatchUpPlaybackRate: setCatchUpPlaybackRate,
+        getCatchUpPlaybackRate: getCatchUpPlaybackRate,
         setLowLatencyMinDrift: setLowLatencyMinDrift,
         getLowLatencyMinDrift: getLowLatencyMinDrift,
         setLowLatencyMaxDriftBeforeSeeking: setLowLatencyMaxDriftBeforeSeeking,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2779,7 +2779,8 @@ function MediaPlayer() {
             mediaPlayerModel: mediaPlayerModel,
             dashManifestModel: dashManifestModel,
             adapter: adapter,
-            videoModel: videoModel
+            videoModel: videoModel,
+            timelineConverter: timelineConverter
         });
 
         abrController.setConfig({

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -85,7 +85,8 @@ function MediaPlayer() {
     const SOURCE_NOT_ATTACHED_ERROR = 'You must first call attachSource() with a valid source before calling this method';
     const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
     const MEDIA_PLAYER_BAD_ARGUMENT_ERROR = 'MediaPlayer Invalid Arguments!';
-    const PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR = 'Playback catchup rate invalid argument! Use a number from 0 to 0.2';
+    const PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR = 'Playback minimum drift has an invalid value! Use a number from 0 to 0.5';
+    const PLAYBACK_LOW_LATENCY_MAX_DRIFT_BAD_ARGUMENT_ERROR = 'Playback maximum drift has an invalid value! Use a number greater or equal to 0';
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
@@ -489,36 +490,87 @@ function MediaPlayer() {
     }
 
     /**
-     * Use this method to set the catch up rate, as a percentage, for low latency live streams. In low latency mode,
-     * when measured latency is higher than the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
-     * dash.js increases playback rate the percentage defined with this method until target is reached.
+     * Set to false if you would like to disable the catch-up mechanism applied to low latency live streams
+     * when estimated latency minus target one is higher than a defined limit (({@link module:MediaPlayer#setLowLatencyMinDrift setLowLatencyMinDrift()}))
      *
-     * Valid values for catch up rate are in range 0-20%. Set it to 0% to turn off live catch up feature.
+     * @param {boolean} enable - Will toggle if feature is enabled. True to enable, False to disable.
+     * @default enable = True
+     * @memberof module:MediaPlayer
+     * @instance
+     *
+     */
+    function enableLowLatencyCatchUp(enable) {
+        mediaPlayerModel.setUseLowLatencyCatchUp(enable);
+    }
+
+    /**
+     * Use this method to set the minimum latency deviation allowed before activating catch-up mechanism. In low latency mode,
+     * when the difference between the measured latency and the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
+     * as an absolute number, is higher than the one sets with this method, then dash.js increases/decreases
+     * playback rate until target latency is reached.
+     *
+     * LowLatencyMinDrift should be provided in seconds, and it uses values between 0.0 and 0.5.
      *
      * Note: Catch-up mechanism is only applied when playing low latency live streams.
      *
-     * @param {number} value Percentage in which playback rate is increased when live catch up mechanism is activated.
+     * @param {number} value Maximum difference between measured latency and the target one before applying playback rate modifications.
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
      * @default {number} 0.05
      * @instance
      */
-    function setCatchUpPlaybackRate(value) {
-        if ( typeof value !== 'number' || isNaN(value) || value < 0.0 || value > 0.20) {
-            throw PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR;
+    function setLowLatencyMinDrift(value) {
+        if ( typeof value !== 'number' || isNaN(value) || value < 0.0 || value > 0.50) {
+            throw PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR;
         }
-        playbackController.setCatchUpPlaybackRate(value);
+        mediaPlayerModel.setLowLatencyMinDrift(value);
     }
 
     /**
-     * Returns the current catchup playback rate.
+     * Returns the current latency minimum allowed drift.
      * @returns {number}
-     * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
+     * @see {@link module:MediaPlayer#setLowLatencyMinDrift setLowLatencyMinDrift()}
      * @memberof module:MediaPlayer
      * @instance
      */
-    function getCatchUpPlaybackRate() {
-        return playbackController.getCatchUpPlaybackRate();
+    function getLowLatencyMinDrift() {
+        return mediaPlayerModel.getLowLatencyMinDrift();
+    }
+
+    /**
+     * Use this method to set the maxium latency deviation allowed before dash.js to do a seeking to live position. In low latency mode,
+     * when the difference between the measured latency and the target one ({@link module:MediaPlayer#setLiveDelay setLiveDelay()}),
+     * as an absolute number, is higher than the one sets with this method, then dash.js does a seek to live edge position minus
+     * the target live delay.
+     *
+     * LowLatencyMaxDriftBeforeSeeking should be provided in seconds. If 0, then seeking operations won't be used for
+     * fixing latency deviations.
+     *
+     * Note: Catch-up mechanism is only applied when playing low latency live streams.
+     *
+     * @param {number} value Maximum difference between measured latency and the target one before using seek to
+     * fix drastically live latency deviations.
+     * @memberof module:MediaPlayer
+     * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
+     * @default {number} 0
+     * @instance
+     */
+    function setLowLatencyMaxDriftBeforeSeeking(value) {
+        if ( typeof value !== 'number' || isNaN(value) || value < 0) {
+            throw PLAYBACK_LOW_LATENCY_MAX_DRIFT_BAD_ARGUMENT_ERROR;
+        }
+        mediaPlayerModel.setLowLatencyMaxDriftBeforeSeeking(value);
+    }
+
+    /**
+     * Returns the maximum latency drift before applying a seek operation to reduce the latency.
+     * @returns {number}
+     * @see {@link module:MediaPlayer#setLowLatencyMaxDriftBeforeSeeking setLowLatencyMaxDriftBeforeSeeking()}
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getLowLatencyMaxDriftBeforeSeeking() {
+        return mediaPlayerModel.getLowLatencyMaxDriftBeforeSeeking();
     }
 
     /**
@@ -2909,8 +2961,6 @@ function MediaPlayer() {
         seek: seek,
         setPlaybackRate: setPlaybackRate,
         getPlaybackRate: getPlaybackRate,
-        setCatchUpPlaybackRate: setCatchUpPlaybackRate,
-        getCatchUpPlaybackRate: getCatchUpPlaybackRate,
         setMute: setMute,
         isMuted: isMuted,
         setVolume: setVolume,
@@ -3022,8 +3072,13 @@ function MediaPlayer() {
         getJumpGaps: getJumpGaps,
         setSmallGapLimit: setSmallGapLimit,
         getSmallGapLimit: getSmallGapLimit,
-        getLowLatencyEnabled: getLowLatencyEnabled,
         setLowLatencyEnabled: setLowLatencyEnabled,
+        getLowLatencyEnabled: getLowLatencyEnabled,
+        enableLowLatencyCatchUp: enableLowLatencyCatchUp,
+        setLowLatencyMinDrift: setLowLatencyMinDrift,
+        getLowLatencyMinDrift: getLowLatencyMinDrift,
+        setLowLatencyMaxDriftBeforeSeeking: setLowLatencyMaxDriftBeforeSeeking,
+        getLowLatencyMaxDriftBeforeSeeking: getLowLatencyMaxDriftBeforeSeeking,
         setManifestUpdateRetryInterval: setManifestUpdateRetryInterval,
         getManifestUpdateRetryInterval: getManifestUpdateRetryInterval,
         setLongFormContentDurationThreshold: setLongFormContentDurationThreshold,

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -226,23 +226,6 @@ class MediaPlayerEvents extends EventsBase {
         this.CAN_PLAY = 'canPlay';
 
         /**
-         * Sent when live catch mechanism has been activated, which implies the measured latency of the low latency
-         * stream that is been played has gone beyond the target one.
-         * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
-         * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
-         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_START
-         */
-        this.PLAYBACK_CATCHUP_START = 'playbackCatchupStart';
-
-        /**
-         * Sent live catch up mechanism has been deactivated.
-         * @see {@link module:MediaPlayer#setCatchUpPlaybackRate setCatchUpPlaybackRate()}
-         * @see {@link module:MediaPlayer#setLiveDelay setLiveDelay()}
-         * @event MediaPlayerEvents#PLAYBACK_CATCHUP_END
-         */
-        this.PLAYBACK_CATCHUP_END = 'playbackCatchupEnd';
-
-        /**
          * Sent when playback completes.
          * @event MediaPlayerEvents#PLAYBACK_ENDED
          */

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -252,12 +252,19 @@ function PlaybackController() {
         if (!isDynamic || isNaN(availabilityStartTime)) {
             return NaN;
         }
-        const currentTime = getTime();
+        let currentTime = getTime();
         if (isNaN(currentTime) || currentTime === 0) {
             return 0;
         }
 
-        return ((Math.round(new Date().getTime() - (currentTime * 1000 + availabilityStartTime))) / 1000).toFixed(3);
+        const timeOffset = availabilityStartTime / 1000;
+        // Fix current time for firefox and safari (returned as an absolute time)
+        if (currentTime > availabilityStartTime / 1000) {
+            currentTime -= timeOffset;
+        }
+
+        const now = new Date().getTime();
+        return ((Math.round(now - (currentTime * 1000 + availabilityStartTime))) / 1000).toFixed(3);
     }
 
     function startPlaybackCatchUp() {

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -300,16 +300,7 @@ function TimeSyncController() {
     }
 
     function calculateTimeOffset(serverTime, deviceTime) {
-        const v = (serverTime - deviceTime) / 1000;
-        let offset;
-        // Math.trunc not implemented by IE11
-        if (Math.trunc) {
-            offset = Math.trunc(v);
-        } else {
-            offset = (v - v % 1) || (!isFinite(v) || v === 0 ? v : v < 0 ? -0 : 0);
-        }
-
-        return offset * 1000;
+        return serverTime - deviceTime;
     }
 
     function attemptSync(sources, sourceIndex) {
@@ -348,8 +339,8 @@ function TimeSyncController() {
 
                         setOffsetMs(offset);
 
-                        logger.debug('Local time: ' + new Date(deviceTime));
-                        logger.debug('Server time: ' + new Date(serverTime));
+                        logger.info('Local time: ' + new Date(deviceTime));
+                        logger.info('Server time: ' + new Date(serverTime));
                         logger.info('Server Time - Local Time (ms): ' + offset);
 
                         onComplete(serverTime, offset);

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -71,9 +71,11 @@ const MANIFEST_RETRY_INTERVAL = 500;
 const XLINK_RETRY_ATTEMPTS = 1;
 const XLINK_RETRY_INTERVAL = 500;
 
-const DEFAULT_LOW_LATENCY_LIVE_DELAY = 2.8;
+const DEFAULT_LOW_LATENCY_LIVE_DELAY = 3.0;
 const LOW_LATENCY_REDUCTION_FACTOR = 10;
 const LOW_LATENCY_MULTIPLY_FACTOR = 5;
+const LOW_LATENCY_CATCH_UP_MIN_DRIFT = 0.02;
+const LOW_LATENCY_CATCH_UP_MAX_DRIFT = 0;
 
 //This value influences the startup time for live (in ms).
 const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
@@ -114,8 +116,11 @@ function MediaPlayerModel() {
         jumpGaps,
         smallGapLimit,
         lowLatencyEnabled,
+        useLowLatencyCatchUp,
         manifestUpdateRetryInterval,
-        keepProtectionMediaKeys;
+        keepProtectionMediaKeys,
+        liveCatchUpMinDrift,
+        liveCatchUpMaxDrift;
 
     function setup() {
         UTCTimingSources = [];
@@ -155,6 +160,9 @@ function MediaPlayerModel() {
         customABRRule = [];
         movingAverageMethod = Constants.MOVING_AVERAGE_SLIDING_WINDOW;
         lowLatencyEnabled = false;
+        useLowLatencyCatchUp = true;
+        liveCatchUpMinDrift = LOW_LATENCY_CATCH_UP_MIN_DRIFT;
+        liveCatchUpMaxDrift = LOW_LATENCY_CATCH_UP_MAX_DRIFT;
 
         retryAttempts = {
             [HTTPRequest.MPD_TYPE]:                         MANIFEST_RETRY_ATTEMPTS,
@@ -498,6 +506,34 @@ function MediaPlayerModel() {
         lowLatencyEnabled = value;
     }
 
+    function setUseLowLatencyCatchUp(value) {
+        if (typeof value !== 'boolean') {
+            return;
+        }
+
+        useLowLatencyCatchUp = value;
+    }
+
+    function getUseLowLatencyCatchUp() {
+        return useLowLatencyCatchUp;
+    }
+
+    function setLowLatencyMinDrift(value) {
+        liveCatchUpMinDrift = value;
+    }
+
+    function getLowLatencyMinDrift() {
+        return liveCatchUpMinDrift;
+    }
+
+    function setLowLatencyMaxDriftBeforeSeeking(value) {
+        liveCatchUpMaxDrift = value;
+    }
+
+    function getLowLatencyMaxDriftBeforeSeeking() {
+        return liveCatchUpMaxDrift;
+    }
+
     function setManifestUpdateRetryInterval(value) {
         manifestUpdateRetryInterval = value;
     }
@@ -583,6 +619,12 @@ function MediaPlayerModel() {
         getSmallGapLimit: getSmallGapLimit,
         getLowLatencyEnabled: getLowLatencyEnabled,
         setLowLatencyEnabled: setLowLatencyEnabled,
+        setUseLowLatencyCatchUp: setUseLowLatencyCatchUp,
+        getUseLowLatencyCatchUp: getUseLowLatencyCatchUp,
+        setLowLatencyMinDrift: setLowLatencyMinDrift,
+        getLowLatencyMinDrift: getLowLatencyMinDrift,
+        setLowLatencyMaxDriftBeforeSeeking: setLowLatencyMaxDriftBeforeSeeking,
+        getLowLatencyMaxDriftBeforeSeeking: getLowLatencyMaxDriftBeforeSeeking,
         setManifestUpdateRetryInterval: setManifestUpdateRetryInterval,
         getManifestUpdateRetryInterval: getManifestUpdateRetryInterval,
         setKeepProtectionMediaKeys: setKeepProtectionMediaKeys,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -275,8 +275,10 @@ function MediaPlayerModel() {
     }
 
     function getStableBufferTime() {
-        const result = !isNaN(stableBufferTime) ? stableBufferTime : fastSwitchEnabled ? DEFAULT_MIN_BUFFER_TIME_FAST_SWITCH : DEFAULT_MIN_BUFFER_TIME;
-        return getLowLatencyEnabled() ? result / LOW_LATENCY_REDUCTION_FACTOR : result;
+        if (getLowLatencyEnabled()) {
+            return getLiveDelay() * 0.6;
+        }
+        return !isNaN(stableBufferTime) ? stableBufferTime : fastSwitchEnabled ? DEFAULT_MIN_BUFFER_TIME_FAST_SWITCH : DEFAULT_MIN_BUFFER_TIME;
     }
 
     function setBufferTimeAtTopQuality(value) {
@@ -510,7 +512,6 @@ function MediaPlayerModel() {
         if (typeof value !== 'boolean') {
             return;
         }
-
         useLowLatencyCatchUp = value;
     }
 

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -36,7 +36,7 @@ import {
 from '../vo/metrics/HTTPRequest';
 import Constants from '../constants/Constants';
 import ABRRulesCollection from '../rules/abr/ABRRulesCollection';
-import { checkParameterType, checkIsVideoOrAudioType } from '../utils/SupervisorTools';
+import { checkParameterType, checkRange, checkIsVideoOrAudioType } from '../utils/SupervisorTools';
 
 const LIVE_DELAY_FRAGMENT_COUNT = 4;
 
@@ -75,6 +75,7 @@ const LOW_LATENCY_REDUCTION_FACTOR = 10;
 const LOW_LATENCY_MULTIPLY_FACTOR = 5;
 const LOW_LATENCY_CATCH_UP_MIN_DRIFT = 0.02;
 const LOW_LATENCY_CATCH_UP_MAX_DRIFT = 0;
+const LOW_LATENCY_CATCH_UP_PLAYBACK_RATE = 0.5;
 
 //This value influences the startup time for live (in ms).
 const WALLCLOCK_TIME_UPDATE_INTERVAL = 50;
@@ -115,11 +116,11 @@ function MediaPlayerModel() {
         jumpGaps,
         smallGapLimit,
         lowLatencyEnabled,
-        useLowLatencyCatchUp,
         manifestUpdateRetryInterval,
         keepProtectionMediaKeys,
         liveCatchUpMinDrift,
-        liveCatchUpMaxDrift;
+        liveCatchUpMaxDrift,
+        liveCatchUpPlaybackRate;
 
     const DEFAULT_UTC_TIMING_SOURCE = {
             scheme: 'urn:mpeg:dash:utc:http-xsdate:2014',
@@ -164,9 +165,9 @@ function MediaPlayerModel() {
         customABRRule = [];
         movingAverageMethod = Constants.MOVING_AVERAGE_SLIDING_WINDOW;
         lowLatencyEnabled = false;
-        useLowLatencyCatchUp = true;
         liveCatchUpMinDrift = LOW_LATENCY_CATCH_UP_MIN_DRIFT;
         liveCatchUpMaxDrift = LOW_LATENCY_CATCH_UP_MAX_DRIFT;
+        liveCatchUpPlaybackRate = LOW_LATENCY_CATCH_UP_PLAYBACK_RATE;
 
         retryAttempts = {
             [HTTPRequest.MPD_TYPE]:                         MANIFEST_RETRY_ATTEMPTS,
@@ -570,18 +571,19 @@ function MediaPlayerModel() {
         lowLatencyEnabled = value;
     }
 
-    function setUseLowLatencyCatchUp(value) {
-        if (typeof value !== 'boolean') {
-            return;
-        }
-        useLowLatencyCatchUp = value;
+    function setCatchUpPlaybackRate(value) {
+        checkParameterType(value, 'number');
+        checkRange(value, 0.0, 0.5);
+
+        liveCatchUpPlaybackRate = value;
     }
 
-    function getUseLowLatencyCatchUp() {
-        return useLowLatencyCatchUp;
+    function getCatchUpPlaybackRate() {
+        return liveCatchUpPlaybackRate;
     }
 
     function setLowLatencyMinDrift(value) {
+        checkParameterType(value, 'number');
         liveCatchUpMinDrift = value;
     }
 
@@ -590,6 +592,7 @@ function MediaPlayerModel() {
     }
 
     function setLowLatencyMaxDriftBeforeSeeking(value) {
+        checkParameterType(value, 'number');
         liveCatchUpMaxDrift = value;
     }
 
@@ -691,8 +694,8 @@ function MediaPlayerModel() {
         getSmallGapLimit: getSmallGapLimit,
         getLowLatencyEnabled: getLowLatencyEnabled,
         setLowLatencyEnabled: setLowLatencyEnabled,
-        setUseLowLatencyCatchUp: setUseLowLatencyCatchUp,
-        getUseLowLatencyCatchUp: getUseLowLatencyCatchUp,
+        setCatchUpPlaybackRate: setCatchUpPlaybackRate,
+        getCatchUpPlaybackRate: getCatchUpPlaybackRate,
         setLowLatencyMinDrift: setLowLatencyMinDrift,
         getLowLatencyMinDrift: getLowLatencyMinDrift,
         setLowLatencyMaxDriftBeforeSeeking: setLowLatencyMaxDriftBeforeSeeking,

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -53,7 +53,6 @@ function MetricsModel() {
     let eventBus = EventBus(context).getInstance();
 
     let instance,
-        adapter,
         streamMetrics;
 
     function setup() {
@@ -62,10 +61,6 @@ function MetricsModel() {
 
     function setConfig(config) {
         if (!config) return;
-
-        if (config.adapter) {
-            adapter = config.adapter;
-        }
     }
 
     function metricsChanged() {

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -198,7 +198,6 @@ function VideoModel() {
     }
 
     function addStalledStream(type) {
-
         let event;
 
         if (type === null || element.seeking || stalledStreams.indexOf(type) !== -1) {

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -30,7 +30,6 @@
  */
 
 import FactoryMaker from '../../core/FactoryMaker';
-import BoxParser from '../utils/BoxParser';
 
 /**
 * @module FetchLoader
@@ -38,21 +37,18 @@ import BoxParser from '../utils/BoxParser';
 * @param {Object} cfg - dependencies from parent
 */
 function FetchLoader(cfg) {
+
     cfg = cfg || {};
     const requestModifier = cfg.requestModifier;
+    const boxParser = cfg.boxParser;
 
     let instance;
 
     function load(httpRequest) {
 
         // Variables will be used in the callback functions
-        let firstProgress = true; /*jshint ignore:line*/
-        let needFailureReport = true; /*jshint ignore:line*/
-        let requestStartTime = new Date();
-        let lastTraceTime = requestStartTime; /*jshint ignore:line*/
-        let lastTraceReceivedCount = 0; /*jshint ignore:line*/
-
-        let request = httpRequest.request;
+        const requestStartTime = new Date();
+        const request = httpRequest.request;
 
         const headers = new Headers(); /*jshint ignore:line*/
         if (request.range) {
@@ -160,7 +156,7 @@ function FetchLoader(cfg) {
                         bytes: value.length
                     });
 
-                    const boxesInfo = BoxParser().getInstance().findLastTopIsoBoxCompleted(['moov', 'mdat'], remaining, offset);
+                    const boxesInfo = boxParser.findLastTopIsoBoxCompleted(['moov', 'mdat'], remaining, offset);
                     if (boxesInfo.found) {
                         const end = boxesInfo.lastCompletedOffset + boxesInfo.size;
 

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -110,7 +110,8 @@ function FetchLoader(cfg) {
                     httpRequest.response.response = buffer;
                     const event = {
                         loaded: buffer.byteLength,
-                        total: buffer.byteLength
+                        total: buffer.byteLength,
+                        stream: false
                     };
                     httpRequest.progress(event);
                     httpRequest.onload();
@@ -138,7 +139,8 @@ function FetchLoader(cfg) {
                             loaded: bytesReceived,
                             total: isNaN(totalBytes) ? bytesReceived : totalBytes,
                             lengthComputable: true,
-                            time: calculateDownloadedTime(downLoadedData, bytesReceived)
+                            time: calculateDownloadedTime(downLoadedData, bytesReceived),
+                            stream: true
                         });
 
                         httpRequest.response.response = remaining.buffer;

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -49,6 +49,7 @@ function HTTPLoader(cfg) {
     const metricsModel = cfg.metricsModel;
     const mediaPlayerModel = cfg.mediaPlayerModel;
     const requestModifier = cfg.requestModifier;
+    const boxParser = cfg.boxParser;
     const useFetch = cfg.useFetch || false;
 
     let instance;
@@ -218,11 +219,13 @@ function HTTPLoader(cfg) {
         let loader;
         if (useFetch && window.fetch && request.responseType === 'arraybuffer') {
             loader = FetchLoader(context).create({
-                requestModifier: requestModifier
+                requestModifier: requestModifier,
+                boxParser: boxParser
             });
         } else {
             loader = XHRLoader(context).create({
-                requestModifier: requestModifier
+                requestModifier: requestModifier,
+                boxParser: boxParser
             });
         }
 

--- a/src/streaming/net/XHRLoader.js
+++ b/src/streaming/net/XHRLoader.js
@@ -45,13 +45,8 @@ function XHRLoader(cfg) {
     function load(httpRequest) {
 
         // Variables will be used in the callback functions
-        let firstProgress = true; /*jshint ignore:line*/
-        let needFailureReport = true; /*jshint ignore:line*/
-        let requestStartTime = new Date();
-        let lastTraceTime = requestStartTime; /*jshint ignore:line*/
-        let lastTraceReceivedCount = 0; /*jshint ignore:line*/
-
-        let request = httpRequest.request;
+        const requestStartTime = new Date();
+        const request = httpRequest.request;
 
         let xhr = new XMLHttpRequest();
         xhr.open(httpRequest.method, httpRequest.url, true);

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -84,10 +84,15 @@ function ThroughputHistory(config) {
 
         const latencyTimeInMilliseconds = (httpRequest.tresponse.getTime() - httpRequest.trequest.getTime()) || 1;
         const downloadTimeInMilliseconds = (httpRequest._tfinish.getTime() - httpRequest.tresponse.getTime()) || 1; //Make sure never 0 we divide by this value. Avoid infinity!
-        const downloadTime = httpRequest.trace.reduce((a, b) => a + b.d, 0);
         const downloadBytes = httpRequest.trace.reduce((a, b) => a + b.b[0], 0);
-        let throughputMeasureTime = useDeadTimeLatency ? downloadTimeInMilliseconds : latencyTimeInMilliseconds + downloadTimeInMilliseconds;
-        throughputMeasureTime = mediaPlayerModel.getLowLatencyEnabled() ? downloadTime : throughputMeasureTime;
+
+        let throughputMeasureTime;
+        if (mediaPlayerModel.getLowLatencyEnabled()) {
+            throughputMeasureTime = httpRequest.trace.reduce((a, b) => a + b.d, 0);
+        } else {
+            throughputMeasureTime = useDeadTimeLatency ? downloadTimeInMilliseconds : latencyTimeInMilliseconds + downloadTimeInMilliseconds;
+        }
+
         const throughput = Math.round((8 * downloadBytes) / throughputMeasureTime); // bits/ms = kbits/s
 
         checkSettingsForMediaType(mediaType);

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -92,7 +92,7 @@ function InsufficientBufferRule(config) {
         }
 
         if (lastBufferStateVO.state === BufferController.BUFFER_EMPTY) {
-            logger.info('Switch to index 0; buffer is empty.');
+            logger.debug('Switch to index 0; buffer is empty.');
             switchRequest.quality = 0;
             switchRequest.reason = 'InsufficientBufferRule: Buffer is empty';
         } else {

--- a/src/streaming/rules/abr/SwitchHistoryRule.js
+++ b/src/streaming/rules/abr/SwitchHistoryRule.js
@@ -38,7 +38,7 @@ function SwitchHistoryRule() {
                 if (drops + noDrops >= SAMPLE_SIZE && (drops / noDrops > MAX_SWITCH)) {
                     switchRequest.quality = (i > 0 && switchRequests[i].drops > 0) ? i - 1 : i;
                     switchRequest.reason = {index: switchRequest.quality, drops: drops, noDrops: noDrops, dropSize: dropSize};
-                    logger.info('Switch history rule index: ' + switchRequest.quality + ' samples: ' + (drops + noDrops) + ' drops: ' + drops);
+                    logger.debug('Switch history rule index: ' + switchRequest.quality + ' samples: ' + (drops + noDrops) + ' drops: ' + drops);
                     break;
                 }
             }

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -84,7 +84,7 @@ function ThroughputRule(config) {
             if (bufferStateVO.state === BufferController.BUFFER_LOADED || isDynamic) {
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
                 scheduleController.setTimeToLoadDelay(0);
-                logger.info('requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
+                logger.debug('requesting switch to index: ', switchRequest.quality, 'type: ',mediaType, 'Average throughput', Math.round(throughput), 'kbps');
                 switchRequest.reason = {throughput: throughput, latency: latency};
             }
         }

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -58,7 +58,7 @@ function NextFragmentRequestRule(config) {
         const seekTarget = scheduleController.getSeekTarget();
         const hasSeekTarget = !isNaN(seekTarget);
         const bufferController = streamProcessor.getBufferController();
-        const currentTime = streamProcessor.getPlaybackController().getTime();
+        const currentTime = streamProcessor.getPlaybackController().getNormalizedTime();
         let time = hasSeekTarget ? seekTarget : adapter.getIndexHandlerTime(streamProcessor);
         let bufferIsDivided = false;
         let request;

--- a/src/streaming/utils/SupervisorTools.js
+++ b/src/streaming/utils/SupervisorTools.js
@@ -44,6 +44,12 @@ export function checkInteger(parameter) {
     }
 }
 
+export function checkRange(parameter, min, max) {
+    if (parameter < min || parameter > max) {
+        throw Constants.BAD_ARGUMENT_ERROR + ' : argument out of range';
+    }
+}
+
 export function checkIsVideoOrAudioType(type) {
     if (typeof type !== 'string' || (type !== Constants.AUDIO && type !== Constants.VIDEO)) {
         throw Constants.BAD_ARGUMENT_ERROR;

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -78,6 +78,8 @@ const MANIFEST_UPDATE_RETRY_INTERVAL = 100;
 
 const LOW_LATENCY_CATCH_UP_MIN_DRIFT = 0.02;
 
+const LOW_LATENCY_CATCH_UP_PLAYBACK_RATE = 0.5;
+
 class MediaPlayerModelMock {
 
     // Constants
@@ -219,7 +221,7 @@ class MediaPlayerModelMock {
         this.jumpGaps = false;
         this.smallGapLimit = SMALL_GAP_LIMIT;
         this.lowLatencyEnabled = false;
-        this.useLowLatencyCatchUp = true;
+        this.lowLatencyCatchUpPlaybackRate = LOW_LATENCY_CATCH_UP_PLAYBACK_RATE;
         this.liveCatchUpMinDrift = LOW_LATENCY_CATCH_UP_MIN_DRIFT;
         this.manifestUpdateRetryInterval = MANIFEST_UPDATE_RETRY_INTERVAL;
     }
@@ -544,12 +546,12 @@ class MediaPlayerModelMock {
         return this.liveCatchUpMinDrift;
     }
 
-    setUseLowLatencyCatchUp(value) {
-        this.useLowLatencyCatchUp = value;
+    setCatchUpPlaybackRate(value) {
+        this.lowLatencyCatchUpPlaybackRate = value;
     }
 
-    getUseLowLatencyCatchUp() {
-        return this.useLowLatencyCatchUp;
+    getCatchUpPlaybackRate() {
+        return this.lowLatencyCatchUpPlaybackRate;
     }
 
     reset() {

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -76,6 +76,8 @@ const SMALL_GAP_LIMIT = 0.8;
 
 const MANIFEST_UPDATE_RETRY_INTERVAL = 100;
 
+const LOW_LATENCY_CATCH_UP_MIN_DRIFT = 0.02;
+
 class MediaPlayerModelMock {
 
     // Constants
@@ -158,8 +160,13 @@ class MediaPlayerModelMock {
     static get WALLCLOCK_TIME_UPDATE_INTERVAL() {
         return WALLCLOCK_TIME_UPDATE_INTERVAL;
     }
+
     static get DEFAULT_XHR_WITH_CREDENTIALS() {
         return DEFAULT_XHR_WITH_CREDENTIALS;
+    }
+
+    static get LOW_LATENCY_CATCH_UP_MIN_DRIFT() {
+        return LOW_LATENCY_CATCH_UP_MIN_DRIFT;
     }
 
     constructor() {
@@ -212,6 +219,8 @@ class MediaPlayerModelMock {
         this.jumpGaps = false;
         this.smallGapLimit = SMALL_GAP_LIMIT;
         this.lowLatencyEnabled = false;
+        this.useLowLatencyCatchUp = true;
+        this.liveCatchUpMinDrift = LOW_LATENCY_CATCH_UP_MIN_DRIFT;
         this.manifestUpdateRetryInterval = MANIFEST_UPDATE_RETRY_INTERVAL;
     }
 
@@ -501,6 +510,22 @@ class MediaPlayerModelMock {
 
     getLowLatencyEnabled() {
         return this.lowLatencyEnabled;
+    }
+
+    setLowLatencyMinDrift(value) {
+        this.liveCatchUpMinDrift = value;
+    }
+
+    getLowLatencyMinDrift() {
+        return this.liveCatchUpMinDrift;
+    }
+
+    setUseLowLatencyCatchUp(value) {
+        this.useLowLatencyCatchUp = value;
+    }
+
+    getUseLowLatencyCatchUp() {
+        return this.useLowLatencyCatchUp;
     }
 
     reset() {

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -56,6 +56,10 @@ class PlaybackControllerMock {
         return null;
     }
 
+    getNormalizedTime() {
+        return null;
+    }
+
     getPlaybackRate() {
         return null;
     }
@@ -97,14 +101,6 @@ class PlaybackControllerMock {
 
     getStreamStartTime() {
         return 0;
-    }
-
-    setCatchUpPlaybackRate(value) {
-        this.catchUpPlaybackRate = value;
-    }
-
-    getCatchUpPlaybackRate() {
-        return this.catchUpPlaybackRate;
     }
 }
 

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -9,7 +9,6 @@ class PlaybackControllerMock {
         this.playing = false;
         this.seeking = false;
         this.isDynamic = false;
-        this.catchUpPlaybackRate = 0.05;
     }
 
     initialize() {}

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -15,7 +15,6 @@ const expect = require('chai').expect;
 const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
 const PLAYBACK_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a valid source and view before calling this method';
 const STREAMING_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a source before calling this method';
-const PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR = 'Playback minimum drift has an invalid value! Use a number from 0 to 0.5';
 const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
 
 describe('MediaPlayer', function () {
@@ -359,6 +358,19 @@ describe('MediaPlayer', function () {
                 expect(duration).to.equal(4);
             });
 
+            it('Method setCatchUpPlaybackRate should change catchUpPlaybackRate', function () {
+                let rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(0.5);
+
+                player.setCatchUpPlaybackRate(0.2);
+                rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(0.2);
+
+                player.setCatchUpPlaybackRate(0.0);
+                rate = player.getCatchUpPlaybackRate();
+                expect(rate).to.equal(0.0);
+            });
+
             it('Method setLowLatencyMinDrift should change lowLatencyMinDrift', function () {
                 let rate = player.getLowLatencyMinDrift();
                 expect(rate).to.equal(0.02);
@@ -372,25 +384,14 @@ describe('MediaPlayer', function () {
                 expect(rate).to.equal(0.0);
             });
 
-            it('Method enableLowLatencyCatchUp should enable/disable live catchup mechanism', function () {
-                player.enableLowLatencyCatchUp(false);
-
-                let enableLowLatency = mediaPlayerModel.getUseLowLatencyCatchUp();
+            it('Method setLowLatencyEnabled should enable/disable low latency mode', function () {
+                let enableLowLatency = mediaPlayerModel.getLowLatencyEnabled();
                 expect(enableLowLatency).to.equal(false);
 
-                player.enableLowLatencyCatchUp(true);
-                enableLowLatency = mediaPlayerModel.getUseLowLatencyCatchUp();
+                player.setLowLatencyEnabled(true);
 
+                enableLowLatency = mediaPlayerModel.getLowLatencyEnabled();
                 expect(enableLowLatency).to.equal(true);
-            });
-
-            it('Method setCatchUpPlaybackRate should throw an exception if given bad values', function () {
-                expect(() => {player.setLowLatencyMinDrift(0.9);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setLowLatencyMinDrift(13);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setLowLatencyMinDrift(0.1);}).to.not.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setLowLatencyMinDrift('string');}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setLowLatencyMinDrift(true);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setLowLatencyMinDrift(false);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
             });
         });
     });

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -15,7 +15,7 @@ const expect = require('chai').expect;
 const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
 const PLAYBACK_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a valid source and view before calling this method';
 const STREAMING_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a source before calling this method';
-const PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR = 'Playback catchup rate invalid argument! Use a number from 0 to 0.2';
+const PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR = 'Playback minimum drift has an invalid value! Use a number from 0 to 0.5';
 const MEDIA_PLAYER_BAD_ARGUMENT_ERROR = 'MediaPlayer Invalid Arguments!';
 const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
 
@@ -337,26 +337,38 @@ describe('MediaPlayer', function () {
                 expect(duration).to.equal(4);
             });
 
-            it('Method setCatchUpPlaybackRate should change catchUpPlaybackRate', function () {
-                let rate = player.getCatchUpPlaybackRate();
-                expect(rate).to.equal(0.05);
+            it('Method setLowLatencyMinDrift should change lowLatencyMinDrift', function () {
+                let rate = player.getLowLatencyMinDrift();
+                expect(rate).to.equal(0.02);
 
-                player.setCatchUpPlaybackRate(0.2);
-                rate = player.getCatchUpPlaybackRate();
-                expect(rate).to.equal(0.2);
+                player.setLowLatencyMinDrift(0.1);
+                rate = player.getLowLatencyMinDrift();
+                expect(rate).to.equal(0.1);
 
-                player.setCatchUpPlaybackRate(0.0);
-                rate = player.getCatchUpPlaybackRate();
+                player.setLowLatencyMinDrift(0.0);
+                rate = player.getLowLatencyMinDrift();
                 expect(rate).to.equal(0.0);
             });
 
+            it('Method enableLowLatencyCatchUp should enable/disable live catchup mechanism', function () {
+                player.enableLowLatencyCatchUp(false);
+
+                let enableLowLatency = mediaPlayerModel.getUseLowLatencyCatchUp();
+                expect(enableLowLatency).to.equal(false);
+
+                player.enableLowLatencyCatchUp(true);
+                enableLowLatency = mediaPlayerModel.getUseLowLatencyCatchUp();
+
+                expect(enableLowLatency).to.equal(true);
+            });
+
             it('Method setCatchUpPlaybackRate should throw an exception if given bad values', function () {
-                expect(() => {player.setCatchUpPlaybackRate(0.9);}).to.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setCatchUpPlaybackRate(13);}).to.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setCatchUpPlaybackRate(0.1);}).to.not.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setCatchUpPlaybackRate('string');}).to.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setCatchUpPlaybackRate(true);}).to.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
-                expect(() => {player.setCatchUpPlaybackRate(false);}).to.throw(PLAYBACK_CATCHUP_RATE_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift(0.9);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift(13);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift(0.1);}).to.not.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift('string');}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift(true);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
+                expect(() => {player.setLowLatencyMinDrift(false);}).to.throw(PLAYBACK_LOW_LATENCY_MIN_DRIFT_BAD_ARGUMENT_ERROR);
             });
 
             it('Method setUseDeadTimeLatencyForAbr should throw an exception if given bad values', function () {

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -132,6 +132,11 @@ describe('PlaybackController', function () {
                 expect(playbackController.getTime()).to.equal(videoModelMock.time);
             });
 
+            it('should return current normalized video time', function () {
+                videoModelMock.time = 5;
+                expect(playbackController.getNormalizedTime()).to.equal(videoModelMock.time);
+            });
+
             it('should return video playback rate', function () {
                 videoModelMock.playbackRate = 2;
                 expect(playbackController.getPlaybackRate()).to.equal(videoModelMock.playbackRate);

--- a/test/unit/streaming.models.MediaPlayerModel.js
+++ b/test/unit/streaming.models.MediaPlayerModel.js
@@ -22,6 +22,15 @@ describe('MediaPlayerModel', function () {
         expect(mediaPlayerModel.getLowLatencyEnabled()).to.be.equal(true);
     });
 
+    it('setCatchUpPlaybackRate should throw an exception if input argument is not a number or out of 0-0.5 range', function () {
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate(0.9);}).to.throw(Constants.BAD_ARGUMENT_ERROR);
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate(13);}).to.throw(Constants.BAD_ARGUMENT_ERROR);
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate(0.1);}).to.not.throw(Constants.BAD_ARGUMENT_ERROR);
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate('string');}).to.throw(Constants.BAD_ARGUMENT_ERROR);
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate(true);}).to.throw(Constants.BAD_ARGUMENT_ERROR);
+        expect(() => {mediaPlayerModel.setCatchUpPlaybackRate(false);}).to.throw(Constants.BAD_ARGUMENT_ERROR);
+    });
+
     it('should not set a value to fastSwitchEnabled attribute that is not a boolean type', function () {
         expect(mediaPlayerModel.getFastSwitchEnabled()).to.be.equal(false);
         expect(mediaPlayerModel.setFastSwitchEnabled.bind(mediaPlayerModel, undefined)).to.throw(Constants.BAD_ARGUMENT_ERROR);


### PR DESCRIPTION
Set of improvements for low latency mode:
- Implemented a new rate control mechanism similar to what was described in #2693. This enables playback synchronization across different clients.
- Rate control adaptations to overcome Safari limitations. Due to the way playbackRate works in Safari (stalls when playbackRate changes and the stream has an audio track), our rate control mechanism take this into account and when using Safari it increases the minimum acceptable playbackRate change.
- A new control mechanism has been added to dash.js to better recover from rebuffering situations when in low latency mode.
- Three new config methods added to control the new rate control mechanism: 
  - `setCatchupPlaybackRate` - Sets the maximum playback rate variation (from 0-0.5 and with respect to playback rate 1.0) allowed to reach target latency. 0 means catchup mechanism will be deactivated.
  - `setLowLatencyMinDrift` - Sets the minimum latency deviation allowed before activating catch-up mechanism.
  - `setLowLatencyMaxDriftBeforeSeeking` - Sets the maximum latency deviation allowed before dash.js does a seeking to live position.
- Fixed compatibility issues with Safari and Firefox (#2796). There are some differences in the way timing is reported in Chrome vs Firefox/Safari which caused playback stall problems when working with low latency streams.
- Take into consideration client/server time differences for calculating latency.
- Fixed buffer/latency stability issues.

I also changed the way the graph of dash.js reference player is plotted. For time variable now it uses time since start of the playback instead of using the playback time reported by the player, which caused weird curves mainly when there were seeking operations.

Still I am testing this PR exhaustively but wanted to create it to make it available to anyone interested on testing low latency stuff. 

Any feedback is more than welcome!
