### PR TITLE
Audio Bug fix

### DIFF
--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -486,7 +486,7 @@ function DashMetrics(config) {
     }
 
     function pushPlayListTraceMetrics(endTime, reason) {
-        if (playListTraceMetricsClosed === false && playListMetrics && playListTraceMetrics) {
+        if (playListTraceMetricsClosed === false && playListMetrics && playListTraceMetrics && playListTraceMetrics.start) {
             const startTime = playListTraceMetrics.start;
             const duration = endTime.getTime() - startTime.getTime();
             playListTraceMetrics.duration = duration;

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -338,16 +338,16 @@ function Stream(config) {
 
     function onCurrentTrackChanged(e) {
         if (e.newMediaInfo.streamInfo.id !== streamInfo.id) return;
+        let mediaInfo = e.newMediaInfo;
+        let manifest = manifestModel.getValue();
+
+        adapter.setCurrentMediaInfo(streamInfo.id, mediaInfo.type, mediaInfo);
 
         let processor = getProcessorForMediaInfo(e.newMediaInfo);
         if (!processor) return;
 
         let currentTime = playbackController.getTime();
         logger.info('Stream -  Process track changed at current time ' + currentTime);
-        let mediaInfo = e.newMediaInfo;
-        let manifest = manifestModel.getValue();
-
-        adapter.setCurrentMediaInfo(streamInfo.id, mediaInfo.type, mediaInfo);
 
         logger.debug('Stream -  Update stream controller');
         if (manifest.refreshManifestOnSwitchTrack) {


### PR DESCRIPTION
Hi,

this PR has to solve regression #2966 introduced by myself in PR #2881. This previous PR aimed to remove dependancy between dashAdapter and MediaController. The problem is that the first selected track is not set by function setCurrentMediaInfo because processors are not created at this specific time.

There is still an issue after this new PR that refer to issue #2970.... :-(

@sgadrat-anevia, could you, please, take a look at this PR?

Thanks,
Nico