### PR TITLE
Do not use setInterval

### DIFF
--- a/src/streaming/MediaPlayerFactory.js
+++ b/src/streaming/MediaPlayerFactory.js
@@ -108,7 +108,8 @@ function loadHandler() {
 
 function loadIntervalHandler() {
     if (window.dashjs) {
-        window.clearInterval(loadInterval);
+        clearTimeout(loadInterval);
+        loadInterval = null;
         instance.createAll();
     }
 }
@@ -121,11 +122,18 @@ if (!avoidAutoCreate && typeof window !== 'undefined' && window && window.addEve
             instance.createAll();
         } else {
             // If loaded asynchronously, window.readyState may be 'complete' even if dashjs hasn't loaded yet
-            loadInterval = window.setInterval(loadIntervalHandler, 500);
+            pollLoadHandler();
         }
     } else {
         window.addEventListener('load', loadHandler);
     }
+}
+
+function pollLoadHandler() {
+    loadInterval = window.setTimeout(function () {
+        pollLoadHandler();
+        loadIntervalHandler();
+    }, 500);
 }
 
 export default instance;

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -90,12 +90,12 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, useAppendW
                     buffer.addEventListener('abort', errHandler, false);
 
                 } catch (err) {
-                    // use setInterval to periodically check if updating has been completed
-                    intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
+                    // periodically check if updating has been completed
+                    pollHandler(checkIsUpdateEnded, CHECK_INTERVAL);
                 }
             } else {
-                // use setInterval to periodically check if updating has been completed
-                intervalId = setInterval(checkIsUpdateEnded, CHECK_INTERVAL);
+                // periodically check if updating has been completed
+                pollHandler(checkIsUpdateEnded, CHECK_INTERVAL);
             }
         } catch (ex) {
             // Note that in the following, the quotes are open to allow for extra text after stpp and wvtt
@@ -115,7 +115,7 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, useAppendW
                 buffer.removeEventListener('error', errHandler, false);
                 buffer.removeEventListener('abort', errHandler, false);
             }
-            clearInterval(intervalId);
+            stopPollHandler();
             buffer.appendWindowEnd = Infinity;
             if (!keepBuffer) {
                 try {
@@ -343,6 +343,18 @@ function SourceBufferSink(mediaSource, mediaInfo, onAppendedCallback, useAppendW
         if (!buffer.updating) {
             executeCallback();
         }
+    }
+
+    function pollHandler(handler, interval) {
+        intervalId = setTimeout(function () {
+            pollHandler(handler, interval);
+            handler();
+        }, interval);
+    }
+
+    function stopPollHandler() {
+        clearTimeout(intervalId);
+        intervalId = null;
     }
 
     instance = {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -430,15 +430,23 @@ function PlaybackController() {
     function startUpdatingWallclockTime() {
         if (wallclockTimeIntervalId !== null) return;
 
+        let poll;
         const tick = function () {
             onWallclockTime();
+            if (wallclockTimeIntervalId !== null) {
+                poll();
+            }
         };
 
-        wallclockTimeIntervalId = setInterval(tick, settings.get().streaming.wallclockTimeUpdateInterval);
+        poll = function () {
+            wallclockTimeIntervalId = setTimeout(tick, settings.get().streaming.wallclockTimeUpdateInterval);
+        };
+
+        poll();
     }
 
     function stopUpdatingWallclockTime() {
-        clearInterval(wallclockTimeIntervalId);
+        clearTimeout(wallclockTimeIntervalId);
         wallclockTimeIntervalId = null;
     }
 

--- a/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
+++ b/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
@@ -38,7 +38,7 @@ function BufferLevelHandler(config) {
         reportingController,
         n,
         name,
-        interval,
+        intervalId,
         lastReportedTime;
 
     let context = this.context;
@@ -80,13 +80,13 @@ function BufferLevelHandler(config) {
             n = handlerHelpers.validateN(n_ms);
             reportingController = rc;
             name = handlerHelpers.reconstructFullMetricName(basename, n_ms);
-            interval = setInterval(intervalCallback, n);
+            pollHandler(intervalCallback, n);
         }
     }
 
     function reset() {
-        clearInterval(interval);
-        interval = null;
+        clearTimeout(intervalId);
+        intervalId = null;
         n = 0;
         reportingController = null;
         lastReportedTime = null;
@@ -96,6 +96,13 @@ function BufferLevelHandler(config) {
         if (metric === metricsConstants.BUFFER_LEVEL) {
             storedVOs[type] = vo;
         }
+    }
+
+    function pollHandler(handler, interval) {
+        intervalId = setTimeout(function () {
+            pollHandler(handler, interval);
+            handler();
+        }, interval);
     }
 
     instance = {

--- a/src/streaming/metrics/metrics/handlers/HttpListHandler.js
+++ b/src/streaming/metrics/metrics/handlers/HttpListHandler.js
@@ -39,7 +39,7 @@ function HttpListHandler(config) {
         n,
         type,
         name,
-        interval;
+        intervalId;
 
     let storedVos = [];
 
@@ -78,17 +78,24 @@ function HttpListHandler(config) {
                 requestType
             );
 
-            interval = setInterval(intervalCallback, n);
+            pollHandler(intervalCallback, n);
         }
     }
 
     function reset() {
-        clearInterval(interval);
-        interval = null;
+        clearTimeout(intervalId);
+        intervalId = null;
         n = null;
         type = null;
         storedVos = [];
         reportingController = null;
+    }
+
+    function pollHandler(handler, interval) {
+        intervalId = setTimeout(function () {
+            pollHandler(handler, interval);
+            handler();
+        }, interval);
     }
 
     function handleNewMetric(metric, vo) {

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -531,13 +531,12 @@ function TextTracks() {
         setCueStyleOnTrack.call(this, track);
 
         if (videoSizeCheckInterval) {
-            clearInterval(videoSizeCheckInterval);
-            videoSizeCheckInterval = null;
+            stopPollHandler();
         }
 
         if (track && track.renderingType === 'html') {
             checkVideoSize.call(this, track, true);
-            videoSizeCheckInterval = setInterval(checkVideoSize.bind(this, track), 500);
+            pollHandler(checkVideoSize.bind(this, track), 500);
         }
     }
 
@@ -590,8 +589,7 @@ function TextTracks() {
         trackElementArr = [];
         textTrackQueue = [];
         if (videoSizeCheckInterval) {
-            clearInterval(videoSizeCheckInterval);
-            videoSizeCheckInterval = null;
+            stopPollHandler();
         }
         currentTrackIdx = -1;
         clearCaptionContainer.call(this);
@@ -663,6 +661,19 @@ function TextTracks() {
 
     function getCurrentTrackInfo() {
         return textTrackQueue[currentTrackIdx];
+    }
+
+    function pollHandler(handler, interval) {
+        stopPollHandler();
+        videoSizeCheckInterval = setTimeout(function () {
+            pollHandler(handler, interval);
+            handler();
+        }, interval);
+    }
+
+    function stopPollHandler() {
+        clearTimeout(videoSizeCheckInterval);
+        videoSizeCheckInterval = null;
     }
 
     instance = {


### PR DESCRIPTION
This PR replaces all occurrences of `setInterval()` with self-resuming `setTimeout()`.

The problem with `setInterval()` is that browser schedules all handler invocations for a period of time while interval is active. Which leads to intensive CPU usage when browser or tab goes back from idle state.

**Steps to reproduce**

1. Open any DASH sample, for example `samples/getting-started/auto-load-single-video-src.html` and pause video.
2. Put computer on sleep mode for a while (for example, 10 minutes)
3. Wake up computer: you’ll see that example page hags up for a while and computer fans are spinning.

It happens because browser schedules `setInterval()` callbacks for a period of active time. For example, if you set `setInterval(fn, 100)` and 1 second passes, it _must_ call `fn` 10 times (1000 / 100). Even if a main thread was active for a 300ms, it still schedules 10 `fn` calls for 1 second while timer is active.

The same happens when you put computer asleep or browser tab becomes background: browser will immediately call all scheduled invocations for a period of time when tab was inactive but `setInterval()` active.

To overcome this problem, a self-resuming `setTimeout()` technique is used: schedule one `fn` invocation and schedule next one only if timer was called.