### PR TITLE
add missing ABR strategies to TypeScript defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,7 +180,7 @@ declare namespace dashjs {
             };
             abr?: {
                 movingAverageMethod?: 'slidingWindow' | 'ewma';
-                ABRStrategy?: 'abrDynamic' | 'abrBola';
+                ABRStrategy?: 'abrDynamic' | 'abrBola' | 'abrL2A' | 'abrLoLP' | 'abrThroughput';
                 bandwidthSafetyFactor?: number;
                 useDefaultABRRules?: boolean;
                 useDeadTimeLatency?: boolean;


### PR DESCRIPTION
This adds the following ABR strategies to the TypeScript definitions, since I assume they're all customizable from the settings:

- `abrDynamic`
- `abrBola`
- `abrL2A`
- `abrLoLP`
- `abrThroughput`

Or are they only available in some specific circumstances?