### PR TITLE
Fix annoying typings error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -158,7 +158,7 @@ declare namespace dashjs {
         setMaxAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedBitrateFor(type: 'video' | 'audio'): number;
         getTopBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
-        setMinAllowedBitrateFor(type: 'video' | 'audio', value: number);
+        setMinAllowedBitrateFor(type: 'video' | 'audio', value: number): void;
         getMinAllowedBitrateFor(type: 'video' | 'audio'): number;
         setMaxAllowedRepresentationRatioFor(type: 'video' | 'audio', value: number): void;
         getMaxAllowedRepresentationRatioFor(type: 'video' | 'audio'): number;


### PR DESCRIPTION
Error message: `'setMinAllowedBitrateFor', which lacks return-type annotation, implicitly has an 'any' return type.`

Related issue: #2918 also please check @raskri last comment