### PR TITLE
Clean out embedded subs with the video buffer pruning

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -587,7 +587,12 @@ function TextSourceBuffer() {
     }
 
     function onVideoBufferCleared(e) {
-        textTracks.deleteCuesFromTrackIdx(textTracks.getCurrentTrackIdx(), e.from, e.to);
+        [Constants.CC1, Constants.CC3].forEach(function (id) {
+            const trackIdx = textTracks.getTrackIdxForId(id);
+            if (trackIdx >= 0) {
+                textTracks.deleteCuesFromTrackIdx(trackIdx, e.from, e.to);
+            }
+        });
     }
 
     instance = {

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -587,8 +587,8 @@ function TextSourceBuffer() {
     }
 
     function onVideoBufferCleared(e) {
-        [Constants.CC1, Constants.CC3].forEach(function (id) {
-            const trackIdx = textTracks.getTrackIdxForId(id);
+        embeddedTracks.forEach(function (track) {
+            const trackIdx = textTracks.getTrackIdxForId(track.id);
             if (trackIdx >= 0) {
                 textTracks.deleteCuesFromTrackIdx(trackIdx, e.from, e.to);
             }

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -544,7 +544,7 @@ function TextTracks() {
     }
 
     function cueInRange(cue, start, end) {
-        return (cue.startTime >= start || isNaN(start)) && (cue.endTime <= end || isNaN(end));
+        return (isNaN(start) || cue.startTime >= start) && (isNaN(end) || cue.endTime <= end);
     }
 
     function deleteTrackCues(track, start, end) {

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -543,21 +543,27 @@ function TextTracks() {
         }
     }
 
-    function deleteTrackCues(track) {
+    function cueInRange(cue, start, end) {
+        return (cue.startTime >= start || isNaN(start)) && (cue.endTime <= end || isNaN(end));
+    }
+
+    function deleteTrackCues(track, start, end) {
         if (track.cues) {
             const cues = track.cues;
             const lastIdx = cues.length - 1;
 
             for (let r = lastIdx; r >= 0 ; r--) {
-                track.removeCue(cues[r]);
+                if (cueInRange(cues[r], start, end)) {
+                    track.removeCue(cues[r]);
+                }
             }
         }
     }
 
-    function deleteCuesFromTrackIdx(trackIdx) {
+    function deleteCuesFromTrackIdx(trackIdx, start, end) {
         const track = getTrackByIdx(trackIdx);
         if (track) {
-            deleteTrackCues(track);
+            deleteTrackCues(track, start, end);
         }
     }
 


### PR DESCRIPTION
Fix for #3054 - Subs use up all memory

When the embedded subs are added there's no method to clear them out again. If you run a stream like the one on 3054 you can have a lot of subs in the text track, and if on Edge, there's a corresponding htmlElement for each one.

This PR watches for buffer cleared events and clears out any embedded subs between those times to keep the list small.