### PR TITLE
Play failed when some segments unavailable

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -388,7 +388,7 @@ function DashHandler(config) {
         }
 
         if (segments.length > 0) {
-            representation.segmentAvailabilityRange = {start: segments[0].presentationStartTime, end: segments[len - 1].presentationStartTime};
+            representation.segmentAvailabilityRange = {start: segments[0].presentationStartTime, end: segments[segments.length - 1].presentationStartTime};
             representation.availableSegmentsNumber = segments.length;
             representation.segments = segments;
 


### PR DESCRIPTION
As 'getTimeBasedSegment' returns null if isSegmentAvailable is false,   
so segments' length could be smaller than fragments' length,  
then exception occurs here. 

This issue could be tested with video source 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd'