### PR TITLE
Consider gap/discontinuity limit as tolerance when determining buffer…

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -488,6 +488,11 @@ function BufferController(config) {
         let range,
             length;
 
+        // Consider gap/discontinuity limit as tolerance
+        if (settings.get().streaming.jumpGaps) {
+            tolerance = settings.get().streaming.smallGapLimit;
+        }
+
         range = getRangeAt(time, tolerance);
 
         if (range === null) {


### PR DESCRIPTION
… length
If there is a gap/discontinituity in the stream, the buffer length may be errorneous without considering buffered data beyond the gap, and thus the player may continue download and buffering segments beyond required buffer length