### PR TITLE
Multiperiod transition logic changes

### DIFF
--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -68,6 +68,10 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
                 throw new Error('not really supported');
             }
             buffer = oldBuffer ? oldBuffer : mediaSource.addSourceBuffer(codec);
+            if (buffer.changeType && oldBuffer) {
+                logger.debug('Doing period transition with changeType');
+                buffer.changeType(codec);
+            }
 
             const CHECK_INTERVAL = 50;
             // use updateend event if possible

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -99,9 +99,10 @@ function StreamController() {
         preloadTimerId,
         wallclockTicked,
         buffers,
-        compatible,
+        useSmoothPeriodTransition,
         preloading,
-        lastPlaybackTime;
+        lastPlaybackTime,
+        supportsChangeType;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -243,7 +244,7 @@ function StreamController() {
                 eventBus.trigger(Events.PLAYBACK_ENDED, {'isLast': getActiveStreamInfo().isLast});
             } else {
                 logger.info('Jumping media gap (discontinuity) at time ', time, '. Jumping to time position', seekToPosition);
-                playbackController.seek(seekToPosition);
+                playbackController.seek(seekToPosition, true, true);
             }
         }
     }
@@ -324,7 +325,7 @@ function StreamController() {
                 logger.debug('[toggleEndPeriodTimer] start-up of timer to notify PLAYBACK_ENDED event. It will be triggered in ' + delayPlaybackEnded + ' milliseconds');
                 playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED, {'isLast': getActiveStreamInfo().isLast});}, delayPlaybackEnded);
                 const preloadDelay = delayPlaybackEnded < 2000 ? delayPlaybackEnded / 4 : delayPlaybackEnded - 2000;
-                logger.info('[StreamController][toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
+                logger.info('[toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
                 preloadTimerId = setTimeout(onStreamCanLoadNext,  preloadDelay);
             }
         }
@@ -337,7 +338,7 @@ function StreamController() {
             mediaSourceController.signalEndOfStream(mediaSource);
         } else if (mediaSource && playbackEndedTimerId === undefined) {
             //send PLAYBACK_ENDED in order to switch to a new period, wait until the end of playing
-            logger.info('[StreamController][onStreamBufferingCompleted] end of period detected');
+            logger.info('[onStreamBufferingCompleted] end of period detected');
             isStreamBufferingCompleted = true;
             if (isPaused === false) {
                 toggleEndPeriodTimer();
@@ -349,9 +350,15 @@ function StreamController() {
         const isLast = getActiveStreamInfo().isLast;
         if (mediaSource && !isLast) {
             const newStream = getNextStream();
-            compatible = activeStream.isCompatibleWithStream(newStream);
-            if (compatible) {
-                logger.info('[StreamController][onStreamCanLoadNext] Preloading next stream');
+
+            // Smooth period transition allowed only if both of these conditions are true:
+            // 1.- None of the periods uses contentProtection.
+            // 2.- changeType method implemented by browser or periods use the same codec.
+            useSmoothPeriodTransition = activeStream.isProtectionCompatible(newStream) &&
+                (supportsChangeType || activeStream.isMediaCodecCompatible(newStream));
+
+            if (useSmoothPeriodTransition) {
+                logger.info('[onStreamCanLoadNext] Preloading next stream');
                 activeStream.stopEventController();
                 activeStream.deactivate(true);
                 newStream.preload(mediaSource, buffers);
@@ -462,26 +469,28 @@ function StreamController() {
             toStreamInfo: newStream.getStreamInfo()
         });
 
-        compatible = false;
+        useSmoothPeriodTransition = false;
         if (oldStream) {
             oldStream.stopEventController();
-            compatible = activeStream.isCompatibleWithStream(newStream) && !seekTime || newStream.getPreloaded();
-            oldStream.deactivate(compatible);
+            useSmoothPeriodTransition = (activeStream.isProtectionCompatible(newStream) &&
+                (supportsChangeType || activeStream.isMediaCodecCompatible(newStream))) &&
+                !seekTime || newStream.getPreloaded();
+            oldStream.deactivate(useSmoothPeriodTransition);
         }
 
         activeStream = newStream;
         preloading = false;
-        playbackController.initialize(getActiveStreamInfo(), compatible);
+        playbackController.initialize(getActiveStreamInfo(), useSmoothPeriodTransition);
         if (videoModel.getElement()) {
             //TODO detect if we should close jump to activateStream.
-            openMediaSource(seekTime, oldStream, false, compatible);
+            openMediaSource(seekTime, oldStream, false, useSmoothPeriodTransition);
         } else {
             preloadStream(seekTime);
         }
     }
 
     function preloadStream(seekTime) {
-        activateStream(seekTime, compatible);
+        activateStream(seekTime, useSmoothPeriodTransition);
     }
 
     function switchToVideoElement(seekTime) {
@@ -541,6 +550,15 @@ function StreamController() {
         buffers = activeStream.activate(mediaSource, keepBuffers ? buffers : undefined);
         audioTrackDetected = checkTrackPresence(Constants.AUDIO);
         videoTrackDetected = checkTrackPresence(Constants.VIDEO);
+
+        // check if change type is supported by the browser
+        if (buffers) {
+            const keys = Object.keys(buffers);
+            if (keys.length > 0 && buffers[keys[0]].changeType) {
+                logger.debug('SourceBuffer changeType method supported. Use it to switch codecs in periods transitions');
+                supportsChangeType = true;
+            }
+        }
 
         if (!initialPlayback) {
             if (!isNaN(seekTime)) {

--- a/test/unit/streaming.Stream.js
+++ b/test/unit/streaming.Stream.js
@@ -72,7 +72,14 @@ describe('Stream', function () {
 
     it('should return null when isCompatibleWithStream is called but stream attribute is undefined', () => {
         const stream = Stream(context).create({});
-        const isCompatible = stream.isCompatibleWithStream();
+        const isCompatible = stream.isMediaCodecCompatible();
+
+        expect(isCompatible).to.be.false;                // jshint ignore:line
+    });
+
+    it('should return null when isProtectionCompatible is called but stream attribute is undefined', () => {
+        const stream = Stream(context).create({});
+        const isCompatible = stream.isProtectionCompatible();
 
         expect(isCompatible).to.be.false;                // jshint ignore:line
     });


### PR DESCRIPTION
Changes in the logic that takes care of seamless period transition:

- changeType support. In case the browser implements changeType method for SourceBuffer type of objects, then dash.js will use it for doing smooth period transition even when codec of the periods to be switched are not compatible. Requested in #2774.
- Re-factored the code that takes care of checking for codec and protection compatibility.
- Fixed an issue in jumpGaps features that caused problems when doing transition against not perfectly aligned periods.