### PR TITLE
Fix about Event_asArray attribute

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -798,7 +798,7 @@ function DashManifestModel(config) {
                 if (eventStreams[i].hasOwnProperty(DashConstants.VALUE)) {
                     eventStream.value = eventStreams[i].value;
                 }
-                for (j = 0; j < eventStreams[i].Event_asArray.length; j++) {
+                for (j = 0; eventStreams[i].Event_asArray && j < eventStreams[i].Event_asArray.length; j++) {
                     const event = new Event();
                     event.presentationTime = 0;
                     event.eventStream = eventStream;


### PR DESCRIPTION
Hi,

this PR has to fix an issue about definition of Event_asArray. In order to reproduce it, the stream http://vm2.dashif.org/livesim/periods_60/mpdcallback_30/testpic_2s/Manifest.mpd has to be started (Dash IF test vectors\mpd callback event)

Nico