### PR TITLE
Compare mediaInfo objects in DashAdapter

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -176,7 +176,7 @@ function DashAdapter() {
 
             if (currentMediaInfo[streamInfo.id] && currentMediaInfo[streamInfo.id][type]) {
                 for (let i = 0, ln = adaptations.length; i < ln; i++) {
-                    if (currentMediaInfo[streamInfo.id][type].isMediaInfoEqual(allMediaInfoForType[i])) {
+                    if (areMediaInfosEqual(currentMediaInfo[streamInfo.id][type], allMediaInfoForType[i])) {
                         return adaptations[i];
                     }
                 }
@@ -190,6 +190,27 @@ function DashAdapter() {
         }
 
         return adaptations[0];
+    }
+
+    /**
+     * Compares two mediaInfo objects
+     * @param {MediaInfo} mInfoOne
+     * @param {MediaInfo} mInfoTwo
+     * @returns {boolean}
+     */
+    function areMediaInfosEqual(mInfoOne, mInfoTwo) {
+        if (!mInfoOne || !mInfoTwo) {
+            return false;
+        }
+
+        const sameId = mInfoOne.id === mInfoTwo.id;
+        const sameViewpoint = mInfoOne.viewpoint === mInfoTwo.viewpoint;
+        const sameLang = mInfoOne.lang === mInfoTwo.lang;
+        const sameRoles = mInfoOne.roles.toString() === mInfoTwo.roles.toString();
+        const sameAccessibility = mInfoOne.accessibility.toString() === mInfoTwo.accessibility.toString();
+        const sameAudioChannelConfiguration = mInfoOne.audioChannelConfiguration.toString() === mInfoTwo.audioChannelConfiguration.toString();
+
+        return (sameId && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
     }
 
     /**

--- a/src/dash/vo/MediaInfo.js
+++ b/src/dash/vo/MediaInfo.js
@@ -52,20 +52,6 @@ class MediaInfo {
         this.bitrateList = null;
     }
 
-    isMediaInfoEqual(mediaInfo) {
-        if (!mediaInfo) {
-            return false;
-        }
-
-        const sameId = this.id === mediaInfo.id;
-        const sameViewpoint = this.viewpoint === mediaInfo.viewpoint;
-        const sameLang = this.lang === mediaInfo.lang;
-        const sameRoles = this.roles.toString() === mediaInfo.roles.toString();
-        const sameAccessibility = this.accessibility.toString() === mediaInfo.accessibility.toString();
-        const sameAudioChannelConfiguration = this.audioChannelConfiguration.toString() === mediaInfo.audioChannelConfiguration.toString();
-
-        return (sameId && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
-    }
 }
 
 export default MediaInfo;


### PR DESCRIPTION
The idea of this PR is to move any functions out of the MediaInfo class. We are dispatching MediaInfo objects as part of getTracks() and use it in setTracks(). If the prototype of the instance is lost for some reason we run into an error because the functions defined in the MediaInfo class are not available.