### PR TITLE
Add event DYNAMIC_TO_STATIC 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -217,6 +217,7 @@ declare namespace dashjs {
         on(type: BufferEvent['type'], listener: (e: BufferEvent) => void, scope?: object): void;
         on(type: CaptionRenderedEvent['type'], listener: (e: CaptionRenderedEvent) => void, scope?: object): void;
         on(type: CaptionContainerResizeEvent['type'], listener: (e: CaptionContainerResizeEvent) => void, scope?: object): void;
+        on(type: DynamicToStaticEvent['type'], listener: (e: DynamicToStaticEvent) => void, scope?: object): void;
         on(type: ErrorEvent['type'], listener: (e: ErrorEvent) => void, scope?: object): void;
         on(type: FragmentLoadingCompletedEvent['type'], listener: (e: FragmentLoadingCompletedEvent) => void, scope?: object): void;
         on(type: FragmentLoadingAbandonedEvent['type'], listener: (e: FragmentLoadingAbandonedEvent) => void, scope?: object): void;
@@ -418,6 +419,7 @@ declare namespace dashjs {
         CAN_PLAY: 'canPlay';
         CAPTION_RENDERED: 'captionRendered';
         CAPTION_CONTAINER_RESIZE: 'captionContainerResize';
+        DYNAMIC_TO_STATIC: 'dynamicToStatic';
         ERROR: 'error';
         FRAGMENT_LOADING_ABANDONED: 'fragmentLoadingAbandoned';
         FRAGMENT_LOADING_COMPLETED: 'fragmentLoadingCompleted';
@@ -606,6 +608,9 @@ declare namespace dashjs {
         type: MediaPlayerEvents['CAPTION_CONTAINER_RESIZE'];
     }
 
+    export interface DynamicToStaticEvent extends Event {
+        type: MediaPlayerEvents['DYNAMIC_TO_STATIC'];
+    }    
     export interface FragmentLoadingCompletedEvent extends Event {
         type: MediaPlayerEvents['FRAGMENT_LOADING_COMPLETED'];
         request: FragmentRequest;

--- a/samples/getting-started/listening-to-events.html
+++ b/samples/getting-started/listening-to-events.html
@@ -107,6 +107,7 @@
             <option>BUFFER_EMPTY</option>
             <option>BUFFER_LOADED</option>
             <option>CAN_PLAY</option>
+            <option>DYNAMIC_TO_STATIC</option>
             <option>ERROR</option>
             <option>LOG</option>
             <option>MANIFEST_LOADED</option>

--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -83,7 +83,6 @@ class CoreEvents extends EventsBase {
         this.SEGMENTBASE_INIT_REQUEST_NEEDED = 'segmentBaseInitRequestNeeded';
         this.SEGMENTBASE_SEGMENTSLIST_REQUEST_NEEDED = 'segmentBaseSegmentsListRequestNeeded';
         this.SEEK_TARGET = 'seekTarget';
-        this.DYNAMIC_STREAM_COMPLETED = 'dynamicStreamCompleted';
     }
 }
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -76,7 +76,7 @@ function DashHandler(config) {
         eventBus.on(events.INITIALIZATION_LOADED, onInitializationLoaded, instance);
         eventBus.on(events.SEGMENTS_LOADED, onSegmentsLoaded, instance);
         eventBus.on(events.REPRESENTATION_UPDATE_STARTED, onRepresentationUpdateStarted, instance);
-        eventBus.on(events.DYNAMIC_STREAM_COMPLETED, onDynamicStreamCompleted, instance);
+        eventBus.on(events.DYNAMIC_TO_STATIC, onDynamicToStatic, instance);
     }
 
     function initialize(isDynamic) {
@@ -119,7 +119,7 @@ function DashHandler(config) {
         eventBus.off(events.INITIALIZATION_LOADED, onInitializationLoaded, instance);
         eventBus.off(events.SEGMENTS_LOADED, onSegmentsLoaded, instance);
         eventBus.off(events.REPRESENTATION_UPDATE_STARTED, onRepresentationUpdateStarted, instance);
-        eventBus.off(events.DYNAMIC_STREAM_COMPLETED, onDynamicStreamCompleted, instance);
+        eventBus.off(events.DYNAMIC_TO_STATIC, onDynamicToStatic, instance);
     }
 
     function setRequestUrl(request, destination, representation) {
@@ -420,7 +420,7 @@ function DashHandler(config) {
         eventBus.trigger(events.REPRESENTATION_UPDATE_COMPLETED, {sender: this, representation: representation});
     }
 
-    function onDynamicStreamCompleted() {
+    function onDynamicToStatic() {
         logger.debug('Dynamic stream complete');
         dynamicStreamCompleted = true;
     }

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -148,7 +148,7 @@ function ManifestUpdater() {
         // See DASH-IF IOP v4.3 section 4.6.4 "Transition Phase between Live and On-Demand"
         // Stop manifest update, ignore static manifest and signal end of dynamic stream to detect end of stream
         if (manifestModel.getValue() && manifestModel.getValue().type === DashConstants.DYNAMIC && manifest.type === DashConstants.STATIC) {
-            eventBus.trigger(Events.DYNAMIC_STREAM_COMPLETED);
+            eventBus.trigger(Events.DYNAMIC_TO_STATIC);
             isUpdating = false;
             isStopped = true;
             return;

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -70,6 +70,12 @@ class MediaPlayerEvents extends EventsBase {
         this.BUFFER_LEVEL_STATE_CHANGED = 'bufferStateChanged';
 
         /**
+         * Triggered when a dynamic stream changed to static (transition phase between Live and On-Demand).
+         * @event MediaPlayerEvents#DYNAMIC_TO_STATIC
+         */
+        this.DYNAMIC_TO_STATIC = 'dynamicToStatic';
+
+        /**
          * Triggered when there is an error from the element or MSE source buffer.
          * @event MediaPlayerEvents#ERROR
          */

--- a/test/unit/dash.DashHandler.js
+++ b/test/unit/dash.DashHandler.js
@@ -6,6 +6,7 @@ import Events from '../../src/core/events/Events';
 import EventBus from '../../src/core/EventBus';
 import Debug from '../../src/core/Debug';
 import URLUtils from '../../src/streaming/utils/URLUtils';
+import MediaPlayerEvents from '../../src/streaming/MediaPlayerEvents';
 
 import ObjectsHelper from './helpers/ObjectsHelper';
 import VoHelper from './helpers/VOHelper';
@@ -24,6 +25,8 @@ describe('DashHandler', function () {
     const settings = Settings(context).getInstance();
     const eventBus = EventBus(context).getInstance();
     const debug = Debug(context).getInstance();
+
+    Events.extend(MediaPlayerEvents);
 
     const timelineConverter = objectsHelper.getDummyTimelineConverter();
     const streamProcessor = objectsHelper.getDummyStreamProcessor(testType);


### PR DESCRIPTION
This PR adds public MediaPlayer event DYNAMIC_TO_STATIC to be triggered at transition phase between live and on-demand contents