### PR TITLE
Set DashMetrics as a controller of MetricsModel

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -156,16 +156,13 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         },
 
         getBufferLevel = function () {
-            var videoMetrics = player.getMetricsFor('video');
-            var audioMetrics = player.getMetricsFor('audio');
             var dashMetrics = player.getDashMetrics();
             var bufferLevel = 0;
 
             if (dashMetrics) {
-                if (videoMetrics) {
-                    bufferLevel = dashMetrics.getCurrentBufferLevel(videoMetrics);
-                } else if (audioMetrics) {
-                    bufferLevel = dashMetrics.getCurrentBufferLevel(audioMetrics);
+                bufferLevel = dashMetrics.getCurrentBufferLevel('video', true);
+                if (!bufferLevel) {
+                    bufferLevel = dashMetrics.getCurrentBufferLevel('audio', true);
                 }
             }
             return bufferLevel;

--- a/samples/advanced/abr/LowestBitrateRule.js
+++ b/samples/advanced/abr/LowestBitrateRule.js
@@ -49,7 +49,7 @@ function LowestBitrateRuleClass() {
         // here you can get some informations aboit metrics for example, to implement the rule
         let metricsModel = MetricsModel(context).getInstance();
         var mediaType = rulesContext.getMediaInfo().type;
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        var metrics = metricsModel.getMetricsFor(mediaType, true);
 
         // A smarter (real) rule could need analyze playback metrics to take
         // bitrate switching decision. Printing metrics here as a reference

--- a/samples/advanced/monitoring.html
+++ b/samples/advanced/monitoring.html
@@ -28,13 +28,12 @@
 
             var eventPoller = setInterval(function() {
                 var streamInfo = player.getActiveStream().getStreamInfo();
-                var metrics = player.getMetricsFor('video');
                 var dashMetrics = player.getDashMetrics();
 
-                if (metrics && dashMetrics && streamInfo) {
+                if (dashMetrics && streamInfo) {
                     const periodIdx = streamInfo.index;
-                    var repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
-                    var bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+                    var repSwitch = dashMetrics.getCurrentRepresentationSwitch('video');
+                    var bufferLevel = dashMetrics.getCurrentBufferLevel('video');
                     var bitrate = repSwitch ? Math.round(dashMetrics.getBandwidthForRepresentation(repSwitch.to, periodIdx) / 1000) : NaN;
                     document.getElementById('bufferLevel').innerText = bufferLevel + " secs";
                     document.getElementById('reportedBitrate').innerText = bitrate + " Kbps";

--- a/samples/chromecast/receiver/js/main.js
+++ b/samples/chromecast/receiver/js/main.js
@@ -42,7 +42,7 @@ function ReceiverController($scope) {
 
             if (metrics && dashMetrics) {
                 repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
-                bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+                bufferLevel = dashMetrics.getCurrentBufferLevel(type);
                 httpRequest = dashMetrics.getCurrentHttpRequest(metrics);
                 droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames(metrics);
 

--- a/samples/chromecast/receiver/js/main.js
+++ b/samples/chromecast/receiver/js/main.js
@@ -44,7 +44,7 @@ function ReceiverController($scope) {
                 repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
                 bufferLevel = dashMetrics.getCurrentBufferLevel(type);
                 httpRequest = dashMetrics.getCurrentHttpRequest(metrics);
-                droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames(metrics);
+                droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames();
 
                 if (repSwitch !== null) {
                     bitrateIndexValue = dashMetrics.getIndexForRepresentation(repSwitch.to);

--- a/samples/chromecast/receiver/js/main.js
+++ b/samples/chromecast/receiver/js/main.js
@@ -40,9 +40,9 @@ function ReceiverController($scope) {
                 droppedFramesValue = 0;
 
             if (dashMetrics) {
-                repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
-                bufferLevel = dashMetrics.getCurrentBufferLevel(type);
-                httpRequest = dashMetrics.getCurrentHttpRequest(type);
+                repSwitch = dashMetrics.getCurrentRepresentationSwitch(type, true);
+                bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
+                httpRequest = dashMetrics.getCurrentHttpRequest(type, true);
                 droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames();
 
                 if (repSwitch !== null) {

--- a/samples/chromecast/receiver/js/main.js
+++ b/samples/chromecast/receiver/js/main.js
@@ -25,7 +25,6 @@ function ReceiverController($scope) {
 
         getMetricsFor = function (type) {
             var video = document.querySelector(".dash-video-player video"),
-                metrics = player.getMetricsFor(type),
                 dashMetrics = player.getDashMetrics(),
                 repSwitch,
                 bufferLevel,
@@ -40,10 +39,10 @@ function ReceiverController($scope) {
                 lastFragmentDownloadTime,
                 droppedFramesValue = 0;
 
-            if (metrics && dashMetrics) {
-                repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
+            if (dashMetrics) {
+                repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
                 bufferLevel = dashMetrics.getCurrentBufferLevel(type);
-                httpRequest = dashMetrics.getCurrentHttpRequest(metrics);
+                httpRequest = dashMetrics.getCurrentHttpRequest(type);
                 droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames();
 
                 if (repSwitch !== null) {

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -743,8 +743,8 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         if (metrics && dashMetrics && $scope.streamInfo) {
             var periodIdx = $scope.streamInfo.index;
             var repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
-            var bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
             var maxIndex = dashAdapter.getMaxIndexForBufferType(type, periodIdx);
+            var bufferLevel = dashMetrics.getCurrentBufferLevel(type);
             var index = $scope.player.getQualityFor(type);
             var bitrate = repSwitch ? Math.round(dashAdapter.getBandwidthForRepresentation(repSwitch.to, periodIdx) / 1000) : NaN;
             var droppedFPS = dashMetrics.getCurrentDroppedFrames(metrics) ? dashMetrics.getCurrentDroppedFrames(metrics).droppedFrames : 0;

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -741,9 +741,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
 
         if (dashMetrics && $scope.streamInfo) {
             var periodIdx = $scope.streamInfo.index;
-            var repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
+
             var maxIndex = dashAdapter.getMaxIndexForBufferType(type, periodIdx);
-            var bufferLevel = dashMetrics.getCurrentBufferLevel(type);
+            var repSwitch = dashMetrics.getCurrentRepresentationSwitch(type, true);
+            var bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
             var index = $scope.player.getQualityFor(type);
 
             var bitrate = repSwitch ? Math.round(dashAdapter.getBandwidthForRepresentation(repSwitch.to, periodIdx) / 1000) : NaN;

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -742,7 +742,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
 
         if (metrics && dashMetrics && $scope.streamInfo) {
             var periodIdx = $scope.streamInfo.index;
-            var repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
+            var repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
             var bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
             var maxIndex = dashAdapter.getMaxIndexForBufferType(type, periodIdx);
             var index = $scope.player.getQualityFor(type);

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -736,11 +736,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     }
 
     function updateMetrics(type) {
-        var metrics = $scope.player.getMetricsFor(type);
         var dashMetrics = $scope.player.getDashMetrics();
         var dashAdapter = $scope.player.getDashAdapter();
 
-        if (metrics && dashMetrics && $scope.streamInfo) {
+        if (dashMetrics && $scope.streamInfo) {
             var periodIdx = $scope.streamInfo.index;
             var repSwitch = dashMetrics.getCurrentRepresentationSwitch(type);
             var maxIndex = dashAdapter.getMaxIndexForBufferType(type, periodIdx);
@@ -761,7 +760,7 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             $scope[type + 'DroppedFrames'] = droppedFPS;
             $scope[type + 'LiveLatency'] = liveLatency;
 
-            var httpMetrics = calculateHTTPMetrics(type, dashMetrics.getHttpRequests(metrics));
+            var httpMetrics = calculateHTTPMetrics(type, dashMetrics.getHttpRequests(type));
             if (httpMetrics) {
                 $scope[type + 'Download'] = httpMetrics.download[type].low.toFixed(2) + ' | ' + httpMetrics.download[type].average.toFixed(2) + ' | ' + httpMetrics.download[type].high.toFixed(2);
                 $scope[type + 'Latency'] = httpMetrics.latency[type].low.toFixed(2) + ' | ' + httpMetrics.latency[type].average.toFixed(2) + ' | ' + httpMetrics.latency[type].high.toFixed(2);

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -746,8 +746,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             var maxIndex = dashAdapter.getMaxIndexForBufferType(type, periodIdx);
             var bufferLevel = dashMetrics.getCurrentBufferLevel(type);
             var index = $scope.player.getQualityFor(type);
+
             var bitrate = repSwitch ? Math.round(dashAdapter.getBandwidthForRepresentation(repSwitch.to, periodIdx) / 1000) : NaN;
-            var droppedFPS = dashMetrics.getCurrentDroppedFrames(metrics) ? dashMetrics.getCurrentDroppedFrames(metrics).droppedFrames : 0;
+            var droppedFramesMetrics = dashMetrics.getCurrentDroppedFrames();
+            var droppedFPS = droppedFramesMetrics ? droppedFramesMetrics.droppedFrames : 0;
             var liveLatency = 0;
             if ($scope.isDynamic) {
                 liveLatency = $scope.player.getCurrentLiveLatency();

--- a/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
+++ b/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
@@ -59,15 +59,13 @@ function DownloadRatioRuleClass() {
 
         let mediaType = rulesContext.getMediaInfo().type;
 
-        let metricsModel = MetricsModel(context).getInstance();
         let dashMetrics = DashMetrics(context).getInstance();
         let dashManifest = DashManifestModel(context).getInstance();
-        let metrics = metricsModel.getMetricsFor(mediaType, true);
         let streamController = StreamController(context).getInstance();
         let abrController = rulesContext.getAbrController();
         let current = abrController.getQualityFor(mediaType, streamController.getActiveStreamInfo());
 
-        let requests = dashMetrics.getHttpRequests(metrics),
+        let requests = dashMetrics.getHttpRequests(mediaType),
             lastRequest = null,
             currentRequest = null,
             downloadTime,
@@ -88,10 +86,11 @@ function DownloadRatioRuleClass() {
         switchUpRatioSafetyFactor = 1.5;
         logger.debug("[CustomRules][" + mediaType + "][DownloadRatioRule] Checking download ratio rule... (current = " + current + ")");
 
-        if (!metrics) {
+        if (!requests) {
             logger.debug("[CustomRules][" + mediaType + "][DownloadRatioRule] No metrics, bailing.");
             return SwitchRequest(context).create();
         }
+
 
         // Get last valid request
         i = requests.length - 1;

--- a/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
+++ b/samples/dash-if-reference-player/app/rules/DownloadRatioRule.js
@@ -62,7 +62,7 @@ function DownloadRatioRuleClass() {
         let metricsModel = MetricsModel(context).getInstance();
         let dashMetrics = DashMetrics(context).getInstance();
         let dashManifest = DashManifestModel(context).getInstance();
-        let metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        let metrics = metricsModel.getMetricsFor(mediaType, true);
         let streamController = StreamController(context).getInstance();
         let abrController = rulesContext.getAbrController();
         let current = abrController.getQualityFor(mediaType, streamController.getActiveStreamInfo());

--- a/samples/dash-if-reference-player/app/rules/ThroughputRule.js
+++ b/samples/dash-if-reference-player/app/rules/ThroughputRule.js
@@ -51,7 +51,7 @@ function CustomThroughputRuleClass() {
         // here you can get some informations aboit metrics for example, to implement the rule
         let metricsModel = MetricsModel(context).getInstance();
         var mediaType = rulesContext.getMediaInfo().type;
-        var metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        var metrics = metricsModel.getMetricsFor(mediaType, true);
 
         // this sample only display metrics in console
         console.log(metrics);

--- a/samples/low-latency/index.html
+++ b/samples/low-latency/index.html
@@ -151,7 +151,7 @@
             var currentPlaybackRate = player.getPlaybackRate();
             document.getElementById("playbackrate-tag").innerHTML = Math.round(currentPlaybackRate * 100) / 100;
 
-            var currentBuffer = dashMetrics.getCurrentBufferLevel(metrics);
+            var currentBuffer = dashMetrics.getCurrentBufferLevel("video");
             document.getElementById("buffer-tag").innerHTML = currentBuffer + " secs";
         }, 200);
     });

--- a/samples/low-latency/index.html
+++ b/samples/low-latency/index.html
@@ -139,7 +139,6 @@
         var player = init();
 
         setInterval(function() {
-            var metrics = player.getMetricsFor("video");
             var dashMetrics = player.getDashMetrics();
 
             var currentLatency = parseFloat(player.getCurrentLiveLatency(), 10);

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -28,7 +28,6 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import Constants from '../streaming/constants/Constants';
 import DashConstants from './constants/DashConstants';
 import FragmentRequest from '../streaming/vo/FragmentRequest';
 import DashJSError from '../streaming/vo/DashJSError';
@@ -232,10 +231,9 @@ function DashHandler(config) {
             if (isDynamic()) {
                 const lastSegment = segments[segments.length - 1];
                 const liveEdge = lastSegment.presentationStartTime;
-                const metrics = metricsModel.getMetricsFor(Constants.STREAM);
                 // the last segment is the Expected, not calculated, live edge.
                 timelineConverter.setExpectedLiveEdge(liveEdge);
-                metricsModel.updateManifestUpdateInfo(dashMetrics.getCurrentManifestUpdate(metrics), {presentationStartTime: liveEdge});
+                metricsModel.updateManifestUpdateInfo(dashMetrics.getCurrentManifestUpdate(), {presentationStartTime: liveEdge});
             }
         }
     }

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -233,7 +233,7 @@ function DashHandler(config) {
                 const liveEdge = lastSegment.presentationStartTime;
                 // the last segment is the Expected, not calculated, live edge.
                 timelineConverter.setExpectedLiveEdge(liveEdge);
-                metricsModel.updateManifestUpdateInfo(dashMetrics.getCurrentManifestUpdate(), {presentationStartTime: liveEdge});
+                dashMetrics.updateManifestUpdateInfo({presentationStartTime: liveEdge});
             }
         }
     }

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -61,7 +61,6 @@ function DashHandler(config) {
     let segmentBaseLoader;
     const timelineConverter = config.timelineConverter;
     const dashMetrics = config.dashMetrics;
-    const metricsModel = config.metricsModel;
     const mediaPlayerModel = config.mediaPlayerModel;
     const errHandler = config.errHandler;
     const baseURLController = config.baseURLController;
@@ -81,7 +80,7 @@ function DashHandler(config) {
         segmentBaseLoader = isWebM(config.mimeType) ? WebmSegmentBaseLoader(context).getInstance() : SegmentBaseLoader(context).getInstance();
         segmentBaseLoader.setConfig({
             baseURLController: baseURLController,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             errHandler: errHandler
         });

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -98,6 +98,28 @@ function DashMetrics() {
 
     /**
      * @param {string} mediaType
+     * @param {number} t
+     * @param {number} level
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addBufferLevel(mediaType, t, level) {
+        metricsModel.addBufferLevel(mediaType, t, level);
+    }
+
+    /**
+     * @param {string} mediaType
+     * @param {string} state
+     * @param {number} target
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addBufferState(mediaType, state, target) {
+        metricsModel.addBufferState(mediaType, state, target);
+    }
+
+    /**
+     * @param {string} mediaType
      * @param {boolean} readOnly
      * @returns {*}
      * @memberof module:DashMetrics
@@ -332,6 +354,8 @@ function DashMetrics() {
         updateManifestUpdateInfo: updateManifestUpdateInfo,
         addManifestUpdateStreamInfo: addManifestUpdateStreamInfo,
         addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo
+        addBufferLevel: addBufferLevel,
+        addBufferState: addBufferState,
     };
 
     return instance;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -208,6 +208,15 @@ function DashMetrics() {
     }
 
     /**
+     * @param {number} quality
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addDroppedFrames(quality) {
+        metricsModel.addDroppedFrames(Constants.VIDEO, quality);
+    }
+
+    /**
      * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -198,6 +198,28 @@ function DashMetrics() {
     }
 
     /**
+     * @param {object} updatedFields fields to be updated
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function updateManifestUpdateInfo(updatedFields) {
+        const manifestUpdate = this.getCurrentManifestUpdate();
+        metricsModel.updateManifestUpdateInfo(manifestUpdate, updatedFields);
+    }
+
+    /**
+     * @param {object} streamInfo
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addManifestUpdateStreamInfo(streamInfo) {
+        if (streamInfo) {
+            const manifestUpdate = this.getCurrentManifestUpdate();
+            metricsModel.addManifestUpdateStreamInfo(manifestUpdate, streamInfo.id, streamInfo.index, streamInfo.start, streamInfo.duration);
+        }
+    }
+
+    /**
      * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
@@ -293,7 +315,9 @@ function DashMetrics() {
         getLatestFragmentRequestHeaderValueByID: getLatestFragmentRequestHeaderValueByID,
         getLatestMPDRequestHeaderValueByID: getLatestMPDRequestHeaderValueByID,
         addRepresentationSwitch: addRepresentationSwitch,
-        addDVRInfo: addDVRInfo
+        addDVRInfo: addDVRInfo,
+        updateManifestUpdateInfo: updateManifestUpdateInfo,
+        addManifestUpdateStreamInfo: addManifestUpdateStreamInfo
     };
 
     return instance;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -358,6 +358,7 @@ function DashMetrics() {
     function addDVRInfo(mediaType, currentTime, mpd, range) {
         metricsModel.addDVRInfo(mediaType, currentTime, mpd, range);
     }
+
     /**
      * @param {string} id
      * @returns {*}
@@ -419,6 +420,10 @@ function DashMetrics() {
         return headers;
     }
 
+    function addPlayList(vo) {
+        metricsModel.addPlayList(vo);
+    }
+
     function addDVBErrors(errors) {
         metricsModel.addDVBErrors(errors);
     }
@@ -446,6 +451,8 @@ function DashMetrics() {
         addRequestsQueue: addRequestsQueue,
         addBufferLevel: addBufferLevel,
         addBufferState: addBufferState,
+        addDroppedFrames: addDroppedFrames,
+        addPlayList: addPlayList,
         addDVBErrors: addDVBErrors,
         clearAllCurrentMetrics: clearAllCurrentMetrics
     };

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -38,14 +38,16 @@ import Round10 from './utils/Round10';
  */
 function DashMetrics() {
     let instance;
+    let metricsModel = config.metricsModel;
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} type
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentRepresentationSwitch(metrics) {
+    function getCurrentRepresentationSwitch(type) {
+        let metrics = metricsModel.getMetricsFor(type);
         return getCurrent(metrics, MetricsConstants.TRACK_SWITCH);
     }
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -33,13 +33,23 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import FactoryMaker from '../core/FactoryMaker';
 import MetricsConstants from '../streaming/constants/MetricsConstants';
 import Round10 from './utils/Round10';
+import MetricsModel from '../streaming/models/MetricsModel';
 
 /**
  * @module DashMetrics
  */
-function DashMetrics() {
+
+function DashMetrics(config) {
+
+    config = config || {};
+
+    const context = this.context;
     let instance;
     let metricsModel = config.metricsModel;
+
+    function setup() {
+        metricsModel = metricsModel || MetricsModel(context).getInstance();
+    }
 
     /**
      * @param {string} type
@@ -444,7 +454,7 @@ function DashMetrics() {
         addDVRInfo: addDVRInfo,
         updateManifestUpdateInfo: updateManifestUpdateInfo,
         addManifestUpdateStreamInfo: addManifestUpdateStreamInfo,
-        addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo
+        addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo,
         addManifestUpdate: addManifestUpdate,
         addHttpRequest: addHttpRequest,
         addSchedulingInfo: addSchedulingInfo,
@@ -456,6 +466,8 @@ function DashMetrics() {
         addDVBErrors: addDVBErrors,
         clearAllCurrentMetrics: clearAllCurrentMetrics
     };
+
+    setup();
 
     return instance;
 }

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -41,6 +41,7 @@ import {
 
 /**
  * @module DashMetrics
+ * @param {object} config
  */
 
 function DashMetrics(config) {
@@ -53,7 +54,6 @@ function DashMetrics(config) {
         playListTraceMetrics,
         playListMetrics;
 
-    let manifestModel = config.manifestModel;
     let metricsModel = config.metricsModel;
 
     function setup() {

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -430,10 +430,20 @@ function DashMetrics(config) {
         return headers;
     }
 
+    /**
+     * @param {object} vo
+     * @memberof module:DashMetrics
+     * @instance
+     */
     function addPlayList(vo) {
         metricsModel.addPlayList(vo);
     }
 
+    /**
+     * @param {object} errors
+     * @memberof module:DashMetrics
+     * @instance
+     */
     function addDVBErrors(errors) {
         metricsModel.addDVBErrors(errors);
     }

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -242,6 +242,41 @@ function DashMetrics() {
     }
 
     /**
+     * @param {object} request
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addManifestUpdate(request) {
+        metricsModel.addManifestUpdate(Constants.STREAM, request.type, request.requestStartDate, request.requestEndDate);
+    }
+
+    /**
+     * @param {object} request
+     * @param {string} responseURL
+     * @param {number} responseStatus
+     * @param {object} responseHeaders
+     * @param {object} traces
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addHttpRequest(request, responseURL, responseStatus, responseHeaders, traces) {
+        metricsModel.addHttpRequest(request.mediaType,
+            null,
+            request.type,
+            request.url,
+            responseURL,
+            request.serviceLocation || null,
+            request.range || null,
+            request.requestStartDate,
+            request.firstByteDate,
+            request.requestEndDate,
+            responseStatus,
+            request.duration,
+            responseHeaders,
+            traces);
+    }
+
+    /**
      * @param {object} representation
      * @param {string} mediaType
      * @memberof module:DashMetrics
@@ -354,6 +389,8 @@ function DashMetrics() {
         updateManifestUpdateInfo: updateManifestUpdateInfo,
         addManifestUpdateStreamInfo: addManifestUpdateStreamInfo,
         addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo
+        addManifestUpdate: addManifestUpdate,
+        addHttpRequest: addHttpRequest,
         addBufferLevel: addBufferLevel,
         addBufferState: addBufferState,
     };

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -43,12 +43,13 @@ function DashMetrics() {
 
     /**
      * @param {string} type
+     * @param {boolean} readOnly
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentRepresentationSwitch(type) {
-        let metrics = metricsModel.getMetricsFor(type);
+    function getCurrentRepresentationSwitch(type, readOnly) {
+        let metrics = metricsModel.getMetricsFor(type, readOnly);
         return getCurrent(metrics, MetricsConstants.TRACK_SWITCH);
     }
 
@@ -84,12 +85,13 @@ function DashMetrics() {
 
     /**
      * @param {string} mediaType
+     * @param {boolean} readOnly
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentHttpRequest(mediaType) {
-        let metrics = metricsModel.getMetricsFor(mediaType, true);
+    function getCurrentHttpRequest(mediaType, readOnly) {
+        let metrics = metricsModel.getMetricsFor(mediaType, readOnly);
 
         if (!metrics) {
             return null;
@@ -153,13 +155,12 @@ function DashMetrics() {
     }
 
     /**
-     * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentDroppedFrames(mediaType) {
-        let metrics = metricsModel.getMetricsFor(mediaType);
+    function getCurrentDroppedFrames() {
+        let metrics = metricsModel.getMetricsFor(Constants.VIDEO, true);
         return getCurrent(metrics, MetricsConstants.DROPPED_FRAMES);
     }
 
@@ -228,7 +229,7 @@ function DashMetrics() {
      */
     function getLatestFragmentRequestHeaderValueByID(type, id) {
         let headers = {};
-        let httpRequest = getCurrentHttpRequest(type);
+        let httpRequest = getCurrentHttpRequest(type, true);
         if (httpRequest) {
             headers = parseResponseHeaders(httpRequest._responseHeaders);
         }

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -150,12 +150,13 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentDroppedFrames(metrics) {
+    function getCurrentDroppedFrames(mediaType) {
+        let metrics = metricsModel.getMetricsFor(mediaType);
         return getCurrent(metrics, MetricsConstants.DROPPED_FRAMES);
     }
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -177,6 +177,17 @@ function DashMetrics() {
     }
 
     /**
+     * @param {string} mediaType
+     * @param {Array} loadingRequests
+     * @param {Array} executedRequests
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addRequestsQueue(mediaType, loadingRequests, executedRequests) {
+        metricsModel.addRequestsQueue(mediaType, loadingRequests, executedRequests);
+    }
+
+    /**
      * @param {MetricsList} metrics
      * @param {string} metricName
      * @returns {*}
@@ -224,6 +235,25 @@ function DashMetrics() {
      */
     function getCurrentSchedulingInfo(metrics) {
         return getCurrent(metrics, MetricsConstants.SCHEDULING_INFO);
+    }
+
+    /**
+     * @param {object} request
+     * @param {string} state
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addSchedulingInfo(request, state) {
+        metricsModel.addSchedulingInfo(
+            request.mediaType,
+            new Date(),
+            request.type,
+            request.startTime,
+            request.availabilityStartTime,
+            request.duration,
+            request.quality,
+            request.range,
+            state);
     }
 
     /**
@@ -412,6 +442,8 @@ function DashMetrics() {
         addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo
         addManifestUpdate: addManifestUpdate,
         addHttpRequest: addHttpRequest,
+        addSchedulingInfo: addSchedulingInfo,
+        addRequestsQueue: addRequestsQueue,
         addBufferLevel: addBufferLevel,
         addBufferState: addBufferState,
         addDVBErrors: addDVBErrors,

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -28,6 +28,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+import Constants from '../streaming/constants/Constants';
 import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 import FactoryMaker from '../core/FactoryMaker';
 import MetricsConstants from '../streaming/constants/MetricsConstants';
@@ -165,13 +166,13 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentManifestUpdate(metrics) {
-        return getCurrent(metrics, MetricsConstants.MANIFEST_UPDATE);
+    function getCurrentManifestUpdate() {
+        let streamMetrics = metricsModel.getMetricsFor(Constants.STREAM);
+        return getCurrent(streamMetrics, MetricsConstants.MANIFEST_UPDATE);
     }
 
     /**

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -457,7 +457,7 @@ function DashMetrics(config) {
         }
     }
 
-    function addPlaylistMetrics(mediaStartTime, startReason) {
+    function createPlaylistMetrics(mediaStartTime, startReason) {
         playListMetrics = new PlayList();
 
         playListMetrics.start = new Date();
@@ -465,7 +465,7 @@ function DashMetrics(config) {
         playListMetrics.starttype = startReason;
     }
 
-    function addPlaylistTraceMetrics(representationId, mediaStartTime, speed) {
+    function createPlaylistTraceMetrics(representationId, mediaStartTime, speed) {
         if (playListTraceMetricsClosed === true ) {
             playListTraceMetricsClosed = false;
             playListTraceMetrics = new PlayListTrace();
@@ -531,8 +531,8 @@ function DashMetrics(config) {
         addDroppedFrames: addDroppedFrames,
         addPlayList: addPlayList,
         addDVBErrors: addDVBErrors,
-        addPlaylistMetrics: addPlaylistMetrics,
-        addPlaylistTraceMetrics: addPlaylistTraceMetrics,
+        createPlaylistMetrics: createPlaylistMetrics,
+        createPlaylistTraceMetrics: createPlaylistTraceMetrics,
         updatePlayListTraceMetrics: updatePlayListTraceMetrics,
         pushPlayListTraceMetrics: pushPlayListTraceMetrics,
         clearAllCurrentMetrics: clearAllCurrentMetrics

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -451,8 +451,10 @@ function DashMetrics(config) {
      * @instance
      */
     function addPlayList() {
-        metricsModel.addPlayList(playListMetrics);
-        playListMetrics = null;
+        if (playListMetrics) {
+            metricsModel.addPlayList(playListMetrics);
+            playListMetrics = null;
+        }
     }
 
     function addPlaylistMetrics(mediaStartTime, startReason) {

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -185,12 +185,13 @@ function DashMetrics() {
     }
 
     /**
+     * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentDVRInfo() {
-        const metrics = metricsModel.getMetricsFor(Constants.VIDEO, true) || metricsModel.getMetricsFor(Constants.AUDIO, true);
+    function getCurrentDVRInfo(mediaType) {
+        const metrics = mediaType ? metricsModel.getMetricsFor(mediaType, true) : metricsModel.getMetricsFor(Constants.VIDEO, true) || metricsModel.getMetricsFor(Constants.AUDIO, true);
         return getCurrent(metrics, MetricsConstants.DVR_INFO);
     }
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -380,6 +380,10 @@ function DashMetrics() {
         return headers;
     }
 
+    function addDVBErrors(errors) {
+        metricsModel.addDVBErrors(errors);
+    }
+
     instance = {
         getCurrentRepresentationSwitch: getCurrentRepresentationSwitch,
         getLatestBufferInfoVO: getLatestBufferInfoVO,
@@ -401,6 +405,7 @@ function DashMetrics() {
         addHttpRequest: addHttpRequest,
         addBufferLevel: addBufferLevel,
         addBufferState: addBufferState,
+        addDVBErrors: addDVBErrors,
         clearAllCurrentMetrics: clearAllCurrentMetrics
     };
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -83,12 +83,14 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentHttpRequest(metrics) {
+    function getCurrentHttpRequest(mediaType) {
+        let metrics = metricsModel.getMetricsFor(mediaType, true);
+
         if (!metrics) {
             return null;
         }
@@ -115,12 +117,13 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getHttpRequests(metrics) {
+    function getHttpRequests(mediaType) {
+        let metrics = metricsModel.getMetricsFor(mediaType, true);
         if (!metrics) {
             return [];
         }
@@ -202,9 +205,7 @@ function DashMetrics() {
             httpRequest,
             i;
 
-        let metrics = metricsModel.getMetricsFor(Constants.STREAM, true);
-
-        httpRequestList = getHttpRequests(metrics);
+        httpRequestList = getHttpRequests(Constants.STREAM);
 
         for (i = httpRequestList.length - 1; i >= 0; i--) {
             httpRequest = httpRequestList[i];
@@ -227,8 +228,7 @@ function DashMetrics() {
      */
     function getLatestFragmentRequestHeaderValueByID(type, id) {
         let headers = {};
-        let metrics = metricsModel.getMetricsFor(type, true);
-        let httpRequest = getCurrentHttpRequest(metrics);
+        let httpRequest = getCurrentHttpRequest(type);
         if (httpRequest) {
             headers = parseResponseHeaders(httpRequest._responseHeaders);
         }

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -181,7 +181,7 @@ function DashMetrics() {
      * @instance
      */
     function getCurrentDVRInfo() {
-        const metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
+        const metrics = metricsModel.getMetricsFor(Constants.VIDEO, true) || metricsModel.getMetricsFor(Constants.AUDIO, true);
         return getCurrent(metrics, MetricsConstants.DVR_INFO);
     }
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -191,17 +191,18 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
      * @param {string} id
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getLatestMPDRequestHeaderValueByID(metrics, id) {
+    function getLatestMPDRequestHeaderValueByID(id) {
         let headers = {};
         let httpRequestList,
             httpRequest,
             i;
+
+        let metrics = metricsModel.getMetricsFor(Constants.STREAM, true);
 
         httpRequestList = getHttpRequests(metrics);
 
@@ -218,14 +219,15 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} type
      * @param {string} id
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getLatestFragmentRequestHeaderValueByID(metrics, id) {
+    function getLatestFragmentRequestHeaderValueByID(type, id) {
         let headers = {};
+        let metrics = metricsModel.getMetricsFor(type, true);
         let httpRequest = getCurrentHttpRequest(metrics);
         if (httpRequest) {
             headers = parseResponseHeaders(httpRequest._responseHeaders);

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -119,6 +119,14 @@ function DashMetrics() {
     }
 
     /**
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function clearAllCurrentMetrics () {
+        metricsModel.clearAllCurrentMetrics();
+    }
+
+    /**
      * @param {string} mediaType
      * @param {boolean} readOnly
      * @returns {*}
@@ -393,6 +401,7 @@ function DashMetrics() {
         addHttpRequest: addHttpRequest,
         addBufferLevel: addBufferLevel,
         addBufferState: addBufferState,
+        clearAllCurrentMetrics: clearAllCurrentMetrics
     };
 
     return instance;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -55,6 +55,19 @@ function DashMetrics() {
 
     /**
      * @param {string} mediaType
+     * @param {Date} t time of the switch event
+     * @param {Date} mt media presentation time
+     * @param {string} to id of representation
+     * @param {string} lto if present, subrepresentation reference
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addRepresentationSwitch(mediaType, t, mt, to, lto) {
+        metricsModel.addRepresentationSwitch(mediaType, t, mt, to, lto);
+    }
+
+    /**
+     * @param {string} mediaType
      * @param {boolean} readOnly
      * @param {string} infoType
      * @returns {*}
@@ -196,6 +209,17 @@ function DashMetrics() {
     }
 
     /**
+     * @param {string} mediaType
+     * @param {Date} currentTime time of the switch event
+     * @param {object} mpd mpd reference
+     * @param {object} range range of the dvr info
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addDVRInfo(mediaType, currentTime, mpd, range) {
+        metricsModel.addDVRInfo(mediaType, currentTime, mpd, range);
+    }
+    /**
      * @param {string} id
      * @returns {*}
      * @memberof module:DashMetrics
@@ -267,7 +291,9 @@ function DashMetrics() {
         getCurrentDVRInfo: getCurrentDVRInfo,
         getCurrentManifestUpdate: getCurrentManifestUpdate,
         getLatestFragmentRequestHeaderValueByID: getLatestFragmentRequestHeaderValueByID,
-        getLatestMPDRequestHeaderValueByID: getLatestMPDRequestHeaderValueByID
+        getLatestMPDRequestHeaderValueByID: getLatestMPDRequestHeaderValueByID,
+        addRepresentationSwitch: addRepresentationSwitch,
+        addDVRInfo: addDVRInfo
     };
 
     return instance;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -176,12 +176,12 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentDVRInfo(metrics) {
+    function getCurrentDVRInfo() {
+        const metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
         return getCurrent(metrics, MetricsConstants.DVR_INFO);
     }
 

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -220,6 +220,19 @@ function DashMetrics() {
     }
 
     /**
+     * @param {object} representation
+     * @param {string} mediaType
+     * @memberof module:DashMetrics
+     * @instance
+     */
+    function addManifestUpdateRepresentationInfo(representation, mediaType) {
+        if (representation) {
+            const manifestUpdateInfo = this.getCurrentManifestUpdate();
+            metricsModel.addManifestUpdateRepresentationInfo(manifestUpdateInfo, representation.id, representation.index, representation.streamIndex, mediaType, representation.presentationTimeOffset, representation.startNumber, representation.fragmentInfoType);
+        }
+    }
+
+    /**
      * @param {string} mediaType
      * @returns {*}
      * @memberof module:DashMetrics
@@ -317,7 +330,8 @@ function DashMetrics() {
         addRepresentationSwitch: addRepresentationSwitch,
         addDVRInfo: addDVRInfo,
         updateManifestUpdateInfo: updateManifestUpdateInfo,
-        addManifestUpdateStreamInfo: addManifestUpdateStreamInfo
+        addManifestUpdateStreamInfo: addManifestUpdateStreamInfo,
+        addManifestUpdateRepresentationInfo: addManifestUpdateRepresentationInfo
     };
 
     return instance;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -53,23 +53,27 @@ function DashMetrics() {
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} mediaType
+     * @param {boolean} readOnly
+     * @param {string} infoType
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getLatestBufferLevelVO(metrics) {
-        return getCurrent(metrics, MetricsConstants.BUFFER_LEVEL);
+    function getLatestBufferInfoVO(mediaType, readOnly, infoType) {
+        let metrics = metricsModel.getMetricsFor(mediaType, readOnly);
+        return getCurrent(metrics, infoType);
     }
 
     /**
-     * @param {MetricsList} metrics
+     * @param {string} type
+     * @param {boolean} readOnly
      * @returns {number}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentBufferLevel(metrics) {
-        const vo = getLatestBufferLevelVO(metrics);
+    function getCurrentBufferLevel(type, readOnly) {
+        const vo = getLatestBufferInfoVO(type, readOnly, MetricsConstants.BUFFER_LEVEL);
 
         if (vo) {
             return Round10.round10(vo.level / 1000, -3);
@@ -249,6 +253,7 @@ function DashMetrics() {
 
     instance = {
         getCurrentRepresentationSwitch: getCurrentRepresentationSwitch,
+        getLatestBufferInfoVO: getLatestBufferInfoVO,
         getCurrentBufferLevel: getCurrentBufferLevel,
         getCurrentHttpRequest: getCurrentHttpRequest,
         getHttpRequests: getHttpRequests,

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -108,7 +108,8 @@ function SegmentBaseLoader() {
             },
             searching: false,
             bytesLoaded: 0,
-            bytesToLoad: 1500
+            bytesToLoad: 1500,
+            mediaType: representation.adaptation.type
         };
 
         logger.debug('Start searching for initialization.');
@@ -157,7 +158,8 @@ function SegmentBaseLoader() {
             range: hasRange ? range : { start: 0, end: 1500 },
             searching: !hasRange,
             bytesLoaded: loadingInfo ? loadingInfo.bytesLoaded : 0,
-            bytesToLoad: 1500
+            bytesToLoad: 1500,
+            mediaType: representation.adaptation.type
         };
 
         const request = getFragmentRequest(info);
@@ -292,6 +294,7 @@ function SegmentBaseLoader() {
         request.type = info.init ? HTTPRequest.INIT_SEGMENT_TYPE : HTTPRequest.MEDIA_SEGMENT_TYPE;
         request.url = info.url;
         request.range = info.range.start + '-' + info.range.end;
+        request.mediaType = info.mediaType;
 
         return request;
     }

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -51,7 +51,7 @@ function SegmentBaseLoader() {
         errHandler,
         boxParser,
         requestModifier,
-        metricsModel,
+        dashMetrics,
         mediaPlayerModel,
         httpLoader,
         baseURLController;
@@ -65,7 +65,7 @@ function SegmentBaseLoader() {
         requestModifier = RequestModifier(context).getInstance();
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             requestModifier: requestModifier
         });
@@ -76,8 +76,8 @@ function SegmentBaseLoader() {
             baseURLController = config.baseURLController;
         }
 
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
+        if (config.dashMetrics) {
+            dashMetrics = config.dashMetrics;
         }
 
         if (config.mediaPlayerModel) {

--- a/src/dash/WebmSegmentBaseLoader.js
+++ b/src/dash/WebmSegmentBaseLoader.js
@@ -24,7 +24,7 @@ function WebmSegmentBaseLoader() {
         WebM,
         errHandler,
         requestModifier,
-        metricsModel,
+        dashMetrics,
         mediaPlayerModel,
         httpLoader,
         baseURLController;
@@ -100,18 +100,18 @@ function WebmSegmentBaseLoader() {
         requestModifier = RequestModifier(context).getInstance();
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             requestModifier: requestModifier
         });
     }
 
     function setConfig(config) {
-        if (!config.baseURLController || !config.metricsModel || !config.mediaPlayerModel || !config.errHandler) {
+        if (!config.baseURLController || !config.dashMetrics || !config.mediaPlayerModel || !config.errHandler) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
         baseURLController = config.baseURLController;
-        metricsModel = config.metricsModel;
+        dashMetrics = config.dashMetrics;
         mediaPlayerModel = config.mediaPlayerModel;
         errHandler = config.errHandler;
     }

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -300,7 +300,7 @@ function RepresentationController() {
         if (isAllRepresentationsUpdated()) {
             updating = false;
             abrController.setPlaybackQuality(streamProcessor.getType(), streamProcessor.getStreamInfo(), getQualityForRepresentation(currentVoRepresentation));
-            metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {latency: currentVoRepresentation.segmentAvailabilityRange.end - playbackController.getTime()});
+            dashMetrics.updateManifestUpdateInfo({latency: currentVoRepresentation.segmentAvailabilityRange.end - playbackController.getTime()});
 
             repSwitch = dashMetrics.getCurrentRepresentationSwitch(getCurrentRepresentation().adaptation.type);
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -258,8 +258,7 @@ function RepresentationController() {
         }
 
         let r = e.representation;
-        let streamMetrics = metricsModel.getMetricsFor(Constants.STREAM);
-        let manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(streamMetrics);
+        let manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
         let alreadyAdded = false;
         let postponeTimePeriod = 0;
         let repInfo,

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -259,7 +259,6 @@ function RepresentationController() {
 
         let r = e.representation;
         let streamMetrics = metricsModel.getMetricsFor(Constants.STREAM);
-        var metrics = metricsModel.getMetricsFor(getCurrentRepresentation().adaptation.type);
         let manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(streamMetrics);
         let alreadyAdded = false;
         let postponeTimePeriod = 0;
@@ -304,7 +303,7 @@ function RepresentationController() {
             abrController.setPlaybackQuality(streamProcessor.getType(), streamProcessor.getStreamInfo(), getQualityForRepresentation(currentVoRepresentation));
             metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {latency: currentVoRepresentation.segmentAvailabilityRange.end - playbackController.getTime()});
 
-            repSwitch = dashMetrics.getCurrentRepresentationSwitch(metrics);
+            repSwitch = dashMetrics.getCurrentRepresentationSwitch(getCurrentRepresentation().adaptation.type);
 
             if (!repSwitch) {
                 addRepresentationSwitch();

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -50,7 +50,7 @@ function RepresentationController() {
         abrController,
         indexHandler,
         playbackController,
-        metricsModel,
+        domStorage,
         timelineConverter,
         dashMetrics,
         streamProcessor,
@@ -70,8 +70,8 @@ function RepresentationController() {
         if (config.abrController) {
             abrController = config.abrController;
         }
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
+        if (config.domStorage) {
+            domStorage = config.domStorage;
         }
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;
@@ -116,7 +116,7 @@ function RepresentationController() {
         voAvailableRepresentations = [];
         abrController = null;
         playbackController = null;
-        metricsModel = null;
+        domStorage = null;
         timelineConverter = null;
         dashMetrics = null;
     }
@@ -292,8 +292,7 @@ function RepresentationController() {
             }
 
             if (!alreadyAdded) {
-                metricsModel.addManifestUpdateRepresentationInfo(manifestUpdateInfo, r.id, r.index, r.adaptation.period.index,
-                        streamProcessor.getType(),r.presentationTimeOffset, r.startNumber, r.segmentInfoType);
+                dashMetrics.addManifestUpdateRepresentationInfo(r, streamProcessor.getType());
             }
         }
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -180,7 +180,7 @@ function RepresentationController() {
         const currentRepresentation = getCurrentRepresentation();
         const currentVideoTimeMs = playbackController.getTime() * 1000;
 
-        metricsModel.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTimeMs, currentRepresentation.id);
+        dashMetrics.addRepresentationSwitch(currentRepresentation.adaptation.type, now, currentVideoTimeMs, currentRepresentation.id);
     }
 
     function addDVRMetric() {
@@ -188,7 +188,7 @@ function RepresentationController() {
         const manifestInfo = streamInfo ? streamInfo.manifestInfo : null;
         const isDynamic = manifestInfo ? manifestInfo.isDynamic : null;
         const range = timelineConverter.calcSegmentAvailabilityRange(currentVoRepresentation, isDynamic);
-        metricsModel.addDVRInfo(streamProcessor.getType(), playbackController.getTime(), manifestInfo, range);
+        dashMetrics.addDVRInfo(streamProcessor.getType(), playbackController.getTime(), manifestInfo, range);
     }
 
     function getRepresentationForQuality(quality) {

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -50,7 +50,7 @@ function MssFragmentInfoController(config) {
 
     const streamProcessor = config.streamProcessor;
     const eventBus = config.eventBus;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const playbackController = config.playbackController;
     const ISOBoxer = config.ISOBoxer;
     const baseURLController = config.baseURLController;
@@ -208,7 +208,7 @@ function MssFragmentInfoController(config) {
         try {
             // Process FramgentInfo in order to update segment timeline (DVR window)
             const mssFragmentMoofProcessor = MSSFragmentMoofProcessor(context).create({
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 playbackController: playbackController,
                 ISOBoxer: ISOBoxer,
                 eventBus: eventBus,

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -173,12 +173,11 @@ function MssFragmentMoofProcessor(config) {
     }
 
     function updateDVR(type, range, manifestInfo) {
-        const dvrInfos = metricsModel.getMetricsFor(type).DVRInfo;
-        if (dvrInfos) {
-            if (dvrInfos.length === 0 || (dvrInfos.length > 0 && range.end > dvrInfos[dvrInfos.length - 1].range.end)) {
-                logger.debug('Update DVR Infos [' + range.start + ' - ' + range.end + ']');
                 metricsModel.addDVRInfo(type, playbackController.getTime(), manifestInfo, range);
             }
+        const dvrInfos = dashMetrics.getCurrentDVRInfo(type);
+        if (!dvrInfos || (range.end > dvrInfos.range.end)) {
+            logger.debug('Update DVR Infos [' + range.start + ' - ' + range.end + ']');
         }
     }
 

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -43,7 +43,7 @@ function MssFragmentMoofProcessor(config) {
     let instance,
         type,
         logger;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const playbackController = config.playbackController;
     const errorHandler = config.errHandler;
     const eventBus = config.eventBus;
@@ -173,11 +173,10 @@ function MssFragmentMoofProcessor(config) {
     }
 
     function updateDVR(type, range, manifestInfo) {
-                metricsModel.addDVRInfo(type, playbackController.getTime(), manifestInfo, range);
-            }
         const dvrInfos = dashMetrics.getCurrentDVRInfo(type);
         if (!dvrInfos || (range.end > dvrInfos.range.end)) {
             logger.debug('Update DVR Infos [' + range.start + ' - ' + range.end + ']');
+            dashMetrics.addDVRInfo(type, playbackController.getTime(), manifestInfo, range);
         }
     }
 

--- a/src/mss/MssFragmentProcessor.js
+++ b/src/mss/MssFragmentProcessor.js
@@ -121,7 +121,7 @@ function MssFragmentProcessor(config) {
 
     config = config || {};
     const context = this.context;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const playbackController = config.playbackController;
     const eventBus = config.eventBus;
     const protectionController = config.protectionController;
@@ -141,7 +141,7 @@ function MssFragmentProcessor(config) {
             constants: config.constants, ISOBoxer: ISOBoxer});
 
         mssFragmentMoofProcessor = MSSFragmentMoofProcessor(context).create({
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 playbackController: playbackController,
                 ISOBoxer: ISOBoxer,
                 eventBus: eventBus,

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -45,11 +45,11 @@ function MssHandler(config) {
     const events = config.events;
     const constants = config.constants;
     const initSegmentType = config.initSegmentType;
-    let metricsModel = config.metricsModel;
+    let dashMetrics = config.dashMetrics;
     let playbackController = config.playbackController;
     let protectionController = config.protectionController;
     let mssFragmentProcessor = MssFragmentProcessor(context).create({
-        metricsModel: metricsModel,
+        dashMetrics: dashMetrics,
         playbackController: playbackController,
         protectionController: protectionController,
         eventBus: eventBus,
@@ -140,7 +140,7 @@ function MssHandler(config) {
                     let fragmentInfoController = MssFragmentInfoController(context).create({
                         streamProcessor: processor,
                         eventBus: eventBus,
-                        metricsModel: metricsModel,
+                        dashMetrics: dashMetrics,
                         playbackController: playbackController,
                         baseURLController: config.baseURLController,
                         ISOBoxer: config.ISOBoxer,

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -50,7 +50,7 @@ function FragmentLoader(config) {
         const boxParser = BoxParser(context).getInstance();
         httpLoader = HTTPLoader(context).create({
             errHandler: config.errHandler,
-            metricsModel: config.metricsModel,
+            dashMetrics: config.dashMetrics,
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier,
             boxParser: boxParser,

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -64,14 +64,14 @@ function ManifestLoader(config) {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: config.metricsModel,
+            dashMetrics: config.dashMetrics,
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier
         });
 
         xlinkController = XlinkController(context).create({
             errHandler: errHandler,
-            metricsModel: config.metricsModel,
+            dashMetrics: config.dashMetrics,
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier
         });

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2025,7 +2025,7 @@ function MediaPlayer() {
      * @instance
      */
     function getMetricsFor(type) {
-        return metricsModel.getReadOnlyMetricsFor(type);
+        return metricsModel.getMetricsFor(type, true);
     }
     /*
     ---------------------------------------------------------------------------

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -247,8 +247,8 @@ function MediaPlayer() {
 
         adapter = DashAdapter(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
-        dashMetrics = DashMetrics(context).getInstance();
         metricsModel = MetricsModel(context).getInstance();
+        dashMetrics = DashMetrics(context).getInstance();
 
         textController = TextController(context).getInstance();
         domStorage = DOMStorage(context).getInstance({

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -245,10 +245,9 @@ function MediaPlayer() {
 
         adapter = DashAdapter(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
-        
+
         dashMetrics = DashMetrics(context).getInstance({
-            manifestModel: manifestModel,
-            dashManifestModel: dashManifestModel
+            manifestModel: manifestModel
         });
 
         textController = TextController(context).getInstance();
@@ -2908,8 +2907,7 @@ function MediaPlayer() {
                 dashMetrics: dashMetrics,
                 events: Events,
                 constants: Constants,
-                metricsConstants: MetricsConstants,
-                adapter: adapter
+                metricsConstants: MetricsConstants
             });
         }
     }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2908,7 +2908,8 @@ function MediaPlayer() {
                 dashMetrics: dashMetrics,
                 events: Events,
                 constants: Constants,
-                metricsConstants: MetricsConstants
+                metricsConstants: MetricsConstants,
+                adapter: adapter
             });
         }
     }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -702,7 +702,7 @@ function MediaPlayer() {
      * @instance
      */
     function getDVRWindowSize() {
-        let metric = getDVRInfoMetric();
+        let metric = dashMetrics.getCurrentDVRInfo();
         if (!metric) {
             return 0;
         }
@@ -721,7 +721,7 @@ function MediaPlayer() {
      * @instance
      */
     function getDVRSeekOffset(value) {
-        let metric = getDVRInfoMetric();
+        let metric = dashMetrics.getCurrentDVRInfo();
         if (!metric) {
             return 0;
         }
@@ -758,7 +758,7 @@ function MediaPlayer() {
         if (streamId !== undefined) {
             t = streamController.getTimeRelativeToStreamId(t, streamId);
         } else if (playbackController.getIsDynamic()) {
-            let metric = getDVRInfoMetric();
+            let metric = dashMetrics.getCurrentDVRInfo();
             t = (metric === null) ? 0 : duration() - (metric.range.end - metric.time);
         }
 
@@ -781,7 +781,7 @@ function MediaPlayer() {
 
         if (playbackController.getIsDynamic()) {
 
-            let metric = getDVRInfoMetric();
+            let metric = dashMetrics.getCurrentDVRInfo();
             let range;
 
             if (!metric) {
@@ -2828,7 +2828,6 @@ function MediaPlayer() {
 
         playbackController.setConfig({
             streamController: streamController,
-            metricsModel: metricsModel,
             dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             adapter: adapter,
@@ -2952,13 +2951,8 @@ function MediaPlayer() {
         }
     }
 
-    function getDVRInfoMetric() {
-        let metric = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
-        return dashMetrics.getCurrentDVRInfo(metric);
-    }
-
     function getAsUTC(valToConvert) {
-        let metric = getDVRInfoMetric();
+        let metric = dashMetrics.getCurrentDVRInfo();
         let availableFrom,
             utcValue;
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2924,7 +2924,7 @@ function MediaPlayer() {
             mssHandler = MssHandler(context).create({
                 eventBus: eventBus,
                 mediaPlayerModel: mediaPlayerModel,
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 manifestModel: manifestModel,
                 playbackController: playbackController,
                 protectionController: protectionController,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2017,16 +2017,6 @@ function MediaPlayer() {
         return dashMetrics;
     }
 
-    /**
-     *
-     * @param {string} type
-     * @returns {Object}
-     * @memberof module:MediaPlayer
-     * @instance
-     */
-    function getMetricsFor(type) {
-        return metricsModel.getMetricsFor(type, true);
-    }
     /*
     ---------------------------------------------------------------------------
 
@@ -3050,7 +3040,6 @@ function MediaPlayer() {
         setScheduleWhilePaused: setScheduleWhilePaused,
         getScheduleWhilePaused: getScheduleWhilePaused,
         getDashMetrics: getDashMetrics,
-        getMetricsFor: getMetricsFor,
         getQualityFor: getQualityFor,
         setQualityFor: setQualityFor,
         updatePortalSize: updatePortalSize,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -678,14 +678,14 @@ function MediaPlayer() {
         const types = [Constants.VIDEO, Constants.AUDIO, Constants.FRAGMENTED_TEXT];
         if (!type) {
             const buffer = types.map(
-                t => getTracksFor(t).length > 0 ? getDashMetrics().getCurrentBufferLevel(getMetricsFor(t)) : Number.MAX_VALUE
+                t => getTracksFor(t).length > 0 ? getDashMetrics().getCurrentBufferLevel(t) : Number.MAX_VALUE
             ).reduce(
                 (p, c) => Math.min(p, c)
             );
             return buffer === Number.MAX_VALUE ? NaN : buffer;
         } else {
             if (types.indexOf(type) !== -1) {
-                const buffer = getDashMetrics().getCurrentBufferLevel(getMetricsFor(type));
+                const buffer = getDashMetrics().getCurrentBufferLevel(type);
                 return buffer ? buffer : NaN;
             } else {
                 logger.warn('getBufferLength requested for invalid type');

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -44,7 +44,6 @@ import TextController from './text/TextController';
 import URIFragmentModel from './models/URIFragmentModel';
 import ManifestModel from './models/ManifestModel';
 import MediaPlayerModel from './models/MediaPlayerModel';
-import MetricsModel from './models/MetricsModel';
 import AbrController from './controllers/AbrController';
 import VideoModel from './models/VideoModel';
 import DOMStorage from './utils/DOMStorage';
@@ -133,7 +132,6 @@ function MediaPlayer() {
         metricsReportingController,
         mssHandler,
         adapter,
-        metricsModel,
         mediaPlayerModel,
         errHandler,
         capabilities,
@@ -247,8 +245,11 @@ function MediaPlayer() {
 
         adapter = DashAdapter(context).getInstance();
         manifestModel = ManifestModel(context).getInstance();
-        metricsModel = MetricsModel(context).getInstance();
-        dashMetrics = DashMetrics(context).getInstance();
+        
+        dashMetrics = DashMetrics(context).getInstance({
+            manifestModel: manifestModel,
+            dashManifestModel: dashManifestModel
+        });
 
         textController = TextController(context).getInstance();
         domStorage = DOMStorage(context).getInstance({
@@ -2805,7 +2806,6 @@ function MediaPlayer() {
             mediaPlayerModel: mediaPlayerModel,
             protectionController: protectionController,
             adapter: adapter,
-            metricsModel: metricsModel,
             dashMetrics: dashMetrics,
             errHandler: errHandler,
             timelineConverter: timelineConverter,
@@ -2852,7 +2852,7 @@ function MediaPlayer() {
     function createManifestLoader() {
         return ManifestLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             requestModifier: RequestModifier(context).getInstance(),
             mssHandler: mssHandler
@@ -2905,7 +2905,7 @@ function MediaPlayer() {
                 eventBus: eventBus,
                 mediaElement: getVideoElement(),
                 adapter: adapter,
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 events: Events,
                 constants: Constants,
                 metricsConstants: MetricsConstants

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2840,7 +2840,6 @@ function MediaPlayer() {
             streamController: streamController,
             domStorage: domStorage,
             mediaPlayerModel: mediaPlayerModel,
-            metricsModel: metricsModel,
             dashMetrics: dashMetrics,
             adapter: adapter,
             videoModel: videoModel

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -53,7 +53,7 @@ function Stream(config) {
     const capabilities = config.capabilities;
     const errHandler = config.errHandler;
     const timelineConverter = config.timelineConverter;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const abrController = config.abrController;
     const playbackController = config.playbackController;
     const mediaController = config.mediaController;
@@ -92,7 +92,7 @@ function Stream(config) {
 
         fragmentController = FragmentController(context).create({
             mediaPlayerModel: mediaPlayerModel,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             errHandler: errHandler
         });
 
@@ -374,7 +374,6 @@ function Stream(config) {
             adapter: adapter,
             manifestModel: manifestModel,
             mediaPlayerModel: mediaPlayerModel,
-            metricsModel: metricsModel,
             dashMetrics: config.dashMetrics,
             baseURLController: config.baseURLController,
             stream: instance,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -57,7 +57,7 @@ function StreamProcessor(config) {
     let streamController = config.streamController;
     let mediaController = config.mediaController;
     let textController = config.textController;
-    let metricsModel = config.metricsModel;
+    let domStorage = config.domStorage;
     let dashMetrics = config.dashMetrics;
 
     let instance,
@@ -86,7 +86,6 @@ function StreamProcessor(config) {
             mimeType: mimeType,
             timelineConverter: timelineConverter,
             dashMetrics: dashMetrics,
-            metricsModel: metricsModel,
             mediaPlayerModel: mediaPlayerModel,
             baseURLController: config.baseURLController,
             errHandler: errHandler
@@ -103,7 +102,6 @@ function StreamProcessor(config) {
         scheduleController = ScheduleController(context).create({
             type: type,
             mimeType: mimeType,
-            metricsModel: metricsModel,
             adapter: adapter,
             dashMetrics: dashMetrics,
             timelineConverter: timelineConverter,
@@ -335,7 +333,7 @@ function StreamProcessor(config) {
         if (type === Constants.VIDEO || type === Constants.AUDIO) {
             controller = BufferController(context).create({
                 type: type,
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 mediaPlayerModel: mediaPlayerModel,
                 manifestModel: manifestModel,
                 errHandler: errHandler,
@@ -351,7 +349,7 @@ function StreamProcessor(config) {
             controller = TextBufferController(context).create({
                 type: type,
                 mimeType: mimeType,
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 mediaPlayerModel: mediaPlayerModel,
                 manifestModel: manifestModel,
                 errHandler: errHandler,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -118,7 +118,7 @@ function StreamProcessor(config) {
         representationController = RepresentationController(context).create();
         representationController.setConfig({
             abrController: abrController,
-            metricsModel: metricsModel,
+            domStorage: domStorage,
             dashMetrics: dashMetrics,
             manifestModel: manifestModel,
             playbackController: playbackController,

--- a/src/streaming/XlinkLoader.js
+++ b/src/streaming/XlinkLoader.js
@@ -47,7 +47,7 @@ function XlinkLoader(config) {
 
     let httpLoader = HTTPLoader(context).create({
         errHandler: config.errHandler,
-        metricsModel: config.metricsModel,
+        dashMetrics: config.dashMetrics,
         mediaPlayerModel: config.mediaPlayerModel,
         requestModifier: config.requestModifier
     });

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -84,7 +84,6 @@ function AbrController() {
         droppedFramesHistory,
         throughputHistory,
         isUsingBufferOccupancyABRDict,
-        metricsModel,
         dashMetrics,
         useDeadTimeLatency;
 
@@ -119,7 +118,6 @@ function AbrController() {
 
     function createAbrRulesCollection() {
         abrRulesCollection = ABRRulesCollection(context).create({
-            metricsModel: metricsModel,
             dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel
         });
@@ -175,9 +173,6 @@ function AbrController() {
         }
         if (config.mediaPlayerModel) {
             mediaPlayerModel = config.mediaPlayerModel;
-        }
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
         }
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -439,7 +439,7 @@ function AbrController() {
                         changeQuality(type, oldQuality, newQuality, topQualityIdx, switchRequest.reason);
                     }
                 } else if (debug.getLogToBrowserConsole()) {
-                    const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(type, true));
+                    const bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
                     logger.debug('AbrController (' + type + ') stay on ' + oldQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')');
                 }
             }
@@ -463,7 +463,7 @@ function AbrController() {
             const streamInfo = streamProcessorDict[type].getStreamInfo();
             const id = streamInfo ? streamInfo.id : null;
             if (debug.getLogToBrowserConsole()) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(type, true));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
                 logger.info('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
             }
             setQualityFor(type, id, newQuality);

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -439,7 +439,7 @@ function AbrController() {
                         changeQuality(type, oldQuality, newQuality, topQualityIdx, switchRequest.reason);
                     }
                 } else if (debug.getLogToBrowserConsole()) {
-                    const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
+                    const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(type, true));
                     logger.debug('AbrController (' + type + ') stay on ' + oldQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')');
                 }
             }
@@ -463,7 +463,7 @@ function AbrController() {
             const streamInfo = streamProcessorDict[type].getStreamInfo();
             const id = streamInfo ? streamInfo.id : null;
             if (debug.getLogToBrowserConsole()) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(type));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(type, true));
                 logger.info('AbrController (' + type + ') switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
             }
             setQualityFor(type, id, newQuality);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -59,7 +59,7 @@ function BufferController(config) {
     config = config || {};
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const mediaPlayerModel = config.mediaPlayerModel;
     const errHandler = config.errHandler;
     const streamController = config.streamController;
@@ -523,8 +523,8 @@ function BufferController(config) {
 
     function addBufferMetrics() {
         if (!isActive()) return;
-        metricsModel.addBufferState(type, bufferState, streamProcessor.getScheduleController().getBufferTarget());
-        metricsModel.addBufferLevel(type, new Date(), bufferLevel * 1000);
+        dashMetrics.addBufferState(type, bufferState, streamProcessor.getScheduleController().getBufferTarget());
+        dashMetrics.addBufferLevel(type, new Date(), bufferLevel * 1000);
     }
 
     function checkIfBufferingCompleted() {

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -66,7 +66,7 @@ function FragmentController( config ) {
             model = FragmentModel(context).create({
                 metricsModel: metricsModel,
                 fragmentLoader: FragmentLoader(context).create({
-                    metricsModel: metricsModel,
+                    dashMetrics: dashMetrics,
                     mediaPlayerModel: mediaPlayerModel,
                     errHandler: errHandler,
                     requestModifier: RequestModifier(context).getInstance()

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -47,7 +47,7 @@ function FragmentController( config ) {
 
     const errHandler = config.errHandler;
     const mediaPlayerModel = config.mediaPlayerModel;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
 
     let instance,
         logger,
@@ -64,7 +64,7 @@ function FragmentController( config ) {
         let model = fragmentModels[type];
         if (!model) {
             model = FragmentModel(context).create({
-                metricsModel: metricsModel,
+                dashMetrics: dashMetrics,
                 fragmentLoader: FragmentLoader(context).create({
                     dashMetrics: dashMetrics,
                     mediaPlayerModel: mediaPlayerModel,

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -45,7 +45,6 @@ function PlaybackController() {
     let instance,
         logger,
         streamController,
-        metricsModel,
         dashMetrics,
         adapter,
         videoModel,
@@ -161,8 +160,7 @@ function PlaybackController() {
     }
 
     function seekToLive() {
-        const metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
-        const DVRMetrics = dashMetrics.getCurrentDVRInfo(metrics);
+        const DVRMetrics = dashMetrics.getCurrentDVRInfo();
         const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
 
         seek(DVRWindow.end - mediaPlayerModel.getLiveDelay(), true, false);
@@ -308,9 +306,6 @@ function PlaybackController() {
         if (config.streamController) {
             streamController = config.streamController;
         }
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
-        }
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;
         }
@@ -393,8 +388,7 @@ function PlaybackController() {
     }
 
     function getActualPresentationTime(currentTime) {
-        const metrics = metricsModel.getReadOnlyMetricsFor(Constants.VIDEO) || metricsModel.getReadOnlyMetricsFor(Constants.AUDIO);
-        const DVRMetrics = dashMetrics.getCurrentDVRInfo(metrics);
+        const DVRMetrics = dashMetrics.getCurrentDVRInfo();
         const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
         let actualTime;
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -428,8 +428,7 @@ function ScheduleController(config) {
                 playbackController.seek(seekTarget);
             }
 
-            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
-            metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
+            dashMetrics.updateManifestUpdateInfo({
                 currentTime: seekTarget,
                 presentationStartTime: liveEdge,
                 latency: liveEdge - seekTarget,
@@ -592,9 +591,8 @@ function ScheduleController(config) {
             start();
         }
 
-        const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
         const latency = currentRepresentationInfo.DVRWindow && playbackController ? currentRepresentationInfo.DVRWindow.end - playbackController.getTime() : NaN;
-        metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
+        dashMetrics.updateManifestUpdateInfo({
             latency: latency
         });
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -46,7 +46,6 @@ function ScheduleController(config) {
     config = config || {};
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
-    const metricsModel = config.metricsModel;
     const adapter = config.adapter;
     const dashMetrics = config.dashMetrics;
     const timelineConverter = config.timelineConverter;
@@ -94,7 +93,6 @@ function ScheduleController(config) {
         bufferLevelRule = BufferLevelRule(context).create({
             abrController: abrController,
             dashMetrics: dashMetrics,
-            metricsModel: metricsModel,
             mediaPlayerModel: mediaPlayerModel,
             textController: textController
         });

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -694,7 +694,6 @@ function ScheduleController(config) {
         start: start,
         stop: stop,
         reset: reset,
-        //setPlayList: setPlayList,
         getBufferTarget: getBufferTarget,
         finalisePlayList: finalisePlayList
     };

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -428,7 +428,7 @@ function ScheduleController(config) {
                 playbackController.seek(seekTarget);
             }
 
-            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(metricsModel.getMetricsFor(Constants.STREAM));
+            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
             metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
                 currentTime: seekTarget,
                 presentationStartTime: liveEdge,
@@ -592,7 +592,7 @@ function ScheduleController(config) {
             start();
         }
 
-        const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(metricsModel.getMetricsFor(Constants.STREAM));
+        const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
         const latency = currentRepresentationInfo.DVRWindow && playbackController ? currentRepresentationInfo.DVRWindow.end - playbackController.getTime() : NaN;
         metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
             latency: latency

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -133,7 +133,7 @@ function ScheduleController(config) {
             return;
         }
         logger.debug('Schedule Controller starts');
-        addPlaylistTraceMetrics();
+        createPlaylistTraceMetrics();
         isStopped = false;
 
         if (initialRequest) {
@@ -328,7 +328,7 @@ function ScheduleController(config) {
         }
 
         clearPlayListTraceMetrics(new Date(), PlayListTrace.REPRESENTATION_SWITCH_STOP_REASON);
-        addPlaylistTraceMetrics();
+        createPlaylistTraceMetrics();
     }
 
     function completeQualityChange(trigger) {
@@ -628,10 +628,10 @@ function ScheduleController(config) {
         dashMetrics.pushPlayListTraceMetrics(endTime, stopreason);
     }
 
-    function addPlaylistTraceMetrics() {
+    function createPlaylistTraceMetrics() {
         if (currentRepresentationInfo) {
             const playbackRate = playbackController.getPlaybackRate();
-            dashMetrics.addPlaylistTraceMetrics(currentRepresentationInfo.id, playbackController.getTime() * 1000, playbackRate !== null ? playbackRate.toString() : null);
+            dashMetrics.createPlaylistTraceMetrics(currentRepresentationInfo.id, playbackController.getTime() * 1000, playbackRate !== null ? playbackRate.toString() : null);
         }
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -177,7 +177,7 @@ function StreamController() {
         if (isTrackTypePresent(Constants.VIDEO)) {
             const playbackQuality = videoModel.getPlaybackQuality();
             if (playbackQuality) {
-                metricsModel.addDroppedFrames(Constants.VIDEO, playbackQuality);
+                dashMetrics.addDroppedFrames(playbackQuality);
             }
         }
     }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -619,7 +619,7 @@ function StreamController() {
                 throw new Error('There are no streams');
             }
 
-            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate(metricsModel.getMetricsFor(Constants.STREAM));
+            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
             metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
                 currentTime: playbackController.getTime(),
                 buffered: videoModel.getBufferRange(),

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -273,18 +273,18 @@ function StreamController() {
             flushPlaylistMetrics(PlayListTrace.USER_REQUEST_STOP_REASON);
         }
 
-        addPlaylistMetrics(PlayList.SEEK_START_REASON);
+        createPlaylistMetrics(PlayList.SEEK_START_REASON);
     }
 
     function onPlaybackStarted( /*e*/ ) {
         logger.debug('[onPlaybackStarted]');
         if (initialPlayback) {
             initialPlayback = false;
-            addPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
+            createPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
         } else {
             if (isPaused) {
                 isPaused = false;
-                addPlaylistMetrics(PlayList.RESUME_FROM_PAUSE_START_REASON);
+                createPlaylistMetrics(PlayList.RESUME_FROM_PAUSE_START_REASON);
                 toggleEndPeriodTimer();
             }
         }
@@ -781,8 +781,8 @@ function StreamController() {
         dashMetrics.addPlayList();
     }
 
-    function addPlaylistMetrics(startReason) {
-        dashMetrics.addPlaylistMetrics(playbackController.getTime() * 1000, startReason);
+    function createPlaylistMetrics(startReason) {
+        dashMetrics.createPlaylistMetrics(playbackController.getTime() * 1000, startReason);
     }
 
     function onPlaybackError(e) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -735,7 +735,6 @@ function StreamController() {
             baseURLController.initialize(manifest);
 
             timeSyncController.setConfig({
-                metricsModel: metricsModel,
                 dashMetrics: dashMetrics,
                 baseURLController: baseURLController
             });

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -619,8 +619,7 @@ function StreamController() {
                 throw new Error('There are no streams');
             }
 
-            const manifestUpdateInfo = dashMetrics.getCurrentManifestUpdate();
-            metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
+            dashMetrics.updateManifestUpdateInfo({
                 currentTime: playbackController.getTime(),
                 buffered: videoModel.getBufferRange(),
                 presentationStartTime: streamsInfo[0].start,
@@ -658,7 +657,7 @@ function StreamController() {
                     stream.updateData(streamInfo);
                 }
 
-                metricsModel.addManifestUpdateStreamInfo(manifestUpdateInfo, streamInfo.id, streamInfo.index, streamInfo.start, streamInfo.duration);
+                dashMetrics.addManifestUpdateStreamInfo(streamInfo);
             }
 
             if (!activeStream) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -63,7 +63,6 @@ function StreamController() {
         manifestLoader,
         manifestModel,
         adapter,
-        metricsModel,
         dashMetrics,
         mediaSourceController,
         timeSyncController,
@@ -636,7 +635,6 @@ function StreamController() {
                     stream = Stream(context).create({
                         manifestModel: manifestModel,
                         mediaPlayerModel: mediaPlayerModel,
-                        metricsModel: metricsModel,
                         dashMetrics: dashMetrics,
                         manifestUpdater: manifestUpdater,
                         adapter: adapter,
@@ -782,7 +780,7 @@ function StreamController() {
                     ctrlr.finalisePlayList(time, reason);
                 }
             });
-            metricsModel.addPlayList(playListMetrics);
+            dashMetrics.addPlayList(playListMetrics);
             playListMetrics = null;
         }
     }
@@ -859,7 +857,7 @@ function StreamController() {
     function checkConfig() {
         if (!manifestLoader || !manifestLoader.hasOwnProperty('load') || !timelineConverter || !timelineConverter.hasOwnProperty('initialize') ||
             !timelineConverter.hasOwnProperty('reset') || !timelineConverter.hasOwnProperty('getClientTimeOffset') || !manifestModel || !errHandler ||
-            !metricsModel || !playbackController) {
+            !dashMetrics || !playbackController) {
             throw new Error('setConfig function has to be called previously');
         }
     }
@@ -906,9 +904,6 @@ function StreamController() {
         }
         if (config.adapter) {
             adapter = config.adapter;
-        }
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
         }
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -88,7 +88,6 @@ function StreamController() {
         mediaPlayerModel,
         isPaused,
         initialPlayback,
-        playListMetrics,
         videoTrackDetected,
         audioTrackDetected,
         isPeriodSwitchInProgress,
@@ -773,30 +772,17 @@ function StreamController() {
     function flushPlaylistMetrics(reason, time) {
         time = time || new Date();
 
-        if (playListMetrics) {
-            getActiveStreamProcessors().forEach(p => {
-                const ctrlr = p.getScheduleController();
-                if (ctrlr) {
-                    ctrlr.finalisePlayList(time, reason);
-                }
-            });
-            dashMetrics.addPlayList(playListMetrics);
-            playListMetrics = null;
-        }
+        getActiveStreamProcessors().forEach(p => {
+            const ctrlr = p.getScheduleController();
+            if (ctrlr) {
+                ctrlr.finalisePlayList(time, reason);
+            }
+        });
+        dashMetrics.addPlayList();
     }
 
     function addPlaylistMetrics(startReason) {
-        playListMetrics = new PlayList();
-        playListMetrics.start = new Date();
-        playListMetrics.mstart = playbackController.getTime() * 1000;
-        playListMetrics.starttype = startReason;
-
-        getActiveStreamProcessors().forEach(p => {
-            let ctrlr = p.getScheduleController();
-            if (ctrlr) {
-                ctrlr.setPlayList(playListMetrics);
-            }
-        });
+        dashMetrics.addPlaylistMetrics(playbackController.getTime() * 1000, startReason);
     }
 
     function onPlaybackError(e) {
@@ -948,7 +934,6 @@ function StreamController() {
         initialPlayback = true;
         isPaused = false;
         autoPlay = true;
-        playListMetrics = null;
         playbackEndedTimerId = undefined;
         isPeriodSwitchInProgress = false;
         wallclockTicked = 0;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -979,7 +979,7 @@ function StreamController() {
 
         baseURLController.reset();
         manifestUpdater.reset();
-        metricsModel.clearAllCurrentMetrics();
+        dashMetrics.clearAllCurrentMetrics();
         manifestModel.setValue(null);
         manifestLoader.reset();
         timelineConverter.reset();

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -28,7 +28,6 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import Constants from '../constants/Constants';
 import DashJSError from './../vo/DashJSError';
 import {HTTPRequest} from './../vo/metrics/HTTPRequest';
 import EventBus from './../../core/EventBus';
@@ -52,7 +51,6 @@ function TimeSyncController() {
         isSynchronizing,
         useManifestDateHeaderTimeSource,
         handlers,
-        metricsModel,
         dashMetrics,
         baseURLController;
 
@@ -97,10 +95,6 @@ function TimeSyncController() {
 
     function setConfig(config) {
         if (!config) return;
-
-        if (config.metricsModel) {
-            metricsModel = config.metricsModel;
-        }
 
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;
@@ -275,8 +269,7 @@ function TimeSyncController() {
     }
 
     function checkForDateHeader() {
-        let metrics = metricsModel.getMetricsFor(Constants.STREAM, true);
-        let dateHeaderValue = dashMetrics.getLatestMPDRequestHeaderValueByID(metrics, 'Date');
+        let dateHeaderValue = dashMetrics.getLatestMPDRequestHeaderValueByID('Date');
         let dateHeaderTime = dateHeaderValue !== null ? new Date(dateHeaderValue).getTime() : Number.NaN;
 
         if (!isNaN(dateHeaderTime)) {

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -275,7 +275,7 @@ function TimeSyncController() {
     }
 
     function checkForDateHeader() {
-        let metrics = metricsModel.getReadOnlyMetricsFor(Constants.STREAM);
+        let metrics = metricsModel.getMetricsFor(Constants.STREAM, true);
         let dateHeaderValue = dashMetrics.getLatestMPDRequestHeaderValueByID(metrics, 'Date');
         let dateHeaderTime = dateHeaderValue !== null ? new Date(dateHeaderValue).getTime() : Number.NaN;
 

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -59,7 +59,7 @@ function XlinkController(config) {
 
         xlinkLoader = XlinkLoader(context).create({
             errHandler: config.errHandler,
-            metricsModel: config.metricsModel,
+            dashMetrics: config.dashMetrics,
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier
         });

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -49,7 +49,7 @@ function MetricsReporting() {
     function createMetricsReporting(config) {
         dvbErrorsTranslator = DVBErrorsTranslator(context).getInstance({
             eventBus: config.eventBus,
-            metricsModel: config.metricsModel,
+            dashMetrics: config.dashMetrics,
             metricsConstants: config.metricsConstants,
             events: config.events
         });

--- a/src/streaming/metrics/utils/DVBErrorsTranslator.js
+++ b/src/streaming/metrics/utils/DVBErrorsTranslator.js
@@ -38,7 +38,7 @@ function DVBErrorsTranslator(config) {
     let instance,
         mpd;
     const eventBus = config.eventBus;
-    const metricModel = config.metricsModel;
+    const metricsModel = config.metricsModel;
     const metricsConstants = config.metricsConstants;
     //MediaPlayerEvents have been added to Events in MediaPlayer class
     const Events = config.events;
@@ -64,7 +64,7 @@ function DVBErrorsTranslator(config) {
             o.terror = new Date();
         }
 
-        metricModel.addDVBErrors(o);
+        metricsModel.addDVBErrors(o);
     }
 
     function onManifestUpdate(e) {

--- a/src/streaming/metrics/utils/DVBErrorsTranslator.js
+++ b/src/streaming/metrics/utils/DVBErrorsTranslator.js
@@ -38,7 +38,7 @@ function DVBErrorsTranslator(config) {
     let instance,
         mpd;
     const eventBus = config.eventBus;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const metricsConstants = config.metricsConstants;
     //MediaPlayerEvents have been added to Events in MediaPlayer class
     const Events = config.events;
@@ -64,7 +64,7 @@ function DVBErrorsTranslator(config) {
             o.terror = new Date();
         }
 
-        metricsModel.addDVBErrors(o);
+        dashMetrics.addDVBErrors(o);
     }
 
     function onManifestUpdate(e) {

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -46,7 +46,7 @@ function FragmentModel(config) {
     config = config || {};
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const fragmentLoader = config.fragmentLoader;
 
     let instance,
@@ -276,18 +276,8 @@ function FragmentModel(config) {
     }
 
     function addSchedulingInfoMetrics(request, state) {
-        metricsModel.addSchedulingInfo(
-            request.mediaType,
-            new Date(),
-            request.type,
-            request.startTime,
-            request.availabilityStartTime,
-            request.duration,
-            request.quality,
-            request.range,
-            state);
-
-        metricsModel.addRequestsQueue(request.mediaType, loadingRequests, executedRequests);
+        dashMetrics.addSchedulingInfo(request, state);
+        dashMetrics.addRequestsQueue(request.mediaType, loadingRequests, executedRequests);
     }
 
     function onLoadingCompleted(e) {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -87,16 +87,8 @@ function MetricsModel() {
         metricsChanged();
     }
 
-    function getReadOnlyMetricsFor(type) {
-        if (streamMetrics.hasOwnProperty(type)) {
-            return streamMetrics[type];
-        }
-
-        return null;
-    }
-
-    function getMetricsFor(type) {
-        let metrics;
+    function getMetricsFor(type, readOnly) {
+        let metrics = null;
 
         if (!type) {
             return metrics;
@@ -104,7 +96,7 @@ function MetricsModel() {
 
         if (streamMetrics.hasOwnProperty(type)) {
             metrics = streamMetrics[type];
-        } else {
+        } else if (!readOnly) {
             metrics = new MetricsList();
             streamMetrics[type] = metrics;
         }
@@ -369,7 +361,6 @@ function MetricsModel() {
     instance = {
         clearCurrentMetricsForType: clearCurrentMetricsForType,
         clearAllCurrentMetrics: clearAllCurrentMetrics,
-        getReadOnlyMetricsFor: getReadOnlyMetricsFor,
         getMetricsFor: getMetricsFor,
         addHttpRequest: addHttpRequest,
         addRepresentationSwitch: addRepresentationSwitch,

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -98,6 +98,10 @@ function MetricsModel() {
     function getMetricsFor(type) {
         let metrics;
 
+        if (!type) {
+            return metrics;
+        }
+
         if (streamMetrics.hasOwnProperty(type)) {
             metrics = streamMetrics[type];
         } else {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -270,6 +270,7 @@ function MetricsModel() {
 
     function addRequestsQueue(mediaType, loadingRequests, executedRequests) {
         let vo = new RequestsQueue();
+
         vo.loadingRequests = loadingRequests;
         vo.executedRequests = executedRequests;
 
@@ -337,8 +338,6 @@ function MetricsModel() {
     }
 
     function addPlayList(vo) {
-        let type = Constants.STREAM;
-
         if (vo.trace && Array.isArray(vo.trace)) {
             vo.trace.forEach(trace => {
                 if (trace.hasOwnProperty('subreplevel') && !trace.subreplevel) {
@@ -349,13 +348,11 @@ function MetricsModel() {
             delete vo.trace;
         }
 
-        pushAndNotify(type, MetricsConstants.PLAY_LIST, vo);
+        pushAndNotify(Constants.STREAM, MetricsConstants.PLAY_LIST, vo);
     }
 
     function addDVBErrors(vo) {
-        let type = Constants.STREAM;
-
-        pushAndNotify(type, MetricsConstants.DVB_ERRORS, vo);
+        pushAndNotify(Constants.STREAM, MetricsConstants.DVB_ERRORS, vo);
     }
 
     instance = {

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -46,7 +46,7 @@ function HTTPLoader(cfg) {
 
     const context = this.context;
     const errHandler = cfg.errHandler;
-    const metricsModel = cfg.metricsModel;
+    const dashMetrics = cfg.dashMetrics;
     const mediaPlayerModel = cfg.mediaPlayerModel;
     const requestModifier = cfg.requestModifier;
     const boxParser = cfg.boxParser;
@@ -95,7 +95,7 @@ function HTTPLoader(cfg) {
         let lastTraceReceivedCount = 0;
         let httpRequest;
 
-        if (!requestModifier || !metricsModel || !errHandler) {
+        if (!requestModifier || !dashMetrics || !errHandler) {
             throw new Error('config object is not correct or missing');
         }
 
@@ -107,26 +107,14 @@ function HTTPLoader(cfg) {
             request.firstByteDate = request.firstByteDate || requestStartTime;
 
             if (!request.checkExistenceOnly) {
-                metricsModel.addHttpRequest(
-                    request.mediaType,
-                    null,
-                    request.type,
-                    request.url,
-                    httpRequest.response ? httpRequest.response.responseURL : null,
-                    request.serviceLocation || null,
-                    request.range || null,
-                    request.requestStartDate,
-                    request.firstByteDate,
-                    request.requestEndDate,
-                    httpRequest.response ? httpRequest.response.status : null,
-                    request.duration,
-                    httpRequest.response && httpRequest.response.getAllResponseHeaders ? httpRequest.response.getAllResponseHeaders() :
-                        httpRequest.response ? httpRequest.response.responseHeaders : [],
-                    success ? traces : null
-                );
+                dashMetrics.addHttpRequest(request, httpRequest.response ? httpRequest.response.responseURL : null,
+                                           httpRequest.response ? httpRequest.response.status : null,
+                                           httpRequest.response && httpRequest.response.getAllResponseHeaders ? httpRequest.response.getAllResponseHeaders() :
+                                           httpRequest.response ? httpRequest.response.responseHeaders : [],
+                                           success ? traces : null);
 
                 if (request.type === HTTPRequest.MPD_TYPE) {
-                    metricsModel.addManifestUpdate('stream', request.type, request.requestStartDate, request.requestEndDate);
+                    dashMetrics.addManifestUpdate(request.type, request.requestStartDate, request.requestEndDate);
                 }
             }
         };

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -74,7 +74,6 @@ function ABRRulesCollection(config) {
             );
             qualitySwitchRules.push(
                 InsufficientBufferRule(context).create({
-                    metricsModel: metricsModel,
                     dashMetrics: dashMetrics
                 })
             );

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -62,7 +62,6 @@ function ABRRulesCollection(config) {
             // This is controlled by useBufferOccupancyABR mechanism in AbrController.
             qualitySwitchRules.push(
                 BolaRule(context).create({
-                    metricsModel: metricsModel,
                     dashMetrics: dashMetrics,
                     mediaPlayerModel: mediaPlayerModel
                 })
@@ -87,7 +86,6 @@ function ABRRulesCollection(config) {
             );
             abandonFragmentRules.push(
                 AbandonRequestsRule(context).create({
-                    metricsModel: metricsModel,
                     dashMetrics: dashMetrics,
                     mediaPlayerModel: mediaPlayerModel
                 })

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -46,7 +46,6 @@ function ABRRulesCollection(config) {
     const context = this.context;
 
     const mediaPlayerModel = config.mediaPlayerModel;
-    const metricsModel = config.metricsModel;
     const dashMetrics = config.dashMetrics;
 
     let instance,
@@ -68,7 +67,6 @@ function ABRRulesCollection(config) {
             );
             qualitySwitchRules.push(
                 ThroughputRule(context).create({
-                    metricsModel: metricsModel,
                     dashMetrics: dashMetrics
                 })
             );

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -81,7 +81,7 @@ function AbandonRequestsRule(config) {
             setFragmentRequestDict(mediaType, req.index);
 
             const stableBufferTime = mediaPlayerModel.getStableBufferTime();
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(mediaType));
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
             if ( bufferLevel > stableBufferTime ) {
                 return switchRequest;
             }

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -41,7 +41,6 @@ function AbandonRequestsRule(config) {
 
     const context = this.context;
     const mediaPlayerModel = config.mediaPlayerModel;
-    const metricsModel = config.metricsModel;
     const dashMetrics = config.dashMetrics;
 
     let instance,
@@ -81,7 +80,7 @@ function AbandonRequestsRule(config) {
             setFragmentRequestDict(mediaType, req.index);
 
             const stableBufferTime = mediaPlayerModel.getStableBufferTime();
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
             if ( bufferLevel > stableBufferTime ) {
                 return switchRequest;
             }

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -157,7 +157,7 @@ function BolaRule(config) {
                 // 1. do not change effective buffer level at effectiveBufferLevel === MINIMUM_BUFFER_S ( === Vp * gp )
                 // 2. scale placeholder buffer by Vp subject to offset indicated in 1.
 
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(mediaType));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
                 let effectiveBufferLevel = bufferLevel + bolaState.placeholderBuffer;
 
                 effectiveBufferLevel -= MINIMUM_BUFFER_S;
@@ -335,7 +335,7 @@ function BolaRule(config) {
 
             // Find what maximum buffer corresponding to last segment was, and ensure placeholder is not relatively larger.
             if (!isNaN(bolaState.lastSegmentFinishTimeMs)) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(mediaType));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
                 const bufferAtLastSegmentRequest = bufferLevel + 0.001 * (bolaState.lastSegmentFinishTimeMs - bolaState.lastSegmentRequestTimeMs); // estimate
                 const maxEffectiveBufferForLastSegment = maxBufferLevelForQuality(bolaState, bolaState.lastQuality);
                 const maxPlaceholderBuffer = Math.max(0, maxEffectiveBufferForLastSegment - bufferAtLastSegmentRequest);
@@ -369,7 +369,7 @@ function BolaRule(config) {
             const bolaState = bolaStateDict[e.mediaType];
             if (bolaState && bolaState.state !== BOLA_STATE_ONE_BITRATE) {
                 // deflate placeholderBuffer - note that we want to be conservative when abandoning
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(e.mediaType));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(e.mediaType, true));
                 let wantEffectiveBufferLevel;
                 if (bolaState.abrQuality > 0) {
                     // deflate to point where BOLA just chooses newQuality over newQuality-1
@@ -386,7 +386,7 @@ function BolaRule(config) {
     function getMaxIndex(rulesContext) {
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const metrics = metricsModel.getMetricsFor(mediaType, true);
         const scheduleController = rulesContext.getScheduleController();
         const streamInfo = rulesContext.getStreamInfo();
         const abrController = rulesContext.getAbrController();

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -60,7 +60,6 @@ function BolaRule(config) {
     const context = this.context;
 
     const dashMetrics = config.dashMetrics;
-    const metricsModel = config.metricsModel;
     const mediaPlayerModel = config.mediaPlayerModel;
     const eventBus = EventBus(context).getInstance();
 
@@ -157,7 +156,7 @@ function BolaRule(config) {
                 // 1. do not change effective buffer level at effectiveBufferLevel === MINIMUM_BUFFER_S ( === Vp * gp )
                 // 2. scale placeholder buffer by Vp subject to offset indicated in 1.
 
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
                 let effectiveBufferLevel = bufferLevel + bolaState.placeholderBuffer;
 
                 effectiveBufferLevel -= MINIMUM_BUFFER_S;
@@ -335,7 +334,7 @@ function BolaRule(config) {
 
             // Find what maximum buffer corresponding to last segment was, and ensure placeholder is not relatively larger.
             if (!isNaN(bolaState.lastSegmentFinishTimeMs)) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(mediaType, true));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
                 const bufferAtLastSegmentRequest = bufferLevel + 0.001 * (bolaState.lastSegmentFinishTimeMs - bolaState.lastSegmentRequestTimeMs); // estimate
                 const maxEffectiveBufferForLastSegment = maxBufferLevelForQuality(bolaState, bolaState.lastQuality);
                 const maxPlaceholderBuffer = Math.max(0, maxEffectiveBufferForLastSegment - bufferAtLastSegmentRequest);
@@ -369,7 +368,7 @@ function BolaRule(config) {
             const bolaState = bolaStateDict[e.mediaType];
             if (bolaState && bolaState.state !== BOLA_STATE_ONE_BITRATE) {
                 // deflate placeholderBuffer - note that we want to be conservative when abandoning
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(e.mediaType, true));
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(e.mediaType, true);
                 let wantEffectiveBufferLevel;
                 if (bolaState.abrQuality > 0) {
                     // deflate to point where BOLA just chooses newQuality over newQuality-1
@@ -386,7 +385,6 @@ function BolaRule(config) {
     function getMaxIndex(rulesContext) {
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getMetricsFor(mediaType, true);
         const scheduleController = rulesContext.getScheduleController();
         const streamInfo = rulesContext.getStreamInfo();
         const abrController = rulesContext.getAbrController();
@@ -410,7 +408,7 @@ function BolaRule(config) {
             return switchRequest;
         }
 
-        const bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+        const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
         const throughput = throughputHistory.getAverageThroughput(mediaType, isDynamic);
         const safeThroughput = throughputHistory.getSafeAverageThroughput(mediaType, isDynamic);
         const latency = throughputHistory.getAverageLatency(mediaType);

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -58,7 +58,7 @@ function InsufficientBufferRule(config) {
     }
 
     function checkConfig() {
-        if (!metricsModel || !metricsModel.hasOwnProperty('getReadOnlyMetricsFor') || !dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel')) {
+        if (!metricsModel || !metricsModel.hasOwnProperty('getMetricsFor') || !dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -82,7 +82,7 @@ function InsufficientBufferRule(config) {
         checkConfig();
 
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const metrics = metricsModel.getMetricsFor(mediaType, true);
         const lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         const representationInfo = rulesContext.getRepresentationInfo();
         const fragmentDuration = representationInfo.fragmentDuration;

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -45,7 +45,6 @@ function InsufficientBufferRule(config) {
     const context = this.context;
 
     const eventBus = EventBus(context).getInstance();
-    const metricsModel = config.metricsModel;
     const dashMetrics = config.dashMetrics;
 
     let instance,
@@ -59,7 +58,7 @@ function InsufficientBufferRule(config) {
     }
 
     function checkConfig() {
-        if (!metricsModel || !metricsModel.hasOwnProperty('getMetricsFor') || !dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel')) {
+        if (!dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel') || !dashMetrics.hasOwnProperty('getLatestBufferInfoVO')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -84,7 +83,6 @@ function InsufficientBufferRule(config) {
 
         const mediaType = rulesContext.getMediaType();
         const lastBufferStateVO = dashMetrics.getLatestBufferInfoVO(mediaType, true, MetricsConstants.BUFFER_STATE);
-        //lastBufferStateVO = lastBufferLevelVO && (lastBufferLevelVO.BufferState.length > 0) ? lastBufferLevelVO.BufferState[lastBufferLevelVO.BufferState.length - 1] : null;
         const representationInfo = rulesContext.getRepresentationInfo();
         const fragmentDuration = representationInfo.fragmentDuration;
 

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -35,6 +35,7 @@ import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 import SwitchRequest from '../SwitchRequest';
 import Constants from '../../constants/Constants';
+import MetricsConstants from '../../constants/MetricsConstants';
 
 function InsufficientBufferRule(config) {
 
@@ -82,8 +83,8 @@ function InsufficientBufferRule(config) {
         checkConfig();
 
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getMetricsFor(mediaType, true);
-        const lastBufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
+        const lastBufferStateVO = dashMetrics.getLatestBufferInfoVO(mediaType, true, MetricsConstants.BUFFER_STATE);
+        //lastBufferStateVO = lastBufferLevelVO && (lastBufferLevelVO.BufferState.length > 0) ? lastBufferLevelVO.BufferState[lastBufferLevelVO.BufferState.length - 1] : null;
         const representationInfo = rulesContext.getRepresentationInfo();
         const fragmentDuration = representationInfo.fragmentDuration;
 
@@ -101,7 +102,7 @@ function InsufficientBufferRule(config) {
             const abrController = rulesContext.getAbrController();
             const throughputHistory = abrController.getThroughputHistory();
 
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(metrics);
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
             const throughput = throughputHistory.getAverageThroughput(mediaType);
             const latency = throughputHistory.getAverageLatency(mediaType);
             const bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -49,7 +49,7 @@ function ThroughputRule(config) {
     }
 
     function checkConfig() {
-        if (!metricsModel || !metricsModel.hasOwnProperty('getReadOnlyMetricsFor')) {
+        if (!metricsModel || !metricsModel.hasOwnProperty('getMetricsFor')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -66,7 +66,7 @@ function ThroughputRule(config) {
 
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getReadOnlyMetricsFor(mediaType);
+        const metrics = metricsModel.getMetricsFor(mediaType, true);
         const scheduleController = rulesContext.getScheduleController();
         const abrController = rulesContext.getAbrController();
         const streamInfo = rulesContext.getStreamInfo();

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -34,12 +34,13 @@ import FactoryMaker from '../../../core/FactoryMaker';
 import Debug from '../../../core/Debug';
 import SwitchRequest from '../SwitchRequest';
 import Constants from '../../constants/Constants';
+import MetricsConstants from '../../constants/MetricsConstants';
 
 function ThroughputRule(config) {
 
     config = config || {};
     const context = this.context;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
 
     let instance,
         logger;
@@ -49,7 +50,7 @@ function ThroughputRule(config) {
     }
 
     function checkConfig() {
-        if (!metricsModel || !metricsModel.hasOwnProperty('getMetricsFor')) {
+        if (!dashMetrics || !dashMetrics.hasOwnProperty('getLatestBufferInfoVO')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -66,7 +67,7 @@ function ThroughputRule(config) {
 
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
-        const metrics = metricsModel.getMetricsFor(mediaType, true);
+        const bufferStateVO = dashMetrics.getLatestBufferInfoVO(mediaType, true, MetricsConstants.BUFFER_STATE);
         const scheduleController = rulesContext.getScheduleController();
         const abrController = rulesContext.getAbrController();
         const streamInfo = rulesContext.getStreamInfo();
@@ -74,10 +75,10 @@ function ThroughputRule(config) {
         const throughputHistory = abrController.getThroughputHistory();
         const throughput = throughputHistory.getSafeAverageThroughput(mediaType, isDynamic);
         const latency = throughputHistory.getAverageLatency(mediaType);
-        const bufferStateVO = (metrics.BufferState.length > 0) ? metrics.BufferState[metrics.BufferState.length - 1] : null;
         const useBufferOccupancyABR = rulesContext.useBufferOccupancyABR();
 
-        if (!metrics || isNaN(throughput) || !bufferStateVO || useBufferOccupancyABR) {
+
+        if (isNaN(throughput) || !bufferStateVO || useBufferOccupancyABR) {
             return switchRequest;
         }
 

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -47,7 +47,7 @@ function BufferLevelRule(config) {
         if (!streamProcessor) {
             return true;
         }
-        const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(streamProcessor.getType()));
+        const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(streamProcessor.getType(), true));
         return bufferLevel < getBufferTarget(streamProcessor, videoTrackPresent);
     }
 
@@ -62,7 +62,7 @@ function BufferLevelRule(config) {
         if (type === Constants.FRAGMENTED_TEXT) {
             bufferTarget = textController.isTextEnabled() ? representationInfo.fragmentDuration : 0;
         } else if (type === Constants.AUDIO && videoTrackPresent) {
-            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getReadOnlyMetricsFor(Constants.VIDEO));
+            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(Constants.VIDEO, true));
             if (isNaN(representationInfo.fragmentDuration)) {
                 bufferTarget = videoBufferLevel;
             } else {

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -35,7 +35,6 @@ function BufferLevelRule(config) {
 
     config = config || {};
     const dashMetrics = config.dashMetrics;
-    const metricsModel = config.metricsModel;
     const mediaPlayerModel = config.mediaPlayerModel;
     const textController = config.textController;
     const abrController = config.abrController;
@@ -47,7 +46,7 @@ function BufferLevelRule(config) {
         if (!streamProcessor) {
             return true;
         }
-        const bufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(streamProcessor.getType(), true));
+        const bufferLevel = dashMetrics.getCurrentBufferLevel(streamProcessor.getType(), true);
         return bufferLevel < getBufferTarget(streamProcessor, videoTrackPresent);
     }
 
@@ -62,7 +61,7 @@ function BufferLevelRule(config) {
         if (type === Constants.FRAGMENTED_TEXT) {
             bufferTarget = textController.isTextEnabled() ? representationInfo.fragmentDuration : 0;
         } else if (type === Constants.AUDIO && videoTrackPresent) {
-            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(metricsModel.getMetricsFor(Constants.VIDEO, true));
+            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(Constants.VIDEO, true);
             if (isNaN(representationInfo.fragmentDuration)) {
                 bufferTarget = videoBufferLevel;
             } else {

--- a/src/streaming/text/TextBufferController.js
+++ b/src/streaming/text/TextBufferController.js
@@ -49,7 +49,7 @@ function TextBufferController(config) {
             // in this case, internal buffer ocntroller is a classical BufferController object
             _BufferControllerImpl = BufferController(context).create({
                 type: config.type,
-                metricsModel: config.metricsModel,
+                dashMetrics: config.dashMetrics,
                 mediaPlayerModel: config.mediaPlayerModel,
                 manifestModel: config.manifestModel,
                 errHandler: config.errHandler,

--- a/src/streaming/thumbnail/ThumbnailTracks.js
+++ b/src/streaming/thumbnail/ThumbnailTracks.js
@@ -49,7 +49,7 @@ function ThumbnailTracks(config) {
     const baseURLController = config.baseURLController;
     const stream = config.stream;
     const timelineConverter = config.timelineConverter;
-    const metricsModel = config.metricsModel;
+    const dashMetrics = config.dashMetrics;
     const mediaPlayerModel = config.mediaPlayerModel;
     const errHandler = config.errHandler;
 
@@ -67,7 +67,7 @@ function ThumbnailTracks(config) {
         segmentBaseLoader = SegmentBaseLoader(context).getInstance();
         segmentBaseLoader.setConfig({
             baseURLController: baseURLController,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             errHandler: errHandler
         });

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -31,7 +31,7 @@ describe('DashMetrics', function () {
     });
 
     describe('getCurrentHttpRequest', () => {
-        it('should return null when getCurrentHttpRequest is called and metrics is undefined', () => {
+        it('should return null when getCurrentHttpRequest is called and mediaType is undefined', () => {
             const currentHttpRequest = dashMetrics.getCurrentHttpRequest();
 
             expect(currentHttpRequest).to.be.null;  // jshint ignore:line
@@ -39,7 +39,7 @@ describe('DashMetrics', function () {
 
         it('should return null when getCurrentHttpRequest is called and metrics.httpList is undefined', () => {
             metricsModelMock.setMetrics({});
-            const currentHttpRequest = dashMetrics.getCurrentHttpRequest();
+            const currentHttpRequest = dashMetrics.getCurrentHttpRequest('audio');
 
             expect(currentHttpRequest).to.be.null;  // jshint ignore:line
         });

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -1,13 +1,18 @@
 import DashMetrics from '../../src/dash/DashMetrics';
 
+import ManifestModelMock from './mocks/ManifestModelMock';
+import MetricsModelMock from './mocks/MetricsModelMock';
+
 const expect = require('chai').expect;
 
 const context = {};
-const dashMetrics = DashMetrics(context).getInstance();
 
+const metricsModelMock = new MetricsModelMock();
+const manifestModelMock = new ManifestModelMock();
+const dashMetrics = DashMetrics(context).getInstance({manifestModel: manifestModelMock, metricsModel: metricsModelMock });
 
 describe('DashMetrics', function () {
-    it('should return null when getCurrentRepresentationSwitch is called and metrics is undefined', () => {
+    it('should return null when getCurrentRepresentationSwitch is called and type is undefined', () => {
         const representation = dashMetrics.getCurrentRepresentationSwitch();
 
         expect(representation).to.be.null;  // jshint ignore:line

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -38,8 +38,8 @@ describe('DashMetrics', function () {
         });
 
         it('should return null when getCurrentHttpRequest is called and metrics.httpList is undefined', () => {
-            const metrics = {};
-            const currentHttpRequest = dashMetrics.getCurrentHttpRequest(metrics);
+            metricsModelMock.setMetrics({});
+            const currentHttpRequest = dashMetrics.getCurrentHttpRequest();
 
             expect(currentHttpRequest).to.be.null;  // jshint ignore:line
         });
@@ -54,8 +54,8 @@ describe('DashMetrics', function () {
         });
 
         it('should return an empty array when getHttpRequests is called and metrics.httpList is undefined', () => {
-            const metrics = {};
-            const httpRequestArray = dashMetrics.getHttpRequests(metrics);
+            metricsModelMock.setMetrics({});
+            const httpRequestArray = dashMetrics.getHttpRequests();
 
             expect(httpRequestArray).to.be.instanceOf(Array);    // jshint ignore:line
             expect(httpRequestArray).to.be.empty;                // jshint ignore:line
@@ -69,23 +69,24 @@ describe('DashMetrics', function () {
     });
 
     describe('getLatestMPDRequestHeaderValueByID', () => {
-        it('should return null when getLatestMPDRequestHeaderValueByID is called and metrics and id are undefined', () => {
+        it('should return null when getLatestMPDRequestHeaderValueByID is called and id is undefined', () => {
             const lastMpdRequestHeader = dashMetrics.getLatestMPDRequestHeaderValueByID();
 
             expect(lastMpdRequestHeader).to.be.null;  // jshint ignore:line
         });
 
-        it('should return null when getLatestMPDRequestHeaderValueByID is called and id is undefined', () => {
+        it('should return null when getLatestMPDRequestHeaderValueByID is called and metrics is defined but id is undefined', () => {
             const metrics = { HttpList: [{type: 'MPD', _responseHeaders: ''}, {type: 'MPD', _responseHeaders: ''}]};
+            metricsModelMock.setMetrics(metrics);
 
-            const lastMpdRequestHeader = dashMetrics.getLatestMPDRequestHeaderValueByID(metrics);
+            const lastMpdRequestHeader = dashMetrics.getLatestMPDRequestHeaderValueByID();
 
             expect(lastMpdRequestHeader).to.be.null;  // jshint ignore:line
         });
     });
 
     describe('getLatestFragmentRequestHeaderValueByID', () => {
-        it('should return null when getLatestFragmentRequestHeaderValueByID is called and metrics and id are undefined', () => {
+        it('should return null when getLatestFragmentRequestHeaderValueByID is called and metrics, type and id are undefined', () => {
             const lastFragmentRequestHeader = dashMetrics.getLatestFragmentRequestHeaderValueByID();
 
             expect(lastFragmentRequestHeader).to.be.null;  // jshint ignore:line
@@ -93,7 +94,8 @@ describe('DashMetrics', function () {
 
         it('should return null when getLatestFragmentRequestHeaderValueByID is called and httpRequest._responseHeaders and id are undefined', () => {
             const metrics = { HttpList: [{responsecode: 200}, {responsecode: 200}]};
-            const lastFragmentRequestHeader = dashMetrics.getLatestFragmentRequestHeaderValueByID(metrics);
+            metricsModelMock.setMetrics(metrics);
+            const lastFragmentRequestHeader = dashMetrics.getLatestFragmentRequestHeaderValueByID('stream');
 
             expect(lastFragmentRequestHeader).to.be.null;  // jshint ignore:line
         });

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -62,7 +62,7 @@ describe('DashMetrics', function () {
         });
     });
 
-    it('should return null when getCurrentDroppedFrames is called and mediaType is undefined', () => {
+    it('should return null when getCurrentDroppedFrames is called', () => {
         const droppedFrames = dashMetrics.getCurrentDroppedFrames();
 
         expect(droppedFrames).to.be.null;  // jshint ignore:line

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -62,11 +62,10 @@ describe('DashMetrics', function () {
         });
     });
 
-    it('should return null when getCurrentDroppedFrames is called and metrics[MetricsList.DROPPED_FRAMES] is undefined', () => {
-        const metrics = {};
-        const httpRequestArray = dashMetrics.getCurrentDroppedFrames(metrics);
+    it('should return null when getCurrentDroppedFrames is called and mediaType is undefined', () => {
+        const droppedFrames = dashMetrics.getCurrentDroppedFrames();
 
-        expect(httpRequestArray).to.be.null;  // jshint ignore:line
+        expect(droppedFrames).to.be.null;  // jshint ignore:line
     });
 
     describe('getLatestMPDRequestHeaderValueByID', () => {

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -18,8 +18,8 @@ describe('DashMetrics', function () {
         expect(representation).to.be.null;  // jshint ignore:line
     });
 
-    it('should return null when getLatestBufferLevelVO is called and metrics is undefined', () => {
-        const bufferLevel = dashMetrics.getLatestBufferLevelVO();
+    it('should return null when getLatestBufferInfoVO is called and mediaType, readOnly and infoType are undefined', () => {
+        const bufferLevel = dashMetrics.getLatestBufferInfoVO();
 
         expect(bufferLevel).to.be.null;  // jshint ignore:line
     });

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -18,7 +18,13 @@ describe('DashMetrics', function () {
         expect(representation).to.be.null;  // jshint ignore:line
     });
 
-    it('should return 0 when getCurrentBufferLevel is called and metrics is undefined', () => {
+    it('should return null when getLatestBufferLevelVO is called and metrics is undefined', () => {
+        const bufferLevel = dashMetrics.getLatestBufferLevelVO();
+
+        expect(bufferLevel).to.be.null;  // jshint ignore:line
+    });
+
+    it('should return 0 when getCurrentBufferLevel is called and type is undefined', () => {
         const bufferLevel = dashMetrics.getCurrentBufferLevel();
 
         expect(bufferLevel).to.be.equal(0);  // jshint ignore:line

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -1,5 +1,7 @@
 function DashMetricsMock () {
 
+    this.bufferState = null;
+
     this.getCurrentDVRInfo = function () {
         return null;
     };
@@ -8,8 +10,12 @@ function DashMetricsMock () {
         return 15;
     };
 
-    this.getLatestBufferLevelVO = function () {
-        return null;
+    this.getLatestBufferInfoVO = function () {
+        return this.bufferState;
+    };
+
+    this.setBufferState = function (state) {
+        this.bufferState = state;
     };
 }
 

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -34,6 +34,12 @@ function DashMetricsMock () {
 
     this.addDroppedFrames = function () {
     };
+
+    this.addPlayList = function () {
+    };
+
+    this.addPlaylistTraceMetrics = function () {
+    };
 }
 
 export default DashMetricsMock;

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -38,7 +38,7 @@ function DashMetricsMock () {
     this.addPlayList = function () {
     };
 
-    this.addPlaylistTraceMetrics = function () {
+    this.createPlaylistTraceMetrics = function () {
     };
 }
 

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -14,6 +14,14 @@ function DashMetricsMock () {
         return this.bufferState;
     };
 
+    this.addSchedulingInfo = function () {
+
+    };
+
+    this.addRequestsQueue = function () {
+
+    };
+
     this.addBufferState = function (type, bufferState/*, bufferTarget*/) {
         this.bufferState = bufferState;
     };

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -21,6 +21,9 @@ function DashMetricsMock () {
     this.addBufferLevel = function () {
     };
 
+    this.clearAllCurrentMetrics = function () {
+    };
+
     };
 }
 

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -7,6 +7,10 @@ function DashMetricsMock () {
     this.getCurrentBufferLevel = function () {
         return 15;
     };
+
+    this.getLatestBufferLevelVO = function () {
+        return null;
+    };
 }
 
 export default DashMetricsMock;

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -14,8 +14,13 @@ function DashMetricsMock () {
         return this.bufferState;
     };
 
-    this.setBufferState = function (state) {
-        this.bufferState = state;
+    this.addBufferState = function (type, bufferState/*, bufferTarget*/) {
+        this.bufferState = bufferState;
+    };
+
+    this.addBufferLevel = function () {
+    };
+
     };
 }
 

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -24,6 +24,7 @@ function DashMetricsMock () {
     this.clearAllCurrentMetrics = function () {
     };
 
+    this.addDroppedFrames = function () {
     };
 }
 

--- a/test/unit/mocks/MetricsModelMock.js
+++ b/test/unit/mocks/MetricsModelMock.js
@@ -20,6 +20,10 @@ function MetricsModelMock () {
     this.clearAllCurrentMetrics = function () {
 
     };
+
+    this.getMetricsFor = function (/*type*/) {
+        return;
+    };
 }
 
 export default MetricsModelMock;

--- a/test/unit/mocks/MetricsModelMock.js
+++ b/test/unit/mocks/MetricsModelMock.js
@@ -2,6 +2,7 @@ function MetricsModelMock () {
 
     this.bufferState = 0;
     this.bufferLevel = 0;
+    this.metrics = null;
 
     this.addBufferState = function (type, bufferState/*, bufferTarget*/) {
         this.bufferState = bufferState;
@@ -12,17 +13,15 @@ function MetricsModelMock () {
     };
 
     this.clearAllCurrentMetrics = function () {
-
+        this.metrics = null;
     };
 
-    this.getMetricsFor = function (type, readOnly) {
-        if (readOnly) {
-            return {
-                BufferState: ['bufferStalled']
-            };
-        } else {
-            return;
-        }
+    this.setMetrics = function (metrics) {
+        this.metrics = metrics;
+    };
+
+    this.getMetricsFor = function (/*type, readOnly*/) {
+        return this.metrics;
     };
 }
 

--- a/test/unit/mocks/MetricsModelMock.js
+++ b/test/unit/mocks/MetricsModelMock.js
@@ -11,18 +11,18 @@ function MetricsModelMock () {
         this.bufferState = bufferLevel;
     };
 
-    this.getReadOnlyMetricsFor = function () {
-        return {
-            BufferState: ['bufferStalled']
-        };
-    };
-
     this.clearAllCurrentMetrics = function () {
 
     };
 
-    this.getMetricsFor = function (/*type*/) {
-        return;
+    this.getMetricsFor = function (type, readOnly) {
+        if (readOnly) {
+            return {
+                BufferState: ['bufferStalled']
+            };
+        } else {
+            return;
+        }
     };
 }
 

--- a/test/unit/streaming.MediaPlayerSpec.js
+++ b/test/unit/streaming.MediaPlayerSpec.js
@@ -1199,14 +1199,6 @@ describe('MediaPlayer', function () {
                 const metricsExt = player.getDashMetrics();
                 expect(metricsExt).to.exist; // jshint ignore:line
             });
-
-            it('Method getMetricsFor should return no metrics', function () {
-                const audioMetrics = player.getMetricsFor('audio');
-                const videoMetrics = player.getMetricsFor('video');
-
-                expect(audioMetrics).to.be.null; // jshint ignore:line
-                expect(videoMetrics).to.be.null; // jshint ignore:line
-            });
         });
     });
 });

--- a/test/unit/streaming.controllers.AbrControllerSpec.js
+++ b/test/unit/streaming.controllers.AbrControllerSpec.js
@@ -6,7 +6,6 @@ import Constants from '../../src/streaming/constants/Constants';
 
 import VideoModelMock from './mocks/VideoModelMock';
 import DomStorageMock from './mocks/DomStorageMock';
-import MetricsModelMock from './mocks/MetricsModelMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
 import AdapterMock from './mocks/AdapterMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
@@ -27,13 +26,11 @@ describe('AbrController', function () {
     const adapterMock = new AdapterMock();
     const videoModelMock = new VideoModelMock();
     const domStorageMock = new DomStorageMock();
-    const metricsModelMock = new MetricsModelMock();
     const dashMetricsMock = new DashMetricsMock();
     const mediaPlayerModelMock = new MediaPlayerModelMock();
 
     beforeEach(function () {
         abrCtrl.setConfig({
-            metricsModel: metricsModelMock,
             dashMetrics: dashMetricsMock,
             videoModel: videoModelMock,
             adapter: adapterMock,

--- a/test/unit/streaming.controllers.BufferControllerSpec.js
+++ b/test/unit/streaming.controllers.BufferControllerSpec.js
@@ -8,7 +8,7 @@ import Debug from '../../src/core/Debug';
 import StreamControllerMock from './mocks/StreamControllerMock';
 import PlaybackControllerMock from './mocks/PlaybackControllerMock';
 import StreamProcessorMock from './mocks/StreamProcessorMock';
-import MetricsModelMock from './mocks/MetricsModelMock';
+import DashMetricsMock from './mocks/DashMetricsMock';
 import AdapterMock from './mocks/AdapterMock';
 import MediaSourceMock from './mocks/MediaSourceMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
@@ -36,7 +36,7 @@ describe('BufferController', function () {
     const streamProcessor = new StreamProcessorMock(testType, streamInfo);
     const streamControllerMock = new StreamControllerMock();
     const adapterMock = new AdapterMock();
-    const metricsModelMock = new MetricsModelMock();
+    const dashMetricsMock = new DashMetricsMock();
     const playbackControllerMock = new PlaybackControllerMock();
     const mediaPlayerModelMock = new MediaPlayerModelMock();
     const errorHandlerMock = new ErrorHandlerMock();
@@ -54,7 +54,7 @@ describe('BufferController', function () {
 
         mediaSourceMock = new MediaSourceMock();
         bufferController = BufferController(context).create({
-            metricsModel: metricsModelMock,
+            dashMetrics: dashMetricsMock,
             errHandler: errorHandlerMock,
             streamController: streamControllerMock,
             mediaController: mediaControllerMock,

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -2,7 +2,6 @@ import PlaybackController from '../../src/streaming/controllers/PlaybackControll
 import Events from '../../src/core/events/Events';
 import EventBus from '../../src/core/EventBus';
 
-import MetricsModelMock from './mocks/MetricsModelMock';
 import VideoModelMock from './mocks/VideoModelMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
@@ -18,7 +17,6 @@ describe('PlaybackController', function () {
 
     let playbackController,
         videoModelMock,
-        metricsModelMock,
         dashMetricsMock,
         mediaPlayerModelMock,
         streamControllerMock,
@@ -26,7 +24,6 @@ describe('PlaybackController', function () {
 
     beforeEach(function () {
         videoModelMock = new VideoModelMock();
-        metricsModelMock = new MetricsModelMock();
         dashMetricsMock = new DashMetricsMock();
         mediaPlayerModelMock = new MediaPlayerModelMock();
         streamControllerMock = new StreamControllerMock();
@@ -35,7 +32,6 @@ describe('PlaybackController', function () {
 
         playbackController.setConfig({
             videoModel: videoModelMock,
-            metricsModel: metricsModelMock,
             dashMetrics: dashMetricsMock,
             mediaPlayerModel: mediaPlayerModelMock,
             streamController: streamControllerMock,

--- a/test/unit/streaming.controllers.StreamController.js
+++ b/test/unit/streaming.controllers.StreamController.js
@@ -8,7 +8,7 @@ import AdapterMock from './mocks/AdapterMock';
 import ManifestLoaderMock from './mocks/ManifestLoaderMock';
 import ManifestModelMock from './mocks/ManifestModelMock';
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
-import MetricsModelMock from './mocks/MetricsModelMock';
+import DashMetricsMock from './mocks/DashMetricsMock';
 import ProtectionControllerMock from './mocks/ProtectionControllerMock';
 import VideoModelMock from './mocks/VideoModelMock';
 import PlaybackControllerMock from './mocks/PlaybackControllerMock';
@@ -29,7 +29,7 @@ const objectsHelper = new ObjectsHelper();
 const timelineConverterMock = objectsHelper.getDummyTimelineConverter();
 const manifestModelMock = new ManifestModelMock();
 const errHandlerMock = new ErrorHandlerMock();
-const metricsModelMock = new MetricsModelMock();
+const dashMetricsMock = new DashMetricsMock();
 const protectionControllerMock = new ProtectionControllerMock();
 const videoModelMock = new VideoModelMock();
 const playbackControllerMock = new PlaybackControllerMock();
@@ -125,7 +125,7 @@ describe('StreamController', function () {
                                         timelineConverter: timelineConverterMock,
                                         manifestModel: manifestModelMock,
                                         errHandler: errHandlerMock,
-                                        metricsModel: metricsModelMock,
+                                        dashMetrics: dashMetricsMock,
                                         protectionController: protectionControllerMock,
                                         videoModel: videoModelMock,
                                         playbackController: playbackControllerMock});

--- a/test/unit/streaming.models.FragmentModelSpec.js
+++ b/test/unit/streaming.models.FragmentModelSpec.js
@@ -5,6 +5,8 @@ import Events from '../../src/core/events/Events';
 import FragmentModel from '../../src/streaming/models/FragmentModel';
 import {HTTPRequest} from '../../src/streaming/vo/metrics/HTTPRequest';
 
+import DashMetricsMock from './mocks/DashMetricsMock';
+
 const chai = require('chai');
 const spies = require('chai-spies');
 const sinon = require('sinon');
@@ -21,11 +23,7 @@ describe('FragmentModel', function () {
     const completeMediaRequest = voHelper.getCompleteRequest(HTTPRequest.MEDIA_SEGMENT_TYPE);
     const context = {};
     const eventBus = EventBus(context).getInstance();
-    const metricsModel = {
-        addSchedulingInfo: () => {},
-        addRequestsQueue: () => {}
-    };
-    let fragmentModel = FragmentModel(context).create({metricsModel: metricsModel});
+    let fragmentModel = FragmentModel(context).create({dashMetrics: new DashMetricsMock()});
 
     it('should not have any loading, executed, canceled or failed requests', function () {
         const expectedValue = 0;
@@ -71,7 +69,7 @@ describe('FragmentModel', function () {
             let clock;
 
             beforeEach(function () {
-                fragmentModel = FragmentModel(context).create({metricsModel: metricsModel, fragmentLoader: loader});
+                fragmentModel = FragmentModel(context).create({dashMetrics: new DashMetricsMock(), fragmentLoader: loader});
                 clock = sinon.useFakeTimers();
 
                 setTimeout(function () {

--- a/test/unit/streaming.models.MetricsModel.js
+++ b/test/unit/streaming.models.MetricsModel.js
@@ -7,10 +7,14 @@ describe('MetricsModel', function () {
     const context = {};
     const metricsModel = MetricsModel(context).getInstance();
 
-    it('should return undefined when getMetricsFor is called and type is undefined', function () {
+    beforeEach(function () {
+        metricsModel.clearAllCurrentMetrics();
+    });
+
+    it('should return null when getMetricsFor is called and type is undefined', function () {
         const metrics = metricsModel.getMetricsFor();
 
-        expect(metrics).to.be.undefined;                // jshint ignore:line
+        expect(metrics).to.be.null;                // jshint ignore:line
     });
 
     it('should return an empty MetricsList when getMetricsFor is called and type is defined', function () {
@@ -18,5 +22,11 @@ describe('MetricsModel', function () {
 
         expect(metrics.TcpList).to.be.instanceOf(Array); // jshint ignore:line
         expect(metrics.TcpList).to.be.empty; // jshint ignore:line
+    });
+
+    it('should return null when getMetricsFor is called and type is defined and readOnly is true', function () {
+        const metrics = metricsModel.getMetricsFor('video', true);
+
+        expect(metrics).to.be.null;                // jshint ignore:line
     });
 });

--- a/test/unit/streaming.models.MetricsModel.js
+++ b/test/unit/streaming.models.MetricsModel.js
@@ -1,0 +1,22 @@
+import MetricsModel from '../../src/streaming/models/MetricsModel';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('MetricsModel', function () {
+    const context = {};
+    const metricsModel = MetricsModel(context).getInstance();
+
+    it('should return undefined when getMetricsFor is called and type is undefined', function () {
+        const metrics = metricsModel.getMetricsFor();
+
+        expect(metrics).to.be.undefined;                // jshint ignore:line
+    });
+
+    it('should return an empty MetricsList when getMetricsFor is called and type is defined', function () {
+        const metrics = metricsModel.getMetricsFor('video');
+
+        expect(metrics.TcpList).to.be.instanceOf(Array); // jshint ignore:line
+        expect(metrics.TcpList).to.be.empty; // jshint ignore:line
+    });
+});

--- a/test/unit/streaming.net.HTTPLoader.js
+++ b/test/unit/streaming.net.HTTPLoader.js
@@ -1,7 +1,7 @@
 import HTTPLoader from '../../src/streaming/net/HTTPLoader';
 import RequestModifier from '../../src/streaming/utils/RequestModifier';
 import ErrorHandler from '../../src/streaming/utils/ErrorHandler';
-import MetricsModel from '../../src/streaming/models/MetricsModel';
+import DashMetrics from '../../src/dash/DashMetrics';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
 import {
     HTTPRequest
@@ -15,7 +15,7 @@ const Stream = require('stream');
 const context = {};
 
 let errHandler;
-let metricsModel;
+let dashMetrics;
 let requestModifier;
 let mediaPlayerModelMock;
 let httpLoader;
@@ -25,7 +25,7 @@ describe('HTTPLoader', function () {
     beforeEach(function () {
         mediaPlayerModelMock = new MediaPlayerModelMock();
         errHandler = ErrorHandler(context).getInstance();
-        metricsModel = MetricsModel(context).getInstance();
+        dashMetrics = DashMetrics(context).getInstance();
         requestModifier = RequestModifier(context).getInstance();
     });
 
@@ -106,7 +106,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock,
             useFetch: true
@@ -127,7 +127,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock
         });
@@ -150,7 +150,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock
         });
@@ -173,7 +173,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock,
             useFetch: true
@@ -194,7 +194,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock,
             useFetch: true
@@ -222,7 +222,7 @@ describe('HTTPLoader', function () {
 
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock,
             useFetch: true
@@ -256,7 +256,7 @@ describe('HTTPLoader', function () {
         mediaPlayerModelMock.retryAttempts[HTTPRequest.MEDIA_SEGMENT_TYPE ] = 0;
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
-            metricsModel: metricsModel,
+            dashMetrics: dashMetrics,
             requestModifier: requestModifier,
             mediaPlayerModel: mediaPlayerModelMock,
             useFetch: true

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -60,7 +60,7 @@ describe('InsufficientBufferRule', function () {
         const rule = InsufficientBufferRule(context).create({
             dashMetrics: dashMetricsMock
         });
-        dashMetricsMock.setBufferState(bufferState);
+        dashMetricsMock.addBufferState('video', bufferState);
         let maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
     });
@@ -79,7 +79,7 @@ describe('InsufficientBufferRule', function () {
         const rule = InsufficientBufferRule(context).create({
             dashMetrics: dashMetricsMock
         });
-        dashMetricsMock.setBufferState(bufferState);
+        dashMetricsMock.addBufferState('video', bufferState);
         const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
     });
@@ -97,7 +97,7 @@ describe('InsufficientBufferRule', function () {
             getRepresentationInfo: function () { return representationInfo;}
         };
 
-        dashMetricsMock.setBufferState(bufferState);
+        dashMetricsMock.addBufferState('video', bufferState);
 
         const rule = InsufficientBufferRule(context).create({
             dashMetrics: dashMetricsMock
@@ -106,7 +106,7 @@ describe('InsufficientBufferRule', function () {
         rule.getMaxIndex(rulesContextMock);
 
         bufferState.state = 'bufferStalled';
-        dashMetricsMock.setBufferState(bufferState);
+        dashMetricsMock.addBufferState('video', bufferState);
         representationInfo.fragmentDuration = 4;
         const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(0);

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -32,13 +32,6 @@ describe('InsufficientBufferRule', function () {
 
     it('should return an empty switch request when bufferState is empty', function () {
         const dashMetricsMock = new DashMetricsMock();
-        const metricsModelMockWithEmptyBufferState = {
-            getMetricsFor: function () {
-                return {
-                    BufferState: []
-                };
-            }
-        };
         const rulesContextMock = {
             getMediaInfo: function () {},
             getMediaType: function () { return 'video'; },
@@ -46,7 +39,6 @@ describe('InsufficientBufferRule', function () {
             getRepresentationInfo: function () { return { fragmentDuration: 4 };}
         };
         const rule = InsufficientBufferRule(context).create({
-            metricsModel: metricsModelMockWithEmptyBufferState,
             dashMetrics: dashMetricsMock
         });
 
@@ -56,12 +48,8 @@ describe('InsufficientBufferRule', function () {
 
     it('should return an empty switch request when first call is done with a buffer in state bufferStalled', function () {
         const dashMetricsMock = new DashMetricsMock();
-        const metricsModelMockWithBufferState = {
-            getMetricsFor: function () {
-                return {
-                    BufferState: [{ state: 'bufferStalled' }]
-                };
-            }
+        let bufferState = {
+            state: 'bufferStalled'
         };
         const rulesContextMock = {
             getMediaInfo: function () {},
@@ -70,22 +58,17 @@ describe('InsufficientBufferRule', function () {
             getRepresentationInfo: function () { return { fragmentDuration: 4 };}
         };
         const rule = InsufficientBufferRule(context).create({
-            metricsModel: metricsModelMockWithBufferState,
             dashMetrics: dashMetricsMock
         });
-
+        dashMetricsMock.setBufferState(bufferState);
         let maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
     });
 
     it('should return an empty switch request when first call is done with a buffer in state bufferLoaded and fragmentDuration is NaN', function () {
         const dashMetricsMock = new DashMetricsMock();
-        const metricsModelMockWithBufferState = {
-            getMetricsFor: function () {
-                return {
-                    BufferState: [{ state: 'bufferLoaded' }]
-                };
-            }
+        let bufferState = {
+            state: 'bufferLoaded'
         };
         const rulesContextMock = {
             getMediaInfo: function () {},
@@ -94,10 +77,9 @@ describe('InsufficientBufferRule', function () {
             getRepresentationInfo: function () { return { fragmentDuration: NaN };}
         };
         const rule = InsufficientBufferRule(context).create({
-            metricsModel: metricsModelMockWithBufferState,
             dashMetrics: dashMetricsMock
         });
-
+        dashMetricsMock.setBufferState(bufferState);
         const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(SwitchRequest.NO_CHANGE);
     });
@@ -108,13 +90,6 @@ describe('InsufficientBufferRule', function () {
         };
         let representationInfo = { fragmentDuration: NaN };
         const dashMetricsMock = new DashMetricsMock();
-        const metricsModelMockBuffer = {
-            getMetricsFor: function () {
-                return {
-                    BufferState: [bufferState]
-                };
-            }
-        };
         const rulesContextMock = {
             getMediaInfo: function () {},
             getMediaType: function () { return 'video'; },
@@ -122,14 +97,16 @@ describe('InsufficientBufferRule', function () {
             getRepresentationInfo: function () { return representationInfo;}
         };
 
+        dashMetricsMock.setBufferState(bufferState);
+
         const rule = InsufficientBufferRule(context).create({
-            metricsModel: metricsModelMockBuffer,
             dashMetrics: dashMetricsMock
         });
 
         rule.getMaxIndex(rulesContextMock);
 
         bufferState.state = 'bufferStalled';
+        dashMetricsMock.setBufferState(bufferState);
         representationInfo.fragmentDuration = 4;
         const maxIndexRequest = rule.getMaxIndex(rulesContextMock);
         expect(maxIndexRequest.quality).to.be.equal(0);

--- a/test/unit/streaming.rules.abr.InsufficientBufferRule.js
+++ b/test/unit/streaming.rules.abr.InsufficientBufferRule.js
@@ -33,7 +33,7 @@ describe('InsufficientBufferRule', function () {
     it('should return an empty switch request when bufferState is empty', function () {
         const dashMetricsMock = new DashMetricsMock();
         const metricsModelMockWithEmptyBufferState = {
-            getReadOnlyMetricsFor: function () {
+            getMetricsFor: function () {
                 return {
                     BufferState: []
                 };
@@ -57,7 +57,7 @@ describe('InsufficientBufferRule', function () {
     it('should return an empty switch request when first call is done with a buffer in state bufferStalled', function () {
         const dashMetricsMock = new DashMetricsMock();
         const metricsModelMockWithBufferState = {
-            getReadOnlyMetricsFor: function () {
+            getMetricsFor: function () {
                 return {
                     BufferState: [{ state: 'bufferStalled' }]
                 };
@@ -81,7 +81,7 @@ describe('InsufficientBufferRule', function () {
     it('should return an empty switch request when first call is done with a buffer in state bufferLoaded and fragmentDuration is NaN', function () {
         const dashMetricsMock = new DashMetricsMock();
         const metricsModelMockWithBufferState = {
-            getReadOnlyMetricsFor: function () {
+            getMetricsFor: function () {
                 return {
                     BufferState: [{ state: 'bufferLoaded' }]
                 };
@@ -109,7 +109,7 @@ describe('InsufficientBufferRule', function () {
         let representationInfo = { fragmentDuration: NaN };
         const dashMetricsMock = new DashMetricsMock();
         const metricsModelMockBuffer = {
-            getReadOnlyMetricsFor: function () {
+            getMetricsFor: function () {
                 return {
                     BufferState: [bufferState]
                 };


### PR DESCRIPTION
Hi,

this refactoring branch has to set DashMetrics as a controller of MetricsModel. By doing it, all classes that have to get or set metrics will only take a reference of DashMetrics.

So, MetricsModel is created in DashMetrics class.

A first version of MetricsModel unit test has been also added.

Nico