### PR TITLE
Add signal.onabort handler to AbortController

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -76,6 +76,7 @@ function FetchLoader(cfg) {
         if (typeof window.AbortController === 'function') {
             abortController = new AbortController(); /*jshint ignore:line*/
             httpRequest.abortController = abortController;
+            abortController.signal.onabort = httpRequest.onabort;
         }
 
         const reqOptions = {


### PR DESCRIPTION
Added missing `signal.onabort` in Fetch AbortController setup. The required onabort action to be called is the httpRequest.onabort() handler which deals with the abort cleanup and re-start logic for the media - as perfomed by the XHRLoader.

It leads to a question about how one handles the [legacy?] Chrome behaviour - see Pull Request:
https://github.com/Dash-Industry-Forum/dash.js/pull/3235