### PR TITLE
fix for 'r' parameter in uri

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -228,9 +228,15 @@ function PlaybackController() {
     function computeLiveDelay(fragmentDuration, dvrWindowSize) {
         let delay,
             ret,
+            r,
             startTime;
-        let startTimeParameters = getStartTimeFromUriParameters();
         const END_OF_PLAYLIST_PADDING = 10;
+
+        let uriParameters = uriFragmentModel.getURIFragmentData();
+
+        if (uriParameters) {
+            r = parseInt(uriParameters.r, 10);
+        }
 
         let suggestedPresentationDelay = adapter.getSuggestedPresentationDelay();
 
@@ -240,8 +246,8 @@ function PlaybackController() {
             delay = 0;
         } else if (mediaPlayerModel.getLiveDelay()) {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
-        } else if (startTimeParameters && startTimeParameters.fragT) {
-            delay = startTimeParameters.fragT;
+        } else if (r) {
+            delay = r;
         }
         else if (!isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -229,6 +229,7 @@ function PlaybackController() {
         let delay,
             ret,
             startTime;
+        let startTimeParameters = getStartTimeFromUriParameters();
         const END_OF_PLAYLIST_PADDING = 10;
 
         let suggestedPresentationDelay = adapter.getSuggestedPresentationDelay();
@@ -239,7 +240,10 @@ function PlaybackController() {
             delay = 0;
         } else if (mediaPlayerModel.getLiveDelay()) {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
-        } else if (!isNaN(fragmentDuration)) {
+        } else if (startTimeParameters && startTimeParameters.fragT) {
+            delay = startTimeParameters.fragT;
+        }
+        else if (!isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
         } else {
             delay = streamInfo.manifestInfo.minBufferTime * 2;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -705,7 +705,7 @@ function PlaybackController() {
         const hasVideoTrack = streamController.isTrackTypePresent(Constants.VIDEO);
         const hasAudioTrack = streamController.isTrackTypePresent(Constants.AUDIO);
 
-        initialStartTime = getStreamStartTime(true);
+        initialStartTime = getStreamStartTime(false);
         if (hasAudioTrack && hasVideoTrack) {
             //current stream has audio and video contents
             if (!isNaN(commonEarliestTime[streamInfo.id].audio) && !isNaN(commonEarliestTime[streamInfo.id].video)) {

--- a/test/unit/mocks/URIFragmentModelMock.js
+++ b/test/unit/mocks/URIFragmentModelMock.js
@@ -1,9 +1,14 @@
 class URIFragmentModelMock {
     constructor() {
+        this.uriFragmentData = null;
     }
 
     getURIFragmentData() {
-        return {t: 18.2};
+        return this.uriFragmentData;
+    }
+
+    setURIFragmentData(uri) {
+        this.uriFragmentData = uri;
     }
 }
 

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -165,6 +165,7 @@ describe('PlaybackController', function () {
             });
 
             it('getStartTimeFromUriParameters should return the expected value', function () {
+                uriFragmentModelMock.setURIFragmentData({t: 18.2});
                 const uriParameters = playbackController.getStartTimeFromUriParameters();
                 expect(uriParameters.fragT).to.exist; // jshint ignore:line
                 expect(uriParameters.fragT).to.equal(18.2);


### PR DESCRIPTION
Hi,

this PR has to solve regression issue #3136 . As this parameter is used like liveDelay settings, playbackController has to use it in computeLiveDelay function.

Nico