### PR TITLE
Fix starting of live streams with SegmentTimeline

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -405,7 +405,7 @@ function PlaybackController() {
         if (!DVRWindow) return NaN;
         if (currentTime > DVRWindow.end) {
             actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
-        } else if (currentTime + 0.250 < DVRWindow.start && DVRWindow.start - currentTime > DVRWindow.start - 315360000) {
+        } else if (currentTime > 0 && currentTime + 0.250 < DVRWindow.start && DVRWindow.start - currentTime > DVRWindow.start - 315360000) {
             // Checking currentTime plus 250ms as the 'timeupdate' is fired with a frequency between 4Hz and 66Hz
             // https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate
             // http://w3c.github.io/html/single-page.html#offsets-into-the-media-resource


### PR DESCRIPTION
For live streams with SegmentTimeline thus manifest refreshes, when manifest is updated, the player checks if current playback time is not anterior to DVR window start, and then it seeks to DVR window start (I guess to ensure to download and play available segments)
However, when loading the stream, if manifest is first updated before live is started (currentTime still equal to 0) then a seek to DVR window start is performed.
This PR fixes this issue by ignoring DVR window resynchronization if stream is not started yet.