### PR TITLE
Update buffer level metrics

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -735,6 +735,7 @@ function BufferController(config) {
             if (!bufferResetInProgress) {
                 logger.debug('onRemoved : call updateBufferLevel');
                 updateBufferLevel();
+                addBufferMetrics();
             } else {
                 bufferResetInProgress = false;
                 if (mediaChunk) {


### PR DESCRIPTION
Hi,

this PR has to solve issue #3010. The main problem is that when video buffer is cleared, metrics are not updated immediately. So, when scheduleController asks BufferLevelRule in order to know if new segments have to be requested, the rule returns that buffer is enough filled : wrong answer!

In this specific use case, buffer level metric is never updated at all, ScheduleController is not stopped but no new segment is requested because of the returned value by BufferLevelRule.

@budziq, could you, please, test on your side this fix?

Nico