### PR TITLE
feat capability to match lang regex for initial settings

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2301,13 +2301,12 @@ function MediaPlayer() {
 
     /**
      * This method allows to set media settings that will be used to pick the initial track. Format of the settings
-     * is following:
-     * {lang: langValue,
+     * is following: <br />
+     * {lang: langValue (can be either a string or a regex to match),
      *  viewpoint: viewpointValue,
      *  audioChannelConfiguration: audioChannelConfigurationValue,
      *  accessibility: accessibilityValue,
      *  role: roleValue}
-     *
      *
      * @param {string} type
      * @param {Object} value

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -359,7 +359,7 @@ function MediaController() {
     }
 
     function matchSettings(settings, track) {
-        const matchLang = !settings.lang || (settings.lang === track.lang);
+        const matchLang = !settings.lang || (track.lang.match(settings.lang));
         const matchViewPoint = !settings.viewpoint || (settings.viewpoint === track.viewpoint);
         const matchRole = !settings.role || !!track.roles.filter(function (item) {
             return item === settings.role;

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -397,9 +397,7 @@ describe('MediaController', function () {
     });
 
     describe('Initial Track Management', function () {
-
         it('should check initial media settings to choose initial track', function () {
-
             let trackType = 'audio';
             let streamInfo = {
                 id: 'id'
@@ -435,6 +433,71 @@ describe('MediaController', function () {
 
         });
 
+        it('should check initial media settings to choose initial track with a string/regex lang', function () {
+            const trackType = 'audio';
+            const streamInfo = {
+                id: 'id'
+            };
+            const track = {
+                type: trackType,
+                streamInfo: streamInfo,
+                lang: 'fr',
+                viewpoint: 'viewpoint',
+                roles: 1,
+                accessibility: 1,
+                audioChannelConfiguration: 1
+            };
+
+            mediaController.addTrack(track);
+
+            // call to checkInitialMediaSettingsForType
+            mediaController.setInitialSettings(trackType, {
+                lang: 'fr|en|qtz',
+                viewpoint: 'viewpoint'
+            });
+            mediaController.checkInitialMediaSettingsForType(trackType, streamInfo);
+
+            const currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo);
+            expect(objectUtils.areEqual(currentTrack, track)).to.be.true; // jshint ignore:line
+        });
+
+        it('should check initial media settings to choose initial track with a regex lang', function () {
+            const trackType = 'audio';
+            const streamInfo = {
+                id: 'id'
+            };
+            const frTrack = {
+                type: trackType,
+                streamInfo: streamInfo,
+                lang: 'fr',
+                viewpoint: 'viewpoint',
+                roles: 1,
+                accessibility: 1,
+                audioChannelConfiguration: 1
+            };
+            const qtzTrack = {
+                type: trackType,
+                streamInfo: streamInfo,
+                lang: 'qtz',
+                viewpoint: 'viewpoint',
+                roles: 1,
+                accessibility: 1,
+                audioChannelConfiguration: 1
+            };
+
+            mediaController.addTrack(frTrack);
+            mediaController.addTrack(qtzTrack);
+
+            // call to checkInitialMediaSettingsForType
+            mediaController.setInitialSettings(trackType, {
+                lang: /qtz|mis/,
+                viewpoint: 'viewpoint'
+            });
+            mediaController.checkInitialMediaSettingsForType(trackType, streamInfo);
+
+            const currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo);
+            expect(objectUtils.areEqual(currentTrack, qtzTrack)).to.be.true; // jshint ignore:line
+        });
     });
 
 });


### PR DESCRIPTION
# Why

We can set a specific initial lang but in some cases (legacy manifest cases), a same audio track could be identified by two different langs.
In our case, our legacy manifests use `fr` or `vf` lang where our newest manifests use `lv` which stands for local version.

On the player side, the goal is to always start with the local language version (even if the user has changed it on a previous video).

# How

This PR adds the capability to match the lang which a regex, in our case `/fr|vf|lv/`.

That change doesn't introduce a BC on the API, we can still use a classic string to match.

- [x] Documentation
- [x] Tests