### PR TITLE
Add "highestEfficiency" initial track selection mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1088,5 +1088,5 @@ declare namespace dashjs {
 
     export type MetricType = 'ManifestUpdate' | 'RequestsQueue';
     export type TrackSwitchMode = 'alwaysReplace' | 'neverReplace';
-    export type TrackSelectionMode = 'highestBitrate' | 'widestRange';
+    export type TrackSelectionMode = 'highestBitrate' | 'highestEfficiency' | 'widestRange';
 }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1592,10 +1592,13 @@ function MediaPlayer() {
      * if no initial media settings are set. If initial media settings are set this parameter will be ignored. Available options are:
      *
      * Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE
-     * this mode makes the player select the track with a highest bitrate. This mode is a default mode.
+     * This mode makes the player select the track with a highest bitrate. This mode is a default mode.
+     *
+     * Constants.TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY
+     * This mode makes the player select the track with the lowest bitrate per pixel average.
      *
      * Constants.TRACK_SELECTION_MODE_WIDEST_RANGE
-     * this mode makes the player select the track with a widest range of bitrates
+     * This mode makes the player select the track with a widest range of bitrates.
      *
      * @param {string} mode
      * @memberof module:MediaPlayer

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -235,7 +235,14 @@ class Constants {
         this.TRACK_SELECTION_MODE_HIGHEST_BITRATE = 'highestBitrate';
 
         /**
-         *  @constant {string} TRACK_SELECTION_MODE_WIDEST_RANGE this mode makes the player select the track with a widest range of bitrates
+         *  @constant {string} TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY makes the player select the track with the lowest bitrate per pixel average.
+         *  @memberof Constants#
+         *  @static
+         */
+        this.TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY = 'highestEfficiency';
+
+        /**
+         *  @constant {string} TRACK_SELECTION_MODE_WIDEST_RANGE makes the player select the track with a widest range of bitrates.
          *  @memberof Constants#
          *  @static
          */

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -53,6 +53,7 @@ function MediaController() {
 
     const validTrackSelectionModes = [
         Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE,
+        Constants.TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY,
         Constants.TRACK_SELECTION_MODE_WIDEST_RANGE
     ];
 
@@ -87,10 +88,10 @@ function MediaController() {
         }
 
         if (tracks.length === 0) {
-            setTrack(selectInitialTrack(type, tracksForType), true);
+            setTrack(this.selectInitialTrack(type, tracksForType), true);
         } else {
             if (tracks.length > 1) {
-                setTrack(selectInitialTrack(type, tracks));
+                setTrack(this.selectInitialTrack(type, tracks));
             } else {
                 setTrack(tracks[0]);
             }
@@ -403,48 +404,73 @@ function MediaController() {
         };
     }
 
+    function getTracksWithHighestBitrate (trackArr) {
+        let max = 0;
+        let result = [];
+        let tmp;
+
+        trackArr.forEach(function (track) {
+            tmp = Math.max.apply(Math, track.bitrateList.map(function (obj) { return obj.bandwidth; }));
+
+            if (tmp > max) {
+                max = tmp;
+                result = [track];
+            } else if (tmp === max) {
+                result.push(track);
+            }
+        });
+
+        return result;
+    }
+
+    function getTracksWithHighestEfficiency (trackArr) {
+        let min = Infinity;
+        let result = [];
+        let tmp;
+
+        trackArr.forEach(function (track) {
+            const sum = track.bitrateList.reduce(function (acc, obj) {
+                const resolution = Math.max(1, obj.width * obj.height);
+                const efficiency = obj.bandwidth / resolution;
+                return acc + efficiency;
+            }, 0);
+            tmp = sum / track.bitrateList.length;
+
+            if (tmp < min) {
+                min = tmp;
+                result = [track];
+            } else if (tmp === min) {
+                result.push(track);
+            }
+        });
+
+        return result;
+    }
+
+    function getTracksWithWidestRange (trackArr) {
+        let max = 0;
+        let result = [];
+        let tmp;
+
+        trackArr.forEach(function (track) {
+            tmp = track.representationCount;
+
+            if (tmp > max) {
+                max = tmp;
+                result = [track];
+            } else if (tmp === max) {
+                result.push(track);
+            }
+        });
+
+        return result;
+    }
+
     function selectInitialTrack(type, tracks) {
         if (type === Constants.FRAGMENTED_TEXT) return tracks[0];
 
         let mode = getSelectionModeForInitialTrack();
         let tmpArr = [];
-
-        const getTracksWithHighestBitrate = function (trackArr) {
-            let max = 0;
-            let result = [];
-            let tmp;
-
-            trackArr.forEach(function (track) {
-                tmp = Math.max.apply(Math, track.bitrateList.map(function (obj) { return obj.bandwidth; }));
-
-                if (tmp > max) {
-                    max = tmp;
-                    result = [track];
-                } else if (tmp === max) {
-                    result.push(track);
-                }
-            });
-
-            return result;
-        };
-        const getTracksWithWidestRange = function (trackArr) {
-            let max = 0;
-            let result = [];
-            let tmp;
-
-            trackArr.forEach(function (track) {
-                tmp = track.representationCount;
-
-                if (tmp > max) {
-                    max = tmp;
-                    result = [track];
-                } else if (tmp === max) {
-                    result.push(track);
-                }
-            });
-
-            return result;
-        };
 
         switch (mode) {
             case Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE:
@@ -452,6 +478,13 @@ function MediaController() {
 
                 if (tmpArr.length > 1) {
                     tmpArr = getTracksWithWidestRange(tmpArr);
+                }
+                break;
+            case Constants.TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY:
+                tmpArr = getTracksWithHighestEfficiency(tracks);
+
+                if (tmpArr.length > 1) {
+                    tmpArr = getTracksWithHighestBitrate(tmpArr);
                 }
                 break;
             case Constants.TRACK_SELECTION_MODE_WIDEST_RANGE:
@@ -510,6 +543,10 @@ function MediaController() {
         getInitialSettings: getInitialSettings,
         setSwitchMode: setSwitchMode,
         getSwitchMode: getSwitchMode,
+        selectInitialTrack: selectInitialTrack,
+        getTracksWithHighestBitrate: getTracksWithHighestBitrate,
+        getTracksWithHighestEfficiency: getTracksWithHighestEfficiency,
+        getTracksWithWidestRange: getTracksWithWidestRange,
         setSelectionModeForInitialTrack: setSelectionModeForInitialTrack,
         getSelectionModeForInitialTrack: getSelectionModeForInitialTrack,
         isMultiTrackSupportedByType: isMultiTrackSupportedByType,

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -545,4 +545,100 @@ describe('MediaController', function () {
         });
     });
 
+    describe('Initial Track Selection', function () {
+
+        function testSelectInitialTrack(type, expectedBitrateList, otherBitrateList) {
+            const tracks = [ expectedBitrateList, otherBitrateList ].map(function (bitrateList) {
+                return {
+                    bitrateList: bitrateList,
+                    representationCount: bitrateList.length
+                };
+            });
+            const selection = mediaController.selectInitialTrack(type, tracks);
+            expect(objectUtils.areEqual(selection.bitrateList, expectedBitrateList)).to.be.true; // jshint ignore:line
+        }
+
+        describe('"highestBitrate" mode', function () {
+            beforeEach(function () {
+                mediaController.setSelectionModeForInitialTrack(Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE);
+            });
+
+            it('should select track with highest bitrate', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 2000 } ],
+                    [ { bandwidth: 1000 } ]
+                );
+            });
+
+            it('should tie break using "widestRange"', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 2000 }, { bandwidth: 1000 } ],
+                    [ { bandwidth: 2000 } ]
+                );
+            });
+        });
+
+        describe('"highestEfficiency" mode', function () {
+            beforeEach(function () {
+                mediaController.setSelectionModeForInitialTrack(Constants.TRACK_SELECTION_MODE_HIGHEST_EFFICIENCY);
+            });
+
+            it('should select video track with lowest bitrate among equal resolutions', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 1000, width: 1920, height: 1280 } ],
+                    [ { bandwidth: 2000, width: 1920, height: 1280 } ]
+                );
+            });
+
+            it('should select video track with lowest bitrate among different resolutions', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 1000, width: 1920, height: 1280 } ],
+                    [ { bandwidth: 1000, width: 1080, height: 720 } ]
+                );
+            });
+
+            it('should select audio track with lowest avg bitrate', function () {
+                testSelectInitialTrack(
+                    'audio',
+                    [ { bandwidth: 1000, width: 0, height: 0 } ],
+                    [ { bandwidth: 2000, width: 0, height: 0 } ]
+                );
+            });
+
+            it('should tie break using "highestBitrate"', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 1500, width: 1920, height: 1280 }, { bandwidth: 1000, width: 1080, height: 720 } ],
+                    [ { bandwidth: 1000, width: 1080, height: 720 } ]
+                );
+            });
+        });
+
+        describe('"widestRange" mode', function () {
+            beforeEach(function () {
+                mediaController.setSelectionModeForInitialTrack(Constants.TRACK_SELECTION_MODE_WIDEST_RANGE);
+            });
+
+            it('should select track with most bitrates', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 2000 }, { bandwidth: 1000 } ],
+                    [ { bandwidth: 2000 } ]
+                );
+            });
+
+            it('should tie break using "highestBitrate"', function () {
+                testSelectInitialTrack(
+                    'video',
+                    [ { bandwidth: 3000 }, { bandwidth: 2000 } ],
+                    [ { bandwidth: 2000 }, { bandwidth: 1000 } ]
+                );
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
This PR adds a new initial track selection mode: "highestEfficiency". It picks the variant that offers the lowest bitrate for equivalent resolution (similar to the Shaka Player behavior referenced by @japettyjohn in https://github.com/Dash-Industry-Forum/dash.js/issues/3022#issuecomment-509937141). Similar to Shaka Player, this will prefer VP9 over MP4 if it's offered with a lower average bitrate, which is the behavior I was looking for.

In addition, this PR exposes `selectInitialTrack` and the `getTracksWithHighestBitrate`/etc functions on the class factory so that they can be overridden using `MediaPlayer.extend`, to allow end users to define their own custom strategy.

Included are new tests to cover the new track selection mode as well as the other existing ones.

Re: https://github.com/Dash-Industry-Forum/dash.js/issues/3022