### PR TITLE
Fix #3421 - accept non-compliant imagetype attribute name in SMPTE-TT image

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -81,6 +81,11 @@ function TTMLParser() {
         let metadataHandler = {
 
             onOpenTag: function (ns, name, attrs) {
+                // cope with existing non-compliant content
+                if (attrs[' imagetype'] && !attrs[' imageType']) {
+                    attrs[' imageType'] = attrs[' imagetype'];
+                }
+
                 if (name === 'image' &&
                 (ns === 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt' ||
                  ns === 'http://www.smpte-ra.org/schemas/2052-1/2013/smpte-tt')) {


### PR DESCRIPTION
Turns out #3332 broke one of the test assets (https://livesim.dashif.org/dash/vod/testpic_2s/img_subs.mpd) so was easy to verify the fix.