### PR TITLE
Update schedule controller

### DIFF
--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -205,9 +205,9 @@ function MssParser(config) {
         // If still not defined (optionnal for audio stream, see https://msdn.microsoft.com/en-us/library/ff728116%28v=vs.95%29.aspx),
         // then we consider the stream is an audio AAC stream
         if (fourCCValue === null || fourCCValue === '') {
-            if (type === 'audio') {
+            if (type === constants.AUDIO) {
                 fourCCValue = 'AAC';
-            } else if (type === 'video') {
+            } else if (type === constants.VIDEO) {
                 logger.debug('FourCC is not defined whereas it is required for a QualityLevel element for a StreamIndex of type "video"');
                 return null;
             }
@@ -741,7 +741,7 @@ function MssParser(config) {
                 timestampOffset = prevManifest.timestampOffset;
             } else {
                 for (i = 0; i < adaptations.length; i++) {
-                    if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {
+                    if (adaptations[i].contentType === constants.AUDIO || adaptations[i].contentType === constants.VIDEO) {
                         segments = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray;
                         startTime = segments[0].t / adaptations[i].SegmentTemplate.timescale;
                         if (timestampOffset === undefined) {
@@ -765,7 +765,7 @@ function MssParser(config) {
                         }
                         segments[j].t -= (timestampOffset * adaptations[i].SegmentTemplate.timescale);
                     }
-                    if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {
+                    if (adaptations[i].contentType === constants.AUDIO || adaptations[i].contentType === constants.VIDEO) {
                         period.start = Math.max(segments[0].t, period.start);
                         adaptations[i].SegmentTemplate.presentationTimeOffset = period.start;
                     }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -538,7 +538,7 @@ function BufferController(config) {
 
     function checkIfSufficientBuffer() {
         // No need to check buffer if type is not audio or video (for example if several errors occur during text parsing, so that the buffer cannot be filled, no error must occur on video playback)
-        if (type !== 'audio' && type !== 'video') return;
+        if (type !== Constants.AUDIO && type !== Constants.VIDEO) return;
 
         if (seekClearedBufferingCompleted && !isBufferingCompleted && bufferLevel > 0 && playbackController && playbackController.getTimeToStreamEnd() - bufferLevel < STALL_THRESHOLD) {
             seekClearedBufferingCompleted = false;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -459,8 +459,8 @@ function ScheduleController(config) {
         if (e.sender !== fragmentModel) {
             return;
         }
-        logger.info('OnFragmentLoadingCompleted - Url:', e.request ? e.request.url : 'undefined',
-            ', Range:', e.request.range ? e.request.range : 'undefined');
+        logger.info('OnFragmentLoadingCompleted - Url:', e.request ? e.request.url : 'undefined', e.request.range ?
+            ', Range:' + e.request.range : '');
         if (adapter.getIsTextTrack(type)) {
             setFragmentProcessState(false);
         }


### PR DESCRIPTION
Hi,

this PR has to avoid to push two initialize segments one after the other without any media segment between them.

It occurs, in ScheduleController, due to a call to checkPlaybackQuality of PlaybackController even if the last requested segment is a initialize one.

The issue can occured with the default stream in the sample page with debug log level.

Nico