### PR TITLE
Fix disabling of catchup (leave playback rate alone)

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -594,7 +594,7 @@ function PlaybackController() {
         if (
             isDynamic &&
             settings.get().streaming.lowLatencyEnabled &&
-            settings.get().streaming.lowLatencyEnabled > 0 &&
+            settings.get().streaming.liveCatchUpPlaybackRate > 0 &&
             !isPaused() &&
             !isSeeking()
         ) {


### PR DESCRIPTION
Don't stop playback catchup when you haven't started it because it is disabled by setting catchup playback rate to value 0; e.g: leave playback rate alone in that case.