### PR TITLE
types: allowing partial definition of setting obj

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,96 +77,96 @@ declare namespace dashjs {
     }
 
     export class MediaPlayerSettingClass {
-        debug: {
-            logLevel: LogLevel;
+        debug?: {
+            logLevel?: LogLevel;
         };
-        streaming: {
-            metricsMaxListDepth: number;
-            abandonLoadTimeout: number;
-            liveDelayFragmentCount: number;
-            liveDelay: number;
-            scheduleWhilePaused: boolean;
-            fastSwitchEnabled: boolean;
-            bufferPruningInterval: number;
-            bufferToKeep: number;
-            bufferAheadToKeep: number;
-            jumpGaps: boolean;
-            smallGapLimit: number;
-            stableBufferTime: number;
-            bufferTimeAtTopQuality: number;
-            bufferTimeAtTopQualityLongForm: number;
-            longFormContentDurationThreshold: number;
-            wallclockTimeUpdateInterval: number;
-            lowLatencyEnabled: boolean;
-            keepProtectionMediaKeys: boolean;
-            useManifestDateHeaderTimeSource: boolean;
-            useSuggestedPresentationDelay: boolean;
-            manifestUpdateRetryInterval: number;
-            liveCatchUpMinDrift: number;
-            liveCatchUpMaxDrift: number;
-            liveCatchUpPlaybackRate: number;
-            lastBitrateCachingInfo: {
-                enabled: boolean;
-                ttl: number;
+        streaming?: {
+            metricsMaxListDepth?: number;
+            abandonLoadTimeout?: number;
+            liveDelayFragmentCount?: number;
+            liveDelay?: number;
+            scheduleWhilePaused?: boolean;
+            fastSwitchEnabled?: boolean;
+            bufferPruningInterval?: number;
+            bufferToKeep?: number;
+            bufferAheadToKeep?: number;
+            jumpGaps?: boolean;
+            smallGapLimit?: number;
+            stableBufferTime?: number;
+            bufferTimeAtTopQuality?: number;
+            bufferTimeAtTopQualityLongForm?: number;
+            longFormContentDurationThreshold?: number;
+            wallclockTimeUpdateInterval?: number;
+            lowLatencyEnabled?: boolean;
+            keepProtectionMediaKeys?: boolean;
+            useManifestDateHeaderTimeSource?: boolean;
+            useSuggestedPresentationDelay?: boolean;
+            manifestUpdateRetryInterval?: number;
+            liveCatchUpMinDrift?: number;
+            liveCatchUpMaxDrift?: number;
+            liveCatchUpPlaybackRate?: number;
+            lastBitrateCachingInfo?: {
+                enabled?: boolean;
+                ttl?: number;
             };
-            lastMediaSettingsCachingInfo: {
-                enabled: boolean;
-                ttl: number;
+            lastMediaSettingsCachingInfo?: {
+                enabled?: boolean;
+                ttl?: number;
             };
-            cacheLoadThresholds: {
-                video: number;
-                audio: number;
+            cacheLoadThresholds?: {
+                video?: number;
+                audio?: number;
             };
-            retryIntervals: {
-                'MPD':                       number;
-                'XLinkExpansion':            number;
-                'MediaSegment':              number;
-                'InitializationSegment':     number;
-                'BitstreamSwitchingSegment': number;
-                'IndexSegment':              number;
-                'other':                     number;
+            retryIntervals?: {
+                'MPD'?:                       number;
+                'XLinkExpansion'?:            number;
+                'MediaSegment'?:              number;
+                'InitializationSegment'?:     number;
+                'BitstreamSwitchingSegment'?: number;
+                'IndexSegment'?:              number;
+                'other'?:                     number;
             };
-            retryAttempts: {
-                'MPD':                       number;
-                'XLinkExpansion':            number;
-                'MediaSegment':              number;
-                'InitializationSegment':     number;
-                'BitstreamSwitchingSegment': number;
-                'IndexSegment':              number;
-                'other':                     number;
+            retryAttempts?: {
+                'MPD'?:                       number;
+                'XLinkExpansion'?:            number;
+                'MediaSegment'?:              number;
+                'InitializationSegment'?:     number;
+                'BitstreamSwitchingSegment'?: number;
+                'IndexSegment'?:              number;
+                'other'?:                     number;
             };
-            abr: {
-                movingAverageMethod: 'slidingWindow' | 'ewma';
-                ABRStrategy: 'abrDynamic' | 'abrBola';
-                bandwidthSafetyFactor: number;
-                useDefaultABRRules: boolean;
-                useBufferOccupancyABR: boolean;
-                useDeadTimeLatency: boolean;
-                limitBitrateByPortal: boolean;
-                usePixelRatioInLimitBitrateByPortal: boolean;
-                maxBitrate: {
-                    audio: number;
-                    video: number;
+            abr?: {
+                movingAverageMethod?: 'slidingWindow' | 'ewma';
+                ABRStrategy?: 'abrDynamic' | 'abrBola';
+                bandwidthSafetyFactor?: number;
+                useDefaultABRRules?: boolean;
+                useBufferOccupancyABR?: boolean;
+                useDeadTimeLatency?: boolean;
+                limitBitrateByPortal?: boolean;
+                usePixelRatioInLimitBitrateByPortal?: boolean;
+                maxBitrate?: {
+                    audio?: number;
+                    video?: number;
                 };
-                minBitrate: {
-                    audio: number;
-                    video: number;
+                minBitrate?: {
+                    audio?: number;
+                    video?: number;
                 };
-                maxRepresentationRatio: {
-                    audio: number;
-                    video: number;
+                maxRepresentationRatio?: {
+                    audio?: number;
+                    video?: number;
                 };
-                initialBitrate: {
-                    audio: number;
-                    video: number;
+                initialBitrate?: {
+                    audio?: number;
+                    video?: number;
                 };
-                initialRepresentationRatio: {
-                    audio: number;
-                    video: number;
+                initialRepresentationRatio?: {
+                    audio?: number;
+                    video?: number;
                 };
-                autoSwitchBitrate: {
-                    audio: boolean;
-                    video: boolean;
+                autoSwitchBitrate?: {
+                    audio?: boolean;
+                    video?: boolean;
                 };
             }
         }


### PR DESCRIPTION
The current definition of `MediaPlayerSettingClass` included in `index.d.ts` file causes that the TypeScript transpiler ask you to define the whole object while calling to `updateSettings` method of the `MediaPlayerClass`.

According to the documentation (http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html):

> updateSettings(settingsObj)
> **Update the current settings object being used on the player. Anything left unspecified is not modified.**
> 
> This function does not update the entire object, only properties in the passed in object are updated.

This PR set all the parameters of `MediaPlayerSettingClass` as optional parameters, so the user is able to define only the parameters s/he want to change.