### PR TITLE
Seek value bug fix

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -244,6 +244,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         // seeking
         var mouseTime = calculateTimeByEvent(event);
         if (!isNaN(mouseTime)) {
+            mouseTime = mouseTime < 0 ? 0 : mouseTime;
             player.seek(mouseTime);
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -154,11 +154,11 @@ function PlaybackController() {
                 }
             } else {
                 eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
-                logger.info('Requesting seek to time: ' + time);
                 let initialStartTime = getStreamStartTime(false);
                 if (!isDynamic && time < initialStartTime) {
                     time = initialStartTime;
                 }
+                logger.info('Requesting seek to time: ' + time);
                 videoModel.setCurrentTime(time, stickToBuffered);
             }
         }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -155,6 +155,10 @@ function PlaybackController() {
             } else {
                 eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
                 logger.info('Requesting seek to time: ' + time);
+                let initialStartTime = getStreamStartTime(false);
+                if (!isDynamic && time < initialStartTime) {
+                    time = initialStartTime;
+                }
                 videoModel.setCurrentTime(time, stickToBuffered);
             }
         }


### PR DESCRIPTION
Hi,

this PR has to add a workaround to issue #3042. For static stream use case, if the user wants to seek to a time before the common earliest time (Audio and Video), the seek value will be replaced by this common time.

@tomraut , could you, please, take a look?

Nico