### PR TITLE
Fix sample control bar

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -372,10 +372,6 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
     var updateDuration = function () {
         var duration = player.duration();
         if (duration !== parseFloat(seekbar.max)) { //check if duration changes for live streams..
-            if (!startedPlaying && duration && player.isDynamic()) {
-                seekLive();
-                startedPlaying = true;
-            }
             setDuration(displayUTCTimeCodes ? player.durationAsUTC() : duration);
             seekbar.max = duration;
         }


### PR DESCRIPTION
Remove seek to live on duration updatein sample application.
For each live stream, as soon as the first segment is pushed and thus the &lt;video&gt; duration is updated, a new seek is performed to end of segment (=duration). Thus first image is freezed, and loading/zapping time is increased (wait for more segment to be loaded).

@gitperonam Why did you introduced this seek to live on duration update?