### PR TITLE
Bug fix about id type of mediaInfo for subtitles

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -561,7 +561,7 @@ function TextSourceBuffer() {
         if (embeddedTracks.length > 1 && mediaInfo.isEmbedded) {
             isDefault = (mediaInfo.id && mediaInfo.id === Constants.CC1); // CC1 if both CC1 and CC3 exist
         } else if (embeddedTracks.length === 1) {
-            if (mediaInfo.id && mediaInfo.id.substring(0, 2) === 'CC') { // Either CC1 or CC3
+            if (mediaInfo.id && typeof mediaInfo.id === 'string' && mediaInfo.id.substring(0, 2) === 'CC') { // Either CC1 or CC3
                 isDefault = true;
             }
         } else if (embeddedTracks.length === 0) {


### PR DESCRIPTION
Hi, 

this PR has to solve an issue found in the attached manifest.
[manifest.zip](https://github.com/Dash-Industry-Forum/dash.js/files/2603828/manifest.zip)

Id of the mediaInfo object is an unsigned int because it's an attribute of AdaptationSet :

  `<!-- Adaptation Set -->   <xs:complexType name="AdaptationSetType">     <xs:complexContent>       <xs:extension base="RepresentationBaseType">         <xs:sequence>           <xs:element name="Accessibility" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="Role" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="Rating" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="Viewpoint" type="DescriptorType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="ContentComponent" type="ContentComponentType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="BaseURL" type="BaseURLType" minOccurs="0" maxOccurs="unbounded"/>           <xs:element name="SegmentBase" type="SegmentBaseType" minOccurs="0"/>           <xs:element name="SegmentList" type="SegmentListType" minOccurs="0"/>           <xs:element name="SegmentTemplate" type="SegmentTemplateType" minOccurs="0"/>           <xs:element name="Representation" type="RepresentationType" minOccurs="0" maxOccurs="unbounded"/>         </xs:sequence>         <xs:attribute ref="xlink:href"/>         <xs:attribute ref="xlink:actuate" default="onRequest"/>         <xs:attribute name="id" type="xs:unsignedInt"/> `

In case of embedded subtitles, this attribute contains 'CC1', 'CC2','CC3' or 'CC4' string values. So, in TextSourceBuffer, we have to check the type of this attribute.

Nico

