### PR TITLE
Fix: TS7019: Rest parameter 'params' implicitly has an 'any[]' type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,11 @@ export as namespace dashjs;
 
 declare namespace dashjs {
     interface Logger {
-        debug(...params): void;
-        info(...params): void;
-        warn(...params): void;
-        error(...params): void;
-        fatal(...params): void;
+        debug(...params: any[]): void;
+        info(...params: any[]): void;
+        warn(...params: any[]): void;
+        error(...params: any[]): void;
+        fatal(...params: any[]): void;
     }
 
     enum LogLevel {


### PR DESCRIPTION
Fix for TypeScript with `"noImplicitAny": true` option.
```
ERROR in [at-loader] ./node_modules/dashjs/build/typings/index.d.ts:6:15 
    TS7019: Rest parameter 'params' implicitly has an 'any[]' type.

ERROR in [at-loader] ./node_modules/dashjs/build/typings/index.d.ts:7:14 
    TS7019: Rest parameter 'params' implicitly has an 'any[]' type.

ERROR in [at-loader] ./node_modules/dashjs/build/typings/index.d.ts:8:14 
    TS7019: Rest parameter 'params' implicitly has an 'any[]' type.

ERROR in [at-loader] ./node_modules/dashjs/build/typings/index.d.ts:9:15 
    TS7019: Rest parameter 'params' implicitly has an 'any[]' type.

ERROR in [at-loader] ./node_modules/dashjs/build/typings/index.d.ts:10:15 
    TS7019: Rest parameter 'params' implicitly has an 'any[]' type.
```