### PR TITLE
preload regression fix

### DIFF
--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -121,6 +121,10 @@ function PreBufferSink(onAppendedCallback) {
         // Nothing to do
     }
 
+    function getBuffer() {
+        return this;
+    }
+
     /**
      * Return the all chunks in the buffer the lie between times start and end.
      * Because a chunk cannot be split, this returns the full chunk if any part of its time lies in the requested range.
@@ -159,7 +163,8 @@ function PreBufferSink(onAppendedCallback) {
         reset: reset,
         updateTimestampOffset: updateTimestampOffset,
         hasDiscontinuitiesAfter: hasDiscontinuitiesAfter,
-        waitForUpdateEnd: waitForUpdateEnd
+        waitForUpdateEnd: waitForUpdateEnd,
+        getBuffer: getBuffer
     };
 
     setup();

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -505,7 +505,7 @@ function Stream(config) {
         filterCodecs(Constants.VIDEO);
         filterCodecs(Constants.AUDIO);
 
-        if (element === null || (element && (/^VIDEO$/i).test(element.nodeName))) {
+        if (!element || (element && (/^VIDEO$/i).test(element.nodeName))) {
             initializeMediaForType(Constants.VIDEO, mediaSource);
         }
         initializeMediaForType(Constants.AUDIO, mediaSource);


### PR DESCRIPTION
Hi,

this PR has to solve a regression of preload mode. The main issue was that getBuffer function was not defined in PreBufferSink class. The second one was that the video StreamProcessor wasn't created because video element is undefined in this use case.

So, it solves issue #2984. @bknill, could you, please, take a look at it?

Nico