### PR TITLE
Fixes for Insufficient buffer rule seek reset

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -294,7 +294,8 @@ function BufferController(config) {
                 quality: appendedBytesInfo.quality,
                 startTime: appendedBytesInfo.start,
                 index: appendedBytesInfo.index,
-                bufferedRanges: ranges
+                bufferedRanges: ranges,
+                mediaType: type
             });
         }
     }

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -28,25 +28,13 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-<<<<<<< HEAD
-||||||| merged common ancestors
-import BufferController from '../../controllers/BufferController';
-=======
-import Constants from '../../constants/Constants';
-import BufferController from '../../controllers/BufferController';
->>>>>>> Make InsufficientBufferRule have no side effects; clear seek reset on fragments loaded, make fragment loaded count 2, for close to segment boundary seeks
 import EventBus from '../../../core/EventBus';
 import Events from '../../../core/events/Events';
 import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 import SwitchRequest from '../SwitchRequest';
-<<<<<<< HEAD
 import Constants from '../../constants/Constants';
 import MetricsConstants from '../../constants/MetricsConstants';
-||||||| merged common ancestors
-import Constants from '../../constants/Constants';
-=======
->>>>>>> Make InsufficientBufferRule have no side effects; clear seek reset on fragments loaded, make fragment loaded count 2, for close to segment boundary seeks
 
 function InsufficientBufferRule(config) {
 
@@ -99,7 +87,7 @@ function InsufficientBufferRule(config) {
         const fragmentDuration = representationInfo.fragmentDuration;
 
         // Don't ask for a bitrate change if there is not info about buffer state or if fragmentDuration is not defined
-        if (!lastBufferStateVO || shouldIgnore(mediaType) || !fragmentDuration) {
+        if (shouldIgnore(mediaType) || !fragmentDuration) {
             return switchRequest;
         }
 

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -139,7 +139,7 @@ function InsufficientBufferRule(config) {
     }
 
     function onEndFragment(e) {
-        if (e.mediaType === Constants.AUDIO || e.mediaType === Constants.VIDEO) {
+        if (!isNaN(e.startTime) && (e.mediaType === Constants.AUDIO || e.mediaType === Constants.VIDEO)) {
             if (bufferStateDict[e.mediaType].ignoreCount > 0) {
                 bufferStateDict[e.mediaType].ignoreCount --;
             }

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -124,13 +124,8 @@ describe('InsufficientBufferRule', function () {
         };
         const representationInfo = { fragmentDuration: 4 };
         const dashMetricsMock = new DashMetricsMock();
-        const metricsModelMockBuffer = {
-            getReadOnlyMetricsFor: function () {
-                return {
-                    BufferState: [bufferState]
-                };
-            }
-        };
+        dashMetricsMock.addBufferState('video', bufferState);
+
         const rulesContextMock = {
             getMediaInfo: function () {},
             getMediaType: function () { return 'video'; },
@@ -139,7 +134,6 @@ describe('InsufficientBufferRule', function () {
         };
 
         const rule = InsufficientBufferRule(context).create({
-            metricsModel: metricsModelMockBuffer,
             dashMetrics: dashMetricsMock
         });
 

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -105,10 +105,10 @@ describe('InsufficientBufferRule', function () {
             dashMetrics: dashMetricsMock
         });
 
-        let e = { mediaType: 'video' };
+        let e = { mediaType: 'video', startTime: 0 };
         eventBus.trigger(Events.BYTES_APPENDED_END_FRAGMENT, e);
 
-        e = { mediaType: 'video' };//Event objects can't be reused because they get annotated by eventBus.
+        e = { mediaType: 'video', startTime: 4 };//Event objects can't be reused because they get annotated by eventBus.
         eventBus.trigger(Events.BYTES_APPENDED_END_FRAGMENT, e);
 
         bufferState.state = 'bufferStalled';
@@ -146,12 +146,12 @@ describe('InsufficientBufferRule', function () {
         let maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(-1);
 
-        let e = { mediaType: 'video' };
+        let e = { mediaType: 'video', startTime: 0 };
         eventBus.trigger(Events.BYTES_APPENDED_END_FRAGMENT, e);
         maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(-1);
 
-        e = { mediaType: 'video' };
+        e = { mediaType: 'video', startTime: 4 };
         eventBus.trigger(Events.BYTES_APPENDED_END_FRAGMENT, e);
         maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(0);


### PR DESCRIPTION
Seeking is causing problems with the insufficient buffer rule and causing the quality to drop to 0 occasionally on seek - This PR:
1. Prevents the rules being asked in ScheduleController when 'pruning is in progress' because we discard the result anyway in this case.
2. Changes the insufficient buffer rule to not clear the flag based on getMaxIndex() being called, so there's no side effects for this function if we discard the result.
3. Set the limit to two fragments instead of just one, for cases where we seek very close to the edge of fragment and lose the buffer.

You can test seeking close to segment boundaries with this on big buck bunny:
http://reference.dashif.org/dash.js/v2.9.1/samples/dash-if-reference-player/index.html
`$('video')[0].currentTime = -0.1 + 4 * 20`
