### PR TITLE
Stop EventController

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -219,6 +219,8 @@ function Stream(config) {
 
     function reset() {
 
+        stopEventController();
+
         if (playbackController) {
             playbackController.pause();
         }


### PR DESCRIPTION
When stopping a stream, the event controller (and thus its timer) is never stopped.
Thus, we do create as many timers (with a 100ms interval) as loaded streams.

This PR fixes this issue.