### PR TITLE
Fix multiperiod representation update

### DIFF
--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -177,7 +177,10 @@ function RepresentationController(config) {
         for (let i = 0, ln = voAvailableRepresentations.length; i < ln; i++) {
             updateRepresentation(voAvailableRepresentations[i], isDynamic);
             if (notifyUpdate) {
-                eventBus.trigger(events.REPRESENTATION_UPDATE_STARTED, { sender: instance, representation:  voAvailableRepresentations[i]});
+                eventBus.trigger(events.REPRESENTATION_UPDATE_STARTED, {
+                    sender: instance,
+                    representation: voAvailableRepresentations[i]
+                });
             }
         }
     }
@@ -190,7 +193,7 @@ function RepresentationController(config) {
 
     function startDataUpdate() {
         updating = true;
-        eventBus.trigger(events.DATA_UPDATE_STARTED, { sender: instance });
+        eventBus.trigger(events.DATA_UPDATE_STARTED, {sender: instance});
     }
 
     function endDataUpdate(error) {
@@ -215,7 +218,7 @@ function RepresentationController(config) {
 
             updateAvailabilityWindow(playbackController.getIsDynamic(), true);
         };
-        eventBus.trigger(events.AST_IN_FUTURE, { delay: delay });
+        eventBus.trigger(events.AST_IN_FUTURE, {delay: delay});
         setTimeout(update, delay);
     }
 
@@ -237,10 +240,8 @@ function RepresentationController(config) {
             repSwitch;
 
         if (r.adaptation.period.mpd.manifest.type === dashConstants.DYNAMIC && !r.adaptation.period.mpd.manifest.ignorePostponeTimePeriod) {
-            let segmentAvailabilityTimePeriod = r.segmentAvailabilityRange.end - r.segmentAvailabilityRange.start;
             // We must put things to sleep unless till e.g. the startTime calculation in ScheduleController.onLiveEdgeSearchCompleted fall after the segmentAvailabilityRange.start
-            let liveDelay = playbackController.getLiveDelay();
-            postponeTimePeriod = (liveDelay - segmentAvailabilityTimePeriod) * 1000;
+            postponeTimePeriod = playbackController.getRepresentationUpdatePostponeTimePeriod(r, streamInfo);
         }
 
         if (postponeTimePeriod > 0) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -670,26 +670,6 @@ function PlaybackController() {
         }
     }
 
-    function getRepresentationUpdatePostponeTimePeriod(representation, streamInfo) {
-        try {
-            const streamController = getStreamController();
-            const activeStreamInfo = streamController.getActiveStreamInfo();
-            let startTimeAnchor = representation.segmentAvailabilityRange.start;
-
-            if (activeStreamInfo && activeStreamInfo.id && activeStreamInfo.id !== streamInfo.id) {
-                // We need to consider the currently playing period if a period switch is performed.
-                startTimeAnchor = Math.min(getTime(), startTimeAnchor);
-            }
-
-            let segmentAvailabilityTimePeriod = representation.segmentAvailabilityRange.end - startTimeAnchor;
-            let liveDelay = getLiveDelay();
-
-            return (liveDelay - segmentAvailabilityTimePeriod) * 1000;
-        } catch (e) {
-            return 0;
-        }
-    }
-
     function onFragmentLoadProgress(e) {
         // If using fetch and stream mode is not available, readjust live latency so it is 20% higher than segment duration
         if (e.stream === false && settings.get().streaming.lowLatencyEnabled && !isNaN(e.request.duration)) {
@@ -823,8 +803,7 @@ function PlaybackController() {
         pause: pause,
         isSeeking: isSeeking,
         seek: seek,
-        reset: reset,
-        getRepresentationUpdatePostponeTimePeriod
+        reset: reset
     };
 
     setup();


### PR DESCRIPTION
The goal of this PR is to consider multiperiod manifests when updating the representations in the RepresentationController. The update of the Representations is postponed whenever live delay is larger than availwindow.end - availwindow.start. 

However, for multiperiod we might still be playing in the previous period when a new period is introduced and the respective RepresentationController updates the representations. Live delay might be too large so we need to consider the currently playing period as starttime anchor: Math.min(availwindow.start,currenttime)