### PR TITLE
adding fix for when using web components

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -346,11 +346,13 @@ function VideoModel() {
     }
 
     function getVideoRelativeOffsetTop() {
-        return element && element.parentNode ? element.getBoundingClientRect().top - element.parentNode.getBoundingClientRect().top : NaN;
+        const parentElement = element.parentNode.host || element.parentNode;
+        return parentElement ? element.getBoundingClientRect().top - parentElement.parentNode.getBoundingClientRect().top : NaN;
     }
 
     function getVideoRelativeOffsetLeft() {
-        return element && element.parentNode ? element.getBoundingClientRect().left - element.parentNode.getBoundingClientRect().left : NaN;
+        const parentElement = element.parentNode.host || element.parentNode;
+        return parentElement ? element.getBoundingClientRect().left - parentElement.getBoundingClientRect().left : NaN;
     }
 
     function getTextTracks() {


### PR DESCRIPTION
resolving an issue where if the user places the video element that dashjs is attached to inside a shadow dom at its root, it will throw an error.
this error is caused by the captions trying to use getBoundingClientRect() on the parent and in this case that will be a document fragment where getBoundingClientRect() will not be accessible.

the applied fix is to return the host value of the parent if available; which will instead return the web component node and then if host is not found fallback to the just the normal parentNode