### PR TITLE
CMCD update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ pip-log.txt
 # Mac crap
 .DS_Store
 build/typings/
+
+# Vim
+.vimrc

--- a/index.d.ts
+++ b/index.d.ts
@@ -196,6 +196,11 @@ declare namespace dashjs {
                     audio?: boolean;
                     video?: boolean;
                 };
+            },
+            cmcd?: {
+                enabled?: boolean,
+                sid?: string,
+                cid: string
             }
         }
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,7 +200,7 @@ declare namespace dashjs {
             cmcd?: {
                 enabled?: boolean,
                 sid?: string,
-                cid: string
+                cid?: string
             }
         }
     }

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -10,6 +10,7 @@
     <!--<script src="../../dist/dash.all.min.js"></script>-->
 
     <script class="code">
+        var CMCD_DATA_GENERATED = dashjs.MetricsReporting.events.CMCD_DATA_GENERATED;
         function init() {
             var video,
                 player,
@@ -21,13 +22,14 @@
             player.initialize(); 
             version = player.getVersion();
 
+            player.on(CMCD_DATA_GENERATED, handleCmcdDataGeneratedEvent);
+
             player.updateSettings({
                 streaming: {
                     cmcd: {
                         enabled: true, /* enable reporting of cmcd parameters */
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */
                         cid: '21cf726cfe3d937b5f974f72bb5bd06a', /* content id send with each request */
-                        did: 'dash.js-v' + version/* device id send with each request */
                     }
                 }
             });
@@ -35,6 +37,25 @@
             player.attachView(video);
             player.attachSource(url);
 
+        }
+
+        function handleCmcdDataGeneratedEvent(event) {
+            log("type: " +  event.mediaType);
+            log("file: " + event.url.split("/").pop())
+            var keys = Object.keys(event.cmcdData);
+            keys = keys.sort();
+            for (var key of keys) {
+                log(key.padEnd(4) + ": " + event.cmcdData[key]);
+            }
+            log("");
+        }
+
+        function log(msg) {
+            msg = msg.length > 200 ? msg.substring(0, 200) + "..." : msg; /* to avoid repeated wrapping with large objects */
+            var tracePanel = document.getElementById("trace");
+            tracePanel.innerHTML += msg + "\n";
+            tracePanel.scrollTop = tracePanel.scrollHeight;
+            console.log(msg);
         }
     </script>
 
@@ -44,18 +65,24 @@
             height: 360px;
             background-color: #666666;
         }
+        textarea {
+            width: 500px;
+            height:360px;
+            font-size: 10px;
+        }
     </style>
 </head>
-<body>
-<div>
-    <video controls="true">
-    </video>
-</div>
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        init();
-    });
-</script>
-<script src="../highlighter.js"></script>
-</body>
+    <body>
+        <div>
+            <video controls="true">
+            </video>
+            <textarea id="trace" placeholder="Sent CMCD data will be displayed here"></textarea>
+        </div>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                init();
+            });
+        </script>
+        <script src="../highlighter.js"></script>
+    </body>
 </html>

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -607,7 +607,6 @@ app.controller('DashController', function ($scope, sources, contributors, dashif
 
         config.streaming.cmcd.sid = $scope.cmcdSessionId ? $scope.cmcdSessionId : null;
         config.streaming.cmcd.cid = $scope.cmcdContentId ? $scope.cmcdContentId : null;
-        config.streaming.cmcd.did = $scope.cmcdDeviceId ? $scope.cmcdDeviceId : null;
 
         $scope.player.updateSettings(config);
 

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -331,8 +331,6 @@
                     <input type="text" class="form-control" placeholder="mandatory session id" ng-model="cmcdSessionId">
                     <label class="options-label">Content ID:</label>
                     <input type="text" class="form-control" placeholder="content id" ng-model="cmcdContentId">
-                    <label class="options-label">Device ID:</label>
-                    <input type="text" class="form-control" placeholder="device id" ng-model="cmcdDeviceId">
                 </div>
             </div>
 

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -456,8 +456,7 @@ function Settings() {
             cmcd: {
                 enabled: false,
                 sid: null,
-                cid: null,
-                did: null
+                cid: null
             }
         }
     };

--- a/src/streaming/metrics/MetricsReportingEvents.js
+++ b/src/streaming/metrics/MetricsReportingEvents.js
@@ -36,6 +36,12 @@ class MetricsReportingEvents extends EventsBase {
 
         this.METRICS_INITIALISATION_COMPLETE = 'internal_metricsReportingInitialized';
         this.BECAME_REPORTING_PLAYER = 'internal_becameReportingPlayer';
+
+        /**
+         * Triggered when CMCD data was generated for a HTTP request
+         * @event MetricsReportingEvents#CMCD_DATA_GENERATED
+         */
+        this.CMCD_DATA_GENERATED = 'cmcdDataGenerated';
     }
 }
 

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -152,6 +152,7 @@ function CmcdModel() {
                 _setDefaultContentId(request);
                 return _getCmcdDataForMpd(request);
             } else if (request.type === HTTPRequest.MEDIA_SEGMENT_TYPE) {
+                _initForMediaType(request.mediaType);
                 return _getCmcdDataForMediaSegment(request);
             } else if (request.type === HTTPRequest.INIT_SEGMENT_TYPE) {
                 return _getCmcdDataForInitSegment(request);
@@ -236,6 +237,21 @@ function CmcdModel() {
         }
 
         return data;
+    }
+
+    function _initForMediaType(mediaType) {
+
+        if (!_initialMediaRequestsDone.hasOwnProperty(mediaType)) {
+            _initialMediaRequestsDone[mediaType] = false;
+        }
+
+        if (!_isStartup.hasOwnProperty(mediaType)) {
+            _isStartup[mediaType] = false;
+        }
+
+        if (!_bufferLevelStarved.hasOwnProperty(mediaType)) {
+            _bufferLevelStarved[mediaType] = false;
+        }
     }
 
     function _getCmcdDataForInitSegment() {

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -181,6 +181,7 @@ function CmcdModel() {
         const dl = _getDeadlineByType(request.mediaType);
         const bl = _getBufferLevelByType(request.mediaType);
         const tb = _getTopBitrateByType(request.mediaType);
+        const pr = internalData.pr;
 
         if (encodedBitrate) {
             data.br = encodedBitrate;
@@ -208,6 +209,10 @@ function CmcdModel() {
 
         if (!isNaN(tb)) {
             data.tb = tb;
+        }
+
+        if (!isNaN(pr) && pr !== 1) {
+            data.pr = pr;
         }
 
         if (_bufferLevelStarved) {
@@ -278,8 +283,12 @@ function CmcdModel() {
     }
 
     function _getTopBitrateByType(mediaType) {
-        const info = abrController.getTopBitrateInfoFor(mediaType);
-        return info.bitrate;
+        try {
+            const info = abrController.getTopBitrateInfoFor(mediaType);
+            return info.bitrate;
+        } catch (e) {
+            return null;
+        }
     }
 
     function _getObjectDurationByRequest(request) {
@@ -349,7 +358,7 @@ function CmcdModel() {
 
     function _onBufferLevelStateChanged(data) {
         try {
-            if (data.state && data.mediaType) {
+            if (data.state) {
                 if (data.state === MediaPlayerEvents.BUFFER_EMPTY) {
                     if (!_bufferLevelStarved) {
                         _bufferLevelStarved = true;

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -69,7 +69,8 @@ function CmcdModel() {
         dashMetrics,
         playbackController,
         _isStartup,
-        _bufferLevelStarved;
+        _bufferLevelStarved,
+        _initialMediaRequestsDone;
 
     let context = this.context;
     let eventBus = EventBus(context).getInstance();
@@ -115,7 +116,8 @@ function CmcdModel() {
             cid: null
         };
         _bufferLevelStarved = {};
-        _isStartup = false;
+        _isStartup = {};
+        _initialMediaRequestsDone = {};
     }
 
     function getQueryParameter(request) {
@@ -227,9 +229,10 @@ function CmcdModel() {
             _bufferLevelStarved[request.mediaType] = false;
         }
 
-        if (_isStartup) {
+        if (_isStartup[request.mediaType] || !_initialMediaRequestsDone[request.mediaType]) {
             data.su = true;
-            _isStartup = false;
+            _isStartup[request.mediaType] = false;
+            _initialMediaRequestsDone[request.mediaType] = true;
         }
 
         return data;
@@ -367,11 +370,12 @@ function CmcdModel() {
         try {
             if (data.state && data.mediaType) {
                 if (data.state === MediaPlayerEvents.BUFFER_EMPTY) {
+
                     if (!_bufferLevelStarved[data.mediaType]) {
                         _bufferLevelStarved[data.mediaType] = true;
                     }
-                    if (!_isStartup) {
-                        _isStartup = true;
+                    if (!_isStartup[data.mediaType]) {
+                        _isStartup[data.mediaType] = true;
                     }
                 }
             }
@@ -387,8 +391,10 @@ function CmcdModel() {
             }
         }
 
-        if (!_isStartup) {
-            _isStartup = true;
+        for (let key in _isStartup) {
+            if (_isStartup.hasOwnProperty(key)) {
+                _isStartup[key] = true;
+            }
         }
     }
 

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -9,6 +9,8 @@ function AbrControllerMock () {
     this.windowResizeEventCalled = false;
     this.throughputHistory = undefined;
     this.currentStreamId = undefined;
+    this.topBitrateInfo = null;
+    let self = this;
 
     this.QUALITY_DEFAULT = function () {
         return QUALITY_DEFAULT;
@@ -25,8 +27,13 @@ function AbrControllerMock () {
 
     this.getTopQualityIndexFor = function () {};
 
+
     this.getTopBitrateInfoFor = function () {
-        return null;
+        return self.topBitrateInfo;
+    };
+
+    this.setTopBitrateInfo = function (info) {
+        self.topBitrateInfo = info;
     };
 
     this.getInitialBitrateFor = function (/*type*/) {
@@ -50,7 +57,11 @@ function AbrControllerMock () {
     };
 
     this.getThroughputHistory = function () {
-        return this.throughputHistory;
+        return self.throughputHistory;
+    };
+
+    this.setThroughputHistory = function (history) {
+        self.throughputHistory = history;
     };
 
     this.updateTopQualityIndex = function () {};

--- a/test/unit/mocks/DashMetricsMock.js
+++ b/test/unit/mocks/DashMetricsMock.js
@@ -2,6 +2,8 @@ function DashMetricsMock() {
 
     this.bufferState = null;
     this.currentDVRInfo = null;
+    this.currentBufferLevel = 15;
+    let self = this;
 
     this.getCurrentDVRInfo = function () {
         return this.currentDVRInfo;
@@ -12,7 +14,11 @@ function DashMetricsMock() {
     };
 
     this.getCurrentBufferLevel = function () {
-        return 15;
+        return self.currentBufferLevel;
+    };
+
+    this.setCurrentBufferLevel = function (level) {
+        self.currentBufferLevel = level;
     };
 
     this.addSchedulingInfo = function () {

--- a/test/unit/streaming.models.CmcdModel.js
+++ b/test/unit/streaming.models.CmcdModel.js
@@ -1,0 +1,40 @@
+import CmcdModel from '../../src/streaming/models/CmcdModel';
+
+import AbrControllerMock from './mocks/AbrControllerMock';
+import DashMetricsMock from './mocks/DashMetricsMock';
+import PlaybackControllerMock from './mocks/PlaybackControllerMock';
+
+//const expect = require('chai').expect;
+const context = {};
+
+describe('CmcdModel', function () {
+    let cmcdModel;
+
+    let abrControllerMock = new AbrControllerMock();
+    let dashMetricsMock = new DashMetricsMock();
+    let playbackControllerMock = new PlaybackControllerMock();
+
+    beforeEach(function () {
+        cmcdModel = CmcdModel(context).getInstance();
+    });
+
+    afterEach(function () {
+        cmcdModel = null;
+        cmcdModel.reset();
+    });
+
+    describe('if confgured', function () {
+        beforeEach(function () {
+            cmcdModel.setConfig({
+                abrController: abrControllerMock,
+                dashMetrics: dashMetricsMock,
+                playbackController: playbackControllerMock
+            });
+        });
+
+        it('getQueryParameter() returns correct metrics', function () {
+            let request = {};
+            cmcdModel.getQueryParameter(request);
+        });
+    });
+});

--- a/test/unit/streaming.models.CmcdModel.js
+++ b/test/unit/streaming.models.CmcdModel.js
@@ -1,6 +1,9 @@
 import CmcdModel from '../../src/streaming/models/CmcdModel';
 import Settings from '../../src/core/Settings';
 import {HTTPRequest} from '../../src/streaming/vo/metrics/HTTPRequest';
+import EventBus from '../../src/core/EventBus';
+import MediaPlayerEvents from '../../src/streaming/MediaPlayerEvents';
+import DashConstants from '../../src/dash/constants/DashConstants';
 
 import AbrControllerMock from './mocks/AbrControllerMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
@@ -8,6 +11,8 @@ import PlaybackControllerMock from './mocks/PlaybackControllerMock';
 
 const expect = require('chai').expect;
 const context = {};
+
+const eventBus = EventBus(context).getInstance();
 
 describe('CmcdModel', function () {
     let cmcdModel;
@@ -21,6 +26,7 @@ describe('CmcdModel', function () {
 
     beforeEach(function () {
         cmcdModel = CmcdModel(context).getInstance();
+        cmcdModel.initialize();
     });
 
     afterEach(function () {
@@ -154,6 +160,116 @@ describe('CmcdModel', function () {
             expect(metrics).to.have.property('ot');
             expect(metrics.ot).to.equal(MANIFEST_OBJECT_TYPE);
         });
+
+        it('getQueryParameter() recognizes playback rate change through events', function () {
+            const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
+            const MEDIA_TYPE = 'video';
+            const BITRATE = 10000;
+            const DURATION = 987.213;
+            const CHANGED_PLAYBACK_RATE = 2.4;
+
+            let request = {
+                type: REQUEST_TYPE,
+                mediaType: MEDIA_TYPE,
+                quality: 0,
+                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                duration: DURATION
+            };
+            let parameters = cmcdModel.getQueryParameter(request);
+            let metrics = parseQuery(parameters.value);
+            expect(metrics).to.not.have.property('pr');
+
+            eventBus.trigger(MediaPlayerEvents.PLAYBACK_RATE_CHANGED, { playbackRate: CHANGED_PLAYBACK_RATE });
+
+            parameters = cmcdModel.getQueryParameter(request);
+            metrics = parseQuery(parameters.value);
+            expect(metrics).to.have.property('pr');
+            expect(metrics.pr).to.equal(CHANGED_PLAYBACK_RATE);
+        });
+
+        it('getQueryParameter() recognizes playback seek through events', function () {
+            const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
+            const MEDIA_TYPE = 'video';
+            const BITRATE = 10000;
+            const DURATION = 987.213;
+
+            let request = {
+                type: REQUEST_TYPE,
+                mediaType: MEDIA_TYPE,
+                quality: 0,
+                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                duration: DURATION
+            };
+            let parameters = cmcdModel.getQueryParameter(request);
+            let metrics = parseQuery(parameters.value);
+            expect(metrics).to.not.have.property('bs');
+            expect(metrics).to.not.have.property('su');
+
+            eventBus.trigger(MediaPlayerEvents.PLAYBACK_SEEKED);
+
+            parameters = cmcdModel.getQueryParameter(request);
+            metrics = parseQuery(parameters.value);
+            expect(metrics).to.have.property('bs');
+            expect(metrics.bs).to.equal(true);
+            expect(metrics).to.have.property('su');
+            expect(metrics.su).to.equal(true);
+        });
+
+        it('getQueryParameter() recognizes buffer starvation through events', function () {
+            const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
+            const MEDIA_TYPE = 'video';
+            const BITRATE = 10000;
+            const DURATION = 987.213;
+
+            let request = {
+                type: REQUEST_TYPE,
+                mediaType: MEDIA_TYPE,
+                quality: 0,
+                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                duration: DURATION
+            };
+            let parameters = cmcdModel.getQueryParameter(request);
+            let metrics = parseQuery(parameters.value);
+            expect(metrics).to.not.have.property('bs');
+            expect(metrics).to.not.have.property('su');
+
+            eventBus.trigger(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, { state: MediaPlayerEvents.BUFFER_EMPTY });
+
+            parameters = cmcdModel.getQueryParameter(request);
+            metrics = parseQuery(parameters.value);
+            expect(metrics).to.have.property('bs');
+            expect(metrics.bs).to.equal(true);
+            expect(metrics).to.have.property('su');
+            expect(metrics.su).to.equal(true);
+        });
+
+        it('getQueryParameter() recognizes manifest load through events', function () {
+            const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
+            const MEDIA_TYPE = 'video';
+            const BITRATE = 10000;
+            const DURATION = 987.213;
+
+            let request = {
+                type: REQUEST_TYPE,
+                mediaType: MEDIA_TYPE,
+                quality: 0,
+                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                duration: DURATION
+            };
+            let parameters = cmcdModel.getQueryParameter(request);
+            let metrics = parseQuery(parameters.value);
+            expect(metrics).to.not.have.property('st');
+            expect(metrics).to.not.have.property('sf');
+
+            eventBus.trigger(MediaPlayerEvents.MANIFEST_LOADED, { protocol: 'MSS', data: { type: DashConstants.DYNAMIC }});
+
+            parameters = cmcdModel.getQueryParameter(request);
+            metrics = parseQuery(parameters.value);
+            expect(metrics).to.have.property('st');
+            expect(metrics.st).to.equal('l');
+            expect(metrics).to.have.property('sf');
+            expect(metrics.sf).to.equal('s');
+        });
     });
 });
 
@@ -161,13 +277,13 @@ function parseQuery(query) {
     query = decodeURIComponent(query);
     let keyValues = query.split(',');
     return keyValues.map(keyValue => keyValue.indexOf('=') === -1 ? [keyValue, true] : keyValue.split('='))
-        .map(keyValue => isInt(keyValue[1]) ? [keyValue[0], parseInt(keyValue[1])] : keyValue)
+        .map(keyValue => isNumber(keyValue[1]) ? [keyValue[0], Number(keyValue[1])] : keyValue)
         .map(keyValue => isString(keyValue[1]) && keyValue[1].indexOf('"') !== -1 ? [keyValue[0], keyValue[1].replace(/"/g, '')] : keyValue)
         .map(keyValue => isBoolean(keyValue[1]) ? [keyValue[0], parseBoolean(keyValue[1])] : keyValue)
         .reduce((acc, keyValue) => { acc[keyValue[0]] = keyValue[1]; return acc; }, {});
 }
 
-function isInt(value) {
+function isNumber(value) {
     if (typeof value === 'boolean') return false;
     return !isNaN(value);
 }

--- a/test/unit/streaming.models.CmcdModel.js
+++ b/test/unit/streaming.models.CmcdModel.js
@@ -87,6 +87,7 @@ describe('CmcdModel', function () {
         });
 
         it('getQueryParameter() returns correct metrics for media segments', function () {
+            dashMetricsMock.setCurrentBufferLevel(15.34511);
             const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
             const MEDIA_TYPE = 'video';
             const BITRATE = 10000;

--- a/test/unit/streaming.models.CmcdModel.js
+++ b/test/unit/streaming.models.CmcdModel.js
@@ -22,7 +22,7 @@ describe('CmcdModel', function () {
     let playbackControllerMock = new PlaybackControllerMock();
 
     let settings = Settings(context).getInstance();
-    settings.update({ streaming: { cmcd: { enabled: true }}});
+    settings.update({streaming: {cmcd: {enabled: true}}});
 
     beforeEach(function () {
         cmcdModel = CmcdModel(context).getInstance();
@@ -103,13 +103,17 @@ describe('CmcdModel', function () {
             const BUFFER_LEVEL = parseInt(dashMetricsMock.getCurrentBufferLevel() * 10) * 100;
             const VIDEO_OBJECT_TYPE = 'v';
 
-            abrControllerMock.setTopBitrateInfo({ bitrate: TOP_BITRATE });
-            abrControllerMock.setThroughputHistory({ getSafeAverageThroughput: function () { return MEASURED_THROUGHPUT; }});
+            abrControllerMock.setTopBitrateInfo({bitrate: TOP_BITRATE});
+            abrControllerMock.setThroughputHistory({
+                getSafeAverageThroughput: function () {
+                    return MEASURED_THROUGHPUT;
+                }
+            });
             let request = {
                 type: REQUEST_TYPE,
                 mediaType: MEDIA_TYPE,
                 quality: 0,
-                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
                 duration: DURATION
             };
 
@@ -172,14 +176,14 @@ describe('CmcdModel', function () {
                 type: REQUEST_TYPE,
                 mediaType: MEDIA_TYPE,
                 quality: 0,
-                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
                 duration: DURATION
             };
             let parameters = cmcdModel.getQueryParameter(request);
             let metrics = parseQuery(parameters.value);
             expect(metrics).to.not.have.property('pr');
 
-            eventBus.trigger(MediaPlayerEvents.PLAYBACK_RATE_CHANGED, { playbackRate: CHANGED_PLAYBACK_RATE });
+            eventBus.trigger(MediaPlayerEvents.PLAYBACK_RATE_CHANGED, {playbackRate: CHANGED_PLAYBACK_RATE});
 
             parameters = cmcdModel.getQueryParameter(request);
             metrics = parseQuery(parameters.value);
@@ -197,9 +201,10 @@ describe('CmcdModel', function () {
                 type: REQUEST_TYPE,
                 mediaType: MEDIA_TYPE,
                 quality: 0,
-                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
                 duration: DURATION
             };
+            cmcdModel.getQueryParameter(request); // first initial request will set startup to true
             let parameters = cmcdModel.getQueryParameter(request);
             let metrics = parseQuery(parameters.value);
             expect(metrics).to.not.have.property('bs');
@@ -225,15 +230,19 @@ describe('CmcdModel', function () {
                 type: REQUEST_TYPE,
                 mediaType: MEDIA_TYPE,
                 quality: 0,
-                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
                 duration: DURATION
             };
+            cmcdModel.getQueryParameter(request); // first initial request will set startup to true
             let parameters = cmcdModel.getQueryParameter(request);
             let metrics = parseQuery(parameters.value);
             expect(metrics).to.not.have.property('bs');
             expect(metrics).to.not.have.property('su');
 
-            eventBus.trigger(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, { state: MediaPlayerEvents.BUFFER_EMPTY });
+            eventBus.trigger(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, {
+                state: MediaPlayerEvents.BUFFER_EMPTY,
+                mediaType: request.mediaType
+            });
 
             parameters = cmcdModel.getQueryParameter(request);
             metrics = parseQuery(parameters.value);
@@ -253,7 +262,7 @@ describe('CmcdModel', function () {
                 type: REQUEST_TYPE,
                 mediaType: MEDIA_TYPE,
                 quality: 0,
-                mediaInfo: { bitrateList: [{ bandwidth: BITRATE }] },
+                mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
                 duration: DURATION
             };
             let parameters = cmcdModel.getQueryParameter(request);
@@ -261,7 +270,7 @@ describe('CmcdModel', function () {
             expect(metrics).to.not.have.property('st');
             expect(metrics).to.not.have.property('sf');
 
-            eventBus.trigger(MediaPlayerEvents.MANIFEST_LOADED, { protocol: 'MSS', data: { type: DashConstants.DYNAMIC }});
+            eventBus.trigger(MediaPlayerEvents.MANIFEST_LOADED, {protocol: 'MSS', data: {type: DashConstants.DYNAMIC}});
 
             parameters = cmcdModel.getQueryParameter(request);
             metrics = parseQuery(parameters.value);
@@ -280,7 +289,10 @@ function parseQuery(query) {
         .map(keyValue => isNumber(keyValue[1]) ? [keyValue[0], Number(keyValue[1])] : keyValue)
         .map(keyValue => isString(keyValue[1]) && keyValue[1].indexOf('"') !== -1 ? [keyValue[0], keyValue[1].replace(/"/g, '')] : keyValue)
         .map(keyValue => isBoolean(keyValue[1]) ? [keyValue[0], parseBoolean(keyValue[1])] : keyValue)
-        .reduce((acc, keyValue) => { acc[keyValue[0]] = keyValue[1]; return acc; }, {});
+        .reduce((acc, keyValue) => {
+            acc[keyValue[0]] = keyValue[1];
+            return acc;
+        }, {});
 }
 
 function isNumber(value) {


### PR DESCRIPTION
Updating the CMCD implementation to the current specification.

- changed query key from 'Common-Media-Client-Data' to 'CMCD'
- omitting '=true' in query string for boolean parameters
- enclosing string values in double quotes, except tokens
- sorting CMCD metrics alphabetically by key name
- URL encoding CMCD metrics
- added new metrics: 
  - bl (Buffer length)
  - bs (Buffer starvation)
  - su (Startup)
  - tb (Top bitrate)
  - pr (Playback rate)
- removed former metrics: 
  - bs (Buffer size)
  - did (Device ID)
- rounding values of metrics: 
  - dl (Deadline)
  - mtp (Measured throughput)
- added object type:
  - o (other)
- omitting CMCD version if it is 1
- extended CMCD sample
- implemented unit tests for CMCD logic

resolves #3402 