### PR TITLE
Fix regression for representationInfo's segmentDuration

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -112,6 +112,8 @@ function RepresentationController(config) {
         voAvailableRepresentations = availableRepresentations;
 
         currentVoRepresentation = getRepresentationForQuality(quality);
+
+        // In case segmentDuration is not set (ex. SegmentTimeline), request a segment to determine the segmentDuration
         if (currentVoRepresentation && isNaN(currentVoRepresentation.segmentDuration)) {
             indexHandler.getSegmentRequestForTime(null, currentVoRepresentation, 0);
         }
@@ -163,6 +165,7 @@ function RepresentationController(config) {
     }
 
     function updateRepresentation(representation, isDynamic) {
+        // In case segmentDuration is not set (ex. SegmentTimeline), request a segment to determine the segmentDuration
         if (isNaN(representation.segmentDuration)) {
             indexHandler.getSegmentRequestForTime(null, representation, 0);
         }

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -38,6 +38,7 @@ function RepresentationController(config) {
     const eventBus = config.eventBus;
     const events = config.events;
     const errors = config.errors;
+    const indexHandler = config.indexHandler;
     const abrController = config.abrController;
     const dashMetrics = config.dashMetrics;
     const playbackController = config.playbackController;
@@ -111,6 +112,10 @@ function RepresentationController(config) {
         voAvailableRepresentations = availableRepresentations;
 
         currentVoRepresentation = getRepresentationForQuality(quality);
+        if (currentVoRepresentation && isNaN(currentVoRepresentation.segmentDuration)) {
+            indexHandler.getSegmentRequestForTime(null, currentVoRepresentation, 0);
+        }
+
         realAdaptation = newRealAdaptation;
 
         if (type !== Constants.VIDEO && type !== Constants.AUDIO && type !== Constants.FRAGMENTED_TEXT) {
@@ -158,6 +163,9 @@ function RepresentationController(config) {
     }
 
     function updateRepresentation(representation, isDynamic) {
+        if (isNaN(representation.segmentDuration)) {
+            indexHandler.getSegmentRequestForTime(null, representation, 0);
+        }
         representation.segmentAvailabilityRange = timelineConverter.calcSegmentAvailabilityRange(representation, isDynamic);
 
         if ((representation.segmentAvailabilityRange.end < representation.segmentAvailabilityRange.start) && !representation.useCalculatedLiveEdgeTime) {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -138,6 +138,7 @@ function StreamProcessor(config) {
         representationController = RepresentationController(context).create({
             streamId: streamInfo.id,
             type: type,
+            indexHandler: indexHandler,
             abrController: abrController,
             dashMetrics: dashMetrics,
             playbackController: playbackController,
@@ -543,9 +544,6 @@ function StreamProcessor(config) {
         const bytes = chunk.bytes;
         const quality = chunk.quality;
         const currentRepresentation = getRepresentationInfo(quality);
-
-        // Update current representation info (to update fragmentDuration for example in case of SegmentTimeline)
-        scheduleController.setCurrentRepresentation(currentRepresentation);
 
         const voRepresentation = representationController && currentRepresentation ? representationController.getRepresentationForQuality(currentRepresentation.quality) : null;
         const eventStreamMedia = adapter.getEventsFor(currentRepresentation.mediaInfo);


### PR DESCRIPTION
This PR fixes a regression introduced in v3.0.
Since v3.0, segments info lists are no more pre-computed, each segment info is now computed when requesting a segment.
As a consequence, segment duration for any representation is not set until a media segment is requested.
Since segmentDuration may be used prior to any media segment request (for example buffer target calculation for text tracks, or segment availability range computation), this leads to some dysfunction (for example text track switching for streams with SegmentTimeline).
