### PR TITLE
Fix url anchor time

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -383,9 +383,9 @@ function PlaybackController() {
         // TODO: consider end time of MediaRange to stop playback at provided end time
         fragData.t = fragData.t.split(',')[0];
 
-        // "t=<time>" : time is relative to period start (for static streams) or DVR window range start (for dynamic streams)
+        // "t=<time>" : time is relative to 1st period start (for static streams) or DVR window range start (for dynamic streams)
         // "t=posix:<time>" : time is absolute start time as number of seconds since 01-01-1970
-        startTime = (isDynamic && fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : (rangeStart + parseInt(fragData.t));
+        startTime = (isDynamic && fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : parseInt(fragData.t);
 
         return startTime;
     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -383,7 +383,7 @@ function PlaybackController() {
         // TODO: consider end time of MediaRange to stop playback at provided end time
         fragData.t = fragData.t.split(',')[0];
 
-        // "t=<time>" : time is relative to 1st period start (for static streams) or DVR window range start (for dynamic streams)
+        // "t=<time>" : time is relative to 1st period start
         // "t=posix:<time>" : time is absolute start time as number of seconds since 01-01-1970
         startTime = (isDynamic && fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : parseInt(fragData.t);
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -120,7 +120,7 @@ function PlaybackController() {
                 const dvrWindow = dvrInfo ? dvrInfo.range : null;
                 if (dvrWindow) {
                     // #t shall be relative to period start
-                    const startTimeFromUri = getStartTimeFromUriParameters(streamInfo.start, true);
+                    const startTimeFromUri = getStartTimeFromUriParameters(true);
                     if (!isNaN(startTimeFromUri)) {
                         logger.info('Start time from URI parameters: ' + startTimeFromUri);
                         startTime = Math.max(Math.min(startTime, startTimeFromUri), dvrWindow.start);
@@ -130,7 +130,7 @@ function PlaybackController() {
                 // For static stream, start by default at period start
                 startTime = streamInfo.start;
                 // If start time in URI, take max value between period start and time from URI (if in period range)
-                const startTimeFromUri = getStartTimeFromUriParameters(streamInfo.start, false);
+                const startTimeFromUri = getStartTimeFromUriParameters(false);
                 if (!isNaN(startTimeFromUri) && startTimeFromUri < (startTime + streamInfo.duration)) {
                     logger.info('Start time from URI parameters: ' + startTimeFromUri);
                     startTime = Math.max(startTime, startTimeFromUri);
@@ -371,22 +371,20 @@ function PlaybackController() {
         }
     }
 
-    function getStartTimeFromUriParameters(rangeStart, isDynamic) {
+    function getStartTimeFromUriParameters(isDynamic) {
         const fragData = uriFragmentModel.getURIFragmentData();
         if (!fragData || !fragData.t) {
             return NaN;
         }
-
-        let startTime = NaN;
-
+        const refStream = streamController.getStreams()[0];
+        const refStreamStartTime = refStream.getStreamInfo().start;
         // Consider only start time of MediaRange
         // TODO: consider end time of MediaRange to stop playback at provided end time
         fragData.t = fragData.t.split(',')[0];
-
         // "t=<time>" : time is relative to 1st period start
         // "t=posix:<time>" : time is absolute start time as number of seconds since 01-01-1970
-        startTime = (isDynamic && fragData.t.indexOf('posix:') !== -1) ? parseInt(fragData.t.substring(6)) : parseInt(fragData.t);
-
+        const posix = fragData.t.indexOf('posix:') !== -1 ? fragData.t.substring(6) === 'now' ? Date.now() / 1000 : parseInt(fragData.t.substring(6)) : NaN;
+        let startTime = (isDynamic && !isNaN(posix)) ? posix - availabilityStartTime / 1000 : parseInt(fragData.t) + refStreamStartTime;
         return startTime;
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -730,7 +730,7 @@ function StreamController() {
 
                 // we need to figure out what the correct starting period is
                 let initialStream = null;
-                const startTimeFromUri = playbackController.getStartTimeFromUriParameters(streamsInfo[0].start, adapter.getIsDynamic());
+                const startTimeFromUri = playbackController.getStartTimeFromUriParameters(adapter.getIsDynamic());
 
                 initialStream = getStreamForTime(startTimeFromUri);
 

--- a/test/functional/tests/playFromTime.js
+++ b/test/functional/tests/playFromTime.js
@@ -35,7 +35,7 @@ exports.register = function (stream) {
                 stream_.url += '#t=' + startTime;
             } else {
                 startTime = Math.floor(Date.now() / 1000) - TIME_OFFSET;
-                stream_.url += '#t=' + startTime;
+                stream_.url += '#t=posix:' + startTime;
             }
             utils.log(NAME, 'Playback start time: ' + startTime);
             await command.execute(player.loadStream, [stream_]);

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -7,7 +7,12 @@ class StreamControllerMock {
         this.streamId = 'streamId';
     }
 
-    initialize() {
+    initialize(streams) {
+        this.streams = streams;
+    }
+
+    getStreams() {
+        return this.streams;
     }
 
     getActiveStreamCommonEarliestTime() {

--- a/test/unit/mocks/StreamMock.js
+++ b/test/unit/mocks/StreamMock.js
@@ -1,6 +1,11 @@
 function StreamMock () {
+
+    this.initialize = function (streamInfo) {
+        this.streamInfo = streamInfo;
+    };
+
     this.getStreamInfo = function () {
-        return {};
+        return this.streamInfo ? this.streamInfo : {};
     };
 
     this.getFragmentController = function () {

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -357,7 +357,7 @@ describe('PlaybackController', function () {
             let uriStartTime = 10;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
-            expectedSeekTime = staticStreamInfo.start + uriStartTime;
+            expectedSeekTime = uriStartTime;
 
             playbackController.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
@@ -422,10 +422,10 @@ describe('PlaybackController', function () {
         it('should start dynamic stream at #t', function (done) {
             doneFn = done;
 
-            let uriStartTime = (dvrWindowRange.start - dynamicStreamInfo.start) + 10;
+            let uriStartTime = 80;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
-            expectedSeekTime = dynamicStreamInfo.start + uriStartTime;
+            expectedSeekTime = uriStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -7,6 +7,7 @@ import VideoModelMock from './mocks/VideoModelMock';
 import MediaPlayerModelMock from './mocks/MediaPlayerModelMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
 import StreamControllerMock from './mocks/StreamControllerMock';
+import StreamMock from './mocks/StreamMock';
 import URIFragmentModelMock from './mocks/URIFragmentModelMock';
 import AdapterMock from './mocks/AdapterMock';
 
@@ -21,6 +22,7 @@ describe('PlaybackController', function () {
         videoModelMock,
         dashMetricsMock,
         mediaPlayerModelMock,
+        streamMock,
         streamControllerMock,
         uriFragmentModelMock,
         adapterMock,
@@ -30,6 +32,7 @@ describe('PlaybackController', function () {
         videoModelMock = new VideoModelMock();
         dashMetricsMock = new DashMetricsMock();
         mediaPlayerModelMock = new MediaPlayerModelMock();
+        streamMock = new StreamMock();
         streamControllerMock = new StreamControllerMock();
         uriFragmentModelMock = new URIFragmentModelMock();
         adapterMock = new AdapterMock();
@@ -45,6 +48,8 @@ describe('PlaybackController', function () {
             adapter: adapterMock,
             settings: settings
         });
+
+        streamControllerMock.initialize([streamMock]);
     });
 
     afterEach(function () {
@@ -72,6 +77,7 @@ describe('PlaybackController', function () {
             };
 
             playbackController.initialize(streamInfo);
+            streamMock.initialize(streamInfo);
 
             expect(playbackController.getIsDynamic()).to.equal(true);
         });
@@ -90,6 +96,7 @@ describe('PlaybackController', function () {
             };
 
             playbackController.initialize(streamInfo);
+            streamMock.initialize(streamInfo);
         });
 
         it('should return NaN when getLiveDelay is called after a call to computeLiveDelay with no parameter', function () {
@@ -326,7 +333,7 @@ describe('PlaybackController', function () {
         let doneFn;
 
         let staticStreamInfo = { manifestInfo: { isDynamic: false }, start: 10, duration: 600 };
-        let dynamicStreamInfo = { manifestInfo: { isDynamic: true }, start: 50, duration: Infinity };
+        let dynamicStreamInfo = { manifestInfo: { isDynamic: true }, start: 10, duration: Infinity };
         let dvrWindowRange = { start: 70, end: 100 };
         let liveStartTime = 85;
 
@@ -348,6 +355,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = staticStreamInfo.start;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
@@ -357,21 +365,23 @@ describe('PlaybackController', function () {
             let uriStartTime = 10;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
-            expectedSeekTime = uriStartTime;
+            expectedSeekTime = staticStreamInfo.start + uriStartTime;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
         it('should start static stream at period start if #t is before period start', function (done) {
             doneFn = done;
 
-            let uriStartTime = -10;
+            let uriStartTime = -20;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
             expectedSeekTime = staticStreamInfo.start;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
@@ -384,6 +394,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = staticStreamInfo.start;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
@@ -396,6 +407,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = staticStreamInfo.start;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
@@ -407,6 +419,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = staticStreamInfo.start;
 
             playbackController.initialize(staticStreamInfo);
+            streamMock.initialize(staticStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {});
         });
 
@@ -416,18 +429,20 @@ describe('PlaybackController', function () {
             expectedSeekTime = liveStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
         it('should start dynamic stream at #t', function (done) {
             doneFn = done;
 
-            let uriStartTime = 80;
+            let uriStartTime = 70;
             uriFragmentModelMock.setURIFragmentData({t: uriStartTime.toString()});
 
-            expectedSeekTime = uriStartTime;
+            expectedSeekTime = dynamicStreamInfo.start + uriStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -440,6 +455,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = dvrWindowRange.start;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -451,6 +467,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = liveStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -463,6 +480,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = uriStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -475,6 +493,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = dvrWindowRange.start;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -487,6 +506,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = liveStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
 
@@ -498,6 +518,7 @@ describe('PlaybackController', function () {
             expectedSeekTime = liveStartTime;
 
             playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
     });


### PR DESCRIPTION
This PR is fixing anchor time management in case of multiple periods
Anchor time shall be relative to 1st period but currently anchor time is computed as being relative to targeted (from anchor time) period start time