### PR TITLE
Change the way Promises support is checked

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -267,7 +267,7 @@ function VideoModel() {
         if (element) {
             element.autoplay = true;
             const p = element.play();
-            if (p && (typeof Promise !== 'undefined') && (p instanceof Promise)) {
+            if (p && p.catch && typeof Promise !== 'undefined') {
                 p.catch((e) => {
                     if (e.name === 'NotAllowedError') {
                         eventBus.trigger(Events.PLAYBACK_NOT_ALLOWED);


### PR DESCRIPTION
Following @chevonc suggestion (#2873), this PR changes the way Promises support is checked in dash.js to support cases in which dash.js is bundled with a Promises library different than the native one.