### PR TITLE
Fragmented text bug fix

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -359,7 +359,7 @@ function Stream(config) {
                 processor.switchTrackAsked();
                 processor.getFragmentModel().abortRequests();
             } else {
-                processor.getScheduleController().setSeekTarget(NaN);
+                processor.getScheduleController().setSeekTarget(currentTime);
                 processor.setIndexHandlerTime(currentTime);
                 processor.resetIndexHandler();
             }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -40,6 +40,7 @@ import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import MediaController from './MediaController';
+import MetricsConstants from '../constants/MetricsConstants';
 
 function ScheduleController(config) {
 
@@ -254,7 +255,14 @@ function ScheduleController(config) {
         // Validate that the fragment request executed and appended into the source buffer is as
         // good of quality as the current quality and is the correct media track.
         const time = playbackController.getTime();
-        const safeBufferLevel = currentRepresentationInfo.fragmentDuration * 1.5;
+        let safeBufferLevel = 1.5;
+
+        if (isNaN(currentRepresentationInfo.fragmentDuration)) { //fragmentDuration of representationInfo is not defined,
+            // call metrics function to have data in the latest scheduling info...
+            // if no metric, returns 0. In this case, rule will return false.
+            const bufferInfo = dashMetrics.getLatestBufferInfoVO(Constants.FRAGMENTED_TEXT, true, MetricsConstants.SCHEDULING_INFO);
+            safeBufferLevel = bufferInfo ? bufferInfo.duration * 1.5 : 1.5;
+        }
         const request = fragmentModel.getRequests({
             state: FragmentModel.FRAGMENT_MODEL_EXECUTED,
             time: time + safeBufferLevel,


### PR DESCRIPTION
Hi,

this PR has to solve two different issues about the management of fragmented subtitles. First issue can be reproduced by loading the stream https://livesim.dashif.org/dash/vod/testpic_2s/multi_subs.mpd. If the user seeks to a random position, and then change the language of the selected subtitle track, dash.js was downloading all the segments of the new track from the begining not from the current time.
Second issue can also be reproduced, with Prince of Persia MSS stream. The user can't switch between two subtitles languages.

Nico
