### PR TITLE
Fix regression with enableText

### DIFF
--- a/samples/captioning/caption_vtt.html
+++ b/samples/captioning/caption_vtt.html
@@ -18,6 +18,7 @@
                 player;
 
             player = dashjs.MediaPlayer({}).create();
+            player.setTextDefaultEnabled(true);
             player.initialize(video, url, true);
         }
     </script>

--- a/samples/captioning/caption_vtt.html
+++ b/samples/captioning/caption_vtt.html
@@ -18,8 +18,8 @@
                 player;
 
             player = dashjs.MediaPlayer({}).create();
-            player.setTextDefaultEnabled(true);
             player.initialize(video, url, true);
+            player.setTextDefaultEnabled(true);
         }
     </script>
 

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -28,6 +28,7 @@
 
             player = dashjs.MediaPlayer().create();
             player.initialize(videoElement, url, true);
+            player.setTextDefaultEnabled(true);
             player.setInitialMediaSettingsFor('fragmentedText', { 
                 lang: 'swe'
             });

--- a/samples/captioning/ttml-ebutt-sample.html
+++ b/samples/captioning/ttml-ebutt-sample.html
@@ -33,6 +33,7 @@
 
             player = dashjs.MediaPlayer().create();
             player.initialize(videoElement, url, true);
+            player.setTextDefaultEnabled(true);
             player.attachTTMLRenderingDiv(TTMLRenderingDiv);
             controlbar = new ControlBar(player); // Checkout ControlBar.js for more info on how to target/add text tracks to UI
             controlbar.initialize();

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -148,13 +148,13 @@ describe('TextController', function () {
         it('should enable/disable text', function () {
 
             let textEnabled = textController.isTextEnabled();
-            expect(textEnabled).to.equal(true); // jshint ignore:line
-
-            textController.enableText(false);
-            expect(textController.isTextEnabled()).to.equal(false); // jshint ignore:line
+            expect(textEnabled).to.equal(false); // jshint ignore:line
 
             textController.enableText(true);
             expect(textController.isTextEnabled()).to.equal(true); // jshint ignore:line
+
+            textController.enableText(false);
+            expect(textController.isTextEnabled()).to.equal(false); // jshint ignore:line
         });
     });
 


### PR DESCRIPTION
As with PR #3245, we now disable text by default, we have introduced a regression. Using enableText(true) does nothing if setTextDefaultEnabled is not set to true.

This PR 
- fix this regression
- allows us to call enableText(true/false) even before text tracks are added
- enable text by default in sample multi-track-captions.html

