### PR TITLE
Fixed imageType attribute name in TTMLParser

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -81,7 +81,9 @@ function TTMLParser() {
         let metadataHandler = {
 
             onOpenTag: function (ns, name, attrs) {
-                if (name === 'image' && ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt') {
+                if (name === 'image' &&
+                (ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt' ||
+                 ns === 'http://www.smpte-ra.org/schemas/2052-1/2013/smpte-tt')) {
                     if (!attrs[' imageType'] || attrs[' imageType'].value !== 'PNG') {
                         logger.warn('smpte-tt imageType != PNG. Discarded');
                         return;

--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -82,8 +82,8 @@ function TTMLParser() {
 
             onOpenTag: function (ns, name, attrs) {
                 if (name === 'image' && ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt') {
-                    if (!attrs[' imagetype'] || attrs[' imagetype'].value !== 'PNG') {
-                        logger.warn('smpte-tt imagetype != PNG. Discarded');
+                    if (!attrs[' imageType'] || attrs[' imageType'].value !== 'PNG') {
+                        logger.warn('smpte-tt imageType != PNG. Discarded');
                         return;
                     }
                     currentImageId = attrs['http://www.w3.org/XML/1998/namespace id'].value;


### PR DESCRIPTION
- Fixed `imageType` attribute name to align with http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt XSD
- Extended ns verification in TTMLParser with SMPTE ST 2052-1:2013 namespace since it has XSD identical to 2052-1:2010

Issue with `imageType` attribute was already raised in https://github.com/Dash-Industry-Forum/dash.js/issues/730#issue-103753899 and https://github.com/Dash-Industry-Forum/dash.js/pull/729#issue-43632363