### PR TITLE
 Use FetchLoader for media segments download only to fix init segments caching issue in low latency mode 

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -192,7 +192,7 @@ function BufferController(config) {
         if (e.fragmentModel !== streamProcessor.getFragmentModel()) return;
         logger.info('Init fragment finished loading saving to', type + '\'s init cache');
         initCache.save(e.chunk);
-        logger.debug('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality);
+        logger.debug('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality,  ', data size:', e.chunk.bytes.byteLength);
         appendToBuffer(e.chunk);
     }
 
@@ -200,7 +200,7 @@ function BufferController(config) {
         const chunk = initCache.extract(streamId, representationId);
         bufferResetInProgress = bufferResetEnabled === true ? bufferResetEnabled : false;
         if (chunk) {
-            logger.info('Append Init fragment', type, ' with representationId:', chunk.representationId, ' and quality:', chunk.quality);
+            logger.info('Append Init fragment', type, ' with representationId:', chunk.representationId, ' and quality:', chunk.quality, ', data size:', chunk.bytes.byteLength);
             appendToBuffer(chunk);
         } else {
             eventBus.trigger(Events.INIT_REQUESTED, { sender: instance });

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -217,7 +217,7 @@ function HTTPLoader(cfg) {
         };
 
         let loader;
-        if (useFetch && window.fetch && request.responseType === 'arraybuffer') {
+        if (useFetch && window.fetch && request.responseType === 'arraybuffer' && request.type === HTTPRequest.MEDIA_SEGMENT_TYPE) {
             loader = FetchLoader(context).create({
                 requestModifier: requestModifier,
                 boxParser: boxParser

--- a/test/unit/streaming.net.HTTPLoader.js
+++ b/test/unit/streaming.net.HTTPLoader.js
@@ -2,8 +2,11 @@ import HTTPLoader from '../../src/streaming/net/HTTPLoader';
 import RequestModifier from '../../src/streaming/utils/RequestModifier';
 import ErrorHandler from '../../src/streaming/utils/ErrorHandler';
 import MetricsModel from '../../src/streaming/models/MetricsModel';
-
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
+import {
+    HTTPRequest
+}
+    from '../../src/streaming/vo/metrics/HTTPRequest';
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
@@ -110,7 +113,7 @@ describe('HTTPLoader', function () {
         });
         global.fetch.returns(Promise.resolve(new global.Response('', { status: 200 })));
 
-        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'json' }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
+        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'json', type: HTTPRequest.MEDIA_SEGMENT_TYPE }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
         expect(self.requests.length).to.equal(1);
         self.requests[0].respond(200);
         sinon.assert.notCalled(global.fetch);
@@ -162,7 +165,7 @@ describe('HTTPLoader', function () {
         expect(callbackError.calledBefore(callbackCompleted)).to.be.true; // jshint ignore:line
     });
 
-    it('should use FetchLoader if it is an arraybuffer request, useFetch is true and body is not an Stream. It should call success and complete callback when load is called successfully', (done) => {
+    it('should use XHRLoader if it is not a MEDIA_SEGMENT_TYPE request even if useFetch is set to true and it is an arraybuffer request', () => {
         let self = this.ctx;
         const callbackSucceeded = sinon.spy();
         const callbackCompleted = sinon.spy();
@@ -176,7 +179,28 @@ describe('HTTPLoader', function () {
             useFetch: true
         });
         global.fetch.returns(Promise.resolve(new global.Response('', { status: 200 })));
-        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer' }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
+
+        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer', type: HTTPRequest.INIT_SEGMENT_TYPE}, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
+        expect(self.requests.length).to.equal(1);
+        self.requests[0].respond(200);
+        sinon.assert.notCalled(global.fetch);
+    });
+
+    it('should use XHRLoader if it is an arraybuffer and  MEDIA_SEGMENT_TYPE request, useFetch is true and body is not an Stream. It should call success and complete callback when load is called successfully', (done) => {
+        let self = this.ctx;
+        const callbackSucceeded = sinon.spy();
+        const callbackCompleted = sinon.spy();
+        const callbackError = sinon.spy();
+
+        httpLoader = HTTPLoader(context).create({
+            errHandler: errHandler,
+            metricsModel: metricsModel,
+            requestModifier: requestModifier,
+            mediaPlayerModel: mediaPlayerModelMock,
+            useFetch: true
+        });
+        global.fetch.returns(Promise.resolve(new global.Response('', { status: 200 })));
+        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer', type: HTTPRequest.MEDIA_SEGMENT_TYPE }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
 
         // Added a setTimeout as fetch uses promises (finishing method load) and it doesn't call callbacks immediately
         setTimeout(function () {
@@ -190,7 +214,7 @@ describe('HTTPLoader', function () {
         }, 10);
     });
 
-    it('should use FetchLoader if it is an arraybuffer request, useFetch is true and body is an Stream. It should call success and complete callback when load is called successfully', (done) => {
+    it('should use FetchLoader if it is an arraybuffer and MEDIA_SEGMENT_TYPE request, useFetch is true and body is an Stream. It should call success and complete callback when load is called successfully', (done) => {
         let self = this.ctx;
         const callbackSucceeded = sinon.spy();
         const callbackCompleted = sinon.spy();
@@ -210,7 +234,7 @@ describe('HTTPLoader', function () {
         stream.push(null);
 
         global.fetch.returns(Promise.resolve(new global.Response(stream, { status: 200 })));
-        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer' }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
+        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer', type: HTTPRequest.MEDIA_SEGMENT_TYPE }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
 
         setTimeout(function () {
             expect(self.requests.length).to.equal(0);
@@ -223,12 +247,13 @@ describe('HTTPLoader', function () {
         }, 10);
     });
 
-    it('should use FetchLoader if it is an arraybuffer request and call error and complete callback when load is called with error', (done) => {
+    it('should use FetchLoader if it is an arraybuffer and MEDIA_SEGMENT_TYPE request and call error and complete callback when load is called with error', (done) => {
         let self = this.ctx;
         const callbackSucceeded = sinon.spy();
         const callbackCompleted = sinon.spy();
         const callbackError = sinon.spy();
 
+        mediaPlayerModelMock.retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE ] = 0;
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
             metricsModel: metricsModel,
@@ -237,7 +262,7 @@ describe('HTTPLoader', function () {
             useFetch: true
         });
         global.fetch.returns(Promise.resolve(new global.Response('', { status: 404 })));
-        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer' }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
+        httpLoader.load({ request: { checkExistenceOnly: true, responseType: 'arraybuffer', type: HTTPRequest.MEDIA_SEGMENT_TYPE }, success: callbackSucceeded, complete: callbackCompleted, error: callbackError });
         setTimeout(function () {
             expect(self.requests.length).to.equal(0);
             sinon.assert.calledOnce(global.fetch);


### PR DESCRIPTION
Changes to address https://github.com/Dash-Industry-Forum/dash.js/issues/2837
Currently init segments caching in low latency mode is working incorrectly - it is storing only last  data chunk in cache.
Easiest way of fixing it is disabling fetch download for init segments. 

- Extended 'Append Init fragment' log msgs with data size info
- Use FetchLoader for media segments download only.