### PR TITLE
Fix how timeout is handle in license requests

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -680,7 +680,7 @@ function ProtectionController(config) {
             }
         };
 
-        xhr.onerror = function () {
+        xhr.ontimeout = xhr.onerror = function () {
             if (retriesCount <= 0) {
                 onError(this);
             } else {

--- a/src/streaming/utils/LiveEdgeFinder.js
+++ b/src/streaming/utils/LiveEdgeFinder.js
@@ -52,10 +52,11 @@ function LiveEdgeFinder(config) {
     function getLiveEdge() {
         checkConfig();
         const representationInfo = streamProcessor.getRepresentationInfo();
-        let liveEdge = representationInfo.DVRWindow.end;
+        const dvrEnd = representationInfo.DVRWindow ? representationInfo.DVRWindow.end : 0;
+        let liveEdge = dvrEnd;
         if (representationInfo.useCalculatedLiveEdgeTime) {
             liveEdge = timelineConverter.getExpectedLiveEdge();
-            timelineConverter.setClientTimeOffset(liveEdge - representationInfo.DVRWindow.end);
+            timelineConverter.setClientTimeOffset(liveEdge - dvrEnd);
         }
         return liveEdge;
     }


### PR DESCRIPTION
Fix how dash.js manages timeout of license requests. 

In this same PR I am fixing an issue I could reproduce quite sporadically related with live streaming playback. In one of my test streams sometimes getLiveEdge is called while DVRInfo is still not set what raised an exception.