### PR TITLE
Fix bug: Headers string not appending \r 

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -99,7 +99,7 @@ function FetchLoader(cfg) {
 
             let responseHeaders = '';
             for (const key of response.headers.keys()) {
-                responseHeaders += key + ': ' + response.headers.get(key) + '\n';
+                responseHeaders += key + ': ' + response.headers.get(key) + '\r\n';
             }
             httpRequest.response.responseHeaders = responseHeaders;
 


### PR DESCRIPTION
The FetchLoader() currently only adds '\n' which results in a concatenated headers string that is not the same as that produced by XMLHttpRequest() and thus not correctly parsed by the DashMetrics.parseResponseHeaders() function (https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/dash/DashMetrics.js#L434)