### PR TITLE
Add segment quality in HTTPRequest metrics

### DIFF
--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -339,6 +339,7 @@ function DashMetrics(config) {
             null,
             request.type,
             request.url,
+            request.quality,
             responseURL,
             request.serviceLocation || null,
             request.range || null,

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -134,7 +134,7 @@ function MetricsModel(config) {
         return vo;
     }
 
-    function addHttpRequest(mediaType, tcpid, type, url, actualurl, serviceLocation, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders, traces) {
+    function addHttpRequest(mediaType, tcpid, type, url, quality, actualurl, serviceLocation, range, trequest, tresponse, tfinish, responsecode, mediaduration, responseHeaders, traces) {
         let vo = new HTTPRequest();
 
         // ISO 23009-1 D.4.3 NOTE 2:
@@ -152,6 +152,7 @@ function MetricsModel(config) {
                 null,
                 type,
                 url,
+                quality,
                 null,
                 null,
                 range,
@@ -178,6 +179,7 @@ function MetricsModel(config) {
         vo._tfinish = tfinish;
         vo._stream = mediaType;
         vo._mediaduration = mediaduration;
+        vo._quality = quality;
         vo._responseHeaders = responseHeaders;
         vo._serviceLocation = serviceLocation;
 

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -114,6 +114,11 @@ class HTTPRequest {
          */
         this._mediaduration = null;
         /**
+         * The media segment quality
+         * @public
+         */
+        this._quality = null;
+        /**
          * all the response headers from request.
          * @public
          */


### PR DESCRIPTION
The segment quality information in HTTPRequest metrics can be useful at application level.
For example, we can compare the real encoding bit rate of a segment regarding the theoretical bit rate as indicated in the manifest.