### PR TITLE
use resizeObserver when available for resizing captions

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -57,7 +57,8 @@ function TextTracks() {
         fullscreenAttribute,
         displayCCOnTop,
         previousISDState,
-        topZIndex;
+        topZIndex,
+        resizeObserver;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -537,7 +538,14 @@ function TextTracks() {
 
         if (track && track.renderingType === 'html') {
             checkVideoSize.call(this, track, true);
-            videoSizeCheckInterval = setInterval(checkVideoSize.bind(this, track), 500);
+            if (window.ResizeObserver) {
+                resizeObserver = new window.ResizeObserver(() => {
+                    checkVideoSize.call(this, track, true);
+                });
+                resizeObserver.observe(videoModel.getElement());
+            } else {
+                videoSizeCheckInterval = setInterval(checkVideoSize.bind(this, track), 500);
+            }
         }
     }
 
@@ -592,6 +600,10 @@ function TextTracks() {
         if (videoSizeCheckInterval) {
             clearInterval(videoSizeCheckInterval);
             videoSizeCheckInterval = null;
+        }
+        if (resizeObserver && videoModel) {
+            resizeObserver.unobserve(videoModel.getElement());
+            resizeObserver = null;
         }
         currentTrackIdx = -1;
         clearCaptionContainer.call(this);

--- a/test/unit/streaming.text.TextController.js
+++ b/test/unit/streaming.text.TextController.js
@@ -37,12 +37,16 @@ describe('TextController', function () {
                 }
             };
         }
+        if (typeof window === 'undefined') {
+            global.window = {};
+        }
     });
 
     afterEach(function () {
         if (typeof window !== 'undefined' && global !== window) {
             delete global.document;
         }
+        delete global.window;
     });
 
     beforeEach(function () {


### PR DESCRIPTION
This PR will avoid polling every 500ms to check if video element size has changed to redraw HTML captions
It will be used on browsers that supports ResizeObserver (which is the case for most of them today)
[See support](https://caniuse.com/resizeobserver)

ResizeObserver can observe changes for the size of an element and call a callback only when needed.