### PR TITLE
fix multiple subtitles displayed for multiperiod streams

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -153,7 +153,9 @@ function Stream(config) {
 
     function initialize(strInfo, prtctnController) {
         streamInfo = strInfo;
-        fragmentController.setStreamId(strInfo.id);
+        if (strInfo) {
+            fragmentController.setStreamId(strInfo.id);
+        }
         protectionController = prtctnController;
         registerProtectionEvents();
     }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -151,9 +151,10 @@ function Stream(config) {
         }
     }
 
-    function initialize(StreamInfo, ProtectionController) {
-        streamInfo = StreamInfo;
-        protectionController = ProtectionController;
+    function initialize(strInfo, prtctnController) {
+        streamInfo = strInfo;
+        fragmentController.setStreamId(strInfo.id);
+        protectionController = prtctnController;
         registerProtectionEvents();
     }
 

--- a/src/streaming/controllers/FragmentController.js
+++ b/src/streaming/controllers/FragmentController.js
@@ -52,7 +52,8 @@ function FragmentController( config ) {
 
     let instance,
         logger,
-        fragmentModels;
+        fragmentModels,
+        streamId;
 
     function setup() {
         logger = debug.getLogger(instance);
@@ -131,6 +132,8 @@ function FragmentController( config ) {
         const isInit = request.isInitializationRequest();
         const streamInfo = request.mediaInfo.streamInfo;
 
+        if (streamInfo && streamInfo.id !== streamId) return;
+
         if (e.error) {
             if (e.request.mediaType === Constants.AUDIO || e.request.mediaType === Constants.VIDEO || e.request.mediaType === Constants.FRAGMENTED_TEXT) {
                 // add service location to blacklist controller - only for audio or video. text should not set errors
@@ -149,8 +152,13 @@ function FragmentController( config ) {
         });
     }
 
+    function setStreamId (id) {
+        streamId = id;
+    }
+
     instance = {
         getModel: getModel,
+        setStreamId: setStreamId,
         reset: reset
     };
 


### PR DESCRIPTION
This PR fixes the issue #3361.
There are as many FragmentController as periods in the manifest and they all reacted to Events.FRAGMENT_LOADING_COMPLETED. 
With this PR the streamInfo.id is stored in the FragmentController and now it only reacts to the events with the corresponding stream id.