### PR TITLE
Fix ABR controller if min allowed bitrate is set

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -579,9 +579,18 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
 
         const initBitrate = parseInt($scope.initialVideoBitrate);
         if (!isNaN(initBitrate)) {
-            config.abr = {
+            config.streaming.abr = {
                 'initialBitrate': {
                     'video': initBitrate
+                }
+            }
+        }
+
+        const minBitrate = parseInt($scope.minVideoBitrate);
+        if (!isNaN(minBitrate)) {
+            config.streaming.abr = {
+                'minBitrate': {
+                    'video': minBitrate
                 }
             }
         }

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -595,6 +595,14 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
             }
         }
 
+        const maxBitrate = parseInt($scope.maxVideoBitrate);
+        if (!isNaN(maxBitrate)) {
+            config.streaming.abr = {
+                'maxBitrate': {
+                    'video': maxBitrate
+                }
+            }
+        }        
         $scope.player.updateSettings(config);
 
         $scope.controlbar.reset();

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -233,6 +233,8 @@
                     <input type="text" class="form-control" placeholder="value in kbps" ng-model="initialVideoBitrate">
                     <label class="options-label">Minimum bitrate Video:</label>
                     <input type="text" class="form-control" placeholder="value in kbps" ng-model="minVideoBitrate">
+                    <label class="options-label">Maximum bitrate Video:</label>
+                    <input type="text" class="form-control" placeholder="value in kbps" ng-model="maxVideoBitrate">
                     <label class="options-label">Audio:</label>
                     <input type="text" class="form-control" placeholder="audio initial lang, e.g. 'en'" ng-model="initialSettings.audio">
                     <label class="options-label">Video:</label>

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -231,6 +231,8 @@
                 <div class="options-item-body">
                     <label class="options-label">Initial bitrate Video:</label>
                     <input type="text" class="form-control" placeholder="value in kbps" ng-model="initialVideoBitrate">
+                    <label class="options-label">Minimum bitrate Video:</label>
+                    <input type="text" class="form-control" placeholder="value in kbps" ng-model="minVideoBitrate">
                     <label class="options-label">Audio:</label>
                     <input type="text" class="form-control" placeholder="audio initial lang, e.g. 'en'" ng-model="initialSettings.audio">
                     <label class="options-label">Video:</label>

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -332,7 +332,7 @@ function AbrController() {
                 const topQualityIdx = getTopQualityIndexFor(type, streamId);
                 const switchRequest = abrRulesCollection.getMaxQuality(rulesContext);
                 let newQuality = switchRequest.quality;
-                if (minIdx !== undefined && newQuality < minIdx) {
+                if (minIdx !== undefined && ((newQuality > SwitchRequest.NO_CHANGE) ? newQuality : oldQuality) < minIdx) {
                     newQuality = minIdx;
                 }
                 if (newQuality > topQualityIdx) {


### PR DESCRIPTION
Before the fix:
- set min allowed bitrate on player, for example 500kb/s
- start a new stream
- ABR controller selects highest quality as initial bitrate, for example 2Mb/s, since previous bitrate stored in local storage is high

=> then at first pass in ABR controller before downloading 1st video segment:
- no rule is applied
- a switch request with NO_CHANGE quality (=-1) is applied
- this quality (-1) is compared to min allowed quality
- since -1 < min allowed quality, min allowed quality is selected instead of highest quality

This PR fixes this issue.

Additionnaly, this PR adds the possibility to set min and max video bitrate in the options of the dash-if-reference-player sample webapp.
And it fixes also the assignement of ABR settings in the webapp. 