### PR TITLE
dvb:probability should be 1000 by default

### DIFF
--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -183,6 +183,8 @@ class Constants {
         this.SUPPLEMENTAL_PROPERTY_LL_SCHEME = 'urn:dvb:dash:lowlatency:critical:2019';
         this.XML = 'XML';
         this.ARRAY_BUFFER = 'ArrayBuffer';
+        this.DVB_REPORTING_URL = 'dvb:reportingUrl';
+        this.DVB_PROBABILITY = 'dvb:probability';
     }
 
     constructor () {

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -137,7 +137,7 @@ function DVBReporting(config) {
 
         rangeController = rc;
 
-        reportingUrl = entry['dvb:reportingUrl'];
+        reportingUrl = entry.dvb_reportingUrl;
 
         // If a required attribute is missing, the Reporting descriptor may
         // be ignored by the Player
@@ -151,11 +151,10 @@ function DVBReporting(config) {
         // static for the duration of the MPD, regardless of MPD updates.
         // (i.e. only calling reset (or failure) changes this state)
         if (!reportingPlayerStatusDecided) {
-            // NOTE: DVB spec has a typo where it incorrectly references the
-            // priority attribute, which should be probability
-            probability = entry['dvb:probability'] || entry['dvb:priority'] || 0;
-            // If the @priority attribute is set to 1000, it shall be a reporting Player.
-            // If the @priority attribute is missing, the Player shall not be a reporting Player.
+            probability = entry.dvb_probability;
+            // TS 103 285 Clause 10.12.3.4
+            // If the @probability attribute is set to 1000, it shall be a reporting Player.
+            // If the @probability attribute is absent it will take the default value of 1000.
             // For any other value of the @probability attribute, it shall decide at random whether to be a
             // reporting Player, such that the probability of being one is @probability/1000.
             if (probability && (probability === 1000 || ((probability / 1000) >= randomNumberGenerator.random()))) {

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -88,10 +88,16 @@ function ManifestParsing (config) {
                             return;
                         }
 
-                        for (const prop in reporting) {
-                            if (reporting.hasOwnProperty(prop)) {
-                                reportingEntry[prop] = reporting[prop];
-                            }
+                        if (reporting.hasOwnProperty('value')) {
+                            reportingEntry.value = reporting.value;
+                        }
+
+                        if (reporting.hasOwnProperty(constants.DVB_REPORTING_URL)) {
+                            reportingEntry.dvb_reportingUrl = reporting[constants.DVB_REPORTING_URL];
+                        }
+
+                        if (reporting.hasOwnProperty(constants.DVB_PROBABILITY)) {
+                            reportingEntry.dvb_probability = reporting[constants.DVB_PROBABILITY];
                         }
 
                         metricEntry.Reporting.push(reportingEntry);

--- a/src/streaming/metrics/vo/Reporting.js
+++ b/src/streaming/metrics/vo/Reporting.js
@@ -32,11 +32,19 @@
  * @class
  * @ignore
  */
+
+// TS 103 285 Clause 10.12.3.3
+const DEFAULT_DVB_PROBABILITY = 1000;
+
 class Reporting {
     constructor() {
-        // Reporting is a DescriptorType and doesn't have any additional fields
+
         this.schemeIdUri = '';
         this.value = '';
+
+        // DVB Extensions
+        this.dvb_reportingUrl = '';
+        this.dvb_probability = DEFAULT_DVB_PROBABILITY;
     }
 }
 

--- a/test/unit/streaming.constants.Constants.js
+++ b/test/unit/streaming.constants.Constants.js
@@ -27,5 +27,7 @@ describe('Constants', function () {
         expect(Constants.START_TIME).to.equal('starttime');
         expect(Constants.BAD_ARGUMENT_ERROR).to.equal('Invalid Arguments');
         expect(Constants.MISSING_CONFIG_ERROR).to.equal('Missing config parameter(s)');
+        expect(Constants.DVB_REPORTING_URL).to.equal('dvb:reportingUrl');
+        expect(Constants.DVB_PROBABILITY).to.equal('dvb:probability');
     });
 });


### PR DESCRIPTION
If dvb:probability is absent in the Metric's Reporting descriptor it should default to 1000 (a reporting player) as per DVB spec (Clause 10.12.3.3). The typo that referenced dvb:priority instead of dvb:priority has been corrected in the DVB spec now for some time and it's probably fair (and safe) to remove the fallback to this.

Made some changes to be more explicit about attribute names and default values. I based these on how the DVB extensions are handled for BaseURL elements.

Straight off the bat, I work for the BBC and you should be able to see I'm part of the BBC's organisation on Github. We signed the CLA in 2014 (point 4):
https://github.com/Dash-Industry-Forum/dash.js/wiki/Meeting-Minutes#minutes-april-4th-2014