### PR TITLE
exitFullscreen ->  fullscreenElement

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -435,6 +435,8 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
         if (document.fullscreenElement) {
             document.exitFullscreen();
+        } else if (document.exitFullscreen) {
+           document.exitFullscreen(); 
         } else if (document.mozCancelFullScreen) {
             document.mozCancelFullScreen();
         } else if (document.msExitFullscreen) {

--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -433,7 +433,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         window.removeEventListener('mousemove', onFullScreenMouseMove);
         clearFullscreenState();
 
-        if (document.exitFullscreen) {
+        if (document.fullscreenElement) {
             document.exitFullscreen();
         } else if (document.mozCancelFullScreen) {
             document.mozCancelFullScreen();


### PR DESCRIPTION
- document.exitFullscreen ->  document.fullscreenElement in exitFullscreen.
- document.exitFullscreen throws `TypeError: Document not active on exitFullscreen`
