### PR TITLE
Reverse order of samplesize variance test to match usage

### DIFF
--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -159,7 +159,7 @@ function ThroughputHistory(config) {
         } else if (isThroughput) {
             // if throughput samples vary a lot, average over a wider sample
             for (let i = 1; i < sampleSize; ++i) {
-                const ratio = arr[i] / arr[i - 1];
+                const ratio = arr[arr.length - i] / arr[arr.length - i - 1];
                 if (ratio >= THROUGHPUT_INCREASE_SCALE || ratio <= 1 / THROUGHPUT_DECREASE_SCALE) {
                     sampleSize += 1;
                     if (sampleSize === arr.length) { // cannot increase sampleSize beyond arr.length


### PR DESCRIPTION
The current `getSampleSize()` function expands the `sampleSize` based on checking the variance of subsequent samples from the beginning, but does so in the opposite order to which `getAverageSlidingWindow()` actually uses the resulting samples - which takes those from the end. This fix corrects the check so that it operates from the end(newest) items of the queue backwards.