### PR TITLE
[MSS] fix missing DVRWindowLength for live streams

### DIFF
--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -596,9 +596,15 @@ function MssParser(config) {
         timescale =  smoothStreamingMedia.getAttribute('TimeScale');
         manifest.timescale = timescale ? parseFloat(timescale) : DEFAULT_TIME_SCALE;
         let dvrWindowLength = parseFloat(smoothStreamingMedia.getAttribute('DVRWindowLength'));
+        // If the DVRWindowLength field is omitted for a live presentation or set to 0, the DVR window is effectively infinite
+        if (manifest.type === 'dynamic' && (dvrWindowLength === 0 || isNaN(dvrWindowLength))) {
+            dvrWindowLength = Infinity;
+        }
+        // Star-over
         if (dvrWindowLength === 0 && smoothStreamingMedia.getAttribute('CanSeek') === 'TRUE') {
             dvrWindowLength = Infinity;
         }
+
         if (dvrWindowLength > 0) {
             manifest.timeShiftBufferDepth = dvrWindowLength / manifest.timescale;
         }


### PR DESCRIPTION
According to the MSDN specification (https://msdn.microsoft.com/en-us/library/ff469578.aspx), if the DVRWindowLength field is omitted for a live presentation or set to 0, the DVR window is effectively infinite.