### PR TITLE
fixes manifest updates even while paused if enabled

### DIFF
--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -97,7 +97,6 @@ function ManifestUpdater() {
     }
 
     function reset() {
-
         eventBus.off(Events.PLAYBACK_STARTED, onPlaybackStarted, this);
         eventBus.off(Events.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.off(Events.STREAMS_COMPOSED, onStreamsComposed, this);
@@ -165,7 +164,7 @@ function ManifestUpdater() {
     }
 
     function onRefreshTimer() {
-        if (isPaused && !settings.get().streaming.scheduleWhilePaused) {
+        if (isPaused) {
             return;
         }
         if (isUpdating) {
@@ -189,8 +188,11 @@ function ManifestUpdater() {
     }
 
     function onPlaybackPaused(/*e*/) {
-        isPaused = true;
-        stopManifestRefreshTimer();
+        isPaused = !settings.get().streaming.scheduleWhilePaused;
+
+        if (isPaused) {
+            stopManifestRefreshTimer();
+        }
     }
 
     function onStreamsComposed(/*e*/) {


### PR DESCRIPTION
This fixes the `scheduleWhilePaused` handling so that the manifest continues to be updated when the player is paused (in case the flag is turned on).