### PR TITLE
[MSS] Auto buffers length configuration for live streams

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -939,23 +939,7 @@
         },
         {
           "url": "http://2is7server2.rd.francetelecom.com/hasplayer/LIVE_1.isml/manifest",
-          "name": "Prince Of Persia - Live",
-          "bufferConfig" : {
-            "liveDelay": 16,
-            "stableBufferTime": 16,
-            "bufferTimeAtTopQuality": 16,
-            "bufferTimeAtTopQualityLongForm": 16
-          }
-        },
-        {
-          "url": "http://2is7server1.rd.francetelecom.com/C4/C4-50_TVApp2.isml/Manifest",
-          "name": "Arte (subtitles)",
-          "bufferConfig" : {
-            "liveDelay": 16,
-            "stableBufferTime": 16,
-            "bufferTimeAtTopQuality": 16,
-            "bufferTimeAtTopQualityLongForm": 16
-          }
+          "name": "Prince Of Persia - Live"
         },
         {
           "url": "http://2is7server1.rd.francetelecom.com/VOD/BBB-SD/big_buck_bunny_1080p_stereo.ism/Manifest",

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -40,6 +40,7 @@ function MssParser(config) {
     const debug = config.debug;
     const constants = config.constants;
     const manifestModel = config.manifestModel;
+    const mediaPlayerModel = config.mediaPlayerModel;
 
     const DEFAULT_TIME_SCALE = 10000000.0;
     const SUPPORTED_CODECS = ['AAC', 'AACL', 'AVC1', 'H264', 'TTML', 'DFXP'];
@@ -74,13 +75,11 @@ function MssParser(config) {
     };
 
     let instance,
-        logger,
-        mediaPlayerModel;
+        logger;
 
 
     function setup() {
         logger = debug.getLogger(instance);
-        mediaPlayerModel = config.mediaPlayerModel;
     }
 
     function mapPeriod(smoothStreamingMedia, timescale) {
@@ -581,6 +580,7 @@ function MssParser(config) {
             startTime,
             segments,
             timescale,
+            segmentDuration,
             i, j;
 
         // Set manifest node properties
@@ -668,8 +668,10 @@ function MssParser(config) {
             }
 
             if (adaptations[i].contentType === 'video') {
+                // Get video segment duration
+                segmentDuration = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray[0].d / adaptations[i].SegmentTemplate.timescale;
                 // Set minBufferTime
-                manifest.minBufferTime = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray[0].d / adaptations[i].SegmentTemplate.timescale * 2;
+                manifest.minBufferTime = segmentDuration * 2;
 
                 if (manifest.type === 'dynamic' ) {
                     // Set availabilityStartTime
@@ -687,8 +689,25 @@ function MssParser(config) {
             }
         }
 
-        if (manifest.timeShiftBufferDepth < manifest.minBufferTime) {
-            manifest.minBufferTime = manifest.timeShiftBufferDepth;
+        // Cap minBufferTime to timeShiftBufferDepth
+        manifest.minBufferTime = Math.min(manifest.minBufferTime, manifest.timeShiftBufferDepth);
+
+        // In case of live streams:
+        // 1- configure player buffering properties according to target live delay
+        // 2- adapt live delay and then buffers length in case timeShiftBufferDepth is too small compared to target live delay (see PlaybackController.computeLiveDelay())
+        if (manifest.type === 'dynamic') {
+            let targetLiveDelay = mediaPlayerModel.getLiveDelay();
+            if (!targetLiveDelay) {
+                targetLiveDelay = segmentDuration * mediaPlayerModel.getLiveDelayFragmentCount();
+            }
+            let targetDelayCapping = Math.max(manifest.timeShiftBufferDepth - 10/*END_OF_PLAYLIST_PADDING*/, manifest.timeShiftBufferDepth / 2);
+            let liveDelay = Math.min(targetDelayCapping, targetLiveDelay);
+            mediaPlayerModel.setLiveDelay(liveDelay);
+            // Consider a margin of one segment in order to avoid Precondition Failed errors (412), for example if audio and video are not correctly synchronized
+            let bufferTime = liveDelay - segmentDuration;
+            mediaPlayerModel.setStableBufferTime(bufferTime);
+            mediaPlayerModel.setBufferTimeAtTopQuality(bufferTime);
+            mediaPlayerModel.setBufferTimeAtTopQualityLongForm(bufferTime);
         }
 
         // Delete Content Protection under root manifest node


### PR DESCRIPTION
This PR integrates automatic buffers configuration according to live delay for MSS live streams, thus avoiding Precondition failed (412) errors.
Thanks to this PR you do not need anymore to provide live delay and buffes length configuration when loading a live MSS stream, except if you want a live delay different from default one (= segment duration x 4)