### PR TITLE
Only reset the seek target if a valid segment request has been found

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -455,13 +455,15 @@ function StreamProcessor(config) {
         // Don't schedule next fragments while pruning to avoid buffer inconsistencies
         if (!bufferController.getIsPruningInProgress()) {
             request = findNextRequest(e.seekTarget, e.replacement);
-            scheduleController.setSeekTarget(NaN);
-            if (request && !e.replacement) {
-                if (!isNaN(request.startTime + request.duration)) {
-                    setIndexHandlerTime(request.startTime + request.duration);
+            if (request) {
+                scheduleController.setSeekTarget(NaN);
+                if (!e.replacement) {
+                    if (!isNaN(request.startTime + request.duration)) {
+                        setIndexHandlerTime(request.startTime + request.duration);
+                    }
+                    request.delayLoadingTime = new Date().getTime() + scheduleController.getTimeToLoadDelay();
+                    scheduleController.setTimeToLoadDelay(0);
                 }
-                request.delayLoadingTime = new Date().getTime() + scheduleController.getTimeToLoadDelay();
-                scheduleController.setTimeToLoadDelay(0);
             }
         }
 


### PR DESCRIPTION
The goal of this PR is to fix #3224. Before this PR the seek target in the ScheduleController was reset regardless if a valid segment request could be generated or not. Now it is only reset if a request could be generated.