### PR TITLE
Revert BufferLevelRule

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -491,7 +491,7 @@ function ScheduleController(config) {
     }
 
     function getBufferTarget() {
-        return bufferLevelRule.getBufferTarget(type, currentRepresentationInfo);
+        return bufferLevelRule.getBufferTarget(type, currentRepresentationInfo, hasVideoTrack);
     }
 
     function getType() {

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -79,8 +79,7 @@ function BufferLevelRule(config) {
             } else {
                 bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
             }
-        }
-        else {
+        } else {
             const streamInfo = representationInfo.mediaInfo.streamInfo;
             if (abrController.isPlayingAtTopQuality(streamInfo)) {
                 const isLongFormContent = streamInfo.manifestInfo.duration >= settings.get().streaming.longFormContentDurationThreshold;

--- a/src/streaming/rules/scheduling/BufferLevelRule.js
+++ b/src/streaming/rules/scheduling/BufferLevelRule.js
@@ -44,15 +44,15 @@ function BufferLevelRule(config) {
     function setup() {
     }
 
-    function execute(type, representationInfo) {
+    function execute(type, representationInfo, hasVideoTrack) {
         if (!type || !representationInfo) {
             return true;
         }
         const bufferLevel = dashMetrics.getCurrentBufferLevel(type);
-        return bufferLevel < getBufferTarget(type, representationInfo);
+        return bufferLevel < getBufferTarget(type, representationInfo, hasVideoTrack);
     }
 
-    function getBufferTarget(type, representationInfo) {
+    function getBufferTarget(type, representationInfo, hasVideoTrack) {
         let bufferTarget = NaN;
 
         if (!type || !representationInfo) {
@@ -72,7 +72,15 @@ function BufferLevelRule(config) {
             } else { // text is disabled, rule will return false
                 bufferTarget = 0;
             }
-        }  else {
+        }  else if (type === Constants.AUDIO && hasVideoTrack) {
+            const videoBufferLevel = dashMetrics.getCurrentBufferLevel(Constants.VIDEO);
+            if (isNaN(representationInfo.fragmentDuration)) {
+                bufferTarget = videoBufferLevel;
+            } else {
+                bufferTarget = Math.max(videoBufferLevel, representationInfo.fragmentDuration);
+            }
+        }
+        else {
             const streamInfo = representationInfo.mediaInfo.streamInfo;
             if (abrController.isPlayingAtTopQuality(streamInfo)) {
                 const isLongFormContent = streamInfo.manifestInfo.duration >= settings.get().streaming.longFormContentDurationThreshold;

--- a/test/unit/streaming.rules.scheduling.BufferLevelRule.js
+++ b/test/unit/streaming.rules.scheduling.BufferLevelRule.js
@@ -61,7 +61,7 @@ describe('BufferLevelRule', function () {
 
     it('should return 15 (value returns by getCurrentBufferLevel of DashMetricsMock) if streamProcessor is defined and current representation is audio and videoTrackPresent is true', function () {
         const result = bufferLevelRule.getBufferTarget(testAudioType, representationInfo, true);
-        expect(result).to.be.equal(12); // jshint ignore:line
+        expect(result).to.be.equal(15); // jshint ignore:line
     });
 
     it('should return 12 (DEFAULT_MIN_BUFFER_TIME of MediaPlayerModelMock) if streamProcessor is defined and current representation is audio and videoTrackPresent is false', function () {


### PR DESCRIPTION
This PR revert changes on BufferLevelRule in PR #3360, in order to restore alignement of audio buffer target to current video buffer level