### PR TITLE
Live seeking

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -229,7 +229,6 @@ function StreamProcessor(config) {
 
     function onDataUpdateCompleted(e) {
         if (e.sender.getType() !== getType() || e.sender.getStreamId() !== streamInfo.id) return;
-        logger.info('DataUpdateCompleted');
 
         if (!e.error) {
             // Update representation if no error

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -306,20 +306,20 @@ function BufferController(config) {
         if (isNaN(seekTarget)) return;
 
         const segmentDuration = representationController.getCurrentRepresentation().segmentDuration;
+        const currentTime = playbackController.getTime();
 
-        // Check if current buffered range already contains seek target
+        // Check if current buffered range already contains seek target (and current video element time)
         let range = getRangeAt(seekTarget, 0);
-        if (range) return;
+        if (currentTime === seekTarget && range) return;
 
-        // Get range corresponding to to seek target
+        // Get buffered range corresponding to the seek target
         range = getRangeAt(seekTarget, segmentDuration);
         if (!range) return;
 
-        const currentTime = playbackController.getTime();
-        if (Math.abs(currentTime - range.start) > segmentDuration) {
-            // If current video model time is decorrelated from seek target / appended buffer then seek video element to seek target
+        if (Math.abs(currentTime - seekTarget) > segmentDuration) {
+            // If current video model time is decorrelated from seek target (and appended buffer) then seek video element to seek target
             // (in case of live streams on some browsers/devices for which we can't set video element time at unavalaible range)
-            playbackController.seek(seekTarget, false, true);
+            playbackController.seek(Math.max(seekTarget, range.start), false, true);
             seekTarget = NaN;
         } else if (currentTime < range.start) {
             // If appended buffer starts after seek target (segments timeline/template tolerance) then seek to range start

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -282,6 +282,12 @@ function BufferController(config) {
             showBufferRanges(ranges);
             onPlaybackProgression();
             adjustSeekTarget();
+        } else if (replacingBuffer) {
+            // When replacing buffer due to switch track, and once new initialization segment has been appended
+            // (and previous buffered data removed) then seek stream to current time
+            const currentTime = playbackController.getTime();
+            logger.debug('AppendToBuffer seek target should be ' + currentTime);
+            triggerEvent(Events.SEEK_TARGET, {time: currentTime});
         }
 
         if (appendedBytesInfo) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -301,10 +301,18 @@ function BufferController(config) {
     }
 
     function adjustSeekTarget () {
+        // Check buffered data only for audio and video
+        if (type !== Constants.AUDIO && type !== Constants.VIDEO) return;
         if (isNaN(seekTarget)) return;
 
         const segmentDuration = representationController.getCurrentRepresentation().segmentDuration;
-        const range = getRangeAt(seekTarget, segmentDuration);
+
+        // Check if current buffered range already contains seek target
+        let range = getRangeAt(seekTarget, 0);
+        if (range) return;
+
+        // Get range corresponding to to seek target
+        range = getRangeAt(seekTarget, segmentDuration);
         if (!range) return;
 
         const currentTime = playbackController.getTime();
@@ -455,7 +463,7 @@ function BufferController(config) {
         let len,
             i;
 
-        const toler = (tolerance || 0.15);
+        const toler = !isNaN(tolerance) ? tolerance : 0.15;
 
         if (ranges !== null && ranges !== undefined) {
             for (i = 0, len = ranges.length; i < len; i++) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -179,21 +179,22 @@ function PlaybackController() {
     }
 
     function seek(time, stickToBuffered, internalSeek) {
-        if (streamInfo && videoModel) {
-            if (internalSeek === true) {
-                if (time !== videoModel.getTime()) {
-                    // Internal seek = seek video model only (disable 'seeking' listener),
-                    // buffer(s) are already appended at given time (see onBytesAppended())
-                    videoModel.removeEventListener('seeking', onPlaybackSeeking);
-                    logger.info('Requesting internal seek to time: ' + time);
-                    videoModel.setCurrentTime(time, stickToBuffered);
-                }
-            } else {
-                seekTarget = time;
-                eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
-                logger.info('Requesting seek to time: ' + time);
-                videoModel.setCurrentTime(time, stickToBuffered);
-            }
+        if (!streamInfo || !videoModel) return;
+
+        let currentTime = !isNaN(seekTarget) ? seekTarget : videoModel.getTime();
+        if (time === currentTime) return;
+
+        if (internalSeek === true) {
+            // Internal seek = seek video model only (disable 'seeking' listener)
+            // buffer(s) are already appended at requested time
+            videoModel.removeEventListener('seeking', onPlaybackSeeking);
+            logger.info('Requesting internal seek to time: ' + time);
+            videoModel.setCurrentTime(time, stickToBuffered);
+        } else {
+            seekTarget = time;
+            eventBus.trigger(Events.PLAYBACK_SEEK_ASKED);
+            logger.info('Requesting seek to time: ' + time);
+            videoModel.setCurrentTime(time, stickToBuffered);
         }
     }
 

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -458,11 +458,12 @@ function ScheduleController(config) {
             latency: latency
         });
 
-        //if, during the seek command, the scheduleController is waiting : stop waiting, request chunk as soon as possible
         if (!isFragmentProcessingInProgress) {
+            // Restart scheduler if in pending state
             startScheduleTimer(0);
         } else {
-            logger.debug('onPlaybackSeeking, call fragmentModel.abortRequests in order to seek quicker');
+            // Abort current requests
+            logger.debug('Abort requests');
             fragmentModel.abortRequests();
         }
     }


### PR DESCRIPTION
Following PR #3308, this PR resolves live seeking for non-modern browsers for which seeking at a time on video element fails when there is no buffered data at requested time.
Data requires to be buffered first, before seeking video element to original seek target time