### PR TITLE
Fix events payload

### DIFF
--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -91,6 +91,13 @@ function EventBus() {
 
         payload.type = type;
 
+        if (filters.streamId) {
+            payload.streamId = filters.streamId;
+        }
+        if (filters.mediaType) {
+            payload.mediaType = filters.mediaType;
+        }
+
         handlers[type] = handlers[type].filter((item) => item);
         handlers[type].forEach(handler => {
             if (!handler) return;

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -423,6 +423,9 @@ function StreamProcessor(config) {
     }
 
     function onInitFragmentNeeded(e) {
+        // Event propagation may have been stopped (see MssHandler)
+        if (!e.sender) return;
+
         if (adapter.getIsTextTrack(mimeType) && !textController.isTextEnabled()) return;
 
         if (bufferController && e.representationId) {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -190,7 +190,7 @@ function ScheduleController(config) {
                         logger.debug('Quality has changed, get init request for representationid = ' + currentRepresentationInfo.id);
                     }
                     eventBus.trigger(Events.INIT_FRAGMENT_NEEDED,
-                        { representationId: currentRepresentationInfo.id },
+                        { representationId: currentRepresentationInfo.id, sender: instance },
                         { streamId: streamInfo.id, mediaType: type }
                     );
                     lastInitQuality = currentRepresentationInfo.quality;
@@ -201,7 +201,7 @@ function ScheduleController(config) {
                     if (replacement && replacement.isInitializationRequest()) {
                         // To be sure the specific init segment had not already been loaded
                         eventBus.trigger(Events.INIT_FRAGMENT_NEEDED,
-                            { representationId: replacement.representationId },
+                            { representationId: replacement.representationId, sender: instance },
                             { streamId: streamInfo.id, mediaType: type }
                         );
                         checkPlaybackQuality = false;

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -158,7 +158,7 @@ function NotFragmentedTextBufferController(config) {
 
         // // Text data file is contained in initialization segment
         eventBus.trigger(Events.INIT_FRAGMENT_NEEDED,
-            { representationId: e.currentRepresentation.id },
+            { representationId: e.currentRepresentation.id, sender: instance },
             { streamId: streamInfo.id, mediaType: type }
         );
     }


### PR DESCRIPTION
Fix regression introduced by PR #3372:
- add streamId and mediaType in events payload
- restore evet propagation management (for smooth streaming scenario)