### PR TITLE
[MSS] use new settings system for MSSParser buffer  configuration

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1972,7 +1972,8 @@ function MediaPlayer() {
                 debug: debug,
                 initSegmentType: HTTPRequest.INIT_SEGMENT_TYPE,
                 BASE64: BASE64,
-                ISOBoxer: ISOBoxer
+                ISOBoxer: ISOBoxer,
+                settings: settings
             });
         }
     }


### PR DESCRIPTION
fix problem related to #3051 
Old settings configuration was wrongly used instead of the new v3 settings configuration system