### PR TITLE
Update getSegmentByIndex function in TimelineSegmentsGetter class

### DIFF
--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -137,11 +137,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
         let found = false;
 
         iterateSegments(representation, function (time, scaledTime, base, list, frag, fTimescale, availabilityIdx, i) {
-            // In some cases when requiredMediaTime = actual end time of the last segment
-            // it is possible that this time a bit exceeds the declared end time of the last segment.
-            // in this case we still need to include the last segment in the segment list. to do this we
-            // use a correction factor = 1.5. This number is used because the largest possible deviation is
-            // is 50% of segment duration.
             if (found || lastSegmentTime < 0) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;
@@ -164,7 +159,8 @@ function TimelineSegmentsGetter(config, isDynamic) {
                     frag.tManifest);
 
                 return true;
-            } else if (scaledTime >= lastSegmentTime - 0.5) {
+            } else if (scaledTime >= lastSegmentTime - frag.d * 0.5 / fTimescale) { // same logic, if deviation is
+                // 50% of segment duration, segment is found if scaledTime is greater than or equal to (startTime of previous segment - half of the previous segment duration)
                 found = true;
             }
 
@@ -193,7 +189,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
             // it is possible that this time a bit exceeds the declared end time of the last segment.
             // in this case we still need to include the last segment in the segment list. to do this we
             // use a correction factor = 1.5. This number is used because the largest possible deviation is
-            // is 50% of segment duration.
+            // 50% of segment duration.
             if (scaledTime >= (requiredMediaTime - (frag.d / fTimescale) * 1.5)) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;


### PR DESCRIPTION
Hi,

this PR has to solve issue #3056. The static stream (SegmentTimeline) has segments duration less than 0.5 second. So, the function getSegmentByIndex can't use 0.5 value to detect segment index : an infinite loop is started in this case.

@jeffcunat and I propose to replace the value 0.5 by half the duration of the previous segment (largest possible deviation is 50% of segment duration).

@sinjuice, could you, please, take a look at this PR?

Thanks,

Nico