### PR TITLE
types: define enum LogLevel as const

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace dashjs {
         fatal(...params: any[]): void;
     }
 
-    enum LogLevel {
+    const enum LogLevel {
         LOG_LEVEL_NONE = 0,
         LOG_LEVEL_FATAL = 1,
         LOG_LEVEL_ERROR = 2,


### PR DESCRIPTION
The `LogLevel` enum defined in `index.d.ts` declares an enum that is not exported from dash.js, so any references to `LogLevel` will pass compilation but fail runtime. 

By declaring this enum as `const enum` the value is inlined during compilation, removing any references to LogLevel in the compiled JavaScript. 

See https://basarat.gitbooks.io/typescript/content/docs/enums.html#const-enums for more info.