### PR TITLE
Fixing type defitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -865,7 +865,7 @@ declare namespace dashjs {
         clearkeys?: { [key: string]: string };
 
         /** Priority level of the key system to be selected (0 is the highest prority, -1 for undefined priority) */
-        priority?: number = -1;
+        priority?: number;
     }
 
     export interface KeySystem {


### PR DESCRIPTION
After commit 042e07d, the TypeScript transpiler fails since the type definitions wrongly includes a default value for the `priority` parameter, throwing the error `TS1039: Initializers are not allowed in ambient contexts`.
