### PR TITLE
onabort callback for HTTPLoader is called twice

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -299,7 +299,6 @@ function HTTPLoader(cfg) {
             // set them to undefined so they are not called
             x.onloadend = x.onerror = x.onprogress = undefined;
             x.loader.abort(x);
-            x.onabort();
         });
         requests = [];
     }


### PR DESCRIPTION
When the AbandonRequestRule calls abandon on a segment load, it enqueues two segment replacement requests in ScheduleController (and re-loads the same segment at the lower quality twice). This is because the onAbort callback for HTTPLoader is called twice, once through the XHRLoader with `x.loader.abort(x)`, and again on `x.onabort()`.

So this PR removes the second x.onabort call.