### PR TITLE
DashMetrics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare namespace dashjs {
         scanType?: string;
     }
 
-    export type MediaType = 'video' | 'audio' | 'text' | 'fragmentedText' | 'embeddedText';
+    export type MediaType = 'video' | 'audio' | 'text' | 'fragmentedText' | 'embeddedText' | 'image';
 
     export class MediaInfo {
         id: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -813,14 +813,14 @@ declare namespace dashjs {
         t: Date;
     }
 
-    export interface ILatestBufferLevelVO {
-        level: number;
-        t: Date;
+    export interface IBufferState {
+        target: number;
+        state: string;
     }
 
     export interface DashMetrics {
         getCurrentRepresentationSwitch(type: 'video' | 'audio' | 'image', readOnly: boolean): ICurrentRepresentationSwitch;
-        getLatestBufferInfoVO(): ILatestBufferLevelVO;
+        getCurrentBufferState(type: 'video' | 'audio' | 'image', readOnly: boolean): IBufferState;
         getCurrentBufferLevel(type: 'video' | 'audio' | 'image', readOnly: boolean): number;
         getCurrentHttpRequest(type: 'video' | 'audio' | 'image', readOnly: boolean): object;
         getHttpRequests(type: 'video' | 'audio' | 'image'): object[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,10 +51,12 @@ declare namespace dashjs {
         scanType?: string;
     }
 
+    export type MediaType = 'video' | 'audio' | 'text' | 'fragmentedText' | 'embeddedText';
+
     export class MediaInfo {
         id: string | null;
         index: number | null;
-        type: 'video' | 'audio' | 'text' | 'fragmentedText' | 'embeddedText' | null;
+        type: MediaType | null;
         streamInfo: StreamInfo | null;
         representationCount: number;
         labels: string[];
@@ -238,18 +240,18 @@ declare namespace dashjs {
         formatUTC(time: number, locales: string, hour12: boolean, withDate?: boolean): string;
         getVersion(): string;
         getDebug(): Debug;
-        getBufferLength(type: 'video' | 'audio' | 'fragmentedText'): number;
+        getBufferLength(type: MediaType): number;
         getVideoModel(): VideoModel;
         getTTMLRenderingDiv(): HTMLDivElement | null;
         getVideoElement(): HTMLVideoElement;
         getSource(): string | object;
-        getTopBitrateInfoFor(type: 'video' | 'audio'): BitrateInfo;
+        getTopBitrateInfoFor(type: MediaType): BitrateInfo;
         setAutoPlay(value: boolean): void;
         getAutoPlay(): boolean;
         getDashMetrics(): DashMetrics;
         getDashAdapter(): DashAdapter;
-        getQualityFor(type: 'video' | 'audio' | 'image'): number;
-        setQualityFor(type: 'video' | 'audio' | 'image', value: number): void;
+        getQualityFor(type: MediaType): number;
+        setQualityFor(type: MediaType, value: number): void;
         updatePortalSize(): void;
         enableText(enable: boolean): void;
         setTextTrack(idx: number): void;
@@ -258,16 +260,16 @@ declare namespace dashjs {
         getTextDefaultEnabled(): boolean | undefined;
         setTextDefaultEnabled(enable: boolean): void;
         getThumbnail(time: number): Thumbnail;
-        getBitrateInfoListFor(type: 'video' | 'audio' | 'image'): BitrateInfo[];
+        getBitrateInfoListFor(type: MediaType): BitrateInfo[];
         getStreamsFromManifest(manifest: object): StreamInfo[];
-        getTracksFor(type: 'video' | 'audio' | 'text' | 'fragmentedText'): MediaInfo[];
-        getTracksForTypeFromManifest(type: 'video' | 'audio' | 'text' | 'fragmentedText', manifest: object, streamInfo: StreamInfo): MediaInfo[];
-        getCurrentTrackFor(type: 'video' | 'audio' | 'text' | 'fragmentedText'): MediaInfo | null;
-        setInitialMediaSettingsFor(type: 'video' | 'audio', value: MediaSettings): void;
-        getInitialMediaSettingsFor(type: 'video' | 'audio'): MediaSettings;
+        getTracksFor(type: MediaType): MediaInfo[];
+        getTracksForTypeFromManifest(type: MediaType, manifest: object, streamInfo: StreamInfo): MediaInfo[];
+        getCurrentTrackFor(type: MediaType): MediaInfo | null;
+        setInitialMediaSettingsFor(type: MediaType, value: MediaSettings): void;
+        getInitialMediaSettingsFor(type: MediaType): MediaSettings;
         setCurrentTrack(track: MediaInfo): void;
-        getTrackSwitchModeFor(type: 'video' | 'audio'): TrackSwitchMode;
-        setTrackSwitchModeFor(type: 'video' | 'audio', mode: TrackSwitchMode): void;
+        getTrackSwitchModeFor(type: MediaType): TrackSwitchMode;
+        setTrackSwitchModeFor(type: MediaType, mode: TrackSwitchMode): void;
         setSelectionModeForInitialTrack(mode: TrackSelectionMode): void;
         getSelectionModeForInitialTrack(): TrackSelectionMode;
         retrieveManifest(url: string, callback: (manifest: object | null, error: any) => void): void;
@@ -418,12 +420,12 @@ declare namespace dashjs {
 
     export interface BufferEvent extends Event {
         type: MediaPlayerEvents['BUFFER_EMPTY' | 'BUFFER_LOADED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
     }
 
     export interface BufferStateChangedEvent extends Event {
         type: MediaPlayerEvents['BUFFER_LEVEL_STATE_CHANGED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
         sender: object;
         state: 'bufferStalled' | 'bufferLoaded';
         streamInfo: StreamInfo;
@@ -537,7 +539,7 @@ declare namespace dashjs {
         type: MediaPlayerEvents['FRAGMENT_LOADING_ABANDONED'];
         streamProcessor: object;
         request: object;
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
     }
 
     export class KeyError {
@@ -608,14 +610,14 @@ declare namespace dashjs {
 
     export interface MetricEvent extends Event {
         type: MediaPlayerEvents['METRIC_ADDED' | 'METRIC_UPDATED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
         metric: MetricType;
         value: object;
     }
 
     export interface MetricChangedEvent extends Event {
         type: MediaPlayerEvents['METRIC_CHANGED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
     }
 
     export interface PeriodSwitchEvent extends Event {
@@ -678,21 +680,21 @@ declare namespace dashjs {
 
     export interface TrackChangeRenderedEvent extends Event {
         type: MediaPlayerEvents['TRACK_CHANGE_RENDERED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
         oldMediaInfo: MediaInfo;
         newMediaInfo: MediaInfo;
     }
 
     export interface QualityChangeRenderedEvent extends Event {
         type: MediaPlayerEvents['QUALITY_CHANGE_RENDERED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
         oldQuality: number;
         newQuality: number;
     }
 
     export interface QualityChangeRequestedEvent extends Event {
         type: MediaPlayerEvents['QUALITY_CHANGE_REQUESTED'];
-        mediaType: 'video' | 'audio' | 'fragmentedText';
+        mediaType: MediaType;
         oldQuality: number;
         newQuality: number;
         streamInfo: StreamInfo | null;
@@ -746,7 +748,7 @@ declare namespace dashjs {
         firstByteDate: Date;
         index: number;
         mediaInfo: MediaInfo;
-        mediaType: 'video' | 'audio' | 'text' | 'fragmentedText' | 'embeddedText';
+        mediaType: MediaType;
         quality: number;
         representationId: string;
         requestStartDate: Date;
@@ -784,7 +786,7 @@ declare namespace dashjs {
         getStartTime(): number;
         getId(): string;
         getStreamInfo(): StreamInfo | null;
-        getBitrateListFor(type: 'video' | 'audio' | 'image'): BitrateInfo[];
+        getBitrateListFor(type: MediaType): BitrateInfo[];
         updateData(updatedStreamInfo: StreamInfo): void;
         reset(): void;
     }
@@ -819,17 +821,17 @@ declare namespace dashjs {
     }
 
     export interface DashMetrics {
-        getCurrentRepresentationSwitch(type: 'video' | 'audio' | 'image', readOnly: boolean): ICurrentRepresentationSwitch;
-        getCurrentBufferState(type: 'video' | 'audio' | 'image', readOnly: boolean): IBufferState;
-        getCurrentBufferLevel(type: 'video' | 'audio' | 'image', readOnly: boolean): number;
-        getCurrentHttpRequest(type: 'video' | 'audio' | 'image', readOnly: boolean): object;
-        getHttpRequests(type: 'video' | 'audio' | 'image'): object[];
+        getCurrentRepresentationSwitch(type: MediaType, readOnly: boolean): ICurrentRepresentationSwitch;
+        getCurrentBufferState(type: MediaType, readOnly: boolean): IBufferState;
+        getCurrentBufferLevel(type: MediaType, readOnly: boolean): number;
+        getCurrentHttpRequest(type: MediaType, readOnly: boolean): object;
+        getHttpRequests(type: MediaType): object[];
         getCurrentDroppedFrames(): IDroppedFrames;
-        getCurrentSchedulingInfo(type: 'video' | 'audio' | 'image'): object;
-        getCurrentDVRInfo(type: 'video' | 'audio' | 'image'): IDVRInfo[];
+        getCurrentSchedulingInfo(type: MediaType): object;
+        getCurrentDVRInfo(type: MediaType): IDVRInfo[];
         getCurrentManifestUpdate(): any;
         getLatestFragmentRequestHeaderValueByID(id: string): string;
-        getLatestMPDRequestHeaderValueByID(type: 'video' | 'audio' | 'image', id: string): string;
+        getLatestMPDRequestHeaderValueByID(type: MediaType, id: string): string;
     }
 
     export interface DashAdapter {
@@ -842,7 +844,7 @@ declare namespace dashjs {
          * @param bufferType String 'audio' or 'video',
          * @param periodIdx Make sure this is the period index not id
          */
-        getMaxIndexForBufferType(bufferType: 'video' | 'audio', periodIdx: number): number;
+        getMaxIndexForBufferType(bufferType: MediaType, periodIdx: number): number;
     }
 
     export class ProtectionData {

--- a/index.d.ts
+++ b/index.d.ts
@@ -821,10 +821,10 @@ declare namespace dashjs {
     }
 
     export interface DashMetrics {
-        getCurrentRepresentationSwitch(type: MediaType, readOnly: boolean): ICurrentRepresentationSwitch;
-        getCurrentBufferState(type: MediaType, readOnly: boolean): IBufferState;
-        getCurrentBufferLevel(type: MediaType, readOnly: boolean): number;
-        getCurrentHttpRequest(type: MediaType, readOnly: boolean): object;
+        getCurrentRepresentationSwitch(type: MediaType): ICurrentRepresentationSwitch;
+        getCurrentBufferState(type: MediaType): IBufferState;
+        getCurrentBufferLevel(type: MediaType): number;
+        getCurrentHttpRequest(type: MediaType): object;
         getHttpRequests(type: MediaType): object[];
         getCurrentDroppedFrames(): IDroppedFrames;
         getCurrentSchedulingInfo(type: MediaType): object;

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -113,6 +113,17 @@ function DashMetrics(config) {
      * @memberof module:DashMetrics
      * @instance
      */
+    function getCurrentBufferState(type, readOnly) {
+        return getLatestBufferInfoVO(type, readOnly, MetricsConstants.BUFFER_STATE);
+    }
+
+    /**
+     * @param {string} type
+     * @param {boolean} readOnly
+     * @returns {number}
+     * @memberof module:DashMetrics
+     * @instance
+     */
     function getCurrentBufferLevel(type, readOnly) {
         const vo = getLatestBufferInfoVO(type, readOnly, MetricsConstants.BUFFER_LEVEL);
 
@@ -512,6 +523,7 @@ function DashMetrics(config) {
     instance = {
         getCurrentRepresentationSwitch: getCurrentRepresentationSwitch,
         getLatestBufferInfoVO: getLatestBufferInfoVO,
+        getCurrentBufferState: getCurrentBufferState,
         getCurrentBufferLevel: getCurrentBufferLevel,
         getCurrentHttpRequest: getCurrentHttpRequest,
         getHttpRequests: getHttpRequests,

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -94,27 +94,14 @@ function DashMetrics(config) {
     }
 
     /**
-     * @param {string} mediaType
-     * @param {boolean} readOnly
-     * @param {string} infoType
-     * @returns {*}
-     * @memberof module:DashMetrics
-     * @instance
-     */
-    function getLatestBufferInfoVO(mediaType, readOnly, infoType) {
-        const metrics = metricsModel.getMetricsFor(mediaType, readOnly);
-        return getCurrent(metrics, infoType);
-    }
-
-    /**
      * @param {string} type
      * @param {boolean} readOnly
      * @returns {number}
-     * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentBufferState(type, readOnly) {
-        return getLatestBufferInfoVO(type, readOnly, MetricsConstants.BUFFER_STATE);
+    function getCurrentBufferState(type) {
+        const metrics = metricsModel.getMetricsFor(type, true);
+        return getCurrent(metrics, MetricsConstants.BUFFER_STATE);
     }
 
     /**

--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -70,13 +70,12 @@ function DashMetrics(config) {
 
     /**
      * @param {string} mediaType
-     * @param {boolean} readOnly
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentRepresentationSwitch(mediaType, readOnly) {
-        const metrics = metricsModel.getMetricsFor(mediaType, readOnly);
+    function getCurrentRepresentationSwitch(mediaType) {
+        const metrics = metricsModel.getMetricsFor(mediaType, true);
         return getCurrent(metrics, MetricsConstants.TRACK_SWITCH);
     }
 
@@ -95,7 +94,6 @@ function DashMetrics(config) {
 
     /**
      * @param {string} type
-     * @param {boolean} readOnly
      * @returns {number}
      * @instance
      */
@@ -106,16 +104,16 @@ function DashMetrics(config) {
 
     /**
      * @param {string} type
-     * @param {boolean} readOnly
      * @returns {number}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentBufferLevel(type, readOnly) {
-        const vo = getLatestBufferInfoVO(type, readOnly, MetricsConstants.BUFFER_LEVEL);
+    function getCurrentBufferLevel(type) {
+        const metrics = metricsModel.getMetricsFor(type, true);
+        const metric = getCurrent(metrics, MetricsConstants.BUFFER_LEVEL);
 
-        if (vo) {
-            return Round10.round10(vo.level / 1000, -3);
+        if (metric) {
+            return Round10.round10(metric.level / 1000, -3);
         }
 
         return 0;
@@ -153,13 +151,12 @@ function DashMetrics(config) {
 
     /**
      * @param {string} mediaType
-     * @param {boolean} readOnly
      * @returns {*}
      * @memberof module:DashMetrics
      * @instance
      */
-    function getCurrentHttpRequest(mediaType, readOnly) {
-        const metrics = metricsModel.getMetricsFor(mediaType, readOnly);
+    function getCurrentHttpRequest(mediaType) {
+        const metrics = metricsModel.getMetricsFor(mediaType, true);
 
         if (!metrics) {
             return null;
@@ -223,14 +220,8 @@ function DashMetrics(config) {
         if (!metrics) {
             return null;
         }
-
         const list = metrics[metricName];
-
-        if (!list || list.length <= 0) {
-            return null;
-        }
-
-        return list[list.length - 1];
+        return (!list || list.length === 0) ? null : list[list.length - 1];
     }
 
     /**
@@ -509,7 +500,6 @@ function DashMetrics(config) {
 
     instance = {
         getCurrentRepresentationSwitch: getCurrentRepresentationSwitch,
-        getLatestBufferInfoVO: getLatestBufferInfoVO,
         getCurrentBufferState: getCurrentBufferState,
         getCurrentBufferLevel: getCurrentBufferLevel,
         getCurrentHttpRequest: getCurrentHttpRequest,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -583,7 +583,7 @@ function MediaPlayer() {
      * and the presentation does not include any adaption sets of valid media
      * type.
      *
-     * @param {string} type - the media type of the buffer
+     * @param {MediaType} type - the media type of the buffer (@link MediaType)
      * @returns {number} The length of the buffer for the given media type, in
      *  seconds, or NaN
      * @memberof module:MediaPlayer
@@ -756,7 +756,7 @@ function MediaPlayer() {
      *
      * It calls getTopQualityIndexFor internally
      *
-     * @param {string} type - 'video' or 'audio' are the type options.
+     * @param {MediaType} type - 'video' or 'audio' are the type options.
      * @memberof module:MediaPlayer
      * @returns {BitrateInfo | null}
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
@@ -774,7 +774,7 @@ function MediaPlayer() {
      * rules update this value before every new download unless setAutoSwitchQualityFor(type, false) is called. For 'image'
      * type, thumbnails, there is no ABR algorithm and quality is set manually.
      *
-     * @param {string} type - 'video', 'audio' or 'image' (thumbnails)
+     * @param {MediaType} type - 'video', 'audio' or 'image' (thumbnails)
      * @returns {number} the quality index, 0 corresponding to the lowest bitrate
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setAutoSwitchQualityFor setAutoSwitchQualityFor()}
@@ -802,7 +802,7 @@ function MediaPlayer() {
      * Sets the current quality for media type instead of letting the ABR Heuristics automatically selecting it.
      * This value will be overwritten by the ABR rules unless setAutoSwitchQualityFor(type, false) is called.
      *
-     * @param {string} type - 'video', 'audio' or 'image'
+     * @param {MediaType} type - 'video', 'audio' or 'image'
      * @param {number} value - the quality index, 0 corresponding to the lowest bitrate
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setAutoSwitchQualityFor setAutoSwitchQualityFor()}
@@ -1008,7 +1008,7 @@ function MediaPlayer() {
     /**
      * Returns the average throughput computed in the ABR logic
      *
-     * @param {string} type
+     * @param {MediaType} type
      * @return {number} value
      * @memberof module:MediaPlayer
      * @instance
@@ -1313,7 +1313,7 @@ function MediaPlayer() {
     ---------------------------------------------------------------------------
     */
     /**
-     * @param {string} type
+     * @param {MediaType} type
      * @returns {Array}
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
@@ -1344,7 +1344,7 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available tracks for a given media type
-     * @param {string} type
+     * @param {MediaType} type
      * @returns {Array} list of {@link MediaInfo}
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
@@ -1360,7 +1360,7 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available tracks for a given media type and streamInfo from a given manifest
-     * @param {string} type
+     * @param {MediaType} type
      * @param {Object} manifest
      * @param {Object} streamInfo
      * @returns {Array}  list of {@link MediaInfo}
@@ -1379,7 +1379,7 @@ function MediaPlayer() {
     }
 
     /**
-     * @param {string} type
+     * @param {MediaType} type
      * @returns {Object|null} {@link MediaInfo}
      *
      * @memberof module:MediaPlayer
@@ -1403,7 +1403,7 @@ function MediaPlayer() {
      *  accessibility: accessibilityValue,
      *  role: roleValue}
      *
-     * @param {string} type
+     * @param {MediaType} type
      * @param {Object} value
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~MEDIA_PLAYER_NOT_INITIALIZED_ERROR MEDIA_PLAYER_NOT_INITIALIZED_ERROR} if called before initialize function
@@ -1424,7 +1424,7 @@ function MediaPlayer() {
      *  audioChannelConfiguration: audioChannelConfigurationValue,
      *  accessibility: accessibilityValue,
      *  role: roleValue}
-     * @param {string} type
+     * @param {MediaType} type
      * @returns {Object}
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~MEDIA_PLAYER_NOT_INITIALIZED_ERROR MEDIA_PLAYER_NOT_INITIALIZED_ERROR} if called before initialize function
@@ -1453,7 +1453,7 @@ function MediaPlayer() {
     /**
      * This method returns the current track switch mode.
      *
-     * @param {string} type
+     * @param {MediaType} type
      * @returns {string} mode
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~MEDIA_PLAYER_NOT_INITIALIZED_ERROR MEDIA_PLAYER_NOT_INITIALIZED_ERROR} if called before initialize function
@@ -1476,7 +1476,7 @@ function MediaPlayer() {
      * MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE
      * (used to clear the buffered data (prior to current playback position) after track switch. Default for audio)
      *
-     * @param {string} type
+     * @param {MediaType} type
      * @param {string} mode
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~MEDIA_PLAYER_NOT_INITIALIZED_ERROR MEDIA_PLAYER_NOT_INITIALIZED_ERROR} if called before initialize function

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -73,6 +73,13 @@ import ISOBoxer from 'codem-isoboxer';
 import DashJSError from './vo/DashJSError';
 import { checkParameterType } from './utils/SupervisorTools';
 
+/* jscs:disable */
+/**
+ * The media types
+ * @typedef {("video" | "audio" | "text" | "fragmentedText" | "embeddedText" | "image")} MediaType
+ */
+/* jscs:enable */
+
 /**
  * @module MediaPlayer
  * @description The MediaPlayer is the primary dash.js Module and a Facade to build your player around.
@@ -583,7 +590,7 @@ function MediaPlayer() {
      * and the presentation does not include any adaption sets of valid media
      * type.
      *
-     * @param {MediaType} type - the media type of the buffer (@link MediaType)
+     * @param {MediaType} type - 'video', 'audio' or 'fragmentedText'
      * @returns {number} The length of the buffer for the given media type, in
      *  seconds, or NaN
      * @memberof module:MediaPlayer
@@ -753,10 +760,9 @@ function MediaPlayer() {
     */
     /**
      * Gets the top quality BitrateInfo checking portal limit and max allowed.
-     *
      * It calls getTopQualityIndexFor internally
      *
-     * @param {MediaType} type - 'video' or 'audio' are the type options.
+     * @param {MediaType} type - 'video' or 'audio'
      * @memberof module:MediaPlayer
      * @returns {BitrateInfo | null}
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -336,7 +336,7 @@ function AbrController() {
                         changeQuality(type, oldQuality, newQuality, topQualityIdx, switchRequest.reason);
                     }
                 } else if (settings.get().debug.logLevel === Debug.LOG_LEVEL_DEBUG) {
-                    const bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
+                    const bufferLevel = dashMetrics.getCurrentBufferLevel(type);
                     logger.debug('[' + type + '] stay on ' + oldQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ')');
                 }
             }
@@ -360,7 +360,7 @@ function AbrController() {
             const streamInfo = streamProcessorDict[type].getStreamInfo();
             const id = streamInfo ? streamInfo.id : null;
             if (settings.get().debug.logLevel === Debug.LOG_LEVEL_DEBUG) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(type, true);
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(type);
                 logger.info('[' + type + '] switch from ' + oldQuality + ' to ' + newQuality + '/' + topQualityIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
             }
             setQualityFor(type, id, newQuality);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -267,8 +267,8 @@ function ScheduleController(config) {
         if (isNaN(currentRepresentationInfo.fragmentDuration)) { //fragmentDuration of representationInfo is not defined,
             // call metrics function to have data in the latest scheduling info...
             // if no metric, returns 0. In this case, rule will return false.
-            const bufferInfo = dashMetrics.getLatestBufferInfoVO(currentRepresentationInfo.mediaInfo.type, true, MetricsConstants.SCHEDULING_INFO);
-            safeBufferLevel = bufferInfo ? bufferInfo.duration * 1.5 : 1.5;
+            const schedulingInfo = dashMetrics.getCurrentSchedulingInfo(currentRepresentationInfo.mediaInfo.type);
+            safeBufferLevel = schedulingInfo ? schedulingInfo.duration * 1.5 : 1.5;
         }
         const request = fragmentModel.getRequests({
             state: FragmentModel.FRAGMENT_MODEL_EXECUTED,

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -278,7 +278,7 @@ function CmcdModel() {
     function _getDeadlineByType(mediaType) {
         try {
             const playbackRate = internalData.pr;
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
 
             if (!isNaN(playbackRate) && !isNaN(bufferLevel)) {
                 return parseInt((bufferLevel / playbackRate) * 1000);
@@ -297,7 +297,7 @@ function CmcdModel() {
                 return internalData.bs[mediaType];
             }
 
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
             const duration = request.duration;
             if (bufferLevel < duration) {
                 return BUFFER_STATES.RISK;

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -81,7 +81,7 @@ function AbandonRequestsRule(config) {
             setFragmentRequestDict(mediaType, req.index);
 
             const stableBufferTime = mediaPlayerModel.getStableBufferTime();
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
             if ( bufferLevel > stableBufferTime ) {
                 return switchRequest;
             }

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -156,7 +156,7 @@ function BolaRule(config) {
                 // 1. do not change effective buffer level at effectiveBufferLevel === MINIMUM_BUFFER_S ( === Vp * gp )
                 // 2. scale placeholder buffer by Vp subject to offset indicated in 1.
 
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
                 let effectiveBufferLevel = bufferLevel + bolaState.placeholderBuffer;
 
                 effectiveBufferLevel -= MINIMUM_BUFFER_S;
@@ -334,7 +334,7 @@ function BolaRule(config) {
 
             // Find what maximum buffer corresponding to last segment was, and ensure placeholder is not relatively larger.
             if (!isNaN(bolaState.lastSegmentFinishTimeMs)) {
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
                 const bufferAtLastSegmentRequest = bufferLevel + 0.001 * (bolaState.lastSegmentFinishTimeMs - bolaState.lastSegmentRequestTimeMs); // estimate
                 const maxEffectiveBufferForLastSegment = maxBufferLevelForQuality(bolaState, bolaState.lastQuality);
                 const maxPlaceholderBuffer = Math.max(0, maxEffectiveBufferForLastSegment - bufferAtLastSegmentRequest);
@@ -368,7 +368,7 @@ function BolaRule(config) {
             const bolaState = bolaStateDict[e.mediaType];
             if (bolaState && bolaState.state !== BOLA_STATE_ONE_BITRATE) {
                 // deflate placeholderBuffer - note that we want to be conservative when abandoning
-                const bufferLevel = dashMetrics.getCurrentBufferLevel(e.mediaType, true);
+                const bufferLevel = dashMetrics.getCurrentBufferLevel(e.mediaType);
                 let wantEffectiveBufferLevel;
                 if (bolaState.abrQuality > 0) {
                     // deflate to point where BOLA just chooses newQuality over newQuality-1
@@ -414,7 +414,7 @@ function BolaRule(config) {
             return switchRequest;
         }
 
-        const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+        const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
         const throughput = throughputHistory.getAverageThroughput(mediaType, isDynamic);
         const safeThroughput = throughputHistory.getSafeAverageThroughput(mediaType, isDynamic);
         const latency = throughputHistory.getAverageLatency(mediaType);

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -99,7 +99,7 @@ function InsufficientBufferRule(config) {
             const abrController = rulesContext.getAbrController();
             const throughputHistory = abrController.getThroughputHistory();
 
-            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
+            const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
             const throughput = throughputHistory.getAverageThroughput(mediaType);
             const latency = throughputHistory.getAverageLatency(mediaType);
             const bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -57,7 +57,7 @@ function InsufficientBufferRule(config) {
     }
 
     function checkConfig() {
-        if (!dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel') || !dashMetrics.hasOwnProperty('getLatestBufferInfoVO')) {
+        if (!dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferLevel') || !dashMetrics.hasOwnProperty('getCurrentBufferState')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -81,16 +81,16 @@ function InsufficientBufferRule(config) {
         checkConfig();
 
         const mediaType = rulesContext.getMediaType();
-        const lastBufferStateVO = dashMetrics.getLatestBufferInfoVO(mediaType, true, MetricsConstants.BUFFER_STATE);
+        const currentBufferState = dashMetrics.getCurrentBufferState(mediaType);
         const representationInfo = rulesContext.getRepresentationInfo();
         const fragmentDuration = representationInfo.fragmentDuration;
 
         // Don't ask for a bitrate change if there is not info about buffer state or if fragmentDuration is not defined
-        if (!lastBufferStateVO || !wasFirstBufferLoadedEventTriggered(mediaType, lastBufferStateVO) || !fragmentDuration) {
+        if (!currentBufferState || !wasFirstBufferLoadedEventTriggered(mediaType, currentBufferState) || !fragmentDuration) {
             return switchRequest;
         }
 
-        if (lastBufferStateVO.state === MetricsConstants.BUFFER_EMPTY) {
+        if (currentBufferState.state === MetricsConstants.BUFFER_EMPTY) {
             logger.debug('[' + mediaType + '] Switch to index 0; buffer is empty.');
             switchRequest.quality = 0;
             switchRequest.reason = 'InsufficientBufferRule: Buffer is empty';

--- a/src/streaming/rules/abr/ThroughputRule.js
+++ b/src/streaming/rules/abr/ThroughputRule.js
@@ -48,7 +48,7 @@ function ThroughputRule(config) {
     }
 
     function checkConfig() {
-        if (!dashMetrics || !dashMetrics.hasOwnProperty('getLatestBufferInfoVO')) {
+        if (!dashMetrics || !dashMetrics.hasOwnProperty('getCurrentBufferState')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
     }
@@ -65,7 +65,7 @@ function ThroughputRule(config) {
 
         const mediaInfo = rulesContext.getMediaInfo();
         const mediaType = rulesContext.getMediaType();
-        const bufferStateVO = dashMetrics.getLatestBufferInfoVO(mediaType, true, MetricsConstants.BUFFER_STATE);
+        const currentBufferState = dashMetrics.getCurrentBufferState(mediaType);
         const scheduleController = rulesContext.getScheduleController();
         const abrController = rulesContext.getAbrController();
         const streamInfo = rulesContext.getStreamInfo();
@@ -76,12 +76,12 @@ function ThroughputRule(config) {
         const useBufferOccupancyABR = rulesContext.useBufferOccupancyABR();
 
 
-        if (isNaN(throughput) || !bufferStateVO || useBufferOccupancyABR) {
+        if (isNaN(throughput) || !currentBufferState || useBufferOccupancyABR) {
             return switchRequest;
         }
 
         if (abrController.getAbandonmentStateFor(mediaType) !== MetricsConstants.ABANDON_LOAD) {
-            if (bufferStateVO.state === MetricsConstants.BUFFER_LOADED || isDynamic) {
+            if (currentBufferState.state === MetricsConstants.BUFFER_LOADED || isDynamic) {
                 switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, throughput, latency);
                 scheduleController.setTimeToLoadDelay(0);
                 logger.debug('[' + mediaType + '] requesting switch to index: ', switchRequest.quality, 'Average throughput', Math.round(throughput), 'kbps');

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -48,7 +48,7 @@ function BufferLevelRule(config) {
         if (!streamProcessor) {
             return true;
         }
-        const bufferLevel = dashMetrics.getCurrentBufferLevel(streamProcessor.getType(), true);
+        const bufferLevel = dashMetrics.getCurrentBufferLevel(streamProcessor.getType());
         return bufferLevel < getBufferTarget(streamProcessor, videoTrackPresent);
     }
 
@@ -74,7 +74,7 @@ function BufferLevelRule(config) {
                 bufferTarget = 0;
             }
         } else if (type === Constants.AUDIO && videoTrackPresent) {
-            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(Constants.VIDEO, true);
+            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(Constants.VIDEO);
             if (isNaN(representationInfo.fragmentDuration)) {
                 bufferTarget = videoBufferLevel;
             } else {

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -65,8 +65,8 @@ function BufferLevelRule(config) {
                 if (isNaN(representationInfo.fragmentDuration)) { //fragmentDuration of representationInfo is not defined,
                     // call metrics function to have data in the latest scheduling info...
                     // if no metric, returns 0. In this case, rule will return false.
-                    const bufferInfo = dashMetrics.getLatestBufferInfoVO(Constants.FRAGMENTED_TEXT, true, MetricsConstants.SCHEDULING_INFO);
-                    bufferTarget = bufferInfo ? bufferInfo.duration : 0;
+                    const schedulingInfo = dashMetrics.getCurrentSchedulingInfo(MetricsConstants.SCHEDULING_INFO);
+                    bufferTarget = schedulingInfo ? schedulingInfo.duration : 0;
                 } else {
                     bufferTarget = representationInfo.fragmentDuration;
                 }

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -18,12 +18,6 @@ describe('DashMetrics', function () {
         expect(representation).to.be.null;  // jshint ignore:line
     });
 
-    it('should return null when getLatestBufferInfoVO is called and mediaType, readOnly and infoType are undefined', () => {
-        const bufferLevel = dashMetrics.getLatestBufferInfoVO();
-
-        expect(bufferLevel).to.be.null;  // jshint ignore:line
-    });
-
     it('should return 0 when getCurrentBufferLevel is called and type is undefined', () => {
         const bufferLevel = dashMetrics.getCurrentBufferLevel();
 

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -11,10 +11,6 @@ function DashMetricsMock () {
         return 15;
     };
 
-    this.getLatestBufferInfoVO = function () {
-        return this.bufferState;
-    };
-
     this.addSchedulingInfo = function () {
 
     };

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -7,6 +7,10 @@ function DashMetricsMock () {
         return this.currentDVRInfo;
     };
 
+    this.getCurrentBufferState = function () {
+        return this.bufferState;
+    };
+
     this.getCurrentBufferLevel = function () {
         return 15;
     };


### PR DESCRIPTION
The goal of PR is to fix the DashMetrics class and its type declaration:
- add the method getCurrentBufferState()
- remove the method getLatestBufferInfoVO
- update types declaration

Questions (@epiclabsDASH ?):
- what's the use for the readonly parameter in DashMetrics methods? From outside dash.js, shouldn't it always be fixed to 'true'?
- why the input media type for DashMetrics methods is only either 'video', 'audio', or 'image'?
- more generally, in types declaration file, in many methods all possible media types are described (for example `type: 'video' | 'audio' | 'fragmentedText'`). why not declaring a general type "MediaType", to be used by all methods?