### PR TITLE
add MediaPlayer.destroy to free all memory

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -47,3 +47,4 @@
 * @siropeich [Siro Blanco, Epic Labs]
 * @epiclabsDASH [Jesus Oliva, Epic Labs]
 * @adripanico [Adrian Caballero, Epic Labs]
+* @ahfarmer [Andrew Farmer, Rhombus Systems]

--- a/src/core/FactoryMaker.js
+++ b/src/core/FactoryMaker.js
@@ -35,7 +35,7 @@
 const FactoryMaker = (function () {
 
     let instance;
-    const singletonContexts = [];
+    let singletonContexts = [];
     const singletonFactories = {};
     const classFactories = {};
 
@@ -92,6 +92,17 @@ const FactoryMaker = (function () {
             context: context,
             instance: instance
         });
+    }
+
+    /**
+     * Use this method to remove all singleton instances associated with a particular context.
+     *
+     * @param {Object} context
+     * @memberof module:FactoryMaker
+     * @instance
+     */
+    function deleteSingletonInstances(context) {
+        singletonContexts = singletonContexts.filter(x => x.context !== context);
     }
 
     /*------------------------------------------------------------------------------------------*/
@@ -239,6 +250,7 @@ const FactoryMaker = (function () {
         extend: extend,
         getSingletonInstance: getSingletonInstance,
         setSingletonInstance: setSingletonInstance,
+        deleteSingletonInstances: deleteSingletonInstances,
         getSingletonFactory: getSingletonFactory,
         getSingletonFactoryByName: getSingletonFactoryByName,
         updateSingletonFactory: updateSingletonFactory,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -347,7 +347,8 @@ function MediaPlayer() {
      * Sets the MPD source and the video element to null. You can also reset the MediaPlayer by
      * calling attachSource with a new source file.
      *
-     * Calling this method is all that is necessary to destroy a MediaPlayer instance.
+     * This call does not destroy the MediaPlayer. To destroy the MediaPlayer and free all of its
+     * memory, call destroy().
      *
      * @memberof module:MediaPlayer
      * @instance
@@ -373,6 +374,17 @@ function MediaPlayer() {
             offlineController.reset();
             offlineController = null;
         }
+    }
+
+    /**
+     * Completely destroys the media player and frees all memory.
+     *
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function destroy() {
+        reset();
+        FactoryMaker.deleteSingletonInstances(context);
     }
 
     /**
@@ -2303,7 +2315,8 @@ function MediaPlayer() {
         getSettings: getSettings,
         updateSettings: updateSettings,
         resetSettings: resetSettings,
-        reset: reset
+        reset: reset,
+        destroy: destroy
     };
 
     setup();


### PR DESCRIPTION
Fixes #3431

Adds a destroy method for when the user is completely done with the MediaPlayer and won't be using it again. This is necessary because reset() does not remove all references to the 'singleton instances' in FactoryMaker.
