### PR TITLE
Key system priority

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -863,6 +863,9 @@ declare namespace dashjs {
          * Corresponding property values are keys, base64-encoded (no padding).
          */
         clearkeys?: { [key: string]: string };
+
+        /** Priority order index (from 0) for selecting key system */
+        priorityIndex?: number = -1;
     }
 
     export interface KeySystem {

--- a/index.d.ts
+++ b/index.d.ts
@@ -864,8 +864,8 @@ declare namespace dashjs {
          */
         clearkeys?: { [key: string]: string };
 
-        /** Priority order index (from 0) for selecting key system */
-        priorityIndex?: number = -1;
+        /** Priority level of the key system to be selected (0 is the highest prority, -1 for undefined priority) */
+        priority?: number = -1;
     }
 
     export interface KeySystem {

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -411,7 +411,7 @@ function ProtectionController(config) {
         supportedKS = supportedKS.sort((ksA, ksB) => {
             let indexA = (protDataSet && protDataSet[ksA.ks.systemString] && protDataSet[ksA.ks.systemString].priority >= 0) ? protDataSet[ksA.ks.systemString].priority : supportedKS.length;
             let indexB = (protDataSet && protDataSet[ksB.ks.systemString] && protDataSet[ksB.ks.systemString].priority >= 0) ? protDataSet[ksB.ks.systemString].priority : supportedKS.length;
-            return (indexA < indexB ? -1 : 0);
+            return indexA - indexB;
         });
 
         let ksIdx;

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -409,8 +409,8 @@ function ProtectionController(config) {
 
         // Reorder key systems according to priority order provided in protectionData
         supportedKS = supportedKS.sort((ksA, ksB) => {
-            let indexA = (protDataSet && protDataSet[ksA.ks.systemString] && protDataSet[ksA.ks.systemString].priorityIndex >= 0) ? protDataSet[ksA.ks.systemString].priorityIndex : supportedKS.length;
-            let indexB = (protDataSet && protDataSet[ksB.ks.systemString] && protDataSet[ksB.ks.systemString].priorityIndex >= 0) ? protDataSet[ksB.ks.systemString].priorityIndex : supportedKS.length;
+            let indexA = (protDataSet && protDataSet[ksA.ks.systemString] && protDataSet[ksA.ks.systemString].priority >= 0) ? protDataSet[ksA.ks.systemString].priority : supportedKS.length;
+            let indexB = (protDataSet && protDataSet[ksB.ks.systemString] && protDataSet[ksB.ks.systemString].priority >= 0) ? protDataSet[ksB.ks.systemString].priority : supportedKS.length;
             return (indexA < indexB ? -1 : 0);
         });
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -407,6 +407,13 @@ function ProtectionController(config) {
         const self = this;
         const requestedKeySystems = [];
 
+        // Reorder key systems according to priority order provided in protectionData
+        supportedKS = supportedKS.sort((ksA, ksB) => {
+            let indexA = (protDataSet && protDataSet[ksA.ks.systemString] && protDataSet[ksA.ks.systemString].priorityIndex >= 0) ? protDataSet[ksA.ks.systemString].priorityIndex : supportedKS.length;
+            let indexB = (protDataSet && protDataSet[ksB.ks.systemString] && protDataSet[ksB.ks.systemString].priorityIndex >= 0) ? protDataSet[ksB.ks.systemString].priorityIndex : supportedKS.length;
+            return (indexA < indexB ? -1 : 0);
+        });
+
         let ksIdx;
         if (keySystem) {
             // We have a key system


### PR DESCRIPTION
The goal of this PR is to enable the key systems selection process to request the key systems access in a given priority order.

By default, in dash.js the key systems order is pre-defined in ProtectionKeyController:
https://github.com/Dash-Industry-Forum/dash.js/blob/f4418b56213e4d5889d9eb0b15074e45c42b7bb8/src/streaming/protection/controllers/ProtectionKeyController.js#L72))

As a use case, on some devices you may have 2 different available CDMs, and for a specific service you would require dash.js to select the second one in the pre-defined order.
Thus the user can set the priority in the protectionData in order to force dash.js selecting the key systems in the user-defined order.

For example, if you provide the following protectionData:

    {
        "com.widevine.alpha": {
            "serverURL": "https://drm-widevine-licensing.axtest.net/AcquireLicense",
            "priority": 0
        },
        "com.microsoft.playready": {
            "serverURL": "https://drm-playready-licensing.axtest.net/AcquireLicense",
        }
    }

Then dash.js will select first and request access to the Widevine key system.

The same goald could have been achieved based on PR #2953, but this PR propose a more easiest way to achieve this.