### PR TITLE
fix for bufferTarget

### DIFF
--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -66,7 +66,7 @@ function BufferLevelRule(config) {
             if (isNaN(representationInfo.fragmentDuration)) {
                 bufferTarget = videoBufferLevel;
             } else {
-                bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
+                bufferTarget = videoBufferLevel + representationInfo.fragmentDuration;
             }
         } else {
             const streamInfo = representationInfo.mediaInfo.streamInfo;


### PR DESCRIPTION
In our tests with live multiperiod sources, we found that sometimes the player will stop unexpectedly. Because the video is used to compute how much audio there should be (and the segments are slightly different in duration), the player sometimes does not buffer enough audio to fill the entire period duration, causing the player to think playback has now ended. So playback stops.

Is this a patch acceptable for merging? If not, is there any danger you foresee in having this patch in our production code? We need multiperiod to function well for seamless key rotation.