### PR TITLE
Fix seeking issue

### DIFF
--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -146,6 +146,10 @@ function PreBufferSink(onAppendedCallback) {
         return chunks.filter( a => ((isNaN(end) || a.start < end) && (isNaN(start) || a.end > start)) );
     }
 
+    function waitForUpdateEnd(callback) {
+        callback();
+    }
+
     instance = {
         getAllBufferRanges: getAllBufferRanges,
         append: append,
@@ -154,7 +158,8 @@ function PreBufferSink(onAppendedCallback) {
         discharge: discharge,
         reset: reset,
         updateTimestampOffset: updateTimestampOffset,
-        hasDiscontinuitiesAfter: hasDiscontinuitiesAfter
+        hasDiscontinuitiesAfter: hasDiscontinuitiesAfter,
+        waitForUpdateEnd: waitForUpdateEnd
     };
 
     setup();

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -167,13 +167,13 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         }
         appendQueue.push(chunk);
         if (!isAppendingInProgress) {
-            waitForUpdateEnd(buffer, appendNextInQueue.bind(this));
+            waitForUpdateEnd(appendNextInQueue.bind(this));
         }
     }
 
     function updateTimestampOffset(MSETimeOffset) {
         if (buffer.timestampOffset !== MSETimeOffset && !isNaN(MSETimeOffset)) {
-            waitForUpdateEnd(buffer, () => {
+            waitForUpdateEnd(() => {
                 buffer.timestampOffset = MSETimeOffset;
             });
         }
@@ -182,13 +182,13 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
     function remove(start, end, forceRemoval) {
         const sourceBufferSink = this;
         // make sure that the given time range is correct. Otherwise we will get InvalidAccessError
-        waitForUpdateEnd(buffer, function () {
+        waitForUpdateEnd(function () {
             try {
                 if ((start >= 0) && (end > start) && (forceRemoval || mediaSource.readyState !== 'ended')) {
                     buffer.remove(start, end);
                 }
                 // updating is in progress, we should wait for it to complete before signaling that this operation is done
-                waitForUpdateEnd(buffer, function () {
+                waitForUpdateEnd(function () {
                     eventBus.trigger(Events.SOURCEBUFFER_REMOVE_COMPLETED, {
                         buffer: sourceBufferSink,
                         from: start,
@@ -243,7 +243,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
                         buffer.append(nextChunk.bytes, nextChunk);
                     }
                     // updating is in progress, we should wait for it to complete before signaling that this operation is done
-                    waitForUpdateEnd(buffer, afterSuccess.bind(this));
+                    waitForUpdateEnd(afterSuccess.bind(this));
                 }
             } catch (err) {
                 logger.fatal('SourceBuffer append failed "' + err + '"');
@@ -304,7 +304,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         if (callbacks.length > 0) {
             const cb = callbacks.shift();
             if (buffer.updating) {
-                waitForUpdateEnd(buffer, cb);
+                waitForUpdateEnd(cb);
             } else {
                 cb();
                 // Try to execute next callback if still not updating
@@ -330,7 +330,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         logger.error('SourceBufferSink error', mediaInfo.type);
     }
 
-    function waitForUpdateEnd(buffer, callback) {
+    function waitForUpdateEnd(callback) {
         callbacks.push(callback);
 
         if (!buffer.updating) {
@@ -346,7 +346,8 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, oldBuffer)
         abort: abort,
         reset: reset,
         updateTimestampOffset: updateTimestampOffset,
-        hasDiscontinuitiesAfter: hasDiscontinuitiesAfter
+        hasDiscontinuitiesAfter: hasDiscontinuitiesAfter,
+        waitForUpdateEnd: waitForUpdateEnd
     };
 
     setup();

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -336,6 +336,7 @@ function BufferController(config) {
             lastIndex = Number.POSITIVE_INFINITY;
         }
         if (type !== Constants.FRAGMENTED_TEXT) {
+            // remove buffer after seeking operations
             pruneAllSafely();
         } else {
             onPlaybackProgression();


### PR DESCRIPTION
In BufferController, when seeking, a segment may being appended into the buffer.
Therefore if we do prune the buffer before the current segment appending process is completed, then the range to be removed is erroneous (does not take into account current segment being appended).
This can have side effects and leads to playback freeze.
On some devices, appending process can take a relatively long time and can more easily highlight this issue.

This PR attempts to fix this issue by waiting for segment appending process to be completed before pruning the buffer at seeking.