### PR TITLE
Optimize live start

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -75,6 +75,7 @@ function StreamProcessor(config) {
     let boxParser = config.boxParser;
 
     let instance,
+        logger,
         isDynamic,
         mediaInfo,
         mediaInfoArr,
@@ -86,6 +87,7 @@ function StreamProcessor(config) {
         streamInitialized;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
         eventBus.on(Events.STREAM_INITIALIZED, onStreamInitialized, instance);
@@ -645,7 +647,9 @@ function StreamProcessor(config) {
 
         const currentRepresentationInfo = getRepresentationInfo();
         const liveEdge = liveEdgeFinder.getLiveEdge(currentRepresentationInfo);
-        const startTime = liveEdge - playbackController.computeLiveDelay(currentRepresentationInfo.fragmentDuration, currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo.DVRWindowSize);
+        const liveDelay = playbackController.computeLiveDelay(currentRepresentationInfo.fragmentDuration, currentRepresentationInfo.mediaInfo.streamInfo.manifestInfo.DVRWindowSize);
+        const startTime = liveEdge - liveDelay;
+        logger.debug('live edge: ' + liveEdge + ', live delay: ' + liveDelay + ', live target: ' + startTime);
         const request = getFragmentRequest(currentRepresentationInfo, startTime, {
             ignoreIsFinished: true
         });

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -211,7 +211,7 @@ function PlaybackController() {
 
     function setLiveStartTime(value) {
         if (liveStartTime !== streamInfo.start) {
-            // Consider only 1st live start time (set by video stream or audio if audio nly)
+            // Consider only 1st live start time (set by video stream or audio if audio only)
             return;
         }
         logger.info('Set live start time: ' + value);

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -210,6 +210,11 @@ function PlaybackController() {
     }
 
     function setLiveStartTime(value) {
+        if (liveStartTime !== streamInfo.start) {
+            // Consider only 1st live start time (set by video stream or audio if audio nly)
+            return;
+        }
+        logger.info('Set live start time: ' + value);
         liveStartTime = value;
     }
 


### PR DESCRIPTION
Set live start time on PlaybackController according to video only timeline, to avoid requesting first staggered video and audio segments in case the audio and video segment timelines are staggered