### PR TITLE
Error on setMediaDuration when mediasource readyState != 'open'

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -520,7 +520,7 @@ function StreamController() {
 
         function onMediaSourceOpen() {
             // Manage situations in which a call to reset happens while MediaSource is being opened
-            if (!mediaSource) return;
+            if (!mediaSource || mediaSource.readyState != 'open') return;
 
             logger.debug('MediaSource is open!');
             window.URL.revokeObjectURL(sourceUrl);


### PR DESCRIPTION
Fix for bug where StreamController.reset() is called but event handler is called after the reset and mediasource.readystate is no longer open.

Playback fails with:
Uncaught DOMException: Failed to set the 'duration' property on 'MediaSource': The MediaSource's readyState is not 'open'
