### PR TITLE
Events with a presentationTime in the past are now removed.

### DIFF
--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -232,6 +232,9 @@ function EventController() {
                         }
                         delete events[eventId];
                     }
+                    else if (presentationTime <= currentVideoTime - presentationTimeThreshold) {
+                        delete events[eventId];
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi,

This is a fix for an issue where the array of pending media events would at no point remove events with a start time (presentation time) in the past. If an event stuck in this state repeats (for example with a looping pseudo-live MPEG-DASH stream) then future instances of this event would be discarded without being triggered.

Joe