### PR TITLE
Fix: Account for schemeIdUri, value and id fields in EventController

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -410,18 +410,26 @@ function DashAdapter() {
             if (!eventBox || !eventStreams || isNaN(mediaStartTime) || !voRepresentation) {
                 return null;
             }
-            const event = new Event();
+
             const schemeIdUri = eventBox.scheme_id_uri;
             const value = eventBox.value;
+
+            if (!eventStreams[schemeIdUri + '/' + value]) {
+                return null;
+            }
+
+            const event = new Event();
             const timescale = eventBox.timescale || 1;
-            const presentationTimeOffset = voRepresentation.presentationTimeOffset || 0;
             const periodStart = voRepresentation.adaptation.period.start;
+            const eventStream = eventStreams[schemeIdUri + '/' + value];
             let presentationTimeDelta = eventBox.presentation_time_delta / timescale; // In case of version 1 events the presentation_time is parsed as presentation_time_delta
             let calculatedPresentationTime;
 
             if (eventBox.version === 0) {
+                const presentationTimeOffset = voRepresentation.presentationTimeOffset || 0;
                 calculatedPresentationTime = periodStart + mediaStartTime - presentationTimeOffset + presentationTimeDelta;
             } else {
+                const presentationTimeOffset = eventStream.presentationTimeOffset || 0;
                 calculatedPresentationTime = periodStart - presentationTimeOffset + presentationTimeDelta;
             }
 
@@ -429,11 +437,7 @@ function DashAdapter() {
             const id = eventBox.id;
             const messageData = eventBox.message_data;
 
-            if (!eventStreams[schemeIdUri + '/' + value]) {
-                return null;
-            }
-
-            event.eventStream = eventStreams[schemeIdUri + '/' + value];
+            event.eventStream = eventStream;
             event.eventStream.value = value;
             event.eventStream.timescale = timescale;
             event.duration = duration;

--- a/test/unit/dash.DashAdapter.js
+++ b/test/unit/dash.DashAdapter.js
@@ -161,7 +161,18 @@ describe('DashAdapter', function () {
             expect(event).to.be.an('object');
         });
 
-        it('should calculate correct start time for a version 0 event', function () {
+        it('should calculate correct start time for a version 0 event without PTO', function () {
+            const representation = { adaptation: { period: { start: 10 } } };
+            const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 12, version: 0 };
+            const eventStreams = { 'id/value': {} };
+            const mediaTime = 5;
+            const event = dashAdapter.getEvent(eventBox, eventStreams, mediaTime, representation);
+
+            expect(event).to.be.an('object');
+            expect(event.calculatedPresentationTime).to.be.equal(27);
+        });
+
+        it('should calculate correct start time for a version 0 event with PTO', function () {
             const representation = { presentationTimeOffset: 5, adaptation: { period: { start: 10 } } };
             const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 12, version: 0 };
             const eventStreams = { 'id/value': {} };
@@ -172,10 +183,32 @@ describe('DashAdapter', function () {
             expect(event.calculatedPresentationTime).to.be.equal(22);
         });
 
-        it('should calculate correct start time for a version 1 event', function () {
-            const representation = { presentationTimeOffset: 5, adaptation: { period: { start: 10 } } };
+        it('should calculate correct start time for a version 1 event without PTO', function () {
+            const representation = { adaptation: { period: { start: 10 } } };
             const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 12, version: 1 };
             const eventStreams = { 'id/value': {} };
+            const mediaTime = 5;
+            const event = dashAdapter.getEvent(eventBox, eventStreams, mediaTime, representation);
+
+            expect(event).to.be.an('object');
+            expect(event.calculatedPresentationTime).to.be.equal(22);
+        });
+
+        it('should calculate correct start time for a version 1 event with PTO in representation', function () {
+            const representation = { presentationTimeOffset: 10, adaptation: { period: { start: 10 } } };
+            const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 12, version: 1 };
+            const eventStreams = { 'id/value': {} };
+            const mediaTime = 5;
+            const event = dashAdapter.getEvent(eventBox, eventStreams, mediaTime, representation);
+
+            expect(event).to.be.an('object');
+            expect(event.calculatedPresentationTime).to.be.equal(22);
+        });
+
+        it('should calculate correct start time for a version 1 event with PTO in eventStream and representation', function () {
+            const representation = { presentationTimeOffset: 10, adaptation: { period: { start: 10 } } };
+            const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 12, version: 1 };
+            const eventStreams = { 'id/value': { presentationTimeOffset: 5 } };
             const mediaTime = 5;
             const event = dashAdapter.getEvent(eventBox, eventStreams, mediaTime, representation);
 
@@ -183,10 +216,16 @@ describe('DashAdapter', function () {
             expect(event.calculatedPresentationTime).to.be.equal(17);
         });
 
-        it('should calculate correct start time for a version 0 event with timescale > 1', function () {
-            const representation = { presentationTimeOffset: 5, adaptation: { period: { start: 10 } } };
-            const eventBox = { scheme_id_uri: 'id', value: 'value', presentation_time_delta: 90000, version: 1, timescale: 45000 };
-            const eventStreams = { 'id/value': {} };
+        it('should calculate correct start time for a version 1 event with timescale > 1 and PTO in eventStream', function () {
+            const representation = { adaptation: { period: { start: 10 } } };
+            const eventBox = {
+                scheme_id_uri: 'id',
+                value: 'value',
+                presentation_time_delta: 90000,
+                version: 1,
+                timescale: 45000
+            };
+            const eventStreams = { 'id/value': { presentationTimeOffset: 5 } };
             const mediaTime = 5;
             const event = dashAdapter.getEvent(eventBox, eventStreams, mediaTime, representation);
 


### PR DESCRIPTION
This PR aims to fix the issue described in #3485 and #3429:

- The events are now sorted by schemeIdUri and not by id. 
- Existing events are only overwritten for similar schemeId, value and id field values
- Events are added if they have similar ids, similar schemeIdUris but different values
- Added additional unit tests
- Fixed a bug in the calculation of Version 1 inband events. Use the PTO from the <InbandEventStream> element instead of the one from the <Representation> element