### PR TITLE
Fix disabling of catchup (leave playback rate alone)

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -592,7 +592,13 @@ function PlaybackController() {
     }
 
     function onPlaybackProgression() {
-        if (isDynamic && mediaPlayerModel.getLowLatencyEnabled() && !isPaused() && !isSeeking()) {
+        if (
+            isDynamic &&
+            mediaPlayerModel.getLowLatencyEnabled() &&
+            mediaPlayerModel.getCatchUpPlaybackRate() > 0 &&
+            !isPaused() &&
+            !isSeeking()
+        ) {
             if (needToCatchUp()) {
                 startPlaybackCatchUp();
             } else {


### PR DESCRIPTION
Don't stop playback catchup when you haven't started it because it is disabled by setting catchup playback rate to value 0; e.g: leave playback rate alone in that case.