### PR TITLE
switch MPD urls to protocol relative when available in https

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -13,7 +13,7 @@
           "name": "SegmentBase, ondemand profile"
         },
         {
-          "url": "http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd",
+          "url": "//demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd",
           "name": "SegmentTimeline/Time"
         },
         {
@@ -166,23 +166,23 @@
       "submenu": [
         {
           "name": "Single adaption set, 7 tiles at 10x1, each thumb 320x180",
-          "url": "http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_tiled_thumbnails.mpd"
+          "url": "//dash.edgesuite.net/akamai/bbb_30fps/bbb_with_tiled_thumbnails.mpd"
         },
         {
           "name": "Single adaption set, 4 tiles at 10x1, each thumb 205x115",
-          "url": "http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_4_tiles_thumbnails.mpd"
+          "url": "//dash.edgesuite.net/akamai/bbb_30fps/bbb_with_4_tiles_thumbnails.mpd"
         },
         {
           "name": "Single adaption set, 1 tile at 10x20, each thumb 102x58",
-          "url": "http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_tiled_thumbnails_2.mpd"
+          "url": "//dash.edgesuite.net/akamai/bbb_30fps/bbb_with_tiled_thumbnails_2.mpd"
         },
         {
           "name": "Two adaption sets with different thumb resolutions",
-          "url": "http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd"
+          "url": "//dash.edgesuite.net/akamai/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd"
         },
         {
           "name": "Live stream, Single adaptation set, 1x1 tiles (livesim)",
-          "url": "http://livesim.dashif.org/livesim/testpic_2s/Manifest_thumbs.mpd"
+          "url": "//livesim.dashif.org/livesim/testpic_2s/Manifest_thumbs.mpd"
         },
         {
           "name": "SegmentBase, Single adaption set, 3x4 tiles",
@@ -812,27 +812,27 @@
       "submenu": [
         {
           "name": "Clear Dynamic SegmentTimeline",
-          "url": "http://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvtime.mpd"
+          "url": "//wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvtime.mpd"
         },
         {
           "name": "Clear Dynamic SegmentTemplate",
-          "url": "http://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvnumber.mpd"
+          "url": "//wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvnumber.mpd"
         },
         {
           "name": "Clear Dynamic SegmentList",
-          "url": "http://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvlist.mpd"
+          "url": "//wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mvlist.mpd"
         },
         {
           "name": "Clear Static SegmentTimeline",
-          "url": "http://wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvtime.mpd"
+          "url": "//wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvtime.mpd"
         },
         {
           "name": "Clear Static SegmentTemplate",
-          "url": "http://wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvnumber.mpd"
+          "url": "//wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvnumber.mpd"
         },
         {
           "name": "Clear Static SegmentList",
-          "url": "http://wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvlist.mpd"
+          "url": "//wowzaec2demo.streamlock.net/vod/_definst_/ElephantsDream/smil:ElephantsDream.smil/manifest_mvlist.mpd"
         },
         {
           "name": "Widevine Dynamic SegmentTimeline",
@@ -899,11 +899,11 @@
         },
         {
           "name": "Unified Streaming - Timeline",
-          "url": "http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd"
+          "url": "//demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd"
         },
         {
           "name": "Unified Streaming (Widevine, persistent)",
-          "url": "http://demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-dash-widevine.ism/.mpd",
+          "url": "//demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-dash-widevine.ism/.mpd",
           "protData": {
               "com.widevine.alpha": {
                   "serverURL": "https://cwip-shaka-proxy.appspot.com/no_auth",


### PR DESCRIPTION
This PR allows some streams to be used when the client page is in https. At the moment, because of mixed content rule, many streams are not playable.

I have also tested the status (OK, NOK) of all test streams (sources.json and dashjs.json) with some remarks. It can be useful to clean up the list of streams. Some streams could simply be accessible in https and some manifests could be updated to use a <BaseUrl> in https too.
I have noticed that many live streams are stil broken in Chrome because of this issue #93 (MseBufferByPts feature not enabled by default)

See the results in this excel file (two sheets, one for sources.json streams and one for dashjs test vectors)
[Test_Streams_Status.xlsx](https://github.com/Dash-Industry-Forum/dash.js/files/2807155/Test_Streams_Status.xlsx)
