### PR TITLE
Regression bug fix

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -533,8 +533,7 @@ function ScheduleController(config) {
         if (streamInfo) {
             if (e.unintended) {
                 // There was an unintended buffer remove, probably creating a gap in the buffer, remove every saved request
-                fragmentModel.removeExecutedRequestsAfterTime(e.from,
-                    streamInfo.duration);
+                fragmentModel.removeExecutedRequestsAfterTime(e.from);
             } else {
                 fragmentModel.syncExecutedRequestsWithBufferedRange(
                     streamProcessor.getBufferController().getBuffer().getAllBufferRanges(),

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -162,7 +162,7 @@ function FragmentModel(config) {
 
     function removeExecutedRequestsAfterTime(time) {
         executedRequests = executedRequests.filter(req => {
-            return isNaN(req.startTime) || (time !== undefined ? req.startTime + req.duration < time : false);
+            return isNaN(req.startTime) || (time !== undefined ? req.startTime < time : false);
         });
     }
 


### PR DESCRIPTION
Hi,

this PR has to solve issue #2937 by removing requests after a specific time only if the start time is less than this specific time.
In this issue, when the stream is reloaded the same request(audio or video) is downloaded, pushed and finally removed in an infinite loop.

@richardbushell, could you, please, take a look at this PR? Thanks

Nico