### PR TITLE
Decrease already seen initData log from warn to info

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -171,7 +171,7 @@ function ProtectionController(config) {
             const currentInitData = protectionModel.getAllInitData();
             for (let i = 0; i < currentInitData.length; i++) {
                 if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
-                    logger.warn('DRM: Ignoring initData because we have already seen it!');
+                    logger.info('DRM: Ignoring initData because we have already seen it!');
                     return;
                 }
             }


### PR DESCRIPTION
I wanted to put up this PR to potentially start a discussion, or, if it's deemed appropriate, to get it merged.

For many encrypted streams, it's not uncommon to see the same initData appear repeatedly. This is especially true for live streams. In running some streams, we end up getting tons of warning logs due to this message.

Since there's no action to be taken, as this is a valid case, I was thinking that it should be at a lower log level than warn, which is generally used for more actionable issues.

Let me know what you think, and thank you. 