### PR TITLE
protect track switch

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -386,7 +386,7 @@ function DashHandler(config) {
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 
-        if (index > 0) {
+        if (index >= 0) {
             logger.debug('Index for ' + type + ' time ' + time + ' is ' + index );
         }
 


### PR DESCRIPTION
Hi,

this PR has to solve issue #2911. When a track switch, with the need to reset buffer, occurs, ScheduleController has to wait that the reset process is over before doing another track switch.

@BucherTomas, could you, please, take a look at it and make me a feedback?

Thanks,
Nico