### PR TITLE
tests browser specific sources

### DIFF
--- a/test/functional/config/streams.js
+++ b/test/functional/config/streams.js
@@ -20,7 +20,7 @@ define([
         for (var j = 0; j < group.submenu.length; j++) {
             var stream = group.submenu[j];
             stream.name = groupName + ' / ' + stream.name;
-            streams.push(stream);    
+            if(stream.browser===undefined || stream.browser.includes(intern.args.browsers)) streams.push(stream);        
         }
     }
 


### PR DESCRIPTION
example sources.json extract.
```

        {
          "url": "https://...",
          "name": "External VTT subtitle file",
          "browser": "chrome"
        }
```
Browser doesn't need to be added, like this
```
        {
          "url": "https://...",
          "name": "External VTT subtitle file"
        }
```
