### PR TITLE
Limit time threshold for segment request calculation

### DIFF
--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -150,7 +150,7 @@ function FragmentModel(config) {
     }
 
     function getRequestThreshold(req) {
-        return isNaN(req.duration) ? 0.25 : req.duration / 8;
+        return isNaN(req.duration) ? 0.25 : Math.min(req.duration / 8, 0.5);
     }
 
     function removeExecutedRequestsBeforeTime(time) {


### PR DESCRIPTION
Fix #2821 following change suggested by @fvalleeHbbTV.

This PR limits the threshold used to do time -> segment number calculation to 0.5 seconds. Previous approach caused instability issues in streams using segments with long duration and timing sync issues.