### PR TITLE
Remove requests only when there is a real discontinuity

### DIFF
--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -113,6 +113,10 @@ function PreBufferSink(onAppendedCallback) {
         return timeranges;
     }
 
+    function hasDiscontinuitiesAfter() {
+        return false;
+    }
+
     function updateTimestampOffset() {
         // Nothing to do
     }
@@ -149,7 +153,8 @@ function PreBufferSink(onAppendedCallback) {
         abort: abort,
         discharge: discharge,
         reset: reset,
-        updateTimestampOffset: updateTimestampOffset
+        updateTimestampOffset: updateTimestampOffset,
+        hasDiscontinuitiesAfter: hasDiscontinuitiesAfter
     };
 
     setup();

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -162,8 +162,7 @@ function FragmentModel(config) {
 
     function removeExecutedRequestsAfterTime(time) {
         executedRequests = executedRequests.filter(req => {
-            const threshold = getRequestThreshold(req);
-            return isNaN(req.startTime) || (time !== undefined ? req.startTime + req.duration < time + threshold : false);
+            return isNaN(req.startTime) || (time !== undefined ? req.startTime + req.duration < time : false);
         });
     }
 

--- a/src/streaming/rules/scheduling/NextFragmentRequestRule.js
+++ b/src/streaming/rules/scheduling/NextFragmentRequestRule.js
@@ -76,11 +76,10 @@ function NextFragmentRequestRule(config) {
         if (bufferController) {
             let range = bufferController.getRangeAt(time);
             const playingRange = bufferController.getRangeAt(currentTime);
-            const bufferRanges = bufferController.getBuffer().getAllBufferRanges();
-            const numberOfBuffers = bufferRanges ? bufferRanges.length : 0;
+            const hasDiscontinuities = bufferController.getBuffer().hasDiscontinuitiesAfter(currentTime);
             if ((range !== null || playingRange !== null) && !hasSeekTarget) {
-                if ( !range || (playingRange && playingRange.start != range.start && playingRange.end != range.end) ) {
-                    if (numberOfBuffers > 1 && mediaType !== Constants.FRAGMENTED_TEXT) {
+                if (!range || (playingRange && playingRange.start != range.start && playingRange.end != range.end)) {
+                    if (hasDiscontinuities && mediaType !== Constants.FRAGMENTED_TEXT) {
                         streamProcessor.getFragmentModel().removeExecutedRequestsAfterTime(playingRange.end);
                         bufferIsDivided = true;
                     }

--- a/test/unit/mocks/StreamProcessorMock.js
+++ b/test/unit/mocks/StreamProcessorMock.js
@@ -35,7 +35,8 @@ class BufferControllerMock {
 
     getBuffer() {
         return {
-            getAllBufferRanges: () => {}
+            getAllBufferRanges: () => {},
+            hasDiscontinuitiesAfter: () => {return false;}
         };
     }
 }


### PR DESCRIPTION
Remove threshold in removeExecutedRequestAfterTime because it causes more problems than solutions on streams with time alignment issues.

Modifies NextFragmentRequestRule so it calls to removeExecutedRequestAfterTime when there is a real discontinuity (buffer separated in 2 ranges itself doesn't mean there is a time discontinuity).