### PR TITLE
Edge Functional Tests

### DIFF
--- a/test/functional/config/browsers/windows.js
+++ b/test/functional/config/browsers/windows.js
@@ -32,7 +32,8 @@ define(function () {
             'com.widevine.alpha': false,
             'com.microsoft.playready': true,
             'org.w3.clearkey': true
-        }
+        },
+        'ms:edgeOptions': { w3c: false }
     };
 
     return {

--- a/test/functional/readme.md
+++ b/test/functional/readme.md
@@ -33,7 +33,14 @@ In ```config``` folder, you will multiple configurations files that are used by 
 In ```selenium``` folder, the following web drivers are available:
 - Chrome
 - Firefox
-- Edge
+- Chromium Edge
+
+#### Legacy Edge
+Download matching Edge driver (MicrosoftWebDriver) from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+
+For Edge version 17 and prior you need to adjust the "Dwebdriver.edge.driver" property in startClient.bat. 
+
+For Version 18 and 19 follow the instructions in the same link above and remove the "Dwebdriver.edge.driver" property and the MicrosoftWebDriver.exe in the selenium folder.
 
 #### Launch the tests
 1. Start selenium hub. Open a new terminal and launch the command:

--- a/test/functional/readme.md
+++ b/test/functional/readme.md
@@ -36,11 +36,11 @@ In ```selenium``` folder, the following web drivers are available:
 - Chromium Edge
 
 #### Legacy Edge
-Download matching Edge driver (MicrosoftWebDriver) from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+Download the matching Edge driver (MicrosoftWebDriver) from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
 
-For Edge version 17 and prior you need to adjust the "Dwebdriver.edge.driver" property in startClient.bat. 
+For Edge version <=17 you need to adjust the "Dwebdriver.edge.driver" property in startClient.bat. 
 
-For Version 18 and 19 follow the instructions in the same link above and remove the "Dwebdriver.edge.driver" property and the MicrosoftWebDriver.exe in the selenium folder.
+For Version 18 and 19 follow the instructions in the link above and remove the "Dwebdriver.edge.driver" property and the MicrosoftWebDriver.exe in the selenium folder.
 
 #### Launch the tests
 1. Start selenium hub. Open a new terminal and launch the command:

--- a/test/functional/selenium/Win10nodeConfig.json
+++ b/test/functional/selenium/Win10nodeConfig.json
@@ -30,9 +30,6 @@
 	"register": true,
 	"registerCycle": 5000,
 	"hubPort": 4444,
-	"hubHost": "127.0.0.1",
-	"Dwebdriver.chrome.driver=chromedriver.exe": "",
-	"Dwebdriver.edge.driver=msedgedriver.exe": "",
-	"Dwebdriver.gecko.driver=geckodriver.exe": ""
+	"hubHost": "127.0.0.1"
 
 }

--- a/test/functional/selenium/startClient.bat
+++ b/test/functional/selenium/startClient.bat
@@ -1,1 +1,3 @@
-java -jar selenium-server-standalone-3.4.0.jar -role node -nodeConfig  Win10nodeConfig.json
+java ^
+ -Dwebdriver.edge.driver="msedgedriver.exe" ^
+ -jar selenium-server-standalone-3.4.0.jar -role node -nodeConfig  Win10nodeConfig.json


### PR DESCRIPTION
-Dwebdriver.edge.driver="msedgedriver.exe"
needs to point at correct Driver(correct version etc.)
For Legacy Edge Version 18 and 19, the Driver is a FOD for Windows and therefore
you dont need to point to the driver, but you need to delete the MicrosoftWebDriver.exe from the folder.