### PR TITLE
Fix invalid MediaPlayerEvents import

### DIFF
--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -29,7 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from './FactoryMaker';
-import {EVENT_MODE_ON_RECEIVE} from '../streaming/MediaPlayerEvents';
+import MediaPlayerEvents from '../streaming/MediaPlayerEvents';
 
 const EVENT_PRIORITY_LOW = 0;
 const EVENT_PRIORITY_HIGH = 5000;
@@ -116,7 +116,7 @@ function EventBus() {
                     return false;
                 }
                 // This is used for dispatching DASH events. By default we use the onStart mode. Consequently we filter everything that has a non matching mode and the onReceive events for handlers that did not specify a mode.
-                if ((filters.mode && handler.mode && handler.mode !== filters.mode) || (!handler.mode && filters.mode && filters.mode === EVENT_MODE_ON_RECEIVE)) {
+                if ((filters.mode && handler.mode && handler.mode !== filters.mode) || (!handler.mode && filters.mode && filters.mode === MediaPlayerEvents.EVENT_MODE_ON_RECEIVE)) {
                     return false;
                 }
                 return true;


### PR DESCRIPTION
This caused an error when processing source using Babel: "Attempted import error: 'EVENT_MODE_ON_RECEIVE' is not exported from '../streaming/MediaPlayerEvents'."

I've changed it to match the other uses of these constants, which caused my builds to succeed. E.g.:

https://github.com/Dash-Industry-Forum/dash.js/blob/7d4d208898c1f5c1dd68957583a9475f4b591cfd/src/streaming/controllers/EventController.js#L126