### PR TITLE
Stop the player from streaming past the availability range

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -72,7 +72,7 @@ function DashHandler(config) {
         logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
-        segmentsController = SegmentsController(context).create(config, isDynamic());
+        segmentsController = SegmentsController(context).create(config);
 
         eventBus.on(Events.INITIALIZATION_LOADED, onInitializationLoaded, instance);
         eventBus.on(Events.SEGMENTS_LOADED, onSegmentsLoaded, instance);
@@ -81,7 +81,7 @@ function DashHandler(config) {
     function initialize(StreamProcessor) {
         streamProcessor = StreamProcessor;
 
-        segmentsController.initialize();
+        segmentsController.initialize(isDynamic());
     }
 
     function getType() {

--- a/src/dash/controllers/SegmentsController.js
+++ b/src/dash/controllers/SegmentsController.js
@@ -39,7 +39,7 @@ import SegmentBaseLoader from '../SegmentBaseLoader';
 import WebmSegmentBaseLoader from '../WebmSegmentBaseLoader';
 
 
-function SegmentsController(config, isDynamic) {
+function SegmentsController(config) {
     config = config || {};
 
     const context = this.context;
@@ -55,10 +55,6 @@ function SegmentsController(config, isDynamic) {
 
     function setup() {
         getters = {};
-        getters[DashConstants.SEGMENT_TIMELINE] = TimelineSegmentsGetter(context).create(config, isDynamic);
-        getters[DashConstants.SEGMENT_TEMPLATE] = TemplateSegmentsGetter(context).create(config, isDynamic);
-        getters[DashConstants.SEGMENT_LIST] = ListSegmentsGetter(context).create(config, isDynamic);
-        getters[DashConstants.SEGMENT_BASE] = SegmentBaseGetter(context).create(config, isDynamic);
 
         segmentBaseLoader = isWebM(config.mimeType) ? WebmSegmentBaseLoader(context).getInstance() : SegmentBaseLoader(context).getInstance();
         segmentBaseLoader.setConfig({
@@ -74,8 +70,13 @@ function SegmentsController(config, isDynamic) {
         return 'webm' === type.toLowerCase();
     }
 
-    function initialize() {
+    function initialize(isDynamic) {
         segmentBaseLoader.initialize();
+
+        getters[DashConstants.SEGMENT_TIMELINE] = TimelineSegmentsGetter(context).create(config, isDynamic);
+        getters[DashConstants.SEGMENT_TEMPLATE] = TemplateSegmentsGetter(context).create(config, isDynamic);
+        getters[DashConstants.SEGMENT_LIST] = ListSegmentsGetter(context).create(config, isDynamic);
+        getters[DashConstants.SEGMENT_BASE] = SegmentBaseGetter(context).create(config, isDynamic);
     }
 
     function update(voRepresentation, type, hasInitialization, hasSegments) {


### PR DESCRIPTION
In DashHandler.setup(), StreamProcessor isn't available, so isDynamic() returns null.

This means the getters in segmentController were being generated with isDynamic set to null, so they would act as though the manifest was static and take the segment availablility as being the same as the manifest availablility.
https://github.com/Dash-Industry-Forum/dash.js/blob/18647a32064feec61ca33438eb16bfb0319232a4/src/dash/controllers/SegmentsController.js#L58

This fixes the problem by moving the isDynamic() call to initialize instead.

This is a fix for #3008 
