### PR TITLE
fix ts definition for setProtectionData

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare namespace dashjs {
         setMediaElement(element: HTMLMediaElement): void;
         setSessionType(type: string): void;
         setRobustnessLevel(level: string): void;
-        setProtectionData(protData: ProtectionData): void;
+        setProtectionData(protDataSet: ProtectionDataSet): void;
         getSupportedKeySystemsFromContentProtection(cps: any[]): SupportedKeySystem[];
         getKeySystems(): KeySystem[];
         setKeySystems(keySystems: KeySystem[]): void;
@@ -305,7 +305,7 @@ declare namespace dashjs {
         getXHRWithCredentialsForType(type: string): boolean;
         getProtectionController(): ProtectionController;
         attachProtectionController(value: ProtectionController): void;
-        setProtectionData(value: ProtectionData): void;
+        setProtectionData(value: ProtectionDataSet): void;
         getOfflineController(): OfflineController;
         enableManifestDateHeaderTimeSource(value: boolean): void;
         displayCaptionsOnTop(value: boolean): void;
@@ -922,7 +922,11 @@ declare namespace dashjs {
         getMaxIndexForBufferType(bufferType: MediaType, periodIdx: number): number;
     }
 
-    export class ProtectionData {
+    export interface ProtectionDataSet {
+        [keySystemName: string]: ProtectionData;
+    }
+
+    export interface ProtectionData {
         /**
          * A license server URL to use with this key system.
          * When specified as a string, a single URL will be used regardless of message type.

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1628,7 +1628,7 @@ function MediaPlayer() {
      * be set before initializing MediaPlayer or, once initialized, before PROTECTION_CREATED event is fired.
      * @see {@link module:MediaPlayer#initialize initialize()}
      * @see {@link ProtectionEvents#event:PROTECTION_CREATED dashjs.Protection.events.PROTECTION_CREATED}
-     * @param {ProtectionData} value - object containing
+     * @param {ProtectionDataSet} value - object containing
      * property names corresponding to key system name strings and associated
      * values being instances of.
      * @memberof module:MediaPlayer

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -231,7 +231,7 @@ function ProtectionKeyController() {
      *
      * @param {ArrayBuffer} initData Concatenated PSSH data for all DRMs
      * supported by the content
-     * @param {ProtectionData} protDataSet user specified protection data - license server url etc
+     * @param {ProtectionDataSet} protDataSet user specified protection data - license server url etc
      * supported by the content
      * @returns {Array.<Object>} array of objects indicating which supported key
      * systems were found.  Empty array is returned if no
@@ -266,7 +266,7 @@ function ProtectionKeyController() {
      *
      * @param {KeySystem} keySystem the key system
      * associated with this license request
-     * @param {ProtectionData} protData protection data to use for the
+     * @param {ProtectionDataSet} protData protection data to use for the
      * request
      * @param {string} [messageType="license-request"] the message type associated with this
      * request.  Supported message types can be found
@@ -304,7 +304,7 @@ function ProtectionKeyController() {
      * Allows application-specific retrieval of ClearKey keys.
      *
      * @param {KeySystem} clearkeyKeySystem They exact ClearKey System to be used
-     * @param {ProtectionData} protData protection data to use for the
+     * @param {ProtectionDataSet} protData protection data to use for the
      * request
      * @param {ArrayBuffer} message the key message from the CDM
      * @return {ClearKeyKeySet|null} the clear keys associated with

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -47,7 +47,7 @@ function KeySystemClearKey(config) {
     /**
      * Returns desired clearkeys (as specified in the CDM message) from protection data
      *
-     * @param {ProtectionData} protectionData the protection data
+     * @param {ProtectionDataSet} protectionData the protection data
      * @param {ArrayBuffer} message the ClearKey CDM message
      * @returns {ClearKeyKeySet} the key set or null if none found
      * @throws {Error} if a keyID specified in the CDM message was not found in the

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -45,7 +45,7 @@ function KeySystemW3CClearKey(config) {
     /**
      * Returns desired clearkeys (as specified in the CDM message) from protection data
      *
-     * @param {ProtectionData} protectionData the protection data
+     * @param {ProtectionDataSet} protectionData the protection data
      * @param {ArrayBuffer} message the ClearKey CDM message
      * @returns {ClearKeyKeySet} the key set or null if none found
      * @throws {Error} if a keyID specified in the CDM message was not found in the


### PR DESCRIPTION
to fix #3349 
A new ProtectionDataSet interface is defined
ProtectionData will still describe protection data for a given key system (still used in ProtectionModel.js)
https://github.com/Dash-Industry-Forum/dash.js/blob/32b50c62aa2d5d2d127add3a7916536d5c4dbf80/src/streaming/protection/models/ProtectionModel.js#L116