### PR TITLE
Fix buffer pruning

### DIFF
--- a/samples/dash-if-reference-player/dashjs_config.json
+++ b/samples/dash-if-reference-player/dashjs_config.json
@@ -11,7 +11,6 @@
         "fastSwitchEnabled": true,
         "bufferPruningInterval": 10,
         "bufferToKeep": 20,
-        "bufferAheadToKeep": 80,
         "jumpGaps": true,
         "smallGapLimit": 1.5,
         "stableBufferTime": -1,

--- a/samples/offline/dashjs_config.json
+++ b/samples/offline/dashjs_config.json
@@ -11,7 +11,6 @@
         "fastSwitchEnabled": false,
         "bufferPruningInterval": 10,
         "bufferToKeep": 20,
-        "bufferAheadToKeep": 80,
         "jumpGaps": false,
         "smallGapLimit": 0.8,
         "stableBufferTime": -1,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -60,7 +60,6 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *          fastSwitchEnabled: false,
  *          bufferPruningInterval: 10,
  *          bufferToKeep: 20,
- *          bufferAheadToKeep: 80,
  *          jumpGaps: true,
  *          jumpLargeGaps: true,
  *          smallGapLimit: 1.5,
@@ -239,10 +238,6 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * This value influences the buffer pruning logic.
  * Allows you to modify the buffer that is kept in source buffer in seconds.
  *  0|-----------bufferToPrune-----------|-----bufferToKeep-----|currentTime|
- * @property {number} [bufferAheadToKeep=80]
- * This value influences the buffer pruning logic.
- * Allows you to modify the buffer ahead of current time position that is kept in source buffer in seconds.
- * <pre>0|--------|currentTime|-----bufferAheadToKeep----|----bufferToPrune-----------|end|</pre>
  * @property {boolean} [jumpGaps=true] Sets whether player should jump small gaps (discontinuities) in the buffer.
  * @property {boolean} [jumpLargeGaps=true] Sets whether player should jump large gaps (discontinuities) in the buffer.
  * @property {number} [smallGapLimit=1.8] Time in seconds for a gap to be considered small.
@@ -392,7 +387,6 @@ function Settings() {
             fastSwitchEnabled: false,
             bufferPruningInterval: 10,
             bufferToKeep: 20,
-            bufferAheadToKeep: 80,
             jumpGaps: true,
             jumpLargeGaps: true,
             smallGapLimit: 1.5,

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -62,7 +62,6 @@ function DashHandler(config) {
         segmentIndex,
         lastSegment,
         requestedTime,
-        currentTime,
         isDynamicManifest,
         dynamicStreamCompleted,
         selectedMimeType,
@@ -94,14 +93,6 @@ function DashHandler(config) {
         return streamInfo;
     }
 
-    function setCurrentTime(value) {
-        currentTime = value;
-    }
-
-    function getCurrentTime() {
-        return currentTime;
-    }
-
     function setCurrentIndex (value) {
         segmentIndex = value;
     }
@@ -117,7 +108,6 @@ function DashHandler(config) {
 
     function resetInitialSettings() {
         resetIndex();
-        currentTime = 0;
         requestedTime = null;
         segmentsController = null;
         selectedMimeType = null;
@@ -438,8 +428,6 @@ function DashHandler(config) {
         getRequestForSegment: getRequestForSegment,
         getSegmentRequestForTime: getSegmentRequestForTime,
         getNextSegmentRequest: getNextSegmentRequest,
-        setCurrentTime: setCurrentTime,
-        getCurrentTime: getCurrentTime,
         setCurrentIndex: setCurrentIndex,
         getCurrentIndex: getCurrentIndex,
         isMediaFinished: isMediaFinished,

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -405,7 +405,7 @@ function Stream(config) {
                 processor.getFragmentModel().abortRequests();
             } else {
                 processor.getScheduleController().setSeekTarget(currentTime);
-                processor.setIndexHandlerTime(currentTime);
+                processor.setBufferingTime(currentTime);
                 processor.resetIndexHandler();
             }
         }
@@ -440,7 +440,7 @@ function Stream(config) {
 
         if (optionalSettings) {
             streamProcessor.setBuffer(optionalSettings.buffer);
-            streamProcessor.setIndexHandlerTime(optionalSettings.currentTime);
+            streamProcessor.setBufferingTime(optionalSettings.currentTime);
             streamProcessors[optionalSettings.replaceIdx] = streamProcessor;
         } else {
             streamProcessors.push(streamProcessor);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -424,7 +424,6 @@ function ScheduleController(config) {
 
         // (Re)start schedule once buffer has been pruned after a QuotaExceededError
         if (e.hasEnoughSpaceToAppend && e.quotaExceeded) {
-            logger.debug('Buffer cleared since quota exceeeded, restart scheduler');
             start();
         }
     }
@@ -432,8 +431,7 @@ function ScheduleController(config) {
     function onQuotaExceeded(e) {
         if (e.streamId !== streamId || e.mediaType !== type) return;
 
-        // Abort current request and stop scheduler (will be restarted once buffer is pruned)
-        fragmentModel.abortRequests();
+        // Stop scheduler (will be restarted once buffer is pruned)
         stop();
         setFragmentProcessState(false);
     }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -345,7 +345,7 @@ function StreamController() {
                 nextStream.preload(mediaSource, buffers);
                 preloadingStreams.push(nextStream);
                 nextStream.getProcessors().forEach(p => {
-                    p.setIndexHandlerTime(nextStream.getStartTime());
+                    p.setBufferingTime(nextStream.getStartTime());
                 });
             }
         }
@@ -569,12 +569,12 @@ function StreamController() {
 
         if (!initialPlayback) {
             if (!isNaN(seekTime)) {
-                playbackController.seek(seekTime); //we only need to call seek here, IndexHandlerTime was set from seeking event
+                playbackController.seek(seekTime); //we only need to call seek here, bufferingTime was set from seeking event
             } else {
                 // let startTime = playbackController.getStreamStartTime(true);
                 // if (!keepBuffers) {
                 //     getActiveStreamProcessors().forEach(p => {
-                //         p.setIndexHandlerTime(startTime);
+                //         p.setBufferingTime(startTime);
                 //     });
                 // }
             }

--- a/src/streaming/models/FragmentModel.js
+++ b/src/streaming/models/FragmentModel.js
@@ -185,6 +185,7 @@ function FragmentModel(config) {
     }
 
     function abortRequests() {
+        logger.debug('abort requests');
         fragmentLoader.abort();
         loadingRequests = [];
     }

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -335,7 +335,7 @@ function TextController() {
                                     break;
                                 }
                             }
-                            streamProcessor.setIndexHandlerTime(videoModel.getTime());
+                            streamProcessor.setBufferingTime(videoModel.getTime());
                             streamProcessor.getScheduleController().start();
                         }
                     }

--- a/test/unit/Streaming.StreamProcessor.js
+++ b/test/unit/Streaming.StreamProcessor.js
@@ -42,13 +42,8 @@ describe('StreamProcessor', function () {
             streamProcessor.reset();
         });
 
-        it('getIndexHandlerTime should return NaN', function () {
-            const time = streamProcessor.getIndexHandlerTime();
-            expect(time).to.be.NaN; // jshint ignore:line
-        });
-
-        it('setIndexHandlerTime should not throw an error', function () {
-            expect(streamProcessor.setIndexHandlerTime.bind(streamProcessor)).to.not.throw();
+        it('setBufferingTime should not throw an error', function () {
+            expect(streamProcessor.setBufferingTime.bind(streamProcessor)).to.not.throw();
         });
 
         it('getInitRequest should return null', function () {


### PR DESCRIPTION
The goal of this PR is:
- to fix next segment request determination after buffer has been pruned, due to QuotaExceededError or automatic pruning process (bug existing since v3.0)
-  to update buffer lengths according to critical buffer size
- to prune buffer only beyond new buffer limits (instead of clearing all buffer) when a QuotaExceededError happended

BTW, I wonder about use of bufferAheadToKeep parameter. If one sets bufferAheadToKeep lower than bufferTimeAtTopQuality(LongForm) then the buffer will always be pruned before reaching buffer length.
Also, since bufferTimeAtTopQuality(LongForm) is used as a limit to append new segments, I don't get the need for bufferAheadToKeep parameter. 