### PR TITLE
Bugfix live edge calculation

### DIFF
--- a/samples/dash-if-reference-player/dashjs_config.json
+++ b/samples/dash-if-reference-player/dashjs_config.json
@@ -5,7 +5,7 @@
     "streaming": {
         "metricsMaxListDepth": 50,
         "abandonLoadTimeout": 10000,
-        "liveDelayFragmentCount": 4,
+        "liveDelayFragmentCount": null,
         "liveDelay": null,
         "scheduleWhilePaused": true,
         "fastSwitchEnabled": true,

--- a/samples/dash-if-reference-player/dashjs_config.json
+++ b/samples/dash-if-reference-player/dashjs_config.json
@@ -1,6 +1,6 @@
 {
     "debug": {
-        "logLevel": 5
+        "logLevel": 4
     },
     "streaming": {
         "metricsMaxListDepth": 50,

--- a/samples/dash-if-reference-player/dashjs_config.json
+++ b/samples/dash-if-reference-player/dashjs_config.json
@@ -1,6 +1,6 @@
 {
     "debug": {
-        "logLevel": 4
+        "logLevel": 5
     },
     "streaming": {
         "metricsMaxListDepth": 50,
@@ -22,7 +22,7 @@
         "lowLatencyEnabled": false,
         "keepProtectionMediaKeys": false,
         "useManifestDateHeaderTimeSource": true,
-        "useSuggestedPresentationDelay": false,
+        "useSuggestedPresentationDelay": true,
         "manifestUpdateRetryInterval": 100,
         "liveCatchUpMinDrift": 0.02,
         "liveCatchUpMaxDrift": 0,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -54,7 +54,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *      streaming: {
  *          metricsMaxListDepth: 1000,
  *          abandonLoadTimeout: 10000,
- *          liveDelayFragmentCount: 4,
+ *          liveDelayFragmentCount: null,
  *          liveDelay: null,
  *          scheduleWhilePaused: true,
  *          fastSwitchEnabled: false,
@@ -203,7 +203,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * @property {number} [abandonLoadTimeout=10000]
  * A timeout value in seconds, which during the ABRController will block switch-up events.
  * This will only take effect after an abandoned fragment event occurs.
- * @property {number} [liveDelayFragmentCount=4]
+ * @property {number} [liveDelayFragmentCount=null]
  * Changing this value will lower or increase live stream latency.  The detected segment duration will be multiplied by this value
  * to define a time in seconds to delay a live stream from the live edge. Lowering this value will lower latency but may decrease
  * the player's ability to build a stable buffer.

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -54,7 +54,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *      streaming: {
  *          metricsMaxListDepth: 1000,
  *          abandonLoadTimeout: 10000,
- *          liveDelayFragmentCount: null,
+ *          liveDelayFragmentCount: NaN,
  *          liveDelay: null,
  *          scheduleWhilePaused: true,
  *          fastSwitchEnabled: false,
@@ -203,7 +203,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * @property {number} [abandonLoadTimeout=10000]
  * A timeout value in seconds, which during the ABRController will block switch-up events.
  * This will only take effect after an abandoned fragment event occurs.
- * @property {number} [liveDelayFragmentCount=null]
+ * @property {number} [liveDelayFragmentCount=NaN]
  * Changing this value will lower or increase live stream latency.  The detected segment duration will be multiplied by this value
  * to define a time in seconds to delay a live stream from the live edge. Lowering this value will lower latency but may decrease
  * the player's ability to build a stable buffer.
@@ -373,7 +373,7 @@ function Settings() {
         streaming: {
             metricsMaxListDepth: 1000,
             abandonLoadTimeout: 10000,
-            liveDelayFragmentCount: null,
+            liveDelayFragmentCount: NaN,
             liveDelay: null,
             scheduleWhilePaused: true,
             fastSwitchEnabled: false,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -373,7 +373,7 @@ function Settings() {
         streaming: {
             metricsMaxListDepth: 1000,
             abandonLoadTimeout: 10000,
-            liveDelayFragmentCount: 4,
+            liveDelayFragmentCount: null,
             liveDelay: null,
             scheduleWhilePaused: true,
             fastSwitchEnabled: false,
@@ -390,7 +390,7 @@ function Settings() {
             lowLatencyEnabled: false,
             keepProtectionMediaKeys: false,
             useManifestDateHeaderTimeSource: true,
-            useSuggestedPresentationDelay: false,
+            useSuggestedPresentationDelay: true,
             useAppendWindowEnd: true,
             manifestUpdateRetryInterval: 100,
             liveCatchUpMinDrift: 0.02,

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -715,7 +715,8 @@ function MssParser(config) {
         if (manifest.type === 'dynamic') {
             let targetLiveDelay = mediaPlayerModel.getLiveDelay();
             if (!targetLiveDelay) {
-                targetLiveDelay = segmentDuration * settings.get().streaming.liveDelayFragmentCount;
+                const liveDelayFragmentCount = settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(settings.get().streaming.liveDelayFragmentCount) ? settings.get().streaming.liveDelayFragmentCount : 4;
+                targetLiveDelay = segmentDuration * liveDelayFragmentCount;
             }
             let targetDelayCapping = Math.max(manifest.timeShiftBufferDepth - 10/*END_OF_PLAYLIST_PADDING*/, manifest.timeShiftBufferDepth / 2);
             let liveDelay = Math.min(targetDelayCapping, targetLiveDelay);

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -240,18 +240,18 @@ function PlaybackController() {
 
         let suggestedPresentationDelay = adapter.getSuggestedPresentationDelay();
 
-        if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
-            delay = suggestedPresentationDelay;
-        } else if (settings.get().streaming.lowLatencyEnabled) {
+        if (settings.get().streaming.lowLatencyEnabled) {
             delay = 0;
         } else if (mediaPlayerModel.getLiveDelay()) {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
+        } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(fragmentDuration)) {
+            delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
+        }  else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
+            delay = suggestedPresentationDelay;
         } else if (r) {
             delay = r;
         }
-        else if (!isNaN(fragmentDuration)) {
-            delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
-        } else {
+        else {
             delay = streamInfo.manifestInfo.minBufferTime * 2;
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -244,11 +244,11 @@ function PlaybackController() {
             delay = 0;
         } else if (mediaPlayerModel.getLiveDelay()) {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
-        } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(fragmentDuration)) {
+        } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(settings.get().streaming.liveDelayFragmentCount) && !isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
         } else if (r) {
             delay = r;
-        } else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
+        } else if (settings.get().streaming.useSuggestedPresentationDelay === true && suggestedPresentationDelay !== null && !isNaN(suggestedPresentationDelay) && suggestedPresentationDelay > 0) {
             delay = suggestedPresentationDelay;
         } else if (!isNaN(fragmentDuration)) {
             delay = fragmentDuration * 4;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -253,7 +253,7 @@ function PlaybackController() {
         } else if (!isNaN(fragmentDuration)) {
             delay = fragmentDuration * 4;
         } else {
-            delay = streamInfo.manifestInfo.minBufferTime * 2;
+            delay = streamInfo.manifestInfo.minBufferTime * 4;
         }
 
         startTime = adapter.getAvailabilityStartTime();

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -246,12 +246,13 @@ function PlaybackController() {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
         } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
-        }  else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
+        } else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
             delay = suggestedPresentationDelay;
         } else if (r) {
             delay = r;
-        }
-        else {
+        } else if (!isNaN(fragmentDuration)) {
+            delay = fragmentDuration * 4;
+        } else {
             delay = streamInfo.manifestInfo.minBufferTime * 2;
         }
 
@@ -758,7 +759,7 @@ function PlaybackController() {
             const minDelay = 1.2 * e.request.duration;
             if (minDelay > mediaPlayerModel.getLiveDelay()) {
                 logger.warn('Browser does not support fetch API with StreamReader. Increasing live delay to be 20% higher than segment duration:', minDelay.toFixed(2));
-                const s = { streaming: { liveDelay: minDelay } };
+                const s = {streaming: {liveDelay: minDelay}};
                 settings.update(s);
             }
         }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -246,10 +246,10 @@ function PlaybackController() {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
         } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
-        } else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
-            delay = suggestedPresentationDelay;
         } else if (r) {
             delay = r;
+        } else if (settings.get().streaming.useSuggestedPresentationDelay && suggestedPresentationDelay !== null) {
+            delay = suggestedPresentationDelay;
         } else if (!isNaN(fragmentDuration)) {
             delay = fragmentDuration * 4;
         } else {

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -602,7 +602,7 @@ describe('MediaPlayer', function () {
 
         it('should configure LiveDelayFragmentCount', function () {
             let liveDelayFragmentCount = player.getSettings().streaming.liveDelayFragmentCount;
-            expect(liveDelayFragmentCount).to.equal(4);
+            expect(liveDelayFragmentCount).to.equal(null);
 
             player.updateSettings({'streaming': { 'liveDelayFragmentCount': 5 }});
 
@@ -612,12 +612,12 @@ describe('MediaPlayer', function () {
 
         it('should configure useSuggestedPresentationDelay', function () {
             let useSuggestedPresentationDelay = player.getSettings().streaming.useSuggestedPresentationDelay;
-            expect(useSuggestedPresentationDelay).to.be.false; // jshint ignore:line
+            expect(useSuggestedPresentationDelay).to.be.true; // jshint ignore:line
 
-            player.updateSettings({'streaming': { 'useSuggestedPresentationDelay': true }});
+            player.updateSettings({'streaming': { 'useSuggestedPresentationDelay': false }});
 
             useSuggestedPresentationDelay = player.getSettings().streaming.useSuggestedPresentationDelay;
-            expect(useSuggestedPresentationDelay).to.be.true; // jshint ignore:line
+            expect(useSuggestedPresentationDelay).to.be.false; // jshint ignore:line
         });
 
         it('should configure scheduleWhilePaused', function () {

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -602,7 +602,7 @@ describe('MediaPlayer', function () {
 
         it('should configure LiveDelayFragmentCount', function () {
             let liveDelayFragmentCount = player.getSettings().streaming.liveDelayFragmentCount;
-            expect(liveDelayFragmentCount).to.equal(null);
+            expect(liveDelayFragmentCount).to.be.NaN; // jshint ignore:line
 
             player.updateSettings({'streaming': { 'liveDelayFragmentCount': 5 }});
 


### PR DESCRIPTION
This PR changes the priority of the live delay calculation to the following descending order 
1. If low latency enabled set delay to 0
2. If live delay was set by the user use this value
3. If live delay fragment count was set by the user use this value
4. If r parameter is present in the url use this parameter
5. If suggestedPresentationDelay in included in the MPD use this value
6. If fragment duration is available use 4*fragment duration
7. Otherwise use minBufferTime*2

This PR also related to a fix applied regarding the suggestedPresentationDelay : https://github.com/Dash-Industry-Forum/dash.js/pull/3199