### PR TITLE
fix issue about media finished detection

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -316,14 +316,17 @@ function DashHandler(config) {
             if (segment) {
                 request = getRequestForSegment(mediaInfo, segment);
                 segmentIndex = segment.availabilityIdx;
-            } else {
-                segmentIndex = indexToRequest - 1;
+            }else {
+                if (isDynamicManifest) {
+                    segmentIndex = indexToRequest - 1;
+                } else {
+                    segmentIndex = indexToRequest;
+                }
             }
         }
 
         if (segment) {
             lastSegment = segment;
-            request = getRequestForSegment(mediaInfo, segment);
         } else {
             const finished = isMediaFinished(representation, segment);
             if (finished) {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -316,7 +316,7 @@ function DashHandler(config) {
             if (segment) {
                 request = getRequestForSegment(mediaInfo, segment);
                 segmentIndex = segment.availabilityIdx;
-            }else {
+            } else {
                 if (isDynamicManifest) {
                     segmentIndex = indexToRequest - 1;
                 } else {


### PR DESCRIPTION
Hi,

this PR has to update PR #3105 that included a regression about media finished detection. In dynamic manifest use case, dashHandler has to keep segmentIndex unchanged if no request has been found. In static manifest, in order to detect media finished status, segmentIndex has to be increased by one to be equals or greater than availableSegmentsNumber.

So, the stream [https://livesim.dashif.org/livesim/modulo_10/testpic_2s/Manifest.mpd](https://livesim.dashif.org/livesim/modulo_10/testpic_2s/Manifest.mpd) can be used to test that the previsous PR is always solved by this new PR. The first VOD stream in the sample page can be used to be sure that the end of the stream is correctly detected.

Nico
