### PR TITLE
Store and use fragmentedText settings in localStorage

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -489,6 +489,8 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             menuHandlersList.push(func);
             captionBtn.addEventListener('click', func);
             captionBtn.classList.remove('hide');
+        } else {
+            setMenuItemsState(e.index + 1, 'caption-list');
         }
     };
 

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -54,8 +54,8 @@
         function setTextDefaultEnabled() {
             var checkbox = document.getElementById("textDefaultEnabled");
             if (!checkbox.indeterminate) {
-                player.setTextDefaultEnabled(checkbox.checked);
                 document.getElementById("textDefaultEnabledValue").innerHTML = checkbox.checked;
+                player.setTextDefaultEnabled(checkbox.checked);
             } else {
                 document.getElementById("textDefaultEnabledValue").innerHTML = 'undefined';
             }

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -13,7 +13,7 @@
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <script class="code">
-        var EXTERNAL_CAPTION_URL = "https://dash.akamaized.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd", // need to manually seek to get stream to start... issue with MPD but only sample with multi adaptations for external sidecar caption text xml
+        var EXTERNAL_CAPTION_URL = "https://dash.akamaized.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd", /* need to manually seek to get stream to start... issue with MPD but only sample with multi adaptations for external sidecar caption text xml */
             FRAGMENTED_CAPTION_URL = "https://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd",
             videoElement,
             controlbar,
@@ -30,7 +30,7 @@
                     setTimeout(showDomStorage, 0);
                 }
             });
-            controlbar = new ControlBar(player); // Checkout ControlBar.js for more info on how to target/add text tracks to UI
+            controlbar = new ControlBar(player); /* Checkout ControlBar.js for more info on how to target/add text tracks to UI */
             controlbar.initialize();
             var checkbox = document.getElementById("textDefaultEnabled");
             checkbox.indeterminate = true;

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -34,6 +34,7 @@
             controlbar.initialize();
             var checkbox = document.getElementById("textDefaultEnabled");
             checkbox.indeterminate = true;
+            document.getElementById("lastMediaSettingsCachingInfoEnabled").checked = player.getSettings().streaming.lastMediaSettingsCachingInfo.enabled;
             showDomStorage();
         }
 
@@ -76,6 +77,20 @@
             }
         }
 
+        function setLastMediaSettingsCachingInfoEnabled() {
+            var checkbox = document.getElementById("lastMediaSettingsCachingInfoEnabled");
+            player.updateSettings({
+                streaming: {
+                    lastMediaSettingsCachingInfo: { enabled: checkbox.checked }
+                }
+            })
+        }
+
+        function clearDomStorage() {
+            localStorage.removeItem('dashjs_fragmentedText_settings');
+            showDomStorage();
+        }
+
     </script>
 
     <style>
@@ -92,6 +107,11 @@
         }
         .settings>div {
             padding: 5px 0;
+        }
+
+        label {
+            font-size: 1.1em;
+            display: block;
         }
 
     </style>
@@ -134,6 +154,9 @@
             </div>
             <div class="settings">
                 <div>
+                    <button onclick="play()">play</button>
+                </div>
+                <div>
                     <label>textDefaultEnabled</label>
                     <input type="checkbox" id="textDefaultEnabled" onchange="setTextDefaultEnabled()"/> <span id="textDefaultEnabledValue">undefined</span>
                 </div>
@@ -149,11 +172,13 @@
                     </select>
                 </div>
                 <div>
-                    <button onclick="play()">play</button>
+                    <label>streaming.lastMediaSettingsCachingInfo.enabled</label>
+                    <input type="checkbox" id="lastMediaSettingsCachingInfoEnabled" onchange="setLastMediaSettingsCachingInfoEnabled()"/>
                 </div>
                 <div>
-                    <label>DOMstorage content</label>
+                    <label>localStorage content</label>
                     <div id="domStorage"></div>
+                    <button onclick="clearDomStorage()">Clear localStorage</button>
                 </div>
             </div>
         </div>

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -32,8 +32,6 @@
             });
             controlbar = new ControlBar(player); /* Checkout ControlBar.js for more info on how to target/add text tracks to UI */
             controlbar.initialize();
-            var checkbox = document.getElementById("textDefaultEnabled");
-            checkbox.indeterminate = true;
             document.getElementById("lastMediaSettingsCachingInfoEnabled").checked = player.getSettings().streaming.lastMediaSettingsCachingInfo.enabled;
             showDomStorage();
         }
@@ -53,12 +51,7 @@
 
         function setTextDefaultEnabled() {
             var checkbox = document.getElementById("textDefaultEnabled");
-            if (!checkbox.indeterminate) {
-                document.getElementById("textDefaultEnabledValue").innerHTML = checkbox.checked;
-                player.setTextDefaultEnabled(checkbox.checked);
-            } else {
-                document.getElementById("textDefaultEnabledValue").innerHTML = 'undefined';
-            }
+            player.setTextDefaultEnabled(checkbox.checked);
         }
 
         function setLang() {
@@ -111,7 +104,6 @@
 
         label {
             font-size: 1.1em;
-            display: block;
         }
 
     </style>
@@ -157,8 +149,8 @@
                     <button onclick="play()">play</button>
                 </div>
                 <div>
+                    <input type="checkbox" id="textDefaultEnabled" onchange="setTextDefaultEnabled()" checked>
                     <label>textDefaultEnabled</label>
-                    <input type="checkbox" id="textDefaultEnabled" onchange="setTextDefaultEnabled()"/> <span id="textDefaultEnabledValue">undefined</span>
                 </div>
                 <div>
                     <label>initial settings Language/Role </label>
@@ -172,8 +164,8 @@
                     </select>
                 </div>
                 <div>
-                    <label>streaming.lastMediaSettingsCachingInfo.enabled</label>
                     <input type="checkbox" id="lastMediaSettingsCachingInfoEnabled" onchange="setLastMediaSettingsCachingInfoEnabled()"/>
+                    <label>streaming.lastMediaSettingsCachingInfo.enabled</label>
                 </div>
                 <div>
                     <label>localStorage content</label>

--- a/samples/captioning/multi-track-captions.html
+++ b/samples/captioning/multi-track-captions.html
@@ -19,22 +19,61 @@
             controlbar,
             player;
 
-        function startVideo() {
-            var url = FRAGMENTED_CAPTION_URL,
-                TTMLRenderingDiv;
-
+        function init() {
+            var TTMLRenderingDiv = document.querySelector("#ttml-rendering-div");
             videoElement = document.querySelector(".videoContainer video");
-            TTMLRenderingDiv = document.querySelector("#ttml-rendering-div");
-
             player = dashjs.MediaPlayer().create();
-            player.initialize(videoElement, url, true);
-            player.setTextDefaultEnabled(true);
-            player.setInitialMediaSettingsFor('fragmentedText', { 
-                lang: 'swe'
-            });
+            player.initialize(videoElement);
             player.attachTTMLRenderingDiv(TTMLRenderingDiv);
+            player.on('currentTrackChanged', function(e) { 
+                if (e.newMediaInfo.type === 'fragmentedText') {
+                    setTimeout(showDomStorage, 0);
+                }
+            });
             controlbar = new ControlBar(player); // Checkout ControlBar.js for more info on how to target/add text tracks to UI
             controlbar.initialize();
+            var checkbox = document.getElementById("textDefaultEnabled");
+            checkbox.indeterminate = true;
+            showDomStorage();
+        }
+
+        function showDomStorage() {
+            document.getElementById("domStorage").innerHTML = localStorage.getItem('dashjs_fragmentedText_settings');
+        }
+
+        function play() {
+            var url = FRAGMENTED_CAPTION_URL;
+            player.attachSource(url);
+            setTextDefaultEnabled();
+            setLang();
+            player.play();
+            showDomStorage();
+        }
+
+        function setTextDefaultEnabled() {
+            var checkbox = document.getElementById("textDefaultEnabled");
+            if (!checkbox.indeterminate) {
+                player.setTextDefaultEnabled(checkbox.checked);
+                document.getElementById("textDefaultEnabledValue").innerHTML = checkbox.checked;
+            } else {
+                document.getElementById("textDefaultEnabledValue").innerHTML = 'undefined';
+            }
+        }
+
+        function setLang() {
+            var lang = document.getElementById("textSettings").value;
+            var role = null;
+            if (lang) {
+                if (lang.indexOf('-') != -1) {
+                    var values = lang.split('-');
+                    lang = values[0];
+                    role = values[1];
+                }
+                player.setInitialMediaSettingsFor('fragmentedText', { 
+                    lang: lang,
+                    role: role
+                });
+            }
         }
 
     </script>
@@ -47,12 +86,20 @@
         .dash-video-player {
             width: 640px;
         }
+
+        .settings {
+            clear: both;
+        }
+        .settings>div {
+            padding: 5px 0;
+        }
+
     </style>
 
-    <body onload="startVideo()">
+    <body onload="init()">
         <div class="dash-video-player code">
             <div class="videoContainer" id="videoContainer">
-                <video preload="auto" autoplay="true" > </video>
+                <video preload="auto"> </video>
                 <div id="ttml-rendering-div"></div>
 
                 <div id="videoController" class="video-controller unselectable">
@@ -83,6 +130,30 @@
                             <div id="seekbar-play" class="seekbar seekbar-play"></div>
                         </div>
                     </div>
+                </div>
+            </div>
+            <div class="settings">
+                <div>
+                    <label>textDefaultEnabled</label>
+                    <input type="checkbox" id="textDefaultEnabled" onchange="setTextDefaultEnabled()"/> <span id="textDefaultEnabledValue">undefined</span>
+                </div>
+                <div>
+                    <label>initial settings Language/Role </label>
+                    <select onchange="setLang()" id="textSettings">
+                        <option value="">-- unset initial lang and role --</option>
+                        <option value="eng-subtitle">eng - subtitles</option>
+                        <option value="eng-caption">eng - captions</option>
+                        <option value="swe">swe - subtitles</option>
+                        <option value="qbb">qbb - subtitles</option>
+                        <option value="nor">nor - subtitles</option>
+                    </select>
+                </div>
+                <div>
+                    <button onclick="play()">play</button>
+                </div>
+                <div>
+                    <label>DOMstorage content</label>
+                    <div id="domStorage"></div>
                 </div>
             </div>
         </div>

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -474,14 +474,9 @@ function Stream(config) {
             return;
         }
 
-        if (type !== Constants.FRAGMENTED_TEXT || (type === Constants.FRAGMENTED_TEXT && textController.getTextDefaultEnabled())) {
-            mediaController.checkInitialMediaSettingsForType(type, streamInfo);
-            initialMediaInfo = mediaController.getCurrentTrackFor(type, streamInfo);
-        }
 
-        if (type === Constants.FRAGMENTED_TEXT && !textController.getTextDefaultEnabled()) {
-            initialMediaInfo = mediaController.getTracksFor(type, streamInfo)[0];
-        }
+        mediaController.checkInitialMediaSettingsForType(type, streamInfo);
+        initialMediaInfo = mediaController.getCurrentTrackFor(type, streamInfo);
 
         eventBus.trigger(Events.STREAM_INITIALIZING, {
             streamInfo: streamInfo,

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -78,12 +78,6 @@ function MediaController() {
         const tracksForType = getTracksFor(type, streamInfo);
         const tracks = [];
 
-        if (type === Constants.FRAGMENTED_TEXT) {
-            // Choose the first track
-            setTrack(tracksForType[0]);
-            return;
-        }
-
         if (!settings) {
             settings = domStorage.getSavedMediaSettings(type);
             setInitialSettings(type, settings);
@@ -100,10 +94,10 @@ function MediaController() {
         }
 
         if (tracks.length === 0) {
-            setTrack(selectInitialTrack(tracksForType));
+            setTrack(type === Constants.FRAGMENTED_TEXT ? tracksForType[0] : selectInitialTrack(tracksForType), true);
         } else {
             if (tracks.length > 1) {
-                setTrack(selectInitialTrack(tracks));
+                setTrack(type === Constants.FRAGMENTED_TEXT ? tracks[0] : selectInitialTrack(tracks));
             } else {
                 setTrack(tracks[0]);
             }
@@ -185,9 +179,10 @@ function MediaController() {
 
     /**
      * @param {MediaInfo} track
+     * @param {boolean} noSettingsSave specify if settings must be not be saved
      * @memberof MediaController#
      */
-    function setTrack(track) {
+    function setTrack(track, noSettingsSave) {
         if (!track || !track.streamInfo) return;
 
         const type = track.type;
@@ -199,28 +194,31 @@ function MediaController() {
 
         tracks[id][type].current = track;
 
-        if (tracks[id][type].current) {
+        if (tracks[id][type].current && !(noSettingsSave && type === Constants.FRAGMENTED_TEXT)) {
             eventBus.trigger(Events.CURRENT_TRACK_CHANGED, {oldMediaInfo: current, newMediaInfo: track, switchMode: switchMode[type]});
         }
 
-        let settings = extractSettings(track);
+        if (!noSettingsSave) {
 
-        if (!settings || !tracks[id][type].storeLastSettings) return;
+            let settings = extractSettings(track);
 
-        if (settings.roles) {
-            settings.role = settings.roles[0];
-            delete settings.roles;
+            if (!settings || !tracks[id][type].storeLastSettings) return;
+
+            if (settings.roles) {
+                settings.role = settings.roles[0];
+                delete settings.roles;
+            }
+
+            if (settings.accessibility) {
+                settings.accessibility = settings.accessibility[0];
+            }
+
+            if (settings.audioChannelConfiguration) {
+                settings.audioChannelConfiguration = settings.audioChannelConfiguration[0];
+            }
+
+            domStorage.setSavedMediaSettings(type, settings);
         }
-
-        if (settings.accessibility) {
-            settings.accessibility = settings.accessibility[0];
-        }
-
-        if (settings.audioChannelConfiguration) {
-            settings.audioChannelConfiguration = settings.audioChannelConfiguration[0];
-        }
-
-        domStorage.setSavedMediaSettings(type, settings);
     }
 
     /**
@@ -243,6 +241,13 @@ function MediaController() {
         if (!type) return null;
 
         return initialSettings[type];
+    }
+
+    /**
+     * @memberof MediaController#
+     */
+    function saveTextSettingsDisabled() {
+        domStorage.setSavedMediaSettings(Constants.FRAGMENTED_TEXT, null);
     }
 
     /**
@@ -384,13 +389,15 @@ function MediaController() {
     function resetInitialSettings() {
         initialSettings = {
             audio: null,
-            video: null
+            video: null,
+            fragmentedText: null
         };
     }
 
     function selectInitialTrack(tracks) {
         let mode = getSelectionModeForInitialTrack();
         let tmpArr = [];
+
         const getTracksWithHighestBitrate = function (trackArr) {
             let max = 0;
             let result = [];
@@ -497,6 +504,7 @@ function MediaController() {
         isMultiTrackSupportedByType: isMultiTrackSupportedByType,
         isTracksEqual: isTracksEqual,
         matchSettings: matchSettings,
+        saveTextSettingsDisabled: saveTextSettingsDisabled,
         setConfig: setConfig,
         reset: reset
     };

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -94,10 +94,10 @@ function MediaController() {
         }
 
         if (tracks.length === 0) {
-            setTrack(type === Constants.FRAGMENTED_TEXT ? tracksForType[0] : selectInitialTrack(tracksForType), true);
+            setTrack(selectInitialTrack(type, tracksForType), true);
         } else {
             if (tracks.length > 1) {
-                setTrack(type === Constants.FRAGMENTED_TEXT ? tracks[0] : selectInitialTrack(tracks));
+                setTrack(selectInitialTrack(type, tracks));
             } else {
                 setTrack(tracks[0]);
             }
@@ -394,7 +394,9 @@ function MediaController() {
         };
     }
 
-    function selectInitialTrack(tracks) {
+    function selectInitialTrack(type, tracks) {
+        if (type === Constants.FRAGMENTED_TEXT) return tracks[0];
+
         let mode = getSelectionModeForInitialTrack();
         let tmpArr = [];
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -300,12 +300,11 @@ function TextController() {
 
         allTracksAreDisabled = idx === -1 ? true : false;
 
-        if (allTracksAreDisabled) {
-            mediaController.saveTextSettingsDisabled();
-        }
-
         let oldTrackIdx = textTracks.getCurrentTrackIdx();
         if (oldTrackIdx !== idx) {
+            if (allTracksAreDisabled && mediaController) {
+                mediaController.saveTextSettingsDisabled();
+            }
             textTracks.setModeForTrackIdx(oldTrackIdx, Constants.TEXT_HIDDEN);
             textTracks.setCurrentTrackIdx(idx);
             textTracks.setModeForTrackIdx(idx, Constants.TEXT_SHOWING);

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -364,6 +364,7 @@ function TextController() {
     }
 
     function resetInitialSettings() {
+        defaultSettings = null;
         allTracksAreDisabled = true;
         textTracksAdded = false;
         disableTextBeforeTextTracksAdded = false;

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -208,7 +208,7 @@ function TextController() {
         }
 
         if (textDefaultEnabled === false || ( textDefaultEnabled === undefined && !defaultSettings ) || disableTextBeforeTextTracksAdded) {
-            // disable text at startup if explicitely configured with setTextDefaultEnanled(false) or if there is no defaultSettings (configuration or from domStorage)
+            // disable text at startup if explicitely configured with setTextDefaultEnabled(false) or if there is no defaultSettings (configuration or from domStorage)
             this.setTextTrack(-1);
         }
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -55,6 +55,7 @@ function TextController() {
         ttmlParser,
         eventBus,
         defaultSettings,
+        initialSettingsSet,
         lastEnabledIndex,
         textDefaultEnabled, // this is used for default settings (each time a file is loaded, we check value of this settings )
         allTracksAreDisabled, // this is used for one session (when a file has been loaded, we use this settings to enable/disable text)
@@ -69,6 +70,7 @@ function TextController() {
         lastEnabledIndex = -1;
         forceTextStreaming = false;
         textTracksAdded = false;
+        initialSettingsSet = false;
         disableTextBeforeTextTracksAdded = false;
         textTracks = TextTracks(context).getInstance();
         vttParser = VTTParser(context).getInstance();
@@ -78,7 +80,7 @@ function TextController() {
 
         textTracks.initialize();
         eventBus.on(Events.TEXT_TRACKS_QUEUE_INITIALIZED, onTextTracksAdded, instance);
-        eventBus.on(Events.CURRENT_TRACK_CHANGED, onSetSettings, instance);
+        eventBus.on(Events.CURRENT_TRACK_CHANGED, onCurrentTrackChanged, instance);
 
         /*
         * register those event callbacks in order to detect switch of periods and set
@@ -178,10 +180,12 @@ function TextController() {
             defaultSettings = {};
         }
         defaultSettings.lang = lang;
+        initialSettingsSet = true;
     }
 
     function setInitialSettings(settings) {
         defaultSettings = settings;
+        initialSettingsSet = true;
     }
 
     function getTextDefaultLanguage() {
@@ -217,8 +221,8 @@ function TextController() {
         textTracksAdded = true;
     }
 
-    function onSetSettings(event) {
-        if (!defaultSettings && event && event.newMediaInfo) {
+    function onCurrentTrackChanged(event) {
+        if (!initialSettingsSet && event && event.newMediaInfo) {
             let mediaInfo = event.newMediaInfo;
             if (mediaInfo.type === Constants.FRAGMENTED_TEXT) {
                 defaultSettings = {
@@ -364,7 +368,6 @@ function TextController() {
     }
 
     function resetInitialSettings() {
-        defaultSettings = null;
         allTracksAreDisabled = true;
         textTracksAdded = false;
         disableTextBeforeTextTracksAdded = false;

--- a/test/unit/mocks/MediaControllerMock.js
+++ b/test/unit/mocks/MediaControllerMock.js
@@ -113,6 +113,8 @@ class MediaControllerMock {
 
     setConfig() {}
 
+    saveTextSettingsDisabled() {}
+
     reset() {
         this.setup();
     }

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -40,7 +40,7 @@ describe('TextController', function () {
     });
 
     afterEach(function () {
-        if (global !== window) {
+        if (typeof window !== 'undefined' && global !== window) {
             delete global.document;
         }
     });

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -40,7 +40,9 @@ describe('TextController', function () {
     });
 
     afterEach(function () {
-        delete global.document;
+        if (global !== window) {
+            delete global.document;
+        }
     });
 
     beforeEach(function () {


### PR DESCRIPTION
fragmentedText initial settings were already stored in localStorage but never used.
This PR allows to reuse previous subtitles settings stored in localStorage.

They are only used when loading a stream if
- settings streaming.lastMediaSettingsCachingInfo.enabled is true
- textDefaultEnabled is not explicitly false (can be undefined if setTextDefaultEnabled is not called)
- setInitialMediaSettingsFor('fragmentedText') has not been called to set preferred language and/or role

This means that, if no other settings are set, dash.js player will reuse previously used subtitles language/role when loading a new stream (like what is already done for audio content)

samples/captioning/multi-track-captions.html has been modified in order to test various settings combination (no more auto-load to be able to set settings before loading)
