### PR TITLE
Force MediaSource reset when there are EME config changes

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -752,6 +752,13 @@ function Stream(config) {
             return !newAdaptation && !currentAdaptation;
         }
 
+        // If any of the periods requires EME, we can't do smooth transition
+        if ((newAdaptation.ContentProtection && !currentAdaptation.ContentProtection) ||
+            (!newAdaptation.ContentProtection && currentAdaptation.ContentProtection)) {
+            return false;
+        }
+
+
         const sameMimeType =  newAdaptation && currentAdaptation && newAdaptation.mimeType === currentAdaptation.mimeType;
         const oldCodecs = currentAdaptation.Representation_asArray.map((representation) => {
             return representation.codecs;


### PR DESCRIPTION
Workaround to #2795. Trying to reuse a MediaSource across two periods, in which one of them defines a DRM system and the other one not, makes Chrome to crash.

This PR avoid the crash although makes period transition in above cases to be not seamless. I will create a new ticket to investigate if this is a limitation of the browser. In that case I will create a ticket in Chromium project.