### PR TITLE
Expose dashjs.isSupported utility for checking MSE support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1089,4 +1089,6 @@ declare namespace dashjs {
     export type MetricType = 'ManifestUpdate' | 'RequestsQueue';
     export type TrackSwitchMode = 'alwaysReplace' | 'neverReplace';
     export type TrackSelectionMode = 'highestBitrate' | 'widestRange';
+
+    export function isSupported(): boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1090,5 +1090,5 @@ declare namespace dashjs {
     export type TrackSwitchMode = 'alwaysReplace' | 'neverReplace';
     export type TrackSelectionMode = 'highestBitrate' | 'widestRange';
 
-    export function isSupported(): boolean;
+    export function supportsMediaSource(): boolean;
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@
 
 import { MediaPlayer } from './index_mediaplayerOnly';
 
-import { supportsMediaSource as isSupported } from './src/streaming/utils/Capabilities'
+import { supportsMediaSource } from './src/streaming/utils/Capabilities';
 import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import Protection from './src/streaming/protection/Protection';
 import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
@@ -41,7 +41,7 @@ dashjs.Protection = Protection;
 dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
 dashjs.Debug = Debug;
-dashjs.isSupported = isSupported
+dashjs.supportsMediaSource = supportsMediaSource;
 
 export default dashjs;
-export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, Debug, isSupported };
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, Debug, supportsMediaSource };

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@
 
 import { MediaPlayer } from './index_mediaplayerOnly';
 
+import { supportsMediaSource as isSupported } from './src/streaming/utils/Capabilities'
 import MetricsReporting from './src/streaming/metrics/MetricsReporting';
 import Protection from './src/streaming/protection/Protection';
 import MediaPlayerFactory from './src/streaming/MediaPlayerFactory';
@@ -40,6 +41,7 @@ dashjs.Protection = Protection;
 dashjs.MetricsReporting = MetricsReporting;
 dashjs.MediaPlayerFactory = MediaPlayerFactory;
 dashjs.Debug = Debug;
+dashjs.isSupported = isSupported
 
 export default dashjs;
-export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, Debug};
+export { MediaPlayer, Protection, MetricsReporting, MediaPlayerFactory, Debug, isSupported };

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -30,6 +30,13 @@
  */
 import FactoryMaker from '../../core/FactoryMaker';
 
+export function supportsMediaSource() {
+    let hasWebKit = ('WebKitMediaSource' in window);
+    let hasMediaSource = ('MediaSource' in window);
+
+    return (hasWebKit || hasMediaSource);
+}
+
 function Capabilities() {
 
     let instance,
@@ -37,13 +44,6 @@ function Capabilities() {
 
     function setup() {
         encryptedMediaSupported = false;
-    }
-
-    function supportsMediaSource() {
-        let hasWebKit = ('WebKitMediaSource' in window);
-        let hasMediaSource = ('MediaSource' in window);
-
-        return (hasWebKit || hasMediaSource);
     }
 
     /**


### PR DESCRIPTION
Similar to https://github.com/Dash-Industry-Forum/dash.js/issues/2055, I was looking for an easy way to test for MSE support before falling back to HLS. This small change exposes the existing `supportsMediaSource` check into a `dashjs.isSupported()` function on the global module object.

Example usage:

```js
if (dashjs.isSupported()) {
  const player = dashjs.MediaPlayer().create()
  // ...
} else {
  // fallback logic
}
```