### PR TITLE
Fix regression for representationInfo's segmentDuration (cont'd)

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -38,7 +38,6 @@ function RepresentationController(config) {
     const eventBus = config.eventBus;
     const events = config.events;
     const errors = config.errors;
-    const indexHandler = config.indexHandler;
     const abrController = config.abrController;
     const dashMetrics = config.dashMetrics;
     const playbackController = config.playbackController;
@@ -112,12 +111,6 @@ function RepresentationController(config) {
         voAvailableRepresentations = availableRepresentations;
 
         currentVoRepresentation = getRepresentationForQuality(quality);
-
-        // In case segmentDuration is not set (ex. SegmentTimeline), request a segment to determine the segmentDuration
-        if (currentVoRepresentation && isNaN(currentVoRepresentation.segmentDuration)) {
-            indexHandler.getSegmentRequestForTime(null, currentVoRepresentation, 0);
-        }
-
         realAdaptation = newRealAdaptation;
 
         if (type !== Constants.VIDEO && type !== Constants.AUDIO && type !== Constants.FRAGMENTED_TEXT) {
@@ -165,10 +158,6 @@ function RepresentationController(config) {
     }
 
     function updateRepresentation(representation, isDynamic) {
-        // In case segmentDuration is not set (ex. SegmentTimeline), request a segment to determine the segmentDuration
-        if (isNaN(representation.segmentDuration)) {
-            indexHandler.getSegmentRequestForTime(null, representation, 0);
-        }
         representation.segmentAvailabilityRange = timelineConverter.calcSegmentAvailabilityRange(representation, isDynamic);
 
         if ((representation.segmentAvailabilityRange.end < representation.segmentAvailabilityRange.start) && !representation.useCalculatedLiveEdgeTime) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -537,6 +537,12 @@ function DashManifestModel() {
                         // SegmentTemplate @duration attribute. We need to find out if @maxSegmentDuration should be used instead of calculated duration if the the duration
                         // exceeds @maxSegmentDuration
                         voRepresentation.segmentDuration = segmentInfo.duration / voRepresentation.timescale;
+                    } else if (realRepresentation.hasOwnProperty(DashConstants.SEGMENT_TEMPLATE)) {
+                        segmentInfo = realRepresentation.SegmentTemplate;
+
+                        if (segmentInfo.hasOwnProperty(DashConstants.SEGMENT_TIMELINE)) {
+                            voRepresentation.segmentDuration = calcSegmentDuration(segmentInfo.SegmentTimeline) / voRepresentation.timescale;
+                        }
                     }
                     if (segmentInfo.hasOwnProperty(DashConstants.MEDIA)) {
                         voRepresentation.media = segmentInfo.media;
@@ -569,6 +575,12 @@ function DashManifestModel() {
         }
 
         return voRepresentations;
+    }
+
+    function calcSegmentDuration(segmentTimeline) {
+        let s0 = segmentTimeline.S_asArray[0];
+        let s1 = segmentTimeline.S_asArray[1];
+        return s0.hasOwnProperty('d') ? s0.d : (s1.t - s0.t);
     }
 
     function calcMSETimeOffset(representation) {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -138,7 +138,6 @@ function StreamProcessor(config) {
         representationController = RepresentationController(context).create({
             streamId: streamInfo.id,
             type: type,
-            indexHandler: indexHandler,
             abrController: abrController,
             dashMetrics: dashMetrics,
             playbackController: playbackController,

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -738,7 +738,7 @@ describe('DashManifestModel', function () {
         });
 
         it('should not return an empty array when getRepresentationsForAdaptation is called and adaptation is defined', () => {
-            const voAdaptation = {period: {index: 0, mpd: {manifest: {Period_asArray: [{AdaptationSet_asArray: [{Representation_asArray: [{SegmentTemplate: {SegmentTimeline: {S_asArray: [{r: 2}]}}}]}]}]}}}, index: 0, type: 'video'};
+            const voAdaptation = {period: {index: 0, mpd: {manifest: {Period_asArray: [{AdaptationSet_asArray: [{Representation_asArray: [{SegmentTemplate: {SegmentTimeline: {S_asArray: [{d: 2, r: 2}]}}}]}]}]}}}, index: 0, type: 'video'};
             const representationArray = dashManifestModel.getRepresentationsForAdaptation(voAdaptation);
 
             expect(representationArray).to.be.instanceOf(Array);    // jshint ignore:line


### PR DESCRIPTION
This PR resolves issue mentioned in PR #3284, but more efficiently (segmentDuration is computed from SegmentTimeline in DashManifestModel) 