### PR TITLE
fix captions bad top position (reference to a wrong parentElement)

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -347,7 +347,7 @@ function VideoModel() {
 
     function getVideoRelativeOffsetTop() {
         const parentElement = element.parentNode.host || element.parentNode;
-        return parentElement ? element.getBoundingClientRect().top - parentElement.parentNode.getBoundingClientRect().top : NaN;
+        return parentElement ? element.getBoundingClientRect().top - parentElement.getBoundingClientRect().top : NaN;
     }
 
     function getVideoRelativeOffsetLeft() {


### PR DESCRIPTION
This mistake could lead to captions not visible at all (outside visible area)