### PR TITLE
updateSettings new streaming parameters : trackSwitchMode and selectionModeForInitialTrack

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,10 @@ declare namespace dashjs {
                 video?: number;
                 audio?: number;
             };
+            trackSwitchMode?: {
+                video?: TrackSwitchMode;
+                audio?: TrackSwitchMode;
+            }
             retryIntervals?: {
                 'MPD'?:                       number;
                 'XLinkExpansion'?:            number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,6 +149,7 @@ declare namespace dashjs {
                 video?: TrackSwitchMode;
                 audio?: TrackSwitchMode;
             }
+            selectionModeForInitialTrack?: TrackSelectionMode
             retryIntervals?: {
                 'MPD'?:                       number;
                 'XLinkExpansion'?:            number;

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -330,8 +330,10 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
         $scope.player.attachTTMLRenderingDiv($('#video-caption')[0]);
     }
 
-    var initVideoTrackSwitchMode = $scope.player.getTrackSwitchModeFor('video');
-    var initAudioTrackSwitchMode = $scope.player.getTrackSwitchModeFor('audio');
+    var currentConfig = $scope.player.getSettings();
+
+    var initVideoTrackSwitchMode = currentConfig.streaming.trackSwitchMode.video;
+    var initAudioTrackSwitchMode = currentConfig.streaming.trackSwitchMode.audio;
 
     //get default track switch mode
     if (initVideoTrackSwitchMode === 'alwaysReplace') {
@@ -647,7 +649,9 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
     };
 
     $scope.changeTrackSwitchMode = function (mode, type) {
-        $scope.player.setTrackSwitchModeFor(type, mode);
+        var switchMode = {};
+        switchMode[type] = mode;
+        $scope.player.updateSettings({'streaming': {'trackSwitchMode' : switchMode}});
     };
 
     $scope.setLogLevel = function () {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -417,6 +417,7 @@ function Settings() {
             lastBitrateCachingInfo: {enabled: true, ttl: 360000},
             lastMediaSettingsCachingInfo: {enabled: true, ttl: 360000},
             cacheLoadThresholds: {video: 50, audio: 5},
+            trackSwitchMode: {audio: Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE, video: Constants.TRACK_SWITCH_MODE_NEVER_REPLACE},
             retryIntervals: {
                 [HTTPRequest.MPD_TYPE]: 500,
                 [HTTPRequest.XLINK_EXPANSION_TYPE]: 500,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -418,6 +418,7 @@ function Settings() {
             lastMediaSettingsCachingInfo: {enabled: true, ttl: 360000},
             cacheLoadThresholds: {video: 50, audio: 5},
             trackSwitchMode: {audio: Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE, video: Constants.TRACK_SWITCH_MODE_NEVER_REPLACE},
+            selectionModeForInitialTrack: Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE,
             retryIntervals: {
                 [HTTPRequest.MPD_TYPE]: 500,
                 [HTTPRequest.XLINK_EXPANSION_TYPE]: 500,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -235,7 +235,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * fragment may be appended in the same range as the playhead or even in the past, in IE11 it may cause a stutter
  * or stall in playback.
  * @property {boolean} [flushBufferAtTrackSwitch=false]
- * When enabled, after a track switch and in case buffer is being replaced (see MEdiaPlayer.setTrackSwitchModeFor(MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE)),
+ * When enabled, after a track switch and in case buffer is being replaced (see MEdiaPlayer.setTrackSwitchModeFor(Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE)),
  * the video element is flushed (seek at current playback time) once a segment of the new track is appended in buffer in order to force video decoder to play new track.
  * This can be required on some devices like GoogleCast devices to make track switching functional. Otherwise track switching will be effective only once after previous
  * buffered track is fully consumed.

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1548,11 +1548,11 @@ function MediaPlayer() {
     /**
      * This method sets the current track switch mode. Available options are:
      *
-     * MediaController.TRACK_SWITCH_MODE_NEVER_REPLACE
+     * Constants.TRACK_SWITCH_MODE_NEVER_REPLACE
      * (used to forbid clearing the buffered data (prior to current playback position) after track switch.
      * Defers to fastSwitchEnabled for placement of new data. Default for video)
      *
-     * MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE
+     * Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE
      * (used to clear the buffered data (prior to current playback position) after track switch. Default for audio)
      *
      * @param {MediaType} type
@@ -1572,10 +1572,10 @@ function MediaPlayer() {
      * This method sets the selection mode for the initial track. This mode defines how the initial track will be selected
      * if no initial media settings are set. If initial media settings are set this parameter will be ignored. Available options are:
      *
-     * MediaController.TRACK_SELECTION_MODE_HIGHEST_BITRATE
+     * Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE
      * this mode makes the player select the track with a highest bitrate. This mode is a default mode.
      *
-     * MediaController.TRACK_SELECTION_MODE_WIDEST_RANGE
+     * Constants.TRACK_SELECTION_MODE_WIDEST_RANGE
      * this mode makes the player select the track with a widest range of bitrates
      *
      * @param {string} mode

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1939,7 +1939,8 @@ function MediaPlayer() {
 
         // configure controllers
         mediaController.setConfig({
-            domStorage: domStorage
+            domStorage: domStorage,
+            settings: settings
         });
 
         streamController.setConfig({

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -185,6 +185,20 @@ class Constants {
          */
         this.TRACK_SWITCH_MODE_NEVER_REPLACE = 'neverReplace';
 
+        /**
+         *  @constant {string} TRACK_SELECTION_MODE_HIGHEST_BITRATE makes the player select the track with a highest bitrate. This mode is a default mode.
+         *  @memberof Constants#
+         *  @static
+         */
+        this.TRACK_SELECTION_MODE_HIGHEST_BITRATE = 'highestBitrate';
+
+        /**
+         *  @constant {string} TRACK_SELECTION_MODE_WIDEST_RANGE this mode makes the player select the track with a widest range of bitrates
+         *  @memberof Constants#
+         *  @static
+         */
+        this.TRACK_SELECTION_MODE_WIDEST_RANGE = 'widestRange';
+
         this.LOCATION = 'Location';
         this.INITIALIZE = 'initialize';
         this.TEXT_SHOWING = 'showing';

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -165,11 +165,26 @@ class Constants {
         this.BAD_ARGUMENT_ERROR = 'Invalid Arguments';
 
         /**
-         *  @constant {string} MISSING_CONFIG_ERROR Missing ocnfiguration parameters type of error
+         *  @constant {string} MISSING_CONFIG_ERROR Missing configuration parameters type of error
          *  @memberof Constants#
          *  @static
          */
         this.MISSING_CONFIG_ERROR = 'Missing config parameter(s)';
+
+        /**
+         *  @constant {string} TRACK_SWITCH_MODE_ALWAYS_REPLACE used to clear the buffered data (prior to current playback position) after track switch. Default for audio
+         *  @memberof Constants#
+         *  @static
+         */
+        this.TRACK_SWITCH_MODE_ALWAYS_REPLACE = 'alwaysReplace';
+
+        /**
+         *  @constant {string} TRACK_SWITCH_MODE_NEVER_REPLACE used to forbid clearing the buffered data (prior to current playback position) after track switch. Defers to fastSwitchEnabled for placement of new data. Default for video
+         *  @memberof Constants#
+         *  @static
+         */
+        this.TRACK_SWITCH_MODE_NEVER_REPLACE = 'neverReplace';
+
         this.LOCATION = 'Location';
         this.INITIALIZE = 'initialize';
         this.TEXT_SHOWING = 'showing';

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -34,7 +34,6 @@ import FragmentModel from '../models/FragmentModel';
 import SourceBufferSink from '../SourceBufferSink';
 import PreBufferSink from '../PreBufferSink';
 import AbrController from './AbrController';
-import MediaController from './MediaController';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
@@ -757,7 +756,7 @@ function BufferController(config) {
         if (!ranges) return;
 
         logger.info('Track change asked');
-        if (mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
+        if (mediaController.getSwitchMode(type) === Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE) {
             if (ranges && ranges.length > 0 && playbackController.getTimeToStreamEnd() > STALL_THRESHOLD) {
                 isBufferingCompleted = false;
                 lastIndex = Number.POSITIVE_INFINITY;

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -34,10 +34,6 @@ import EventBus from '../../core/EventBus';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 
-const TRACK_SELECTION_MODE_HIGHEST_BITRATE = 'highestBitrate';
-const TRACK_SELECTION_MODE_WIDEST_RANGE = 'widestRange';
-const DEFAULT_INIT_TRACK_SELECTION_MODE = TRACK_SELECTION_MODE_HIGHEST_BITRATE;
-
 function MediaController() {
 
     const context = this.context;
@@ -48,7 +44,6 @@ function MediaController() {
         tracks,
         settings,
         initialSettings,
-        selectionMode,
         domStorage;
 
     const validTrackSwitchModes = [
@@ -57,8 +52,8 @@ function MediaController() {
     ];
 
     const validTrackSelectionModes = [
-        TRACK_SELECTION_MODE_HIGHEST_BITRATE,
-        TRACK_SELECTION_MODE_WIDEST_RANGE
+        Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE,
+        Constants.TRACK_SELECTION_MODE_WIDEST_RANGE
     ];
 
     function setup() {
@@ -285,15 +280,22 @@ function MediaController() {
     /**
      * @param {string} mode
      * @memberof MediaController#
+     * @deprecated Please use updateSettings({streaming: { selectionModeForInitialTrack: mode } }) instead
      */
     function setSelectionModeForInitialTrack(mode) {
+        logger.warn('deprecated: Please use updateSettings({streaming: { selectionModeForInitialTrack: mode } }) instead');
         const isModeSupported = (validTrackSelectionModes.indexOf(mode) !== -1);
 
         if (!isModeSupported) {
             logger.warn('Track selection mode is not supported: ' + mode);
             return;
         }
-        selectionMode = mode;
+
+        settings.update({
+            streaming: {
+                selectionModeForInitialTrack: mode
+            }
+        });
     }
 
     /**
@@ -301,7 +303,7 @@ function MediaController() {
      * @memberof MediaController#
      */
     function getSelectionModeForInitialTrack() {
-        return selectionMode || DEFAULT_INIT_TRACK_SELECTION_MODE;
+        return settings.get().streaming.selectionModeForInitialTrack;
     }
 
     /**
@@ -441,14 +443,14 @@ function MediaController() {
         };
 
         switch (mode) {
-            case TRACK_SELECTION_MODE_HIGHEST_BITRATE:
+            case Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE:
                 tmpArr = getTracksWithHighestBitrate(tracks);
 
                 if (tmpArr.length > 1) {
                     tmpArr = getTracksWithWidestRange(tmpArr);
                 }
                 break;
-            case TRACK_SELECTION_MODE_WIDEST_RANGE:
+            case Constants.TRACK_SELECTION_MODE_WIDEST_RANGE:
                 tmpArr = getTracksWithWidestRange(tracks);
 
                 if (tmpArr.length > 1) {
@@ -521,8 +523,5 @@ function MediaController() {
 
 MediaController.__dashjs_factory_name = 'MediaController';
 const factory = FactoryMaker.getSingletonFactory(MediaController);
-factory.TRACK_SELECTION_MODE_HIGHEST_BITRATE = TRACK_SELECTION_MODE_HIGHEST_BITRATE;
-factory.TRACK_SELECTION_MODE_WIDEST_RANGE = TRACK_SELECTION_MODE_WIDEST_RANGE;
-factory.DEFAULT_INIT_TRACK_SELECTION_MODE = DEFAULT_INIT_TRACK_SELECTION_MODE;
 FactoryMaker.updateSingletonFactory(MediaController.__dashjs_factory_name, factory);
 export default factory;

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -36,7 +36,6 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
-import MediaController from './MediaController';
 
 function ScheduleController(config) {
 
@@ -174,7 +173,7 @@ function ScheduleController(config) {
                 if ((currentRepresentationInfo.quality !== lastInitQuality || switchTrack) && (!replacingBuffer)) {
                     if (switchTrack) {
                         logger.debug('Switch track for ' + type + ', representation id = ' + currentRepresentationInfo.id);
-                        replacingBuffer = mediaController.getSwitchMode(type) === MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE;
+                        replacingBuffer = mediaController.getSwitchMode(type) === Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE;
                         if (replacingBuffer && bufferController.replaceBuffer) {
                             bufferController.replaceBuffer();
                         }

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -251,7 +251,7 @@ function ScheduleController(config) {
             const abandonmentState = abrController.getAbandonmentStateFor(type);
 
             // Only replace on track switch when NEVER_REPLACE
-            const trackChanged = !mediaController.isCurrentTrack(request.mediaInfo) && mediaController.getSwitchMode(request.mediaInfo.type) === MediaController.TRACK_SWITCH_MODE_NEVER_REPLACE;
+            const trackChanged = !mediaController.isCurrentTrack(request.mediaInfo) && mediaController.getSwitchMode(request.mediaInfo.type) === Constants.TRACK_SWITCH_MODE_NEVER_REPLACE;
             const qualityChanged = request.quality < currentRepresentationInfo.quality;
 
             if (fastSwitchModeEnabled && (trackChanged || qualityChanged) && bufferLevel >= safeBufferLevel && abandonmentState !== MetricsConstants.ABANDON_LOAD) {

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -91,22 +91,22 @@ describe('MediaController', function () {
     describe('Selection Mode For Initial Track', function () {
         it('should not set selection mode if mode is not supported', function () {
             let mode = mediaController.getSelectionModeForInitialTrack();
-            expect(mode).to.equal(MediaController.DEFAULT_INIT_TRACK_SELECTION_MODE);
+            expect(mode).to.equal(Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
 
             mediaController.setSelectionModeForInitialTrack('unsupported');
 
-            mediaController.getSelectionModeForInitialTrack();
-            expect(mode).to.equal(MediaController.DEFAULT_INIT_TRACK_SELECTION_MODE);
+            mode = mediaController.getSelectionModeForInitialTrack();
+            expect(mode).to.equal(Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
         });
 
         it('should set and get selection mode', function () {
             let mode = mediaController.getSelectionModeForInitialTrack();
-            expect(mode).to.equal(MediaController.DEFAULT_INIT_TRACK_SELECTION_MODE);
+            expect(mode).to.equal(Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
 
-            mediaController.setSelectionModeForInitialTrack(MediaController.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
+            mediaController.setSelectionModeForInitialTrack(Constants.TRACK_SELECTION_MODE_WIDEST_RANGE);
 
-            mediaController.getSelectionModeForInitialTrack();
-            expect(mode).to.equal(MediaController.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
+            mode = mediaController.getSelectionModeForInitialTrack();
+            expect(mode).to.equal(Constants.TRACK_SELECTION_MODE_WIDEST_RANGE);
         });
     });
 

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -79,6 +79,16 @@ describe('MediaController', function () {
             expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
         });
 
+        it('should not set switch mode if type is not supported', function () {
+            let switchmode = mediaController.getSwitchMode('test');
+            expect(switchmode).to.not.exist; // jshint ignore:line
+
+            mediaController.setSwitchMode('test', Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
+
+            switchmode = mediaController.getSwitchMode('test');
+            expect(switchmode).to.not.exist; // jshint ignore:line
+        });
+
         it('should set and get switch mode for video', function () {
             let switchmode = mediaController.getSwitchMode('video');
             expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -31,6 +31,8 @@ describe('MediaController', function () {
 
     afterEach(function () {
         mediaController.reset();
+        mediaController.setSwitchMode('video', Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
+        mediaController.setSwitchMode('audio', Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
         mediaController = null;
     });
 
@@ -68,23 +70,37 @@ describe('MediaController', function () {
 
     describe('Switch Mode', function () {
         it('should not set switch mode if mode is not supported', function () {
-            let switchmode = mediaController.getSwitchMode('test');
-            expect(switchmode).to.not.exist; // jshint ignore:line
+            let switchmode = mediaController.getSwitchMode('video');
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
 
-            mediaController.setSwitchMode('test', 'unsupported');
+            mediaController.setSwitchMode('video', 'unsupported');
 
-            switchmode = mediaController.getSwitchMode('test');
-            expect(switchmode).to.not.exist; // jshint ignore:line
+            switchmode = mediaController.getSwitchMode('video');
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
         });
 
-        it('should set and get switch mode', function () {
-            let switchmode = mediaController.getSwitchMode('test');
-            expect(switchmode).to.not.exist; // jshint ignore:line
+        it('should set and get switch mode for video', function () {
+            let switchmode = mediaController.getSwitchMode('video');
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
 
-            mediaController.setSwitchMode('test', Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+            mediaController.setSwitchMode('video', Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
 
-            switchmode = mediaController.getSwitchMode('test');
+            switchmode = mediaController.getSwitchMode('video');
+
             expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+
+        });
+
+        it('should set and get switch mode for audio', function () {
+            let switchmode = mediaController.getSwitchMode('audio');
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+
+            mediaController.setSwitchMode('audio', Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
+
+            switchmode = mediaController.getSwitchMode('audio');
+
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_NEVER_REPLACE);
+
         });
     });
 

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -81,10 +81,10 @@ describe('MediaController', function () {
             let switchmode = mediaController.getSwitchMode('test');
             expect(switchmode).to.not.exist; // jshint ignore:line
 
-            mediaController.setSwitchMode('test', MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+            mediaController.setSwitchMode('test', Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
 
             switchmode = mediaController.getSwitchMode('test');
-            expect(switchmode).to.equal(MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+            expect(switchmode).to.equal(Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
         });
     });
 

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -3,6 +3,7 @@ import ObjectUtils from '../../src/streaming/utils/ObjectUtils';
 import EventBus from '../../src/core/EventBus';
 import Constants from '../../src/streaming/constants/Constants';
 import Events from '../../src/core/events/Events';
+import Settings from '../../src/core/Settings';
 
 import DomStorageMock from './mocks/DomStorageMock';
 
@@ -15,13 +16,15 @@ describe('MediaController', function () {
     let mediaController;
     let domStorageMock;
     const trackType = Constants.AUDIO;
+    const settings = Settings(context).getInstance();
 
     beforeEach(function () {
 
         domStorageMock = new DomStorageMock();
         mediaController = MediaController(context).getInstance();
         mediaController.setConfig({
-            domStorage: domStorageMock
+            domStorage: domStorageMock,
+            settings: settings
         });
 
     });
@@ -385,7 +388,7 @@ describe('MediaController', function () {
 
                 expect(objectUtils.areEqual(old, track1)).to.be.true; // jshint ignore:line
                 expect(objectUtils.areEqual(current, track2)).to.be.true; // jshint ignore:line
-                expect(switchMode).to.equal(MediaController.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
+                expect(switchMode).to.equal(Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE);
 
                 eventBus.off(Events.CURRENT_TRACK_CHANGED, onTrackChanged);
                 done();


### PR DESCRIPTION
This PR adds two new settings parameters (may have been forgotten when new **updateSettings** function was created in v3)
```
{ streaming: 
  {
    trackSwitchMode: {audio: audioMode , video: videoMode},
    selectionModeForInitialTrack: mode,
  }
}
```
and deprecates setTrackSwitchModeFor and setSelectionModeForInitialTrack functions (still usable though)