### PR TITLE
Fixed for https://github.com/Dash-Industry-Forum/dash.js/issues/2895

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -323,10 +323,10 @@ function StreamController() {
                 const timeToEnd = playbackController.getTimeToStreamEnd();
                 const delayPlaybackEnded = timeToEnd > 0 ? timeToEnd * 1000 : 0;
                 logger.debug('[toggleEndPeriodTimer] start-up of timer to notify PLAYBACK_ENDED event. It will be triggered in ' + delayPlaybackEnded + ' milliseconds');
-                playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED, {'isLast': getActiveStreamInfo().isLast});}, delayPlaybackEnded);
                 const preloadDelay = delayPlaybackEnded < 2000 ? delayPlaybackEnded / 4 : delayPlaybackEnded - 2000;
                 logger.info('[toggleEndPeriodTimer] Going to fire preload in ' + preloadDelay);
                 preloadTimerId = setTimeout(onStreamCanLoadNext,  preloadDelay);
+                playbackEndedTimerId = setTimeout(function () {eventBus.trigger(Events.PLAYBACK_ENDED, {'isLast': getActiveStreamInfo().isLast});}, delayPlaybackEnded);
             }
         }
     }


### PR DESCRIPTION
// Issue Description
You can see when it playback at 02:00, and try to switch to next period.
The player will always buffering and won't try to download next fragment.
// Solution
onEnd will change active stream while onStreamCanLoadNext won't.
So if we call getNextStream in onEnd, we will get next period.
And thus call getNextStream in onStreamCanLoadNext will get next, next period.
Which will prevent the schedule to download fragment nearby currentTime.

To fix the issue, I think it should call onStreamCanLoadNext first then call onEnd.