### PR TITLE
SegmentBase Multi period bug fix

### DIFF
--- a/src/dash/SegmentBaseLoader.js
+++ b/src/dash/SegmentBaseLoader.js
@@ -233,7 +233,7 @@ function SegmentBaseLoader() {
                     }
 
                 } else {
-                    logger.debug('Parsing segments from SIDX. representation ' + representation.id + ' for range : ' + info.range.start + ' - ' + info.range.end);
+                    logger.debug('Parsing segments from SIDX. representation ' + representation.adaptation.type + ' - id: ' + representation.id + ' for range : ' + info.range.start + ' - ' + info.range.end);
                     segments = getSegmentsForSidx(sidx, info);
                     callback(segments, representation, type);
                 }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -341,7 +341,7 @@ function BufferController(config) {
     }
 
     function onPlaybackSeeked() {
-        seekStartTime = undefined;
+        setSeekStartTime(undefined);
     }
 
     // Prune full buffer but what is around current time position
@@ -446,6 +446,9 @@ function BufferController(config) {
     }
 
     function onPlaybackPlaying() {
+        if (seekStartTime !== undefined) {
+            setSeekStartTime(undefined);
+        }
         checkIfSufficientBuffer();
     }
 


### PR DESCRIPTION
Hi,

this PR has to resolve issue #2840 by reseting seekStartTime value in all cases when the stream begins to play. In this specific use case (SegmentBase multi period), no internal seek is done to start, for instance, the second period. The seekStartTime value is still 30.03s. the getWorkingTime function always returns 30.03s. BufferLevelRule doesn't have correct informations to decide or not to request new segment.

@niralipatelgoogle, I know this issue is open for a long time, but it would be great if you can take a look at this fix. Thank you! 

Nico