### PR TITLE
Remove mutual dependancy

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -43,9 +43,9 @@ import { checkInteger } from '../streaming/utils/SupervisorTools';
 function DashAdapter() {
     let instance,
         dashManifestModel,
-        mediaController,
         voPeriods,
-        voAdaptations;
+        voAdaptations,
+        currentMediaInfo;
 
     function setup() {
         reset();
@@ -56,10 +56,6 @@ function DashAdapter() {
 
         if (config.dashManifestModel) {
             dashManifestModel = config.dashManifestModel;
-        }
-
-        if (config.mediaController) {
-            mediaController = config.mediaController;
         }
     }
 
@@ -225,12 +221,11 @@ function DashAdapter() {
         if (!adaptations || adaptations.length === 0) return null;
 
         if (adaptations.length > 1 && streamInfo) {
-            const currentTrack = mediaController.getCurrentTrackFor(type, streamInfo);
             const allMediaInfoForType = getAllMediaInfoForType(streamInfo, type);
 
-            if (currentTrack) {
+            if (currentMediaInfo[streamInfo.id] && currentMediaInfo[streamInfo.id][type]) {
                 for (let i = 0, ln = adaptations.length; i < ln; i++) {
-                    if (mediaController.isTracksEqual(currentTrack, allMediaInfoForType[i])) {
+                    if (currentMediaInfo[streamInfo.id][type].isMediaInfoEqual(allMediaInfoForType[i])) {
                         return adaptations[i];
                     }
                 }
@@ -536,9 +531,16 @@ function DashAdapter() {
         return events;
     }
 
+    function setCurrentMediaInfo(streamId, type, mediaInfo) {
+        currentMediaInfo[streamId] = currentMediaInfo[streamId] || {};
+        currentMediaInfo[streamId][type] = currentMediaInfo[streamId][type] || {};
+        currentMediaInfo[streamId][type] = mediaInfo;
+    }
+
     function reset() {
         voPeriods = [];
         voAdaptations = {};
+        currentMediaInfo = {};
     }
 
     instance = {
@@ -559,7 +561,8 @@ function DashAdapter() {
         setConfig: setConfig,
         updatePeriods: updatePeriods,
         reset: reset,
-        resetIndexHandler: resetIndexHandler
+        resetIndexHandler: resetIndexHandler,
+        setCurrentMediaInfo: setCurrentMediaInfo
     };
 
     setup();

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -55,9 +55,7 @@ function DashManifestModel(config) {
 
     const context = this.context;
     const urlUtils = URLUtils(context).getInstance();
-    const mediaController = config.mediaController;
     const timelineConverter = config.timelineConverter;
-    const adapter = config.adapter;
     const errHandler = config.errHandler;
 
     const PROFILE_DVB = 'urn:dvb:dash:profile:dvb-dash:2014';
@@ -195,12 +193,6 @@ function DashManifestModel(config) {
         return adaptation && adaptation.hasOwnProperty(DashConstants.AUDIOCHANNELCONFIGURATION_ASARRAY) ? adaptation.AudioChannelConfiguration_asArray : [];
     }
 
-    function getIsMain(adaptation) {
-        return getRolesForAdaptation(adaptation).filter(function (role) {
-            return role.value === DashConstants.MAIN;
-        })[0];
-    }
-
     function getRepresentationSortFunction() {
         return (a, b) => a.bandwidth - b.bandwidth;
     }
@@ -269,33 +261,6 @@ function DashManifestModel(config) {
         }
 
         return adaptations;
-    }
-
-    function getAdaptationForType(manifest, periodIndex, type, streamInfo) {
-        const adaptations = getAdaptationsForType(manifest, periodIndex, type);
-
-        if (!adaptations || adaptations.length === 0) return null;
-
-        if (adaptations.length > 1 && streamInfo) {
-            const currentTrack = mediaController.getCurrentTrackFor(type, streamInfo);
-            const allMediaInfoForType = adapter.getAllMediaInfoForType(streamInfo, type);
-
-            if (currentTrack) {
-                for (let i = 0, ln = adaptations.length; i < ln; i++) {
-                    if (mediaController.isTracksEqual(currentTrack, allMediaInfoForType[i])) {
-                        return adaptations[i];
-                    }
-                }
-            }
-
-            for (let i = 0, ln = adaptations.length; i < ln; i++) {
-                if (getIsMain(adaptations[i])) {
-                    return adaptations[i];
-                }
-            }
-        }
-
-        return adaptations[0];
     }
 
     function getCodec(adaptation, representationId, addResolutionInfo) {
@@ -1043,7 +1008,6 @@ function DashManifestModel(config) {
         getIndexForAdaptation: getIndexForAdaptation,
         getAdaptationForId: getAdaptationForId,
         getAdaptationsForType: getAdaptationsForType,
-        getAdaptationForType: getAdaptationForType,
         getCodec: getCodec,
         getMimeType: getMimeType,
         getKID: getKID,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -237,7 +237,6 @@ function MediaPlayer() {
         });
 
         adapter.setConfig({
-            mediaController: mediaController,
             dashManifestModel: dashManifestModel
         });
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -221,9 +221,7 @@ function MediaPlayer() {
 
         adapter = DashAdapter(context).getInstance();
         dashManifestModel = DashManifestModel(context).getInstance({
-            mediaController: mediaController,
             timelineConverter: timelineConverter,
-            adapter: adapter,
             errHandler: errHandler
         });
         manifestModel = ManifestModel(context).getInstance();
@@ -239,6 +237,7 @@ function MediaPlayer() {
         });
 
         adapter.setConfig({
+            mediaController: mediaController,
             dashManifestModel: dashManifestModel
         });
 
@@ -2750,7 +2749,6 @@ function MediaPlayer() {
             mediaPlayerModel: mediaPlayerModel,
             metricsModel: metricsModel,
             dashMetrics: dashMetrics,
-            dashManifestModel: dashManifestModel,
             manifestModel: manifestModel,
             videoModel: videoModel,
             adapter: adapter

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -549,7 +549,7 @@ function Stream(config) {
     }
 
     function filterCodecs(type) {
-        const realAdaptation = dashManifestModel.getAdaptationForType(manifestModel.getValue(), streamInfo.index, type, streamInfo);
+        const realAdaptation = adapter.getAdaptationForType(manifestModel.getValue(), streamInfo.index, type, streamInfo);
 
         if (!realAdaptation || !Array.isArray(realAdaptation.Representation_asArray)) return;
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -346,6 +346,8 @@ function Stream(config) {
         let mediaInfo = e.newMediaInfo;
         let manifest = manifestModel.getValue();
 
+        adapter.setCurrentMediaInfo(streamInfo.id, mediaInfo.type, mediaInfo);
+
         logger.debug('Stream -  Update stream controller');
         if (manifest.refreshManifestOnSwitchTrack) {
             logger.debug('Stream -  Refreshing manifest for switch track');

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -76,7 +76,6 @@ function AbrController() {
         elementWidth,
         elementHeight,
         manifestModel,
-        dashManifestModel,
         adapter,
         videoModel,
         mediaPlayerModel,
@@ -185,9 +184,6 @@ function AbrController() {
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;
         }
-        if (config.dashManifestModel) {
-            dashManifestModel = config.dashManifestModel;
-        }
         if (config.adapter) {
             adapter = config.adapter;
         }
@@ -265,7 +261,7 @@ function AbrController() {
         if (!bitrateDict.hasOwnProperty(type)) {
             if (ratioDict.hasOwnProperty(type)) {
                 const manifest = manifestModel.getValue();
-                const representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
+                const representation = adapter.getAdaptationForType(manifest, 0, type).Representation;
 
                 if (Array.isArray(representation)) {
                     const repIdx = Math.max(Math.round(representation.length * ratioDict[type]) - 1, 0);
@@ -689,7 +685,7 @@ function AbrController() {
         }
 
         const manifest = manifestModel.getValue();
-        const representation = dashManifestModel.getAdaptationForType(manifest, 0, type).Representation;
+        const representation = adapter.getAdaptationForType(manifest, 0, type).Representation;
         let newIdx = idx;
 
         if (elementWidth > 0 && elementHeight > 0) {

--- a/src/streaming/vo/MediaInfo.js
+++ b/src/streaming/vo/MediaInfo.js
@@ -51,6 +51,21 @@ class MediaInfo {
         this.KID = null;
         this.bitrateList = null;
     }
+
+    isMediaInfoEqual(mediaInfo) {
+        if (!mediaInfo) {
+            return false;
+        }
+
+        const sameId = this.id === mediaInfo.id;
+        const sameViewpoint = this.viewpoint === mediaInfo.viewpoint;
+        const sameLang = this.lang === mediaInfo.lang;
+        const sameRoles = this.roles.toString() === mediaInfo.roles.toString();
+        const sameAccessibility = this.accessibility.toString() === mediaInfo.accessibility.toString();
+        const sameAudioChannelConfiguration = this.audioChannelConfiguration.toString() === mediaInfo.audioChannelConfiguration.toString();
+
+        return (sameId && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
+    }
 }
 
 export default MediaInfo;

--- a/test/unit/dash.DashAdapter.js
+++ b/test/unit/dash.DashAdapter.js
@@ -1,20 +1,18 @@
 import DashAdapter from '../../src/dash/DashAdapter';
+import MediaInfo from '../../src/streaming/vo/MediaInfo';
 import Constants from '../../src/streaming/constants/Constants';
 
 import RepresentationControllerMock from './mocks/RepresentationControllerMock';
 import StreamProcessorMock from './mocks/StreamProcessorMock';
-import MediaControllerMock from './mocks/MediaControllerMock';
 import DashManifestModelMock from './mocks/DashManifestModelMock';
 
 const expect = require('chai').expect;
 
 const context = {};
-const mediaControllerMock = new MediaControllerMock();
 const dashManifestModelMock = new DashManifestModelMock();
 const dashAdapter = DashAdapter(context).getInstance();
 dashAdapter.setConfig({
-    dashManifestModel: dashManifestModelMock,
-    mediaController: mediaControllerMock
+    dashManifestModel: dashManifestModelMock
 });
 
 describe('DashAdapter', function () {
@@ -26,26 +24,30 @@ describe('DashAdapter', function () {
         expect(adaptation.id).to.equal(0); // jshint ignore:line
     });
 
-    /*it('should return the correct adaptation when getAdaptationForType is called', () => {
+    it('should return the correct adaptation when getAdaptationForType is called', () => {
         const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{ value: 'main' }] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{ value: 'main' }] }] }] };
 
         const streamInfo = {
             id: 'id'
         };
 
-        const track1 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 0, isText: false, lang: 'eng', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
-        const track2 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 1, isText: false, lang: 'deu', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
+        const track = new MediaInfo();
 
-        mediaControllerMock.addTrack(track1);
-        mediaControllerMock.addTrack(track2);
-        mediaControllerMock.setTrack(track2);
+        track.id = undefined;
+        track.index = 1;
+        track.streamInfo = streamInfo;
+        track.representationCount = 0;
+        track.lang = 'deu';
+        track.roles = ['main'];
+        track.codec = 'audio/mp4;codecs="mp4a.40.2"';
+        track.mimeType = 'audio/mp4';
+
+        dashAdapter.setCurrentMediaInfo(streamInfo.id, 'audio', track);
 
         const adaptation = dashAdapter.getAdaptationForType(manifest, 0, 'audio', streamInfo);
 
-        //in the mediaControllerMock, the currentTrack is lang= deu
-
-        expect(adaptation.lang).to.equal('deu'); // jshint ignore:line
-    });*/
+        expect(adaptation.lang).to.equal('eng'); // jshint ignore:line
+    });
 
     it('should throw an exception when attempting to call getStreamsInfo While the setConfig function was not called, and externalManifest parameter is defined', function () {
         expect(dashAdapter.getStreamsInfo.bind(dashAdapter,{})).to.throw('setConfig function has to be called previously');

--- a/test/unit/dash.DashAdapter.js
+++ b/test/unit/dash.DashAdapter.js
@@ -3,13 +3,49 @@ import Constants from '../../src/streaming/constants/Constants';
 
 import RepresentationControllerMock from './mocks/RepresentationControllerMock';
 import StreamProcessorMock from './mocks/StreamProcessorMock';
+import MediaControllerMock from './mocks/MediaControllerMock';
+import DashManifestModelMock from './mocks/DashManifestModelMock';
 
 const expect = require('chai').expect;
 
 const context = {};
+const mediaControllerMock = new MediaControllerMock();
+const dashManifestModelMock = new DashManifestModelMock();
 const dashAdapter = DashAdapter(context).getInstance();
+dashAdapter.setConfig({
+    dashManifestModel: dashManifestModelMock,
+    mediaController: mediaControllerMock
+});
 
 describe('DashAdapter', function () {
+
+    it('should return the first adaptation when getAdaptationForType is called and streamInfo is undefined', () => {
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0, mimeType: 'video' }, { id: 1, mimeType: 'video' }] }] };
+        const adaptation = dashAdapter.getAdaptationForType(manifest, 0, 'video');
+
+        expect(adaptation.id).to.equal(0); // jshint ignore:line
+    });
+
+    /*it('should return the correct adaptation when getAdaptationForType is called', () => {
+        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{ value: 'main' }] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{ value: 'main' }] }] }] };
+
+        const streamInfo = {
+            id: 'id'
+        };
+
+        const track1 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 0, isText: false, lang: 'eng', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
+        const track2 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 1, isText: false, lang: 'deu', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
+
+        mediaControllerMock.addTrack(track1);
+        mediaControllerMock.addTrack(track2);
+        mediaControllerMock.setTrack(track2);
+
+        const adaptation = dashAdapter.getAdaptationForType(manifest, 0, 'audio', streamInfo);
+
+        //in the mediaControllerMock, the currentTrack is lang= deu
+
+        expect(adaptation.lang).to.equal('deu'); // jshint ignore:line
+    });*/
 
     it('should throw an exception when attempting to call getStreamsInfo While the setConfig function was not called, and externalManifest parameter is defined', function () {
         expect(dashAdapter.getStreamsInfo.bind(dashAdapter,{})).to.throw('setConfig function has to be called previously');

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -4,22 +4,16 @@ import BaseURL from '../../src/dash/vo/BaseURL';
 import MpdHelper from './helpers/MPDHelper';
 import ObjectsHelper from './helpers/ObjectsHelper';
 
-import AdapterMock from './mocks/AdapterMock';
-import MediaControllerMock from './mocks/MediaControllerMock';
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 
 const expect = require('chai').expect;
 
 const context = {};
 const objectsHelper = new ObjectsHelper();
-const adapterMock = new AdapterMock();
-const mediaControllerMock = new MediaControllerMock();
 const errorHandlerMock = new ErrorHandlerMock();
 const timelineConverterMock = objectsHelper.getDummyTimelineConverter();
 const dashManifestModel = DashManifestModel(context).getInstance({
-    mediaController: mediaControllerMock,
     timelineConverter: timelineConverterMock,
-    adapter: adapterMock,
     errHandler: errorHandlerMock
 });
 
@@ -188,34 +182,6 @@ describe('DashManifestModel', function () {
         const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0 }] }] };
 
         expect(dashManifestModel.getAdaptationsForType.bind(dashManifestModel, manifest, 0, undefined)).to.throw('type is not defined');
-    });
-
-    it('should return an empty array when getAdaptationForType is called and streamInfo is undefined', () => {
-        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: 0, mimeType: 'video' }] }] };
-        const adaptation = dashManifestModel.getAdaptationForType(manifest, 0, 'video', undefined);
-
-        expect(adaptation.id).to.equal(0); // jshint ignore:line
-    });
-
-    it('should return the correct adaptation when getAdaptationForType is called', () => {
-        const manifest = { Period_asArray: [{ AdaptationSet_asArray: [{ id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{ value: 'main' }] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{ value: 'main' }] }] }] };
-
-        const streamInfo = {
-            id: 'id'
-        };
-
-        const track1 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 0, isText: false, lang: 'eng', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
-        const track2 = { codec: 'audio/mp4;codecs="mp4a.40.2"', id: undefined, index: 1, isText: false, lang: 'deu', mimeType: 'audio/mp4', roles: ['main'], streamInfo: streamInfo };
-
-        mediaControllerMock.addTrack(track1);
-        mediaControllerMock.addTrack(track2);
-        mediaControllerMock.setTrack(track2);
-
-        const adaptation = dashManifestModel.getAdaptationForType(manifest, 0, 'audio', streamInfo);
-
-        //in the mediaControllerMock, the currentTrack is lang= deu
-
-        expect(adaptation.lang).to.equal('deu'); // jshint ignore:line
     });
 
     it('should return null when getCodec is called and adaptation is undefined', () => {

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -33,6 +33,22 @@ class AdapterMock {
     getStreamsInfo() {
         return [];
     }
+
+    getAdaptationForType() {
+        return {
+            Representation: [
+                {
+                    width: 500
+                },
+                {
+                    width: 750
+                },
+                {
+                    width: 900
+                }
+            ]
+        };
+    }
 }
 
 export default AdapterMock;

--- a/test/unit/mocks/DashManifestModelMock.js
+++ b/test/unit/mocks/DashManifestModelMock.js
@@ -39,6 +39,10 @@ function DashManifestModelMock () {
     this.getIndexForAdaptation = function () {
         return 0;
     };
+
+    this.getRolesForAdaptation = function () {
+        return [];
+    };
 }
 
 export default DashManifestModelMock;

--- a/test/unit/mocks/DashManifestModelMock.js
+++ b/test/unit/mocks/DashManifestModelMock.js
@@ -4,20 +4,16 @@ function DashManifestModelMock () {
         return false;
     };
 
-    this.getAdaptationForType = function () {
-        return {
-            Representation: [
-                {
-                    width: 500
-                },
-                {
-                    width: 750
-                },
-                {
-                    width: 900
-                }
-            ]
-        };
+    this.getAdaptationsForType = function (manifest, periodIndex, type) {
+        let adaptationsArray;
+
+        if (type === 'video') {
+            adaptationsArray = [{ id: 0, mimeType: 'video' }, { id: 1, mimeType: 'video' }];
+        } else {
+            adaptationsArray = [{ id: undefined, mimeType: 'audio', lang: 'eng', Role_asArray: [{ value: 'main' }] }, { id: undefined, mimeType: 'audio', lang: 'deu', Role_asArray: [{ value: 'main' }]}];
+        }
+
+        return adaptationsArray;
     };
 
     this.setRepresentation = function (res) {

--- a/test/unit/streaming.Stream.js
+++ b/test/unit/streaming.Stream.js
@@ -6,7 +6,7 @@ import DashJSError from '../../src/streaming/vo/DashJSError';
 import ProtectionErrors from '../../src/streaming/protection/errors/ProtectionErrors';
 import Constants from '../../src/streaming/constants/Constants';
 
-import DashManifestModelMock from './mocks/DashManifestModelMock';
+import AdapterMock from './mocks/AdapterMock';
 import ManifestModelMock from './mocks/ManifestModelMock';
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 
@@ -17,7 +17,7 @@ const context = {};
 const eventBus = EventBus(context).getInstance();
 
 describe('Stream', function () {
-    const dashManifestModelMock = new DashManifestModelMock();
+    const adapterMock = new AdapterMock();
     const manifestModelMock = new ManifestModelMock();
     const errHandlerMock = new ErrorHandlerMock();
     const streamInfo = {
@@ -89,7 +89,7 @@ describe('Stream', function () {
 
         eventBus.on(Events.STREAM_INITIALIZED, spy);
 
-        const stream = Stream(context).create({dashManifestModel: dashManifestModelMock,
+        const stream = Stream(context).create({adapter: adapterMock,
                                                manifestModel: manifestModelMock});
         stream.updateData(streamInfo);
 

--- a/test/unit/streaming.controllers.AbrControllerSpec.js
+++ b/test/unit/streaming.controllers.AbrControllerSpec.js
@@ -4,7 +4,7 @@ import AbrController from '../../src/streaming/controllers/AbrController';
 import BitrateInfo from '../../src/streaming/vo/BitrateInfo';
 import Constants from '../../src/streaming/constants/Constants';
 
-import DashManifestModelMock from './mocks/DashManifestModelMock';
+import AdapterMock from './mocks/AdapterMock';
 import VideoModelMock from './mocks/VideoModelMock';
 import DomStorageMock from './mocks/DomStorageMock';
 import MetricsModelMock from './mocks/MetricsModelMock';
@@ -25,7 +25,7 @@ describe('AbrController', function () {
     const representationCount = dummyMediaInfo.representationCount;
     const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);
     const manifestModelMock = new ManifestModelMock();
-    const dashManifestModelMock = new DashManifestModelMock();
+    const adapterMock = new AdapterMock();
     const videoModelMock = new VideoModelMock();
     const domStorageMock = new DomStorageMock();
     const metricsModelMock = new MetricsModelMock();
@@ -37,7 +37,7 @@ describe('AbrController', function () {
             dashMetrics: dashMetricsMock,
             videoModel: videoModelMock,
             manifestModel: manifestModelMock,
-            dashManifestModel: dashManifestModelMock,
+            adapter: adapterMock,
             domStorage: domStorageMock
         });
         abrCtrl.registerStreamType('video', streamProcessor);


### PR DESCRIPTION
Hi,

this PR is a first step in order to isolate properly Dash "parser" classes as described in issue #2550.

- Remove mutual dependancy between dashManifestModel and dashAdapter
- Remove mediaController reference in dashAdapter

Nico