### PR TITLE
Fix Issue #3083 for live streams with multiperiod.

### DIFF
--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -149,7 +149,15 @@ function isSegmentAvailable(timelineConverter, representation, segment, isDynami
 
     const segmentTime = timelineConverter.calcPeriodRelativeTimeFromMpdRelativeTime(representation, segment.presentationStartTime);
     if (segmentTime >= periodRelativeEnd) {
-        return false;
+        if (isDynamic) {
+            // segment is not available in current period, but it may be segment available in another period that current one (in DVR window)
+            // if not (time > segmentAvailabilityRange.end), then return false
+            if ( representation.segmentAvailabilityRange && segment.presentationStartTime >= representation.segmentAvailabilityRange.end) {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
Hi 

This PR solves the issue #3083.
The pb was that introduced function in 3.0.0, SegmentUtils::isSegmentAvailable was returning false in case of multiperiod streams if segment time was not found in current period. For live streams, play was never started, because no request was available  at startTime

Jérémie