### PR TITLE
[MSS] Restore default buffer settings

### DIFF
--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -41,16 +41,16 @@ import InitCache from '../streaming/utils/InitCache';
 function MssHandler(config) {
 
     config = config || {};
-    let context = this.context;
-    let eventBus = config.eventBus;
+    const context = this.context;
+    const eventBus = config.eventBus;
     const events = config.events;
     const constants = config.constants;
     const initSegmentType = config.initSegmentType;
-    let dashMetrics = config.dashMetrics;
-    let playbackController = config.playbackController;
-    let streamController = config.streamController;
-    let protectionController = config.protectionController;
-    let mssFragmentProcessor = MssFragmentProcessor(context).create({
+    const dashMetrics = config.dashMetrics;
+    const playbackController = config.playbackController;
+    const streamController = config.streamController;
+    const protectionController = config.protectionController;
+    const mssFragmentProcessor = MssFragmentProcessor(context).create({
         dashMetrics: dashMetrics,
         playbackController: playbackController,
         protectionController: protectionController,
@@ -219,6 +219,11 @@ function MssHandler(config) {
     }
 
     function reset() {
+        if (mssParser) {
+            mssParser.reset();
+            mssParser = undefined;
+        }
+
         eventBus.off(events.INIT_FRAGMENT_NEEDED, onInitFragmentNeeded, this);
         eventBus.off(events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.off(events.PLAYBACK_SEEK_ASKED, onPlaybackSeekAsked, this);

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -79,7 +79,8 @@ function MssParser(config) {
     };
 
     let instance,
-        logger;
+        logger,
+        initialBufferSettings;
 
 
     function setup() {
@@ -722,6 +723,17 @@ function MssParser(config) {
             let liveDelay = Math.min(targetDelayCapping, targetLiveDelay);
             // Consider a margin of one segment in order to avoid Precondition Failed errors (412), for example if audio and video are not correctly synchronized
             let bufferTime = liveDelay - segmentDuration;
+
+            // Store initial buffer settings
+            initialBufferSettings = {
+                'streaming': {
+                    'liveDelay': settings.get().streaming.liveDelay,
+                    'stableBufferTime': settings.get().streaming.stableBufferTime,
+                    'bufferTimeAtTopQuality': settings.get().streaming.bufferTimeAtTopQuality,
+                    'bufferTimeAtTopQualityLongForm': settings.get().streaming.bufferTimeAtTopQualityLongForm
+                }
+            };
+
             settings.update({
                 'streaming': {
                     'liveDelay': liveDelay,
@@ -836,10 +848,18 @@ function MssParser(config) {
         return manifest;
     }
 
+    function reset() {
+        // Restore initial buffer settings
+        if (initialBufferSettings) {
+            settings.update(initialBufferSettings);
+        }
+    }
+
     instance = {
         parse: internalParse,
         getMatchers: getMatchers,
-        getIron: getIron
+        getIron: getIron,
+        reset: reset
     };
 
     setup();


### PR DESCRIPTION
The goal of this PR is to restore live delay and buffer settings in case they are modified by MSS parser for live streams (for example to avoid 412 precondition failed errors)