### PR TITLE
Fix live delay computation

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -239,7 +239,7 @@ function RepresentationController(config) {
         if (r.adaptation.period.mpd.manifest.type === dashConstants.DYNAMIC && !r.adaptation.period.mpd.manifest.ignorePostponeTimePeriod) {
             let segmentAvailabilityTimePeriod = r.segmentAvailabilityRange.end - r.segmentAvailabilityRange.start;
             // We must put things to sleep unless till e.g. the startTime calculation in ScheduleController.onLiveEdgeSearchCompleted fall after the segmentAvailabilityRange.start
-            let liveDelay = playbackController.computeLiveDelay(currentVoRepresentation.segmentDuration, streamInfo.manifestInfo.DVRWindowSize);
+            let liveDelay = playbackController.getLiveDelay();
             postponeTimePeriod = (liveDelay - segmentAvailabilityTimePeriod) * 1000;
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -230,7 +230,7 @@ function PlaybackController() {
      * @returns {number} object
      * @memberof PlaybackController#
      */
-    function computeLiveDelay(fragmentDuration, dvrWindowSize, minBufferTime) {
+    function computeAndSetLiveDelay(fragmentDuration, dvrWindowSize, minBufferTime) {
         let delay,
             ret,
             startTime;
@@ -885,7 +885,7 @@ function PlaybackController() {
         getStreamController: getStreamController,
         setLiveStartTime: setLiveStartTime,
         getLiveStartTime: getLiveStartTime,
-        computeLiveDelay: computeLiveDelay,
+        computeAndSetLiveDelay: computeAndSetLiveDelay,
         getLiveDelay: getLiveDelay,
         setLiveDelay: setLiveDelay,
         getCurrentLiveLatency: getCurrentLiveLatency,

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -660,9 +660,10 @@ function StreamController() {
                 // For multiperiod streams we should avoid a switch of streams after the seek to the live edge. So we do a calculation of the expected seek time to find the right stream object.
                 if (!initialStream && adapter.getIsDynamic() && streams.length) {
                     logger.debug('Dynamic multi-period stream: Trying to find the correct starting period');
-                    const manifestInfo = adapter.getStreamsInfo(undefined, 1)[0].manifestInfo;
+                    const streamInfos = adapter.getStreamsInfo(undefined);
+                    const manifestInfo = streamInfos[0].manifestInfo;
                     const liveEdge = timelineConverter.calcPresentationTimeFromWallTime(new Date(), adapter.getRegularPeriods()[0]);
-                    const targetDelay = playbackController.computeLiveDelay(NaN, manifestInfo.DVRWindowSize, manifestInfo.minBufferTime);
+                    const targetDelay = playbackController.computeLiveDelay(manifestInfo.maxFragmentDuration, manifestInfo.DVRWindowSize, manifestInfo.minBufferTime);
                     const targetTime = liveEdge - targetDelay;
                     initialStream = getStreamForTime(targetTime);
                 }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -660,12 +660,7 @@ function StreamController() {
                 // For multiperiod streams we should avoid a switch of streams after the seek to the live edge. So we do a calculation of the expected seek time to find the right stream object.
                 if (!initialStream && adapter.getIsDynamic() && streams.length) {
                     logger.debug('Dynamic multi-period stream: Trying to find the correct starting period');
-                    const streamInfos = adapter.getStreamsInfo(undefined);
-                    const manifestInfo = streamInfos[0].manifestInfo;
-                    const liveEdge = timelineConverter.calcPresentationTimeFromWallTime(new Date(), adapter.getRegularPeriods()[0]);
-                    const targetDelay = playbackController.computeLiveDelay(manifestInfo.maxFragmentDuration, manifestInfo.DVRWindowSize, manifestInfo.minBufferTime);
-                    const targetTime = liveEdge - targetDelay;
-                    initialStream = getStreamForTime(targetTime);
+                    initialStream = getInitialStream();
                 }
                 switchStream(null, initialStream !== null ? initialStream : streams[0], NaN);
             }
@@ -676,6 +671,78 @@ function StreamController() {
             errHandler.error(new DashJSError(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE, e.message + 'nostreamscomposed', manifestModel.getValue()));
             hasInitialisationError = true;
             reset();
+        }
+    }
+
+    function getInitialStream() {
+        try {
+            const streamInfos = adapter.getStreamsInfo(undefined);
+            const manifestInfo = streamInfos[0].manifestInfo;
+            const liveEdge = timelineConverter.calcPresentationTimeFromWallTime(new Date(), adapter.getRegularPeriods()[0]);
+            const fragmentDuration = getFragmentDurationForLiveDelayCalculation(streamInfos, manifestInfo);
+            const targetDelay = playbackController.computeAndSetLiveDelay(fragmentDuration, manifestInfo.DVRWindowSize, manifestInfo.minBufferTime);
+            const targetTime = liveEdge - targetDelay;
+
+            return getStreamForTime(targetTime);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function getFragmentDurationForLiveDelayCalculation(streamInfos, manifestInfo) {
+        try {
+            let fragmentDuration = NaN;
+
+            // For multiperiod manifests we use the maxFragmentDuration attribute as we do not know the correct starting period
+            if (streamInfos && streamInfos.length > 1) {
+                fragmentDuration = manifestInfo && !isNaN(manifestInfo.maxFragmentDuration) ? manifestInfo.maxFragmentDuration : NaN;
+            }
+
+            // For single period manifests we iterate over all AS and use the maximum segment length
+            else if (streamInfos && streamInfos.length === 1) {
+                const streamInfo = streamInfos[0];
+                const mediaTypes = [Constants.VIDEO, Constants.AUDIO, Constants.FRAGMENTED_TEXT];
+
+
+                const fragmentDurations = mediaTypes
+                    .reduce((acc, mediaType) => {
+                        const mediaInfo = adapter.getMediaInfoForType(streamInfo, mediaType);
+
+                        if (mediaInfo) {
+                            acc.push(mediaInfo);
+                        }
+
+                        return acc;
+                    }, [])
+                    .reduce((acc, mediaInfo) => {
+                        const voRepresentations = adapter.getVoRepresentations(mediaInfo);
+
+                        if (voRepresentations && voRepresentations.length > 0) {
+                            voRepresentations.forEach((voRepresentation) => {
+                                if (voRepresentation) {
+                                    acc.push(voRepresentation);
+                                }
+                            });
+                        }
+
+                        return acc;
+                    }, [])
+                    .reduce((acc, voRepresentation) => {
+                        const representation = adapter.convertDataToRepresentationInfo(voRepresentation);
+
+                        if (representation && representation.fragmentDuration && !isNaN(representation.fragmentDuration)) {
+                            acc.push(representation.fragmentDuration);
+                        }
+
+                        return acc;
+                    }, []);
+
+                fragmentDuration = Math.max(...fragmentDurations);
+            }
+
+            return isFinite(fragmentDuration) ? fragmentDuration : NaN;
+        } catch (e) {
+            return NaN;
         }
     }
 

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -95,7 +95,7 @@ describe('PlaybackController', function () {
         });
 
         it('should return NaN when getLiveDelay is called after a call to computeLiveDelay with no parameter', function () {
-            expect(playbackController.computeLiveDelay.bind(playbackController)).not.to.throw();
+            expect(playbackController.computeAndSetLiveDelay.bind(playbackController)).not.to.throw();
             expect(playbackController.getLiveDelay()).to.be.NaN; // jshint ignore:line
         });
 


### PR DESCRIPTION
The goal of this PR is to fix/adjust live delay calculation:

- Fix live delay calculation for SegmentTimeline manifests for which no valid segment request could be generated with the initial live delay. Increase live delay until a valid segment is found instead of starting playback at the beginning of the DVR window
- When live delay is different from the value initially calculated by `computeLiveDelay` it gets adjusted in `StreamProcessor.findRequestForLiveEdge` -> `playbackController.setLiveDelay`
- If the live delay should be a multiple of the fragment duration use `@maxSegmentDuration` for multiperiod manifests. For single period manifests iterate through the available AdaptationSets and use the largest segment duration.

This PR is supposed to fix #3227 and #3146

Known Issues:
For SegmentTimeline manifests the fragmentDuration is currently NaN. Related to #3284 