### PR TITLE
Fix segment base issue

### DIFF
--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -229,7 +229,7 @@ function SegmentBaseLoader() {
                     }
 
                 } else {
-                    logger.debug('Parsing segments from SIDX.');
+                    logger.debug('Parsing segments from SIDX. representation ' + representation.id + ' for range : ' + info.range.start + ' - ' + info.range.end);
                     segments = getSegmentsForSidx(sidx, info);
                     callback(segments, representation, type);
                 }
@@ -241,7 +241,7 @@ function SegmentBaseLoader() {
         };
 
         httpLoader.load({request: request, success: onload, error: onerror});
-        logger.debug('Perform SIDX load: ' + info.url);
+        logger.debug('Perform SIDX load: ' + info.url + ' with range : ' + info.range.start + ' - ' + info.range.end);
     }
 
     function reset() {

--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -213,6 +213,10 @@ function SegmentBaseLoader() {
                             count++;
 
                             if (count >= len) {
+                                // http requests can be processed in a wrong order, so, we have to reorder segments with an ascending start Time order
+                                segs.sort(function (a, b) {
+                                    return a.startTime - b.startTime < 0 ? -1 : 0;
+                                });
                                 callback(segs, representation, type);
                             }
                         } else {


### PR DESCRIPTION
Hi,

this PR has to solve issue with Segment base stream with 3.0 version. The [stream ](https://dash.akamaized.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd) can be used to reproduce the issue. 

We can see that for some representations, segments are not in the correct order. So, when the player call the getNextFragment, it's not the good segment that is returned. Indeed, if the current fragment has index 24 for time 0:56 , the next one, with index 25 may be at time 2:20.....

I can't explain now, why the issue didn't appear with 2.9.3....If someone can help me.... ;-)

Nico