### PR TITLE
Add onabort handler to legacy Chrome abort code path

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -240,6 +240,7 @@ function FetchLoader(cfg) {
             // For Chrome
             try {
                 request.reader.cancel();
+                request.onabort();
             } catch (e) {
                 // throw exceptions (TypeError) when reader was previously closed,
                 // for example, because a network issue


### PR DESCRIPTION
Add onabort handling to the [legacy?] Chrome behaviour, or the code could be removed.