### PR TITLE
fix memory leak and infinite loop

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -984,7 +984,10 @@ function StreamController() {
                 });
             }
         }
-
+        if (activeStream) {
+            activeStream.stopEventController();
+            activeStream.deactivate(true);
+        }
         eventBus.trigger(Events.STREAM_TEARDOWN_COMPLETE);
         resetInitialSettings();
     }


### PR DESCRIPTION
- EventController s causing more apparent memory leak and infinite loop on low spec devices running single page application
- We're not cleaning our setInterval correctly causing an infinite call every 100 ms https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/EventController.js#L95
- Using StreamController controller to clean up eventController on reset
- This causes ~ .2MB memory leak per playback + wasted cpu execution time 1 setInterval per playback switch that never gets cleared. 