### PR TITLE
Remove r parameter from live delay computation as we use it to jump t…

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -228,17 +228,10 @@ function PlaybackController() {
     function computeLiveDelay(fragmentDuration, dvrWindowSize, minBufferTime = NaN) {
         let delay,
             ret,
-            r,
             startTime;
         const END_OF_PLAYLIST_PADDING = 10;
         const MIN_BUFFER_TIME_FACTOR = 4;
         const FRAGMENT_DURATION_FACTOR = 4;
-
-        let uriParameters = uriFragmentModel.getURIFragmentData();
-
-        if (uriParameters) {
-            r = parseInt(uriParameters.r, 10);
-        }
 
         let suggestedPresentationDelay = adapter.getSuggestedPresentationDelay();
 
@@ -248,8 +241,6 @@ function PlaybackController() {
             delay = mediaPlayerModel.getLiveDelay(); // If set by user, this value takes precedence
         } else if (settings.get().streaming.liveDelayFragmentCount !== null && !isNaN(settings.get().streaming.liveDelayFragmentCount) && !isNaN(fragmentDuration)) {
             delay = fragmentDuration * settings.get().streaming.liveDelayFragmentCount;
-        } else if (r) {
-            delay = r;
         } else if (settings.get().streaming.useSuggestedPresentationDelay === true && suggestedPresentationDelay !== null && !isNaN(suggestedPresentationDelay) && suggestedPresentationDelay > 0) {
             delay = suggestedPresentationDelay;
         } else if (!isNaN(fragmentDuration)) {


### PR DESCRIPTION
…o a specific starting point.