### PR TITLE
Fix cleaning of caption divs

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -445,6 +445,7 @@ function TextTracks() {
                             if (divs[i].id === this.cueID) {
                                 logger.debug('Cue exit id:' + divs[i].id);
                                 captionContainer.removeChild(divs[i]);
+                                --i;
                             }
                         }
                     }


### PR DESCRIPTION
When resizing the player while captions are rendered, it may occur that two DIV elements with the same ID are rendered at the same time. Both contain the same caption/text but one is for the previous player size and the other one for the new player size. The `cue.onexit()` method should remove all child nodes having a given cueID but the for loop used to remove those child nodes does not adjust the index variable when an element with this given ID is found and removed. As a result, the next child node is skipped. This PR is for a small patch that fixes the issue.