### PR TITLE
Update text track management

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -372,9 +372,18 @@ function VideoModel() {
         return null;
     }
 
-    function addTextTrack(kind, label, lang) {
+    function addTextTrack(kind, label, lang, isTTML, isEmbedded) {
+        let track = getTextTrack(kind, label, lang, isTTML, isEmbedded);
         if (element) {
-            return element.addTextTrack(kind, label, lang);
+            if (track) {
+                return track;
+            } else {
+                let createdTrack = element.addTextTrack(kind, label, lang);
+                createdTrack.isEmbedded = isEmbedded;
+                createdTrack.isTTML = isTTML;
+
+                return createdTrack;
+            }
         }
         return null;
     }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -373,19 +373,18 @@ function VideoModel() {
     }
 
     function addTextTrack(kind, label, lang, isTTML, isEmbedded) {
-        let track = getTextTrack(kind, label, lang, isTTML, isEmbedded);
-        if (element) {
-            if (track) {
-                return track;
-            } else {
-                let createdTrack = element.addTextTrack(kind, label, lang);
-                createdTrack.isEmbedded = isEmbedded;
-                createdTrack.isTTML = isTTML;
-
-                return createdTrack;
-            }
+        if (!element) {
+            return null;
         }
-        return null;
+        // check if track of same type has not been already created for previous stream
+        // then use it (no way to remove existing text track from video element)
+        let track = getTextTrack(kind, label, lang, isTTML, isEmbedded);
+        if (!track) {
+            track = element.addTextTrack(kind, label, lang);
+            track.isEmbedded = isEmbedded;
+            track.isTTML = isTTML;
+        }
+        return track;
     }
 
     function appendChild(childElement) {

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -99,11 +99,7 @@ function TextTracks() {
         const lang = textTrackQueue[i].lang;
         const isTTML = textTrackQueue[i].isTTML;
         const isEmbedded = textTrackQueue[i].isEmbedded;
-        const track = videoModel.addTextTrack(kind, label, lang);
-
-        track.isEmbedded = isEmbedded;
-        track.isTTML = isTTML;
-
+        const track = videoModel.addTextTrack(kind, label, lang, isTTML, isEmbedded);
         return track;
     }
 


### PR DESCRIPTION
Hi,

this PR has to not always create a new text track on the html5 video element when a new stream is loaded. Unfortunately, text track can't be removed.
The idea is, when a creation is asked, to detect if this kind of track (same label, same kind, etc....) has been already created. If it's true, this track is returned, otherwise a new track is really created.
does it solve issues #1294, #1394? @davemevans if you can take a look......thanks! ;-)

Nico