### PR TITLE
fix for setLiveSeekableRange

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -361,6 +361,8 @@ function DashManifestModel(config) {
         //If the attribute is not present, the duration of the Media Presentation is unknown.
         if (manifest && manifest.hasOwnProperty(DashConstants.MEDIA_PRESENTATION_DURATION)) {
             mpdDuration = manifest.mediaPresentationDuration;
+        } else if (manifest && manifest.type == 'dynamic') {
+            mpdDuration = Number.POSITIVE_INFINITY;
         } else {
             mpdDuration = Number.MAX_SAFE_INTEGER || Number.MAX_VALUE;
         }


### PR DESCRIPTION
play a live stream and watch below expressions in the debug console
```
document.getElementsByTagName('video')[0].duration
document.getElementsByTagName('video')[0].seekable.start(0)
document.getElementsByTagName('video')[0].seekable.end(0)
```
current: 
duration = 9007199254740991
start = 0
end = 9007199254740991

It does not follow the DVR window.

ref: https://bugs.chromium.org/p/chromium/issues/detail?id=623698
setLiveSeekableRange is ignored if the duration is not +Infinity.

https://github.com/Dash-Industry-Forum/dash.js/blob/548148bef7dd39c28f02992ffb0af147a7a85dc8/src/dash/models/DashManifestModel.js#L358-L369
It return Number.MAX_SAFE_INTEGER and set video duration = 9007199254740991, hence setLiveSeekableRange  is not working

```
    function getDuration(manifest) {
        let mpdDuration;
        //@mediaPresentationDuration specifies the duration of the entire Media Presentation.
        //If the attribute is not present, the duration of the Media Presentation is unknown.
        if (manifest && manifest.hasOwnProperty(DashConstants.MEDIA_PRESENTATION_DURATION)) {
            mpdDuration = manifest.mediaPresentationDuration;
        } else if (manifest && manifest.type == 'dynamic'){
            mpdDuration = Number.POSITIVE_INFINITY;
        } else {
            mpdDuration = Number.MAX_SAFE_INTEGER || Number.MAX_VALUE;
        }

        return mpdDuration;
    }
```
Return positive infinity for dynamic stream could solve this problem.