### PR TITLE
Add SegmentBaseController

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -78,6 +78,8 @@ class CoreEvents extends EventsBase {
         this.WALLCLOCK_TIME_UPDATED = 'wallclockTimeUpdated';
         this.XLINK_ELEMENT_LOADED = 'xlinkElementLoaded';
         this.XLINK_READY = 'xlinkReady';
+        this.SEGMENTBASE_INIT_REQUEST_NEEDED = 'segmentBaseInitRequestNeeded';
+        this.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED = 'segmentBaseSegmentsListRequestNeeded';
     }
 }
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -65,6 +65,7 @@ function DashHandler(config) {
         requestedTime,
         currentTime,
         isDynamicManifest,
+        selectedMimeType,
         segmentsController;
 
     function setup() {
@@ -109,6 +110,7 @@ function DashHandler(config) {
         currentTime = 0;
         requestedTime = null;
         segmentsController = null;
+        selectedMimeType = null;
     }
 
     function reset() {
@@ -171,6 +173,10 @@ function DashHandler(config) {
         return request;
     }
 
+    function setMimeType(newMimeType) {
+        selectedMimeType = newMimeType;
+    }
+
     function setExpectedLiveEdge(liveEdge) {
         timelineConverter.setExpectedLiveEdge(liveEdge);
         dashMetrics.updateManifestUpdateInfo({presentationStartTime: liveEdge});
@@ -191,7 +197,7 @@ function DashHandler(config) {
         if (hasInitialization && hasSegments) {
             eventBus.trigger(Events.REPRESENTATION_UPDATE_COMPLETED, {sender: instance, representation: voRepresentation});
         } else {
-            segmentsController.update(voRepresentation, getType(), hasInitialization, hasSegments);
+            segmentsController.update(voRepresentation, getType(), selectedMimeType, hasInitialization, hasSegments);
         }
     }
 
@@ -417,7 +423,8 @@ function DashHandler(config) {
         setCurrentTime: setCurrentTime,
         getCurrentTime: getCurrentTime,
         reset: reset,
-        resetIndex: resetIndex
+        resetIndex: resetIndex,
+        setMimeType: setMimeType
     };
 
     setup();

--- a/src/dash/WebmSegmentBaseLoader.js
+++ b/src/dash/WebmSegmentBaseLoader.js
@@ -1,20 +1,15 @@
-import Events from '../core/events/Events';
-import EventBus from '../core/EventBus';
 import EBMLParser from '../streaming/utils/EBMLParser';
 import Constants from '../streaming/constants/Constants';
 import FactoryMaker from '../core/FactoryMaker';
 import Debug from '../core/Debug';
-import RequestModifier from '../streaming/utils/RequestModifier';
 import Segment from './vo/Segment';
 import FragmentRequest from '../streaming/vo/FragmentRequest';
 import HTTPLoader from '../streaming/net/HTTPLoader';
 import DashJSError from '../streaming/vo/DashJSError';
-import Errors from '../core/errors/Errors';
 
 function WebmSegmentBaseLoader() {
 
     const context = this.context;
-    const eventBus = EventBus(context).getInstance();
 
     let instance,
         logger,
@@ -24,6 +19,9 @@ function WebmSegmentBaseLoader() {
         dashMetrics,
         mediaPlayerModel,
         httpLoader,
+        eventBus,
+        events,
+        errors,
         baseURLController;
 
     function setup() {
@@ -94,7 +92,6 @@ function WebmSegmentBaseLoader() {
     }
 
     function initialize() {
-        requestModifier = RequestModifier(context).getInstance();
         httpLoader = HTTPLoader(context).create({
             errHandler: errHandler,
             dashMetrics: dashMetrics,
@@ -111,6 +108,10 @@ function WebmSegmentBaseLoader() {
         dashMetrics = config.dashMetrics;
         mediaPlayerModel = config.mediaPlayerModel;
         errHandler = config.errHandler;
+        requestModifier = config.requestModifier;
+        eventBus = config.eventBus;
+        events = config.events;
+        errors = config.errors;
     }
 
     function parseCues(ab) {
@@ -323,13 +324,13 @@ function WebmSegmentBaseLoader() {
         const onload = function () {
             // note that we don't explicitly set rep.initialization as this
             // will be computed when all BaseURLs are resolved later
-            eventBus.trigger(Events.INITIALIZATION_LOADED, {
+            eventBus.trigger(events.INITIALIZATION_LOADED, {
                 representation: representation
             });
         };
 
         const onloadend = function () {
-            eventBus.trigger(Events.INITIALIZATION_LOADED, {
+            eventBus.trigger(events.INITIALIZATION_LOADED, {
                 representation: representation
             });
         };
@@ -389,17 +390,17 @@ function WebmSegmentBaseLoader() {
 
     function onLoaded(segments, representation, type) {
         if (segments) {
-            eventBus.trigger(Events.SEGMENTS_LOADED, {
+            eventBus.trigger(events.SEGMENTS_LOADED, {
                 segments: segments,
                 representation: representation,
                 mediaType: type
             });
         } else {
-            eventBus.trigger(Events.SEGMENTS_LOADED, {
+            eventBus.trigger(events.SEGMENTS_LOADED, {
                 segments: null,
                 representation: representation,
                 mediaType: type,
-                error: new DashJSError(Errors.SEGMENT_BASE_LOADER_ERROR_CODE, Errors.SEGMENT_BASE_LOADER_ERROR_MESSAGE)
+                error: new DashJSError(errors.SEGMENT_BASE_LOADER_ERROR_CODE, errors.SEGMENT_BASE_LOADER_ERROR_MESSAGE)
             });
         }
     }

--- a/src/dash/controllers/SegmentBaseController.js
+++ b/src/dash/controllers/SegmentBaseController.js
@@ -1,0 +1,129 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker';
+
+import SegmentBaseLoader from '../SegmentBaseLoader';
+import WebmSegmentBaseLoader from '../WebmSegmentBaseLoader';
+
+function SegmentBaseController(config) {
+    config = config || {};
+
+    const context = this.context;
+    const eventBus = config.eventBus;
+    const events = config.events;
+    const dashMetrics = config.dashMetrics;
+    const mediaPlayerModel = config.mediaPlayerModel;
+    const errHandler = config.errHandler;
+    const baseURLController = config.baseURLController;
+    const debug = config.debug;
+    const requestModifier = config.requestModifier;
+    const errors = config.errors;
+
+    let instance,
+        segmentBaseLoader,
+        webmSegmentBaseLoader;
+
+    function setup() {
+        segmentBaseLoader = SegmentBaseLoader(context).getInstance();
+        webmSegmentBaseLoader = WebmSegmentBaseLoader(context).getInstance();
+
+        segmentBaseLoader.setConfig({
+            baseURLController: baseURLController,
+            dashMetrics: dashMetrics,
+            mediaPlayerModel: mediaPlayerModel,
+            errHandler: errHandler,
+            eventBus: eventBus,
+            events: events,
+            errors: errors,
+            debug: debug,
+            requestModifier: requestModifier
+        });
+
+        webmSegmentBaseLoader.setConfig({
+            baseURLController: baseURLController,
+            dashMetrics: dashMetrics,
+            mediaPlayerModel: mediaPlayerModel,
+            errHandler: errHandler,
+            eventBus: eventBus,
+            events: events,
+            errors: errors,
+            debug: debug,
+            requestModifier: requestModifier
+        });
+    }
+
+    function isWebM(mimeType) {
+        const type = mimeType ? mimeType.split('/')[1] : '';
+        return 'webm' === type.toLowerCase();
+    }
+
+    function initialize() {
+        eventBus.on(events.SEGMENTBASE_INIT_REQUEST_NEEDED, onInitSegmentBaseNeeded, instance);
+        eventBus.on(events.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED, onSegmentsListSegmentBaseNeeded, instance);
+
+        segmentBaseLoader.initialize();
+        webmSegmentBaseLoader.initialize();
+    }
+
+    function onInitSegmentBaseNeeded(eventObj) {
+        if (isWebM(eventObj.mimeType)) {
+            webmSegmentBaseLoader.loadInitialization(eventObj.representation);
+        } else {
+            segmentBaseLoader.loadInitialization(eventObj.representation);
+        }
+    }
+
+    function onSegmentsListSegmentBaseNeeded(eventObj) {
+        if (isWebM(eventObj.mimeType)) {
+            webmSegmentBaseLoader.loadSegments(eventObj.representation, eventObj.mediaType, eventObj.representation ? eventObj.representation.indexRange : null, eventObj.callback);
+        } else {
+            segmentBaseLoader.loadSegments(eventObj.representation, eventObj.mediaType, eventObj.representation ? eventObj.representation.indexRange : null, eventObj.callback);
+        }
+    }
+
+    function reset() {
+        eventBus.off(events.SEGMENTBASE_INIT_REQUEST_NEEDED, onInitSegmentBaseNeeded, instance);
+        eventBus.off(events.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED, onSegmentsListSegmentBaseNeeded, instance);
+    }
+
+    instance = {
+        initialize: initialize,
+        reset: reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+SegmentBaseController.__dashjs_factory_name = 'SegmentBaseController';
+const factory = FactoryMaker.getSingletonFactory(SegmentBaseController);
+export default factory;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -61,6 +61,7 @@ import {
 from './../core/Version';
 
 //Dash
+import SegmentBaseController from '../dash/controllers/SegmentBaseController';
 import DashAdapter from '../dash/DashAdapter';
 import DashMetrics from '../dash/DashMetrics';
 import TimelineConverter from '../dash/utils/TimelineConverter';
@@ -136,7 +137,8 @@ function MediaPlayer() {
         videoModel,
         textController,
         uriFragmentModel,
-        domStorage;
+        domStorage,
+        segmentBaseController;
 
     /*
     ---------------------------------------------------------------------------
@@ -154,6 +156,7 @@ function MediaPlayer() {
         protectionController = null;
         protectionData = null;
         adapter = null;
+        segmentBaseController = null;
         Events.extend(MediaPlayerEvents);
         mediaPlayerModel = MediaPlayerModel(context).getInstance();
         videoModel = VideoModel(context).getInstance();
@@ -260,6 +263,20 @@ function MediaPlayer() {
             BASE64: BASE64
         });
 
+        segmentBaseController = SegmentBaseController(context).getInstance({
+            dashMetrics: dashMetrics,
+            mediaPlayerModel: mediaPlayerModel,
+            errHandler: errHandler,
+            baseURLController: BaseURLController(context).getInstance(),
+            events: Events,
+            eventBus: eventBus,
+            debug: debug,
+            requestModifier: RequestModifier(context).getInstance(),
+            errors: Errors
+        });
+
+        segmentBaseController.initialize();
+
         restoreDefaultUTCTimingSources();
         setAutoPlay(AutoPlay !== undefined ? AutoPlay : true);
 
@@ -295,6 +312,8 @@ function MediaPlayer() {
             metricsReportingController.reset();
             metricsReportingController = null;
         }
+
+        segmentBaseController.reset();
 
         settings.reset();
     }

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -82,7 +82,6 @@ function StreamProcessor(config) {
     function initialize(mediaSource) {
         indexHandler = DashHandler(context).create({
             type: type,
-            mimeType: mimeType,
             timelineConverter: timelineConverter,
             dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
@@ -281,7 +280,7 @@ function StreamProcessor(config) {
             if (quality > maxQuality) {
                 quality = maxQuality;
             }
-
+            indexHandler.setMimeType(mediaInfo ? mediaInfo.mimeType : null);
             representationController.updateData(newRealAdaptation, voRepresentations, type, quality);
         }
     }

--- a/src/streaming/thumbnail/ThumbnailTracks.js
+++ b/src/streaming/thumbnail/ThumbnailTracks.js
@@ -169,7 +169,7 @@ function ThumbnailTracks(config) {
         }
 
         if (useSegmentBase) {
-            eventBus.trigger(Events.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED, {mimeType: stream.getMediaInfo().mimeType, mediaType: Constants.IMAGE, representation: representation, function(segments, representation) {
+            eventBus.trigger(Events.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED, {mimeType: mediaInfo.mimeType, mediaType: Constants.IMAGE, representation: representation, function(segments, representation) {
                 let cache = [];
                 segments = normalizeSegments(segments, representation);
                 track.segmentDuration = segments[0].duration; //assume all segments have the same duration

--- a/src/streaming/thumbnail/ThumbnailTracks.js
+++ b/src/streaming/thumbnail/ThumbnailTracks.js
@@ -34,8 +34,9 @@ import FactoryMaker from '../../core/FactoryMaker';
 import ThumbnailTrackInfo from '../vo/ThumbnailTrackInfo';
 import URLUtils from '../../streaming/utils/URLUtils';
 import { replaceIDForTemplate, getTimeBasedSegment } from '../../dash/utils/SegmentsUtils';
+import Events from '../../core/events/Events';
+import EventBus from '../../core/EventBus';
 
-import SegmentBaseLoader from '../../dash/SegmentBaseLoader';
 import BoxParser from '../../streaming/utils/BoxParser';
 import XHRLoader from '../../streaming/net/XHRLoader';
 import DashHandler from '../../dash/DashHandler';
@@ -45,14 +46,12 @@ export const THUMBNAILS_SCHEME_ID_URIS = ['http://dashif.org/thumbnail_tile',
 
 function ThumbnailTracks(config) {
     const context = this.context;
+    const eventBus = EventBus(context).getInstance();
 
     const adapter = config.adapter;
     const baseURLController = config.baseURLController;
     const stream = config.stream;
     const timelineConverter = config.timelineConverter;
-    const dashMetrics = config.dashMetrics;
-    const mediaPlayerModel = config.mediaPlayerModel;
-    const errHandler = config.errHandler;
 
     const urlUtils = URLUtils(context).getInstance();
 
@@ -61,19 +60,13 @@ function ThumbnailTracks(config) {
         indexHandler,
         currentTrackIndex,
         mediaInfo,
-        loader, segmentBaseLoader, boxParser;
+        loader,
+        boxParser;
 
     function initialize() {
         reset();
         loader = XHRLoader(context).create({});
         boxParser = BoxParser(context).getInstance();
-        segmentBaseLoader = SegmentBaseLoader(context).getInstance();
-        segmentBaseLoader.setConfig({
-            baseURLController: baseURLController,
-            dashMetrics: dashMetrics,
-            mediaPlayerModel: mediaPlayerModel,
-            errHandler: errHandler
-        });
 
         indexHandler = DashHandler(context).create({timelineConverter: timelineConverter,
                                 baseURLController: baseURLController});
@@ -176,8 +169,8 @@ function ThumbnailTracks(config) {
         }
 
         if (useSegmentBase) {
-            segmentBaseLoader.loadSegments(representation, Constants.IMAGE, representation.indexRange, {}, function (segments, representation) {
-                var cache = [];
+            eventBus.trigger(Events.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED, {mimeType: stream.getMediaInfo().mimeType, mediaType: Constants.IMAGE, representation: representation, function(segments, representation) {
+                let cache = [];
                 segments = normalizeSegments(segments, representation);
                 track.segmentDuration = segments[0].duration; //assume all segments have the same duration
                 track.readThumbnail = function (time, callback) {
@@ -220,7 +213,7 @@ function ThumbnailTracks(config) {
                         });
                     }
                 };
-            });
+            }});
         } else {
             track.startNumber = representation.startNumber;
             track.segmentDuration = representation.segmentDuration;

--- a/src/streaming/vo/FragmentRequest.js
+++ b/src/streaming/vo/FragmentRequest.js
@@ -36,7 +36,7 @@ import { HTTPRequest } from '../vo/metrics/HTTPRequest';
  * @ignore
  */
 class FragmentRequest {
-    constructor() {
+    constructor(url) {
         this.action = FragmentRequest.ACTION_DOWNLOAD;
         this.startTime = NaN;
         this.mediaType = null;
@@ -45,7 +45,7 @@ class FragmentRequest {
         this.duration = NaN;
         this.timescale = NaN;
         this.range = null;
-        this.url = null;
+        this.url = url || null;
         this.serviceLocation = null;
         this.requestStartDate = null;
         this.firstByteDate = null;

--- a/src/streaming/vo/HeadRequest.js
+++ b/src/streaming/vo/HeadRequest.js
@@ -36,8 +36,7 @@ import FragmentRequest from './FragmentRequest';
 
 class HeadRequest extends FragmentRequest {
     constructor(url) {
-        super();
-        this.url = url || null;
+        super(url);
         this.checkForExistenceOnly = true;
     }
 }

--- a/test/unit/dash.SegmentBaseLoader.js
+++ b/test/unit/dash.SegmentBaseLoader.js
@@ -41,7 +41,10 @@ describe('SegmentBaseLoader', function () {
                 baseURLController: new BaseURLControllerMock(),
                 dashMetrics: new DashMetricsMock(),
                 mediaPlayerModel: new MediaPlayerModelMock(),
-                errHandler: new ErrorHandlerMock()
+                errHandler: new ErrorHandlerMock(),
+                eventBus: eventBus,
+                events: Events,
+                errors: Errors
             });
             segmentBaseLoader.initialize();
         });

--- a/test/unit/dash.WebSegmentBaseLoader.js
+++ b/test/unit/dash.WebSegmentBaseLoader.js
@@ -3,6 +3,7 @@ import Constants from '../../src/streaming/constants/Constants';
 import EventBus from '../../src/core/EventBus';
 import Events from '../../src/core/events/Events';
 import Errors from '../../src/core/errors/Errors';
+import RequestModifier from '../../src/streaming/utils/RequestModifier';
 
 import ErrorHandlerMock from './mocks/ErrorHandlerMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
@@ -59,7 +60,11 @@ describe('WebmSegmentBaseLoader', function () {
                 baseURLController: new BaseURLControllerMock(),
                 dashMetrics: new DashMetricsMock(),
                 mediaPlayerModel: new MediaPlayerModelMock(),
-                errHandler: new ErrorHandlerMock()
+                errHandler: new ErrorHandlerMock(),
+                requestModifier: RequestModifier(context).getInstance(),
+                eventBus: eventBus,
+                events: Events,
+                errors: Errors
             });
             webmSegmentBaseLoader.initialize();
         });


### PR DESCRIPTION
Hi,

this PR has to create a new static class, named SegmentBaseController, that has to send request to get init or media segments list in SegmentBase use case.

The idea is to isolate this part of code in order to have in SegmentController only functions to get segment (with time or id) without any network access. In SegmentBase use case, the SegmentController will trigger an event that will be catched by SegmentBaseController to send requests.

In ThumbnailTracks, SegmentBaseLoader was used, I updated this part of code but no tests have been made because the sample stream is not available. :-(
Nico
