### PR TITLE
Initial commit to support version 1 events.

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -307,11 +307,18 @@ function DashAdapter() {
         const schemeIdUri = eventBox.scheme_id_uri;
         const value = eventBox.value;
         const timescale = eventBox.timescale;
-        const presentationTimeDelta = eventBox.presentation_time_delta;
+        let presentationTimeDelta;
+        let calculatedPresentationTime;
+        if (eventBox.version === 0) {
+            presentationTimeDelta = eventBox.presentation_time_delta;
+            calculatedPresentationTime = startTime * timescale + presentationTimeDelta;
+        } else {
+            presentationTimeDelta = 0;
+            calculatedPresentationTime = eventBox.presentation_time_delta;
+        }
         const duration = eventBox.event_duration;
         const id = eventBox.id;
         const messageData = eventBox.message_data;
-        const calculatedPresentationTime = startTime * timescale + presentationTimeDelta;
 
         if (!eventStreams[schemeIdUri + '/' + value]) return null;
 
@@ -460,6 +467,7 @@ function DashAdapter() {
         voAdaptations = {};
         currentMediaInfo = {};
     }
+
     // #endregion PUBLIC FUNCTIONS
 
     // #region PRIVATE FUNCTIONS
@@ -521,7 +529,7 @@ function DashAdapter() {
             return audioChannelConfiguration.value;
         });
 
-        if (mediaInfo.audioChannelConfiguration.length === 0 && Array.isArray(realAdaptation.Representation_asArray) && realAdaptation.Representation_asArray.length > 0 ) {
+        if (mediaInfo.audioChannelConfiguration.length === 0 && Array.isArray(realAdaptation.Representation_asArray) && realAdaptation.Representation_asArray.length > 0) {
             mediaInfo.audioChannelConfiguration = dashManifestModel.getAudioChannelConfigurationForRepresentation(realAdaptation.Representation_asArray[0]).map(function (audioChannelConfiguration) {
                 return audioChannelConfiguration.value;
             });
@@ -655,6 +663,7 @@ function DashAdapter() {
 
         return -1;
     }
+
     // #endregion PRIVATE FUNCTIONS
 
     instance = {

--- a/src/streaming/vo/IsoBox.js
+++ b/src/streaming/vo/IsoBox.js
@@ -65,6 +65,7 @@ class IsoBox {
                 break;
             case 'emsg':
                 this.id = boxData.id;
+                this.version = boxData.version === 1 ? 1 : 0;
                 this.value = boxData.value;
                 this.timescale = boxData.timescale;
                 this.scheme_id_uri = boxData.scheme_id_uri;


### PR DESCRIPTION
This is to support https://github.com/Dash-Industry-Forum/dash.js/issues/3196. 

 I have included a [test package](https://github.com/Dash-Industry-Forum/dash.js/files/4886180/testdata_for_3196.zip), which contains MPEG-DASH audio and video media segments with inband (embedded) version 1 `emsg` data in the video fragmented media segments. Each media segment is 2 seconds long. There are 25 segments for each representation (and, therefore, 50 seconds of playback.) Each fragmented media segment contains 4 `emsg` event boxes.