### PR TITLE
Add possibility to filter and reorder key systems prioritization order at application level

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ declare namespace dashjs {
         setProtectionData(protData: ProtectionData): void;
         getSupportedKeySystemsFromContentProtection(cps: any[]): SupportedKeySystem[];
         getKeySystems(): KeySystem[];
+        setKeySystems(keySystems: KeySystem[]);
         stop(): void;
         reset(): void;
     }

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -754,6 +754,12 @@ function ProtectionController(config) {
         return protectionKeyController ? protectionKeyController.getKeySystems() : [];
     }
 
+    function setKeySystems(keySystems) {
+        if (protectionKeyController) {
+            protectionKeyController.setKeySystems(keySystems);
+        }
+    }
+
     instance = {
         initializeForMedia: initializeForMedia,
         createKeySession: createKeySession,
@@ -767,6 +773,7 @@ function ProtectionController(config) {
         setProtectionData: setProtectionData,
         getSupportedKeySystemsFromContentProtection: getSupportedKeySystemsFromContentProtection,
         getKeySystems: getKeySystems,
+        setKeySystems: setKeySystems,
         stop: stop,
         reset: reset
     };

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -107,6 +107,19 @@ function ProtectionKeyController() {
     }
 
     /**
+     * Sets the prioritized list of key systems to be supported
+     * by this player.
+     *
+     * @param {Array.<KeySystem>} newKeySystems the new prioritized
+     * list of key systems
+     * @memberof module:ProtectionKeyController
+     * @instance
+     */
+    function setKeySystems(newKeySystems) {
+        keySystems = newKeySystems;
+    }
+
+    /**
      * Returns the key system associated with the given key system string
      * name (i.e. 'org.w3.clearkey')
      *
@@ -330,6 +343,7 @@ function ProtectionKeyController() {
         isClearKey: isClearKey,
         initDataEquals: initDataEquals,
         getKeySystems: getKeySystems,
+        setKeySystems: setKeySystems,
         getKeySystemBySystemString: getKeySystemBySystemString,
         getSupportedKeySystemsFromContentProtection: getSupportedKeySystemsFromContentProtection,
         getSupportedKeySystems: getSupportedKeySystems,

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -195,19 +195,13 @@ function ProtectionKeyController() {
                     if (cp.schemeIdUri.toLowerCase() === ks.schemeIdURI) {
                         // Look for DRM-specific ContentProtection
                         let initData = ks.getInitData(cp);
-                        if (!!initData) {
-                            supportedKS.push({
-                                ks: keySystems[ksIdx],
-                                initData: initData,
-                                cdmData: ks.getCDMData(),
-                                sessionId: ks.getSessionId(cp)
-                            });
-                        } else if (this.isClearKey(ks)) {
-                            supportedKS.push({
-                                ks: ks,
-                                initData: null
-                            });
-                        }
+
+                        supportedKS.push({
+                            ks: keySystems[ksIdx],
+                            initData: initData,
+                            cdmData: ks.getCDMData(),
+                            sessionId: ks.getSessionId(cp)
+                        });
                     }
                 }
             }


### PR DESCRIPTION
This PR:
- adds a method to the ProtectionController to enable filtering and reorder key systems prioritization at application level
- reverts PR #2770 and then PR #2318 by considering all key systems declared in mpd (even if no pssh is provided)

This PR follows the conversation we have in issue #2249.
Then with the help of this PR, ClearKey protected content mentionned in #2249 can be supported by dash.js if we do explicitely consider only ClearKey key systems at application level.

This could be achieved this way:

```
    var keySystems = player.getProtectionController().getKeySystems();
    keySystems = keySystems.filter(keySystem => {
        return (keySystem.systemString.indexOf('clearkey') > 0);
    });
    player.getProtectionController().setKeySystems(keySystems);
```

@JohnIball and @Murmur could you try this PR on your side and check that works with your streams.
