### PR TITLE
Bug Fix: Corrected path for retrieving ABRStrategy from Settings

### DIFF
--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -441,7 +441,7 @@ function AbrController() {
     }
 
     function updateIsUsingBufferOccupancyABR(mediaType, bufferLevel) {
-        const strategy = settings.get().streaming.ABRStrategy;
+        const strategy = settings.get().streaming.abr.ABRStrategy;
 
         if (strategy === Constants.ABR_STRATEGY_BOLA) {
             isUsingBufferOccupancyABRDict[mediaType] = true;


### PR DESCRIPTION
The existing path for the ABRStrategy check is wrong so it always falls back to the default strategy.