### PR TITLE
Add protocol in stream's manifestInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -800,6 +800,7 @@ declare namespace dashjs {
         loadedTime: Date;
         maxFragmentDuration: number;
         minBufferTime: number;
+        protocol?: string;
     }
 
     export class StreamInfo {
@@ -807,7 +808,7 @@ declare namespace dashjs {
         index: number;
         start: number;
         duration: number;
-        manifestInfo: object;
+        manifestInfo: IManifestInfo;
         isLast: boolean;
     }
 

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -586,6 +586,7 @@ function DashAdapter() {
         manifestInfo.duration = dashManifestModel.getDuration(mpd.manifest);
         manifestInfo.isDynamic = dashManifestModel.getIsDynamic(mpd.manifest);
         manifestInfo.serviceDescriptions = dashManifestModel.getServiceDescriptions(mpd.manifest);
+        manifestInfo.protocol = mpd.manifest.protocol;
 
         return manifestInfo;
     }

--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -99,6 +99,8 @@ function DashParser() {
         const ironedTime = window.performance.now();
         logger.info('Parsing complete: ( xml2json: ' + (jsonTime - startTime).toPrecision(3) + 'ms, objectiron: ' + (ironedTime - jsonTime).toPrecision(3) + 'ms, total: ' + ((ironedTime - startTime) / 1000).toPrecision(3) + 's)');
 
+        manifest.protocol = 'DASH';
+
         return manifest;
     }
 


### PR DESCRIPTION
...  in order to enable protocol detection once stream is loaded (to distinguish DASH from MSS streams):
`mediaPlayer.getActiveStream().getStreamInfo().manifestInfo.protocol`