### PR TITLE
Restart ScheduleController once buffer is pruned only after QuotaExceedeError

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -84,6 +84,7 @@ function BufferController(config) {
         appendedBytesInfo,
         wallclockTicked,
         isPruningInProgress,
+        isQuotaExceeded,
         initCache,
         seekStartTime,
         seekClearedBufferingCompleted,
@@ -262,6 +263,7 @@ function BufferController(config) {
     function onAppended(e) {
         if (e.error) {
             if (e.error.code === QUOTA_EXCEEDED_ERROR_CODE) {
+                isQuotaExceeded = true;
                 criticalBufferLevel = getTotalBufferedTime() * 0.8;
                 logger.warn('Quota exceeded, Critical Buffer: ' + criticalBufferLevel);
 
@@ -281,6 +283,7 @@ function BufferController(config) {
             }
             return;
         }
+        isQuotaExceeded = false;
 
         appendedBytesInfo = e.chunk;
         if (appendedBytesInfo && !isNaN(appendedBytesInfo.index)) {
@@ -745,7 +748,7 @@ function BufferController(config) {
                     appendToBuffer(mediaChunk);
                 }
             }
-            eventBus.trigger(Events.BUFFER_CLEARED, { sender: instance, from: e.from, to: e.to, unintended: e.unintended,  hasEnoughSpaceToAppend: hasEnoughSpaceToAppend() });
+            eventBus.trigger(Events.BUFFER_CLEARED, { sender: instance, from: e.from, to: e.to, unintended: e.unintended,  hasEnoughSpaceToAppend: hasEnoughSpaceToAppend(), quotaExceeded: isQuotaExceeded });
         }
         //TODO - REMEMBER removed a timerout hack calling clearBuffer after manifestInfo.minBufferTime * 1000 if !hasEnoughSpaceToAppend() Aug 04 2016
     }
@@ -870,6 +873,7 @@ function BufferController(config) {
         appendedBytesInfo = null;
         isBufferingCompleted = false;
         isPruningInProgress = false;
+        isQuotaExceeded = false;
         seekClearedBufferingCompleted = false;
         bufferLevel = 0;
         wallclockTicked = 0;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -551,7 +551,7 @@ function ScheduleController(config) {
             }
         }
 
-        if (e.hasEnoughSpaceToAppend && isStopped) {
+        if (e.hasEnoughSpaceToAppend && e.quotaExceeded && isStopped) {
             start();
         }
     }


### PR DESCRIPTION
In ScheduleController there is a mechanism to restart the scheduler once buffer has been pruned in case of QuotaExceededError.
But scheduler may have been stopped for some other reasons/errors, for example if BaseURL resolution failed (after a segment download error for example).
And since there is a buffer pruning timer (every 10sec by default, see bufferPruningInterval parameter) then the scheduler was also restarted in this case, which is not the desired behavior.
We want the scheduler to restart automatically only after QuotaExceedeError.

This PR fixes this issue.