### PR TITLE
Fix typescript definition of setProtectionData method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare namespace dashjs {
         setMediaElement(element: HTMLMediaElement): void;
         setSessionType(type: string): void;
         setRobustnessLevel(level: string): void;
-        setProtectionData(protData: ProtectionData): void;
+        setProtectionData(protData: ProtectionDataSet): void;
         getSupportedKeySystemsFromContentProtection(cps: any[]): SupportedKeySystem[];
         getKeySystems(): KeySystem[];
         setKeySystems(keySystems: KeySystem[]): void;
@@ -278,7 +278,7 @@ declare namespace dashjs {
         getXHRWithCredentialsForType(type: string): boolean;
         getProtectionController(): ProtectionController;
         attachProtectionController(value: ProtectionController): void;
-        setProtectionData(value: ProtectionData): void;
+        setProtectionData(value: ProtectionDataSet): void;
         enableManifestDateHeaderTimeSource(value: boolean): void;
         displayCaptionsOnTop(value: boolean): void;
         attachTTMLRenderingDiv(div: HTMLDivElement): void;
@@ -863,6 +863,10 @@ declare namespace dashjs {
          * Corresponding property values are keys, base64-encoded (no padding).
          */
         clearkeys?: { [key: string]: string };
+    }
+    
+    export interface ProtectionDataSet {
+        [key: string]: ProtectionData;
     }
 
     export interface KeySystem {

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -321,6 +321,15 @@ function ProtectionKeyController() {
         }
     }
 
+    /**
+     * Attach KeySystem-specific data to use for license acquisition with EME
+     *
+     * @param {Object.<string, ProtectionData>} protectionDataSet an object containing
+     * property names corresponding to key system name strings (e.g. "org.w3.clearkey")
+     * and associated values being instances of {@link ProtectionData}
+     * @memberof module:ProtectionKeyController
+     * @instance
+     */
     function setProtectionData(protectionDataSet) {
         var getProtectionData = function (keySystemString) {
             var protData = null;


### PR DESCRIPTION
The method `setProtectionData()` only accepts `ProtectionData` type in TypeScript. But it's wrong type. Actually, **an object with a value of `ProtectionData`** instance is correct.
Fixed it.