### PR TITLE
HTTPLoader abort()

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -55,14 +55,14 @@ function HTTPLoader(cfg) {
     let instance;
     let requests;
     let delayedRequests;
-    let retryTimers;
+    let retryRequests;
     let downloadErrorToRequestTypeMap;
     let newDownloadErrorToRequestTypeMap;
 
     function setup() {
         requests = [];
         delayedRequests = [];
-        retryTimers = [];
+        retryRequests = [];
 
         downloadErrorToRequestTypeMap = {
             [HTTPRequest.MPD_TYPE]: Errors.DOWNLOAD_ERROR_ID_MANIFEST,
@@ -139,11 +139,16 @@ function HTTPLoader(cfg) {
 
                 if (remainingAttempts > 0) {
                     remainingAttempts--;
-                    retryTimers.push(
-                        setTimeout(function () {
-                            internalLoad(config, remainingAttempts);
-                        }, mediaPlayerModel.getRetryIntervalForType(request.type))
-                    );
+                    let retryRequest = { config: config };
+                    retryRequests.push(retryRequest);
+                    retryRequest.timeout = setTimeout(function () {
+                        if (retryRequests.indexOf(retryRequest) === -1) {
+                            return;
+                        } else {
+                            retryRequests.splice(retryRequests.indexOf(retryRequest), 1);
+                        }
+                        internalLoad(config, remainingAttempts);
+                    }, mediaPlayerModel.getRetryIntervalForType(request.type));
                 } else {
                     errHandler.downloadError(
                         downloadErrorToRequestTypeMap[request.type],
@@ -297,8 +302,14 @@ function HTTPLoader(cfg) {
      * @instance
      */
     function abort() {
-        retryTimers.forEach(t => clearTimeout(t));
-        retryTimers = [];
+        retryRequests.forEach(t => {
+            clearTimeout(t.timeout);
+            // abort request in order to trigger LOADING_ABANDONED event
+            if (t.config.request && t.config.abort) {
+                t.config.abort(t.config.request);
+            }
+        });
+        retryRequests = [];
 
         delayedRequests.forEach(x => clearTimeout(x.delayTimeout));
         delayedRequests = [];


### PR DESCRIPTION
This PR fixes an issue in case we want to abort a request that will be retried.

When we abort a request for which a retry timeout has been set, then HTTPLoader simply cancels the retry timeout, but then LOADING_ABANDONED and therefore FRAGMENT_LOADING_COMPLETED events are not triggered and then schedule process in ScheduleController in never restarted.

To reproduce the issue, you can simulate an unavailable segment (using fiddler for example) and then attempt to perform a seek while segment download retries are executed.
