### PR TITLE
getSegmentForTime is returning indicies off by one segment

### DIFF
--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -94,7 +94,7 @@ function TemplateSegmentsGetter(config, isDynamic) {
         }
 
         const periodTime = timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, requestedTime);
-        const index = Math.floor(periodTime / duration) - 1;
+        const index = Math.floor(periodTime / duration);
 
         return getSegmentByIndex(representation, index);
     }

--- a/test/unit/dash.utils.TemplateSegmentsGetter.js
+++ b/test/unit/dash.utils.TemplateSegmentsGetter.js
@@ -117,13 +117,13 @@ describe('TemplateSegmentsGetter', () => {
             expect(seg.duration).to.equal(5);
 
             seg = templateSegmentsGetter.getSegmentByTime(representation, 12);
-            expect(seg.availabilityIdx).to.equal(1);
-            expect(seg.presentationStartTime).to.equal(5);
+            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.presentationStartTime).to.equal(10);
             expect(seg.duration).to.equal(5);
 
             seg = templateSegmentsGetter.getSegmentByTime(representation, 17);
-            expect(seg.availabilityIdx).to.equal(2);
-            expect(seg.presentationStartTime).to.equal(10);
+            expect(seg.availabilityIdx).to.equal(3);
+            expect(seg.presentationStartTime).to.equal(15);
             expect(seg.duration).to.equal(5);
         });
 


### PR DESCRIPTION
When replacement fragments are requested by ScheduleController, they flow into the getSegmentsForTime function in the templateSegmentsGetter. This function is returning indicies off by one, so replacement fragments would be ordered for the segment before what was wanted.

To reproduce:
Invoke a replacement by suddenly throttling and getting the abandon rule to abandon a high quality segment.
See that the replacement segment ordered is one segment early.

This PR removes the -1 that made the calculation from time incorrect.