### PR TITLE
Fix sourcemaps not including sources anymore

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,9 +27,10 @@ module.exports = function (grunt) {
         uglify: {
             options: {
                 banner: '/*! v<%= pkg.version %>-<%= githash.dist.short %>, <%= grunt.template.today("isoUtcDateTime") %> */',
-                sourceMap: true,
-                sourceMapIncludeSources: true,
-                sourceMapRoot: './src/',
+                sourceMap: {
+                    includeSources: true,
+                    root: './src/'
+                },
                 preserveComments: 'some',
                 mangle: true,
                 compress: {


### PR DESCRIPTION
When updating grunt dependencies to latest one available in #2848, a regression on sourcemaps has been introduced.
As mentioned in [grunt-contrib-uglify](https://github.com/gruntjs/grunt-contrib-uglify) documentation, sourceMapIncludeSources and sourceMapRoot options has been deprecated.
This PR should allow again debugging with breakpoints with sourcemaps

Related original issue : #977
