### PR TITLE
Refactor streams playback start

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -233,7 +233,9 @@ function StreamProcessor(config) {
 
         if (!e.error) {
             scheduleController.setCurrentRepresentation(adapter.convertDataToRepresentationInfo(e.currentRepresentation));
-        } else if (e.error.code !== Errors.SEGMENTS_UPDATE_FAILED_ERROR_CODE) {
+        }
+        if (!e.error || e.error.code === Errors.SEGMENTS_UPDATE_FAILED_ERROR_CODE) {
+            // Update has been postponed, we nevertheless update DVR info
             addDVRMetric();
         }
     }

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -90,8 +90,7 @@ function StreamProcessor(config) {
         logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
 
-        eventBus.on(Events.STREAM_INITIALIZED, onStreamInitialized, instance);
-        eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, instance);
+        eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, instance, EventBus.EVENT_PRIORITY_HIGH); // High priority to be notified before Stream
         eventBus.on(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, instance);
         eventBus.on(Events.INIT_FRAGMENT_NEEDED, onInitFragmentNeeded, instance);
         eventBus.on(Events.MEDIA_FRAGMENT_NEEDED, onMediaFragmentNeeded, instance);
@@ -208,7 +207,6 @@ function StreamProcessor(config) {
             abrController.unRegisterStreamType(type);
         }
 
-        eventBus.off(Events.STREAM_INITIALIZED, onStreamInitialized, instance);
         eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, instance);
         eventBus.off(Events.QUALITY_CHANGE_REQUESTED, onQualityChanged, instance);
         eventBus.off(Events.INIT_FRAGMENT_NEEDED, onInitFragmentNeeded, instance);
@@ -228,27 +226,10 @@ function StreamProcessor(config) {
         return representationController ? representationController.isUpdating() : false;
     }
 
-    function onStreamInitialized(e) {
-        if (!e.streamInfo || streamInfo.id !== e.streamInfo.id) return;
-
-        if (!streamInitialized) {
-            streamInitialized = true;
-            if (isDynamic) {
-                timelineConverter.setTimeSyncCompleted(true);
-                setLiveEdgeSeekTarget();
-            } else {
-                const seekTarget = playbackController.getStreamStartTime(false);
-                bufferController.setSeekStartTime(seekTarget);
-                scheduleController.setCurrentRepresentation(getRepresentationInfo());
-                scheduleController.setSeekTarget(seekTarget);
-            }
-        }
-
-        scheduleController.start();
-    }
 
     function onDataUpdateCompleted(e) {
         if (e.sender.getType() !== getType() || e.sender.getStreamId() !== streamInfo.id) return;
+        logger.info('DataUpdateCompleted');
 
         if (!e.error) {
             scheduleController.setCurrentRepresentation(adapter.convertDataToRepresentationInfo(e.currentRepresentation));
@@ -624,9 +605,12 @@ function StreamProcessor(config) {
         return controller;
     }
 
-    function setLiveEdgeSeekTarget() {
-        if (!liveEdgeFinder) return;
 
+    function getLiveStartTime() {
+        if (!isDynamic) return NaN;
+        if (!liveEdgeFinder) return NaN;
+
+        let liveStartTime = NaN;
         const currentRepresentationInfo = getRepresentationInfo();
         const liveEdge = liveEdgeFinder.getLiveEdge(currentRepresentationInfo);
         const request = findRequestForLiveEdge(liveEdge, currentRepresentationInfo);
@@ -635,31 +619,51 @@ function StreamProcessor(config) {
             // When low latency mode is selected but browser doesn't support fetch
             // start at the beginning of the segment to avoid consuming the whole buffer
             if (settings.get().streaming.lowLatencyEnabled) {
-                const liveStartTime = request.duration < mediaPlayerModel.getLiveDelay() ? request.startTime : request.startTime + request.duration - mediaPlayerModel.getLiveDelay();
-                playbackController.setLiveStartTime(liveStartTime);
+                liveStartTime = request.duration < mediaPlayerModel.getLiveDelay() ? request.startTime : request.startTime + request.duration - mediaPlayerModel.getLiveDelay();
             } else {
-                playbackController.setLiveStartTime(request.startTime);
+                liveStartTime = request.startTime;
             }
         }
 
-        const seekTarget = playbackController.getStreamStartTime(false, liveEdge);
-        bufferController.setSeekStartTime(seekTarget);
-        scheduleController.setCurrentRepresentation(currentRepresentationInfo);
-        scheduleController.setSeekTarget(seekTarget);
-        scheduleController.start();
-
-        // For multi periods stream, if the startTime is beyond current period then seek to corresponding period (see StreamController::onPlaybackSeeking)
-        if (seekTarget > (currentRepresentationInfo.mediaInfo.streamInfo.start + currentRepresentationInfo.mediaInfo.streamInfo.duration)) {
-            playbackController.seek(seekTarget);
-        }
-
-        dashMetrics.updateManifestUpdateInfo({
-            currentTime: seekTarget,
-            presentationStartTime: liveEdge,
-            latency: liveEdge - seekTarget,
-            clientTimeOffset: timelineConverter.getClientTimeOffset()
-        });
+        return liveStartTime;
     }
+
+    // function setLiveEdgeSeekTarget() {
+    //     if (!liveEdgeFinder) return;
+
+    //     const currentRepresentationInfo = getRepresentationInfo();
+    //     const liveEdge = liveEdgeFinder.getLiveEdge(currentRepresentationInfo);
+    //     const request = findRequestForLiveEdge(liveEdge, currentRepresentationInfo);
+
+    //     if (request) {
+    //         // When low latency mode is selected but browser doesn't support fetch
+    //         // start at the beginning of the segment to avoid consuming the whole buffer
+    //         if (settings.get().streaming.lowLatencyEnabled) {
+    //             const liveStartTime = request.duration < mediaPlayerModel.getLiveDelay() ? request.startTime : request.startTime + request.duration - mediaPlayerModel.getLiveDelay();
+    //             playbackController.setLiveStartTime(liveStartTime);
+    //         } else {
+    //             playbackController.setLiveStartTime(request.startTime);
+    //         }
+    //     }
+
+    //     const seekTarget = playbackController.getStreamStartTime(false, liveEdge);
+    //     bufferController.setSeekStartTime(seekTarget);
+    //     scheduleController.setCurrentRepresentation(currentRepresentationInfo);
+    //     scheduleController.setSeekTarget(seekTarget);
+    //     scheduleController.start();
+
+    //     // For multi periods stream, if the startTime is beyond current period then seek to corresponding period (see StreamController::onPlaybackSeeking)
+    //     if (seekTarget > (currentRepresentationInfo.mediaInfo.streamInfo.start + currentRepresentationInfo.mediaInfo.streamInfo.duration)) {
+    //         playbackController.seek(seekTarget);
+    //     }
+
+    //     dashMetrics.updateManifestUpdateInfo({
+    //         currentTime: seekTarget,
+    //         presentationStartTime: liveEdge,
+    //         latency: liveEdge - seekTarget,
+    //         clientTimeOffset: timelineConverter.getClientTimeOffset()
+    //     });
+    // }
 
     function findRequestForLiveEdge(liveEdge, currentRepresentationInfo) {
         try {
@@ -763,6 +767,7 @@ function StreamProcessor(config) {
         getStreamInfo: getStreamInfo,
         selectMediaInfo: selectMediaInfo,
         addMediaInfo: addMediaInfo,
+        getLiveStartTime: getLiveStartTime,
         switchTrackAsked: switchTrackAsked,
         getMediaInfoArr: getMediaInfoArr,
         getMediaInfo: getMediaInfo,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -232,10 +232,11 @@ function StreamProcessor(config) {
         logger.info('DataUpdateCompleted');
 
         if (!e.error) {
+            // Update representation if no error
             scheduleController.setCurrentRepresentation(adapter.convertDataToRepresentationInfo(e.currentRepresentation));
         }
         if (!e.error || e.error.code === Errors.SEGMENTS_UPDATE_FAILED_ERROR_CODE) {
-            // Update has been postponed, we nevertheless update DVR info
+            // Update has been postponed, update nevertheless DVR info
             addDVRMetric();
         }
     }

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -628,43 +628,6 @@ function StreamProcessor(config) {
         return liveStartTime;
     }
 
-    // function setLiveEdgeSeekTarget() {
-    //     if (!liveEdgeFinder) return;
-
-    //     const currentRepresentationInfo = getRepresentationInfo();
-    //     const liveEdge = liveEdgeFinder.getLiveEdge(currentRepresentationInfo);
-    //     const request = findRequestForLiveEdge(liveEdge, currentRepresentationInfo);
-
-    //     if (request) {
-    //         // When low latency mode is selected but browser doesn't support fetch
-    //         // start at the beginning of the segment to avoid consuming the whole buffer
-    //         if (settings.get().streaming.lowLatencyEnabled) {
-    //             const liveStartTime = request.duration < mediaPlayerModel.getLiveDelay() ? request.startTime : request.startTime + request.duration - mediaPlayerModel.getLiveDelay();
-    //             playbackController.setLiveStartTime(liveStartTime);
-    //         } else {
-    //             playbackController.setLiveStartTime(request.startTime);
-    //         }
-    //     }
-
-    //     const seekTarget = playbackController.getStreamStartTime(false, liveEdge);
-    //     bufferController.setSeekStartTime(seekTarget);
-    //     scheduleController.setCurrentRepresentation(currentRepresentationInfo);
-    //     scheduleController.setSeekTarget(seekTarget);
-    //     scheduleController.start();
-
-    //     // For multi periods stream, if the startTime is beyond current period then seek to corresponding period (see StreamController::onPlaybackSeeking)
-    //     if (seekTarget > (currentRepresentationInfo.mediaInfo.streamInfo.start + currentRepresentationInfo.mediaInfo.streamInfo.duration)) {
-    //         playbackController.seek(seekTarget);
-    //     }
-
-    //     dashMetrics.updateManifestUpdateInfo({
-    //         currentTime: seekTarget,
-    //         presentationStartTime: liveEdge,
-    //         latency: liveEdge - seekTarget,
-    //         clientTimeOffset: timelineConverter.getClientTimeOffset()
-    //     });
-    // }
-
     function findRequestForLiveEdge(liveEdge, currentRepresentationInfo) {
         try {
             let request = null;

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -482,11 +482,6 @@ function BufferController(config) {
         let range,
             length;
 
-        // Consider gap/discontinuity limit as tolerance
-        if (settings.get().streaming.jumpGaps) {
-            tolerance = settings.get().streaming.smallGapLimit;
-        }
-
         range = getRangeAt(time, tolerance);
 
         if (range === null) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -283,8 +283,10 @@ function BufferController(config) {
             onPlaybackProgression();
 
             // If seeking, seek video model to range start in case appended segment starts beyond seek target
-            if (!isNaN(seekTarget) && (seekTarget < ranges.start(0) || playbackController.getTime() === 0)) {
+            if (!isNaN(seekTarget) &&
+                (playbackController.getTime() === 0 || playbackController.getTime() < ranges.start(0))) {
                 playbackController.seek(ranges.start(0), true, true);
+                seekTarget = NaN;
             }
         } else {
             if (replacingBuffer) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -369,52 +369,6 @@ function PlaybackController() {
         return start;
     }
 
-    /**
-     * @param {boolean} ignoreStartOffset - ignore URL fragment start offset if true
-     * @param {number} liveEdge - liveEdge value
-     * @returns {number} object
-     * @memberof PlaybackController#
-     */
-    // function getStreamStartTime(ignoreStartOffset, liveEdge) {
-    //     let presentationStartTime;
-    //     let startTimeOffset = NaN;
-
-    //     if (!ignoreStartOffset) {
-    //         const uriParameters = getStartTimeFromUriParameters();
-    //         if (uriParameters) {
-    //             startTimeOffset = !isNaN(uriParameters.fragS) ? uriParameters.fragS : uriParameters.fragT;
-    //         } else {
-    //             startTimeOffset = 0;
-    //         }
-    //     } else {
-    //         startTimeOffset = streamInfo ? streamInfo.start : startTimeOffset;
-    //     }
-
-    //     if (isDynamic) {
-    //         if (!isNaN(startTimeOffset) && streamInfo) {
-    //             presentationStartTime = startTimeOffset - (streamInfo.manifestInfo.availableFrom.getTime() / 1000);
-
-    //             if (presentationStartTime > liveStartTime ||
-    //                 presentationStartTime < (!isNaN(liveEdge) ? (liveEdge - streamInfo.manifestInfo.DVRWindowSize) : NaN)) {
-    //                 presentationStartTime = null;
-    //             }
-    //         }
-    //         presentationStartTime = presentationStartTime || liveStartTime;
-
-    //     } else {
-    //         if (streamInfo) {
-    //             if (!isNaN(startTimeOffset) && startTimeOffset < Math.max(streamInfo.manifestInfo.duration, streamInfo.duration) && startTimeOffset >= 0) {
-    //                 presentationStartTime = startTimeOffset;
-    //             } else {
-    //                 let currentEarliestTime = earliestTime[streamInfo.id]; //set by ready bufferStart after first onBytesAppended
-    //                 presentationStartTime = currentEarliestTime !== undefined ? Math.max(currentEarliestTime.audio !== undefined ? currentEarliestTime.audio : 0, currentEarliestTime.video !== undefined ? currentEarliestTime.video : 0, streamInfo.start) : streamInfo.start;
-    //             }
-    //         }
-    //     }
-
-    //     return presentationStartTime;
-    // }
-
     function getActualPresentationTime(currentTime) {
         const DVRMetrics = dashMetrics.getCurrentDVRInfo();
         const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
@@ -808,7 +762,6 @@ function PlaybackController() {
         initialize: initialize,
         setConfig: setConfig,
         getStartTimeFromUriParameters: getStartTimeFromUriParameters,
-        // getStreamStartTime: getStreamStartTime,
         getTimeToStreamEnd: getTimeToStreamEnd,
         getTime: getTime,
         getNormalizedTime: getNormalizedTime,

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -114,14 +114,14 @@ function PlaybackController() {
             if (isDynamic) {
                 // For dynamic stream, start by default at (live edge - live delay)
                 startTime = e.liveStartTime;
-                // If start time in URI, take min value between live edge time and time from URI (if in DVR window range)
+                // If start time in URI, take min value between live edge time and time from URI (capped by DVR window range)
                 const dvrInfo = dashMetrics.getCurrentDVRInfo();
                 const dvrWindow = dvrInfo ? dvrInfo.range : null;
                 if (dvrWindow) {
                     const startTimeFromUri = getStartTimeFromUriParameters(dvrWindow.start);
-                    if (!isNaN(startTimeFromUri) && startTimeFromUri >= dvrWindow.start) {
+                    if (!isNaN(startTimeFromUri)) {
                         logger.info('Start time from URI parameters: ' + startTimeFromUri);
-                        startTime = Math.min(startTime, startTimeFromUri);
+                        startTime = Math.max(Math.min(startTime, startTimeFromUri), dvrWindow.start);
                     }
                 }
             } else {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -49,18 +49,16 @@ function PlaybackController() {
         adapter,
         videoModel,
         timelineConverter,
-        liveStartTime,
+        streamSwitch,
+        streamSeekTime,
         wallclockTimeIntervalId,
-        earliestTime,
         liveDelay,
-        bufferedRange,
         streamInfo,
         isDynamic,
         mediaPlayerModel,
         playOnceInitialized,
         lastLivePlaybackTime,
         availabilityStartTime,
-        compatibleWithPreviousStream,
         isLowLatencySeekingInProgress,
         playbackStalled,
         minPlaybackRateChange,
@@ -73,14 +71,14 @@ function PlaybackController() {
         reset();
     }
 
-    function initialize(StreamInfo, compatible) {
+    function initialize(StreamInfo, periodSwitch, seekTime) {
         streamInfo = StreamInfo;
         addAllListeners();
         isDynamic = streamInfo.manifestInfo.isDynamic;
         isLowLatencySeekingInProgress = false;
         playbackStalled = false;
-        liveStartTime = streamInfo.start;
-        compatibleWithPreviousStream = compatible;
+        streamSwitch = periodSwitch === true;
+        streamSeekTime = seekTime;
 
         const ua = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
 
@@ -88,11 +86,10 @@ function PlaybackController() {
         const isSafari = /safari/.test(ua) && !/chrome/.test(ua);
         minPlaybackRateChange = isSafari ? 0.25 : 0.02;
 
+        eventBus.on(Events.STREAM_INITIALIZED, onStreamInitialized, this);
         eventBus.on(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
-        eventBus.on(Events.BYTES_APPENDED_END_FRAGMENT, onBytesAppended, this);
         eventBus.on(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
         eventBus.on(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
-        eventBus.on(Events.PERIOD_SWITCH_STARTED, onPeriodSwitchStarted, this);
         eventBus.on(Events.PLAYBACK_PROGRESS, onPlaybackProgression, this);
         eventBus.on(Events.PLAYBACK_TIME_UPDATED, onPlaybackProgression, this);
         eventBus.on(Events.PLAYBACK_ENDED, onPlaybackEnded, this);
@@ -104,11 +101,27 @@ function PlaybackController() {
         }
     }
 
-    function onPeriodSwitchStarted(e) {
-        if (!isDynamic && e.fromStreamInfo && earliestTime[e.fromStreamInfo.id] !== undefined) {
-            delete bufferedRange[e.fromStreamInfo.id];
-            delete earliestTime[e.fromStreamInfo.id];
+    function onStreamInitialized(e) {
+        // Seamless period switch
+        if (streamSwitch && isNaN(streamSeekTime)) return;
+
+        // Seek new stream in priority order:
+        // - at seek time (streamSeekTime) that required period switch
+        // - at start time provided in URI parameters
+        // - at stream/period start time (for static streams) or live start time (for dynamic streams)
+        let startTime = streamSeekTime;
+        if (isNaN(startTime)) {
+            startTime = isDynamic ? e.liveStartTime : e.streamInfo.start;
+            startTime = Math.max(startTime, getStartTimeFromUri());
+            if (startTime === videoModel.getTime()) return;
         }
+
+        // Trigger PLAYBACK_SEEKING event for controllers
+        eventBus.trigger(Events.PLAYBACK_SEEKING, {
+            seekTime: startTime
+        });
+        // Seek video model
+        seek(startTime, false, true);
     }
 
     function getTimeToStreamEnd() {
@@ -116,9 +129,7 @@ function PlaybackController() {
     }
 
     function getStreamEndTime() {
-        const startTime = getStreamStartTime(true);
-        const offset = isDynamic && streamInfo ? startTime - streamInfo.start : 0;
-        return startTime + (streamInfo ? streamInfo.duration - offset : offset);
+        return streamInfo.start + streamInfo.duration;
     }
 
     function play() {
@@ -155,10 +166,6 @@ function PlaybackController() {
                 }
             } else {
                 eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
-                if (streamInfo) {
-                    delete bufferedRange[streamInfo.id];
-                    delete earliestTime[streamInfo.id];
-                }
                 logger.info('Requesting seek to time: ' + time);
                 videoModel.setCurrentTime(time, stickToBuffered);
             }
@@ -207,19 +214,6 @@ function PlaybackController() {
 
     function getStreamController() {
         return streamController;
-    }
-
-    function setLiveStartTime(value) {
-        if (liveStartTime !== streamInfo.start) {
-            // Consider only 1st live start time (set by video stream or audio if audio only)
-            return;
-        }
-        logger.info('Set live start time: ' + value);
-        liveStartTime = value;
-    }
-
-    function getLiveStartTime() {
-        return liveStartTime;
     }
 
     /**
@@ -300,18 +294,16 @@ function PlaybackController() {
     }
 
     function reset() {
-        liveStartTime = NaN;
         playOnceInitialized = false;
-        earliestTime = {};
+        streamSwitch = false;
+        streamSeekTime = NaN;
         liveDelay = 0;
         availabilityStartTime = 0;
-        bufferedRange = {};
         if (videoModel) {
+            eventBus.off(Events.STREAM_INITIALIZED, onStreamInitialized, this);
             eventBus.off(Events.DATA_UPDATE_COMPLETED, onDataUpdateCompleted, this);
             eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, onBufferLevelStateChanged, this);
-            eventBus.off(Events.BYTES_APPENDED_END_FRAGMENT, onBytesAppended, this);
             eventBus.off(Events.LOADING_PROGRESS, onFragmentLoadProgress, this);
-            eventBus.off(Events.PERIOD_SWITCH_STARTED, onPeriodSwitchStarted, this);
             eventBus.off(Events.PLAYBACK_PROGRESS, onPlaybackProgression, this);
             eventBus.off(Events.PLAYBACK_TIME_UPDATED, onPlaybackProgression, this);
             eventBus.off(Events.PLAYBACK_ENDED, onPlaybackEnded, this);
@@ -369,51 +361,57 @@ function PlaybackController() {
         return uriParameters;
     }
 
+    function getStartTimeFromUri() {
+        const uriParameters = getStartTimeFromUriParameters();
+        let start = !isNaN(uriParameters.fragS) ? uriParameters.fragS : (!isNaN(uriParameters.fragT) ? uriParameters.fragT : -1);
+        return start;
+    }
+
     /**
      * @param {boolean} ignoreStartOffset - ignore URL fragment start offset if true
      * @param {number} liveEdge - liveEdge value
      * @returns {number} object
      * @memberof PlaybackController#
      */
-    function getStreamStartTime(ignoreStartOffset, liveEdge) {
-        let presentationStartTime;
-        let startTimeOffset = NaN;
+    // function getStreamStartTime(ignoreStartOffset, liveEdge) {
+    //     let presentationStartTime;
+    //     let startTimeOffset = NaN;
 
-        if (!ignoreStartOffset) {
-            const uriParameters = getStartTimeFromUriParameters();
-            if (uriParameters) {
-                startTimeOffset = !isNaN(uriParameters.fragS) ? uriParameters.fragS : uriParameters.fragT;
-            } else {
-                startTimeOffset = 0;
-            }
-        } else {
-            startTimeOffset = streamInfo ? streamInfo.start : startTimeOffset;
-        }
+    //     if (!ignoreStartOffset) {
+    //         const uriParameters = getStartTimeFromUriParameters();
+    //         if (uriParameters) {
+    //             startTimeOffset = !isNaN(uriParameters.fragS) ? uriParameters.fragS : uriParameters.fragT;
+    //         } else {
+    //             startTimeOffset = 0;
+    //         }
+    //     } else {
+    //         startTimeOffset = streamInfo ? streamInfo.start : startTimeOffset;
+    //     }
 
-        if (isDynamic) {
-            if (!isNaN(startTimeOffset) && streamInfo) {
-                presentationStartTime = startTimeOffset - (streamInfo.manifestInfo.availableFrom.getTime() / 1000);
+    //     if (isDynamic) {
+    //         if (!isNaN(startTimeOffset) && streamInfo) {
+    //             presentationStartTime = startTimeOffset - (streamInfo.manifestInfo.availableFrom.getTime() / 1000);
 
-                if (presentationStartTime > liveStartTime ||
-                    presentationStartTime < (!isNaN(liveEdge) ? (liveEdge - streamInfo.manifestInfo.DVRWindowSize) : NaN)) {
-                    presentationStartTime = null;
-                }
-            }
-            presentationStartTime = presentationStartTime || liveStartTime;
+    //             if (presentationStartTime > liveStartTime ||
+    //                 presentationStartTime < (!isNaN(liveEdge) ? (liveEdge - streamInfo.manifestInfo.DVRWindowSize) : NaN)) {
+    //                 presentationStartTime = null;
+    //             }
+    //         }
+    //         presentationStartTime = presentationStartTime || liveStartTime;
 
-        } else {
-            if (streamInfo) {
-                if (!isNaN(startTimeOffset) && startTimeOffset < Math.max(streamInfo.manifestInfo.duration, streamInfo.duration) && startTimeOffset >= 0) {
-                    presentationStartTime = startTimeOffset;
-                } else {
-                    let currentEarliestTime = earliestTime[streamInfo.id]; //set by ready bufferStart after first onBytesAppended
-                    presentationStartTime = currentEarliestTime !== undefined ? Math.max(currentEarliestTime.audio !== undefined ? currentEarliestTime.audio : 0, currentEarliestTime.video !== undefined ? currentEarliestTime.video : 0, streamInfo.start) : streamInfo.start;
-                }
-            }
-        }
+    //     } else {
+    //         if (streamInfo) {
+    //             if (!isNaN(startTimeOffset) && startTimeOffset < Math.max(streamInfo.manifestInfo.duration, streamInfo.duration) && startTimeOffset >= 0) {
+    //                 presentationStartTime = startTimeOffset;
+    //             } else {
+    //                 let currentEarliestTime = earliestTime[streamInfo.id]; //set by ready bufferStart after first onBytesAppended
+    //                 presentationStartTime = currentEarliestTime !== undefined ? Math.max(currentEarliestTime.audio !== undefined ? currentEarliestTime.audio : 0, currentEarliestTime.video !== undefined ? currentEarliestTime.video : 0, streamInfo.start) : streamInfo.start;
+    //             }
+    //         }
+    //     }
 
-        return presentationStartTime;
-    }
+    //     return presentationStartTime;
+    // }
 
     function getActualPresentationTime(currentTime) {
         const DVRMetrics = dashMetrics.getCurrentDVRInfo();
@@ -602,16 +600,16 @@ function PlaybackController() {
         }
     }
 
-    function checkTimeInRanges(time, ranges) {
-        if (ranges && ranges.length > 0) {
-            for (let i = 0, len = ranges.length; i < len; i++) {
-                if (time >= ranges.start(i) && time < ranges.end(i)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+    // function checkTimeInRanges(time, ranges) {
+    //     if (ranges && ranges.length > 0) {
+    //         for (let i = 0, len = ranges.length; i < len; i++) {
+    //             if (time >= ranges.start(i) && time < ranges.end(i)) {
+    //                 return true;
+    //             }
+    //         }
+    //     }
+    //     return false;
+    // }
 
     function onPlaybackProgression() {
         if (
@@ -689,72 +687,6 @@ function PlaybackController() {
     function stopPlaybackCatchUp() {
         if (videoModel) {
             videoModel.setPlaybackRate(1.0);
-        }
-    }
-
-    function onBytesAppended(e) {
-        let commonEarliestTime,
-            initialStartTime;
-        let ranges = e.bufferedRanges;
-        if (!ranges || !ranges.length) return;
-        if (earliestTime[streamInfo.id] && earliestTime[streamInfo.id].started === true) {
-            //stream has already been started.
-            return;
-        }
-
-        const type = e.mediaType;
-
-        if (bufferedRange[streamInfo.id] === undefined) {
-            bufferedRange[streamInfo.id] = [];
-        }
-
-        bufferedRange[streamInfo.id][type] = ranges;
-
-        if (earliestTime[streamInfo.id] === undefined) {
-            earliestTime[streamInfo.id] = [];
-            earliestTime[streamInfo.id].started = false;
-        }
-
-        if (earliestTime[streamInfo.id][type] === undefined) {
-            earliestTime[streamInfo.id][type] = Math.max(ranges.start(0), streamInfo.start);
-        }
-
-        initialStartTime = getStreamStartTime(false);
-        if (streamController.hasVideoTrack() && streamController.hasAudioTrack()) {
-            //current stream has audio and video contents
-            if (!isNaN(earliestTime[streamInfo.id].audio) && !isNaN(earliestTime[streamInfo.id].video)) {
-
-                if (earliestTime[streamInfo.id].audio < earliestTime[streamInfo.id].video) {
-                    // common earliest is video time
-                    // check buffered audio range has video time, if ok, we seek, otherwise, we wait some other data
-                    commonEarliestTime = earliestTime[streamInfo.id].video > initialStartTime ? earliestTime[streamInfo.id].video : initialStartTime;
-                    ranges = bufferedRange[streamInfo.id].audio;
-                } else {
-                    // common earliest is audio time
-                    // check buffered video range has audio time, if ok, we seek, otherwise, we wait some other data
-                    commonEarliestTime = earliestTime[streamInfo.id].audio > initialStartTime ? earliestTime[streamInfo.id].audio : initialStartTime;
-                    ranges = bufferedRange[streamInfo.id].video;
-                }
-                if (checkTimeInRanges(commonEarliestTime, ranges)) {
-                    if (!(checkTimeInRanges(getNormalizedTime(), bufferedRange[streamInfo.id].audio) && checkTimeInRanges(getNormalizedTime(), bufferedRange[streamInfo.id].video))) {
-                        if (!compatibleWithPreviousStream && commonEarliestTime !== 0) {
-                            seek(commonEarliestTime, true, true);
-                        }
-                    }
-                    earliestTime[streamInfo.id].started = true;
-                }
-            }
-        } else {
-            //current stream has only audio or only video content
-            if (earliestTime[streamInfo.id][type]) {
-                commonEarliestTime = earliestTime[streamInfo.id][type] > initialStartTime ? earliestTime[streamInfo.id][type] : initialStartTime;
-                if (!checkTimeInRanges(getNormalizedTime(), bufferedRange[streamInfo.id][type])) {
-                    if (!compatibleWithPreviousStream) {
-                        seek(commonEarliestTime, false, true);
-                    }
-                }
-                earliestTime[streamInfo.id].started = true;
-            }
         }
     }
 
@@ -874,7 +806,7 @@ function PlaybackController() {
         initialize: initialize,
         setConfig: setConfig,
         getStartTimeFromUriParameters: getStartTimeFromUriParameters,
-        getStreamStartTime: getStreamStartTime,
+        // getStreamStartTime: getStreamStartTime,
         getTimeToStreamEnd: getTimeToStreamEnd,
         getTime: getTime,
         getNormalizedTime: getNormalizedTime,
@@ -883,8 +815,6 @@ function PlaybackController() {
         getEnded: getEnded,
         getIsDynamic: getIsDynamic,
         getStreamController: getStreamController,
-        setLiveStartTime: setLiveStartTime,
-        getLiveStartTime: getLiveStartTime,
         computeAndSetLiveDelay: computeAndSetLiveDelay,
         getLiveDelay: getLiveDelay,
         setLiveDelay: setLiveDelay,

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -118,7 +118,7 @@ function PlaybackController() {
                 const dvrInfo = dashMetrics.getCurrentDVRInfo();
                 const dvrWindow = dvrInfo ? dvrInfo.range : null;
                 if (dvrWindow) {
-                    const startTimeFromUri = getStartTimeFromUriParameters(dvrWindow.start);
+                    const startTimeFromUri = getStartTimeFromUriParameters(dvrWindow.start, true);
                     if (!isNaN(startTimeFromUri)) {
                         logger.info('Start time from URI parameters: ' + startTimeFromUri);
                         startTime = Math.max(Math.min(startTime, startTimeFromUri), dvrWindow.start);
@@ -128,7 +128,7 @@ function PlaybackController() {
                 // For static stream, start by default at period start
                 startTime = streamInfo.start;
                 // If start time in URI, take max value between period start and time from URI (if in period range)
-                const startTimeFromUri = getStartTimeFromUriParameters(streamInfo.start);
+                const startTimeFromUri = getStartTimeFromUriParameters(streamInfo.start, false);
                 if (!isNaN(startTimeFromUri) && startTimeFromUri < (startTime + streamInfo.duration)) {
                     logger.info('Start time from URI parameters: ' + startTimeFromUri);
                     startTime = Math.max(startTime, startTimeFromUri);
@@ -371,7 +371,7 @@ function PlaybackController() {
         }
     }
 
-    function getStartTimeFromUriParameters(rangeStart) {
+    function getStartTimeFromUriParameters(rangeStart, isDynamic) {
         const fragData = uriFragmentModel.getURIFragmentData();
         if (!fragData || !fragData.t) {
             return NaN;
@@ -385,7 +385,7 @@ function PlaybackController() {
 
         // "t=<time>" : time is relative to period start (for static streams) or DVR window range start (for dynamic streams)
         // "t=posix:<time>" : time is absolute start time as number of seconds since 01-01-1970
-        startTime = (fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : (rangeStart + parseInt(fragData.t));
+        startTime = (isDynamic && fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : (rangeStart + parseInt(fragData.t));
 
         return startTime;
     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -116,12 +116,14 @@ function PlaybackController() {
             if (startTime === videoModel.getTime()) return;
         }
 
-        // Trigger PLAYBACK_SEEKING event for controllers
-        eventBus.trigger(Events.PLAYBACK_SEEKING, {
-            seekTime: startTime
-        });
-        // Seek video model
-        seek(startTime, false, true);
+        if (!isNaN(startTime)) {
+            // Trigger PLAYBACK_SEEKING event for controllers
+            eventBus.trigger(Events.PLAYBACK_SEEKING, {
+                seekTime: startTime
+            });
+            // Seek video model
+            seek(startTime, false, true);
+        }
     }
 
     function getTimeToStreamEnd() {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -556,17 +556,6 @@ function PlaybackController() {
         }
     }
 
-    // function checkTimeInRanges(time, ranges) {
-    //     if (ranges && ranges.length > 0) {
-    //         for (let i = 0, len = ranges.length; i < len; i++) {
-    //             if (time >= ranges.start(i) && time < ranges.end(i)) {
-    //                 return true;
-    //             }
-    //         }
-    //     }
-    //     return false;
-    // }
-
     function onPlaybackProgression() {
         if (
             isDynamic &&

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -118,7 +118,8 @@ function PlaybackController() {
                 const dvrInfo = dashMetrics.getCurrentDVRInfo();
                 const dvrWindow = dvrInfo ? dvrInfo.range : null;
                 if (dvrWindow) {
-                    const startTimeFromUri = getStartTimeFromUriParameters(dvrWindow.start, true);
+                    // #t shall be relative to period start
+                    const startTimeFromUri = getStartTimeFromUriParameters(streamInfo.start, true);
                     if (!isNaN(startTimeFromUri)) {
                         logger.info('Start time from URI parameters: ' + startTimeFromUri);
                         startTime = Math.max(Math.min(startTime, startTimeFromUri), dvrWindow.start);

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -371,7 +371,7 @@ function PlaybackController() {
         }
     }
 
-    function getStartTimeFromUriParameters(periodStart) {
+    function getStartTimeFromUriParameters(rangeStart) {
         const fragData = uriFragmentModel.getURIFragmentData();
         if (!fragData || !fragData.t) {
             return NaN;
@@ -380,12 +380,12 @@ function PlaybackController() {
         let startTime = NaN;
 
         // Consider only start time of MediaRange
-        // TODO: consider end time of MediaRange  to stop playback at provided end time
+        // TODO: consider end time of MediaRange to stop playback at provided end time
         fragData.t = fragData.t.split(',')[0];
 
-        // t is relative to period start
-        // posix notation (t=posix:xxx) = absolute time range as number of seconds since 01-01-1970
-        startTime = (fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : (periodStart + parseInt(fragData.t));
+        // "t=<time>" : time is relative to period start (for static streams) or DVR window range start (for dynamic streams)
+        // "t=posix:<time>" : time is absolute start time as number of seconds since 01-01-1970
+        startTime = (fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : (rangeStart + parseInt(fragData.t));
 
         return startTime;
     }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -411,7 +411,7 @@ function ScheduleController(config) {
 
     function onDataUpdateStarted(e) {
         if (e.sender.getType() !== type || e.sender.getStreamId() !== streamId) return;
-        stop();
+        // stop();
     }
 
     function onBufferingCompleted(e) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -362,13 +362,13 @@ function StreamController() {
         if (mediaSource && !isLast) {
             const newStream = getNextStream();
 
-            // Smooth period transition allowed only if both of these conditions are true:
-            // 1.- None of the periods uses contentProtection.
-            // 2.- changeType method implemented by browser or periods use the same codec.
-            let smoothPeriodSwitch = activeStream.isProtectionCompatible(newStream) &&
+            // Seamless period switch allowed only if:
+            // - none of the periods uses contentProtection.
+            // - AND changeType method implemented by browser or periods use the same codec.
+            let seamlessPeriodSwitch = activeStream.isProtectionCompatible(newStream) &&
                 (supportsChangeType || activeStream.isMediaCodecCompatible(newStream));
 
-            if (smoothPeriodSwitch) {
+            if (seamlessPeriodSwitch) {
                 logger.info('[onStreamCanLoadNext] Preloading next stream');
                 activeStream.deactivate(true);
                 newStream.preload(mediaSource, buffers);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -661,7 +661,7 @@ function StreamController() {
 
                 // we need to figure out what the correct starting period is
                 let initialStream = null;
-                const startTimeFormUri = playbackController.getStartTimeFromUriParameters(streamsInfo[0].start);
+                const startTimeFormUri = playbackController.getStartTimeFromUriParameters(streamsInfo[0].start, adapter.getIsDynamic());
                 if (!isNaN(startTimeFormUri)) {
                     initialStream = getStreamForTime(startTimeFormUri);
                 }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -660,11 +660,10 @@ function StreamController() {
                 }
 
                 // we need to figure out what the correct starting period is
-                const startTimeFormUriParameters = playbackController.getStartTimeFromUriParameters();
                 let initialStream = null;
-                if (startTimeFormUriParameters) {
-                    const initialTime = !isNaN(startTimeFormUriParameters.fragS) ? startTimeFormUriParameters.fragS : startTimeFormUriParameters.fragT;
-                    initialStream = getStreamForTime(initialTime);
+                const startTimeFormUri = playbackController.getStartTimeFromUriParameters(streamsInfo[0].start);
+                if (!isNaN(startTimeFormUri)) {
+                    initialStream = getStreamForTime(startTimeFormUri);
                 }
                 // For multiperiod streams we should avoid a switch of streams after the seek to the live edge. So we do a calculation of the expected seek time to find the right stream object.
                 if (!initialStream && adapter.getIsDynamic() && streams.length) {

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -125,9 +125,6 @@ function NotFragmentedTextBufferController(config) {
     function dischargePreBuffer() {
     }
 
-    function setSeekStartTime() { //Unused - TODO Remove need for stub function
-    }
-
     function getBufferLevel() {
         return 0;
     }
@@ -199,7 +196,6 @@ function NotFragmentedTextBufferController(config) {
         initialize: initialize,
         createBuffer: createBuffer,
         getType: getType,
-        setSeekStartTime: setSeekStartTime,
         getBuffer: getBuffer,
         getBufferLevel: getBufferLevel,
         setMediaSource: setMediaSource,

--- a/src/streaming/text/TextBufferController.js
+++ b/src/streaming/text/TextBufferController.js
@@ -107,10 +107,6 @@ function TextBufferController(config) {
         _BufferControllerImpl.setMediaSource(value);
     }
 
-    function setSeekStartTime(value) {
-        _BufferControllerImpl.setSeekStartTime(value);
-    }
-
     function getBufferLevel() {
         return _BufferControllerImpl.getBufferLevel();
     }
@@ -151,7 +147,6 @@ function TextBufferController(config) {
         initialize: initialize,
         createBuffer: createBuffer,
         getType: getType,
-        setSeekStartTime: setSeekStartTime,
         getBuffer: getBuffer,
         setBuffer: setBuffer,
         getBufferLevel: getBufferLevel,

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -56,7 +56,6 @@ describe('PlaybackController', function () {
         it('should initialize', function () {
 
             expect(playbackController.getIsDynamic()).to.not.exist; // jshint ignore:line
-            expect(playbackController.getLiveStartTime()).to.be.NaN; // jshint ignore:line
             expect(playbackController.isPaused()).to.be.null; // jshint ignore:line
             expect(playbackController.isSeeking()).to.be.null; // jshint ignore:line
             expect(playbackController.getTime()).to.be.null; // jshint ignore:line
@@ -74,9 +73,7 @@ describe('PlaybackController', function () {
 
             playbackController.initialize(streamInfo);
 
-
             expect(playbackController.getIsDynamic()).to.equal(true);
-            expect(playbackController.getLiveStartTime()).to.equal(10);
         });
     });
 

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -373,6 +373,18 @@ describe('PlaybackController', function () {
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
+        it('should start static stream at period start if #t=posix: notation is used', function (done) {
+            doneFn = done;
+
+            let uriStartTime = 30;
+            uriFragmentModelMock.setURIFragmentData({t: 'posix:' + uriStartTime.toString()});
+
+            expectedSeekTime = staticStreamInfo.start;
+
+            playbackController.initialize(staticStreamInfo);
+            eventBus.trigger(Events.STREAM_INITIALIZED, {});
+        });
+
         it('should start dynamic stream at live start time', function (done) {
             doneFn = done;
 

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -420,7 +420,7 @@ describe('PlaybackController', function () {
             let uriStartTime = 0;
             uriFragmentModelMock.setURIFragmentData({t: 'posix:' + uriStartTime.toString()});
 
-            expectedSeekTime = liveStartTime;
+            expectedSeekTime = dvrWindowRange.start;
 
             playbackController.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -326,8 +326,8 @@ describe('PlaybackController', function () {
         let doneFn;
 
         let staticStreamInfo = { manifestInfo: { isDynamic: false }, start: 10, duration: 600 };
-        let dynamicStreamInfo = { manifestInfo: { isDynamic: true }, start: 0, duration: Infinity };
-        let dvrWindowRange = { start: 10, end: 90 };
+        let dynamicStreamInfo = { manifestInfo: { isDynamic: true }, start: 50, duration: Infinity };
+        let dvrWindowRange = { start: 70, end: 100 };
 
         let onPlaybackSeeking = function (e) {
             eventBus.off(Events.PLAYBACK_SEEKING, onPlaybackSeeking);
@@ -388,7 +388,7 @@ describe('PlaybackController', function () {
         it('should start dynamic stream at live start time', function (done) {
             doneFn = done;
 
-            let liveStartTime = 90;
+            let liveStartTime = 80;
 
             expectedSeekTime = liveStartTime;
 
@@ -399,23 +399,23 @@ describe('PlaybackController', function () {
         it('should start dynamic stream at #t', function (done) {
             doneFn = done;
 
-            let liveStartTime = 70;
+            let liveStartTime = 80;
             dashMetricsMock.addDVRInfo('video', Date.now(), null, dvrWindowRange);
-            let uriStartTime = 50;
+            let uriStartTime = 25;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
-            expectedSeekTime = dvrWindowRange.start + uriStartTime;
+            expectedSeekTime = dynamicStreamInfo.start + uriStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
-        it('should start dynamic stream at #t=posix:', function (done) {
+        it('should start dynamic stream at #t=posix', function (done) {
             doneFn = done;
 
-            let liveStartTime = 70;
+            let liveStartTime = 80;
             dashMetricsMock.addDVRInfo('video', Date.now(), null, dvrWindowRange);
-            let uriStartTime = 50;
+            let uriStartTime = 75;
             uriFragmentModelMock.setURIFragmentData({t: 'posix:' + uriStartTime.toString()});
 
             expectedSeekTime = uriStartTime;
@@ -424,10 +424,24 @@ describe('PlaybackController', function () {
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
+        it('should start dynamic stream at live start time if #t is before DVR window range', function (done) {
+            doneFn = done;
+
+            let liveStartTime = 80;
+            dashMetricsMock.addDVRInfo('video', Date.now(), null, dvrWindowRange);
+            let uriStartTime = 0;
+            uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
+
+            expectedSeekTime = dvrWindowRange.start;
+
+            playbackController.initialize(dynamicStreamInfo);
+            eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
+        });
+
         it('should start dynamic stream at live start time if #t=posix is before DVR window range', function (done) {
             doneFn = done;
 
-            let liveStartTime = 70;
+            let liveStartTime = 80;
             dashMetricsMock.addDVRInfo('video', Date.now(), null, dvrWindowRange);
             let uriStartTime = 0;
             uriFragmentModelMock.setURIFragmentData({t: 'posix:' + uriStartTime.toString()});
@@ -441,9 +455,9 @@ describe('PlaybackController', function () {
         it('should start dynamic stream at live start time if #t=posix is beyond live start time', function (done) {
             doneFn = done;
 
-            let liveStartTime = 70;
+            let liveStartTime = 80;
             dashMetricsMock.addDVRInfo('video', Date.now(), null, dvrWindowRange);
-            let uriStartTime = 80;
+            let uriStartTime = 110;
             uriFragmentModelMock.setURIFragmentData({t: 'posix:' + uriStartTime.toString()});
 
             expectedSeekTime = liveStartTime;


### PR DESCRIPTION
This PR intends to refactor and simplify streams playback start process:
- always use seeking process from PlaybackController to seek controllersevent for initial playback start
- adjust seek time in BufferController according to effective appended ranges (in case of misalignement between manifest and coded fragments)

The changes are illustrated in following sequence diagram: https://sketchboard.me/nCcqJmksDzlb#/

