### PR TITLE
Fix 3490

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -633,13 +633,15 @@ function Stream(config) {
         if (protectionController) {
             // Need to check if streamProcessors exists because streamProcessors
             // could be cleared in case an error is detected while initializing DRM keysystem
+            protectionController.clearMediaInfoArrayByStreamId(getId());
             for (let i = 0; i < ln && streamProcessors[i]; i++) {
-                if (streamProcessors[i].getType() === Constants.AUDIO ||
-                    streamProcessors[i].getType() === Constants.VIDEO ||
-                    streamProcessors[i].getType() === Constants.FRAGMENTED_TEXT) {
+                const type = streamProcessors[i].getType();
+                if (type === Constants.AUDIO ||
+                    type === Constants.VIDEO ||
+                    type === Constants.FRAGMENTED_TEXT) {
                     let mediaInfo = streamProcessors[i].getMediaInfo();
                     if (mediaInfo) {
-                        protectionController.initializeForMedia(mediaInfo);
+                        protectionController.initializeForMedia(mediaInfo, type);
                     }
                 }
             }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -641,7 +641,7 @@ function Stream(config) {
                     type === Constants.FRAGMENTED_TEXT) {
                     let mediaInfo = streamProcessors[i].getMediaInfo();
                     if (mediaInfo) {
-                        protectionController.initializeForMedia(mediaInfo, type);
+                        protectionController.initializeForMedia(mediaInfo);
                     }
                 }
             }

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -116,7 +116,6 @@ function ProtectionController(config) {
 
         eventBus.on(events.INTERNAL_KEY_MESSAGE, onKeyMessage, this);
         eventBus.on(events.INTERNAL_KEY_STATUS_CHANGED, onKeyStatusChanged, this);
-
         mediaInfoArr.push(mediaInfo);
 
         // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
@@ -125,6 +124,16 @@ function ProtectionController(config) {
         if (supportedKS && supportedKS.length > 0) {
             selectKeySystem(supportedKS, true);
         }
+    }
+
+    /**
+     * Removes all entries from the mediaInfoArr array for a specific stream id
+     * @param {String} streamId
+     */
+    function clearMediaInfoArrayByStreamId(streamId) {
+        mediaInfoArr = mediaInfoArr.filter((mediaInfo) => {
+            return mediaInfo.streamInfo.id !== streamId;
+        });
     }
 
     /**
@@ -168,13 +177,11 @@ function ProtectionController(config) {
         if (initDataForKS) {
 
             // Check for duplicate initData
-            const currentInitData = protectionModel.getAllInitData();
-            for (let i = 0; i < currentInitData.length; i++) {
-                if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
-                    logger.info('DRM: Ignoring initData because we have already seen it!');
-                    return;
-                }
+            if (_isInitDataDuplicate(initDataForKS)) {
+                logger.info('DRM: Ignoring initData because we have already seen it!');
+                return;
             }
+
             try {
                 protectionModel.createKeySession(initDataForKS, protData, getSessionType(keySystem), cdmData);
             } catch (error) {
@@ -190,6 +197,32 @@ function ProtectionController(config) {
                 data: null,
                 error: new DashJSError(ProtectionErrors.KEY_SESSION_CREATED_ERROR_CODE, ProtectionErrors.KEY_SESSION_CREATED_ERROR_MESSAGE + 'Selected key system is ' + (keySystem ? keySystem.systemString : null) + '.  needkey/encrypted event contains no initData corresponding to that key system!')
             });
+        }
+    }
+
+    /**
+     * Checks if the provided init data is equal to one of the existing init data values
+     * @param {any} initDataForKS
+     * @return {boolean}
+     * @private
+     */
+    function _isInitDataDuplicate(initDataForKS) {
+        try {
+
+            if (!initDataForKS) {
+                return false;
+            }
+
+            const currentInitData = protectionModel.getAllInitData();
+            for (let i = 0; i < currentInitData.length; i++) {
+                if (protectionKeyController.initDataEquals(initDataForKS, currentInitData[i])) {
+                    return true;
+                }
+            }
+
+            return false;
+        } catch (e) {
+            return false;
         }
     }
 
@@ -350,7 +383,7 @@ function ProtectionController(config) {
 
         setMediaElement(null);
 
-        keySystem = undefined;//TODO-Refactor look at why undefined is needed for this. refactor
+        keySystem = undefined;
 
         if (protectionModel) {
             protectionModel.reset();
@@ -410,8 +443,6 @@ function ProtectionController(config) {
     }
 
     function selectKeySystem(supportedKS, fromManifest) {
-        const self = this;
-        const requestedKeySystems = [];
 
         // Reorder key systems according to priority order provided in protectionData
         supportedKS = supportedKS.sort((ksA, ksB) => {
@@ -420,135 +451,170 @@ function ProtectionController(config) {
             return indexA - indexB;
         });
 
+
+        // First time, so we need to select a key system
+        if (keySystem === undefined) {
+            _selectInitialKeySystem(supportedKS, fromManifest);
+        }
+
+        // We already selected a key system. we only need to trigger a new license exchange if the init data has changed
+        else if (keySystem) {
+            _selectWithExistingKeySystem(supportedKS, fromManifest);
+        }
+
+        // We are in the process of selecting a key system, so just save the data which might be coming from additional AdaptationSets.
+        else {
+            pendingNeedKeyData.push(supportedKS);
+        }
+    }
+
+    function _selectWithExistingKeySystem(supportedKS, fromManifest) {
+        const self = this;
+        const requestedKeySystems = [];
+
+        const ksIdx = supportedKS.findIndex((entry) => {
+            return entry.ks === keySystem;
+        });
+
+        if (ksIdx !== -1) {
+            //  we only need to call this if the init data has changed
+            if (supportedKS[ksIdx].initData) {
+                const initDataForKs = CommonEncryption.getPSSHForKeySystem(keySystem, supportedKS[ksIdx].initData);
+                if (_isInitDataDuplicate(initDataForKs)) {
+                    logger.info('DRM: Ignoring initData because we have already seen it!');
+                    return;
+                }
+            }
+
+            requestedKeySystems.push({
+                ks: supportedKS[ksIdx].ks,
+                configs: [getKeySystemConfiguration(keySystem)]
+            });
+
+            // Ensure that we would be granted key system access using the key
+            // system and codec information
+            const onKeySystemAccessComplete = function (event) {
+                eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
+                if (event.error) {
+                    if (!fromManifest) {
+                        eventBus.trigger(events.KEY_SYSTEM_SELECTED, { error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + event.error) });
+                    }
+                } else {
+                    logger.info('DRM: KeySystem Access Granted');
+                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, { data: event.data });
+                    const protData = getProtData(keySystem);
+                    if (protectionKeyController.isClearKey(keySystem)) {
+                        // For Clearkey: if parameters for generating init data was provided by the user, use them for generating
+                        // initData and overwrite possible initData indicated in encrypted event (EME)
+                        if (protData && protData.hasOwnProperty('clearkeys')) {
+                            const initData = { kids: Object.keys(protData.clearkeys) };
+                            supportedKS[ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
+                        }
+                    }
+                    if (supportedKS[ksIdx].sessionId) {
+                        // Load MediaKeySession with sessionId
+                        loadKeySession(supportedKS[ksIdx].sessionId, supportedKS[ksIdx].initData);
+                    } else if (supportedKS[ksIdx].initData) {
+                        // Create new MediaKeySession with initData
+                        createKeySession(supportedKS[ksIdx].initData, supportedKS[ksIdx].cdmData);
+                    }
+                }
+            };
+
+            eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
+            protectionModel.requestKeySystemAccess(requestedKeySystems);
+        }
+
+
+    }
+
+    function _selectInitialKeySystem(supportedKS, fromManifest) {
+        const self = this;
+        const requestedKeySystems = [];
         let ksIdx;
-        if (keySystem) {
-            // We have a key system
-            for (ksIdx = 0; ksIdx < supportedKS.length; ksIdx++) {
-                if (keySystem === supportedKS[ksIdx].ks) {
 
-                    requestedKeySystems.push({
-                        ks: supportedKS[ksIdx].ks,
-                        configs: [getKeySystemConfiguration(keySystem)]
+        // First time through, so we need to select a key system
+        keySystem = null;
+        pendingNeedKeyData.push(supportedKS);
+
+        // Add all key systems to our request list since we have yet to select a key system
+        for (let i = 0; i < supportedKS.length; i++) {
+            requestedKeySystems.push({
+                ks: supportedKS[i].ks,
+                configs: [getKeySystemConfiguration(supportedKS[i].ks)]
+            });
+        }
+
+        let keySystemAccess;
+        const onKeySystemAccessComplete = function (event) {
+            eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
+            if (event.error) {
+                keySystem = undefined;
+                eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
+                if (!fromManifest) {
+                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, {
+                        data: null,
+                        error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + event.error)
                     });
+                }
+            } else {
+                keySystemAccess = event.data;
+                logger.info('DRM: KeySystem Access Granted (' + keySystemAccess.keySystem.systemString + ')!  Selecting key system...');
+                protectionModel.selectKeySystem(keySystemAccess);
+            }
+        };
+        var onKeySystemSelected = function (event) {
+            eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
+            eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
+            if (!event.error) {
+                if (!protectionModel) {
+                    return;
+                }
+                keySystem = protectionModel.getKeySystem();
+                eventBus.trigger(events.KEY_SYSTEM_SELECTED, { data: keySystemAccess });
+                // Set server certificate from protData
+                const protData = getProtData(keySystem);
+                if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
+                    protectionModel.setServerCertificate(BASE64.decodeArray(protData.serverCertificate).buffer);
+                }
 
-                    // Ensure that we would be granted key system access using the key
-                    // system and codec information
-                    const onKeySystemAccessComplete = function (event) {
-                        eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
-                        if (event.error) {
-                            if (!fromManifest) {
-                                eventBus.trigger(events.KEY_SYSTEM_SELECTED, { error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + event.error) });
-                            }
-                        } else {
-                            logger.info('DRM: KeySystem Access Granted');
-                            eventBus.trigger(events.KEY_SYSTEM_SELECTED, { data: event.data });
-                            const protData = getProtData(keySystem);
+                // Create key session for the remaining AdaptationSets which have been added to pendingNeedKeyData
+                for (let i = 0; i < pendingNeedKeyData.length; i++) {
+                    for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
+                        if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {
                             if (protectionKeyController.isClearKey(keySystem)) {
                                 // For Clearkey: if parameters for generating init data was provided by the user, use them for generating
                                 // initData and overwrite possible initData indicated in encrypted event (EME)
                                 if (protData && protData.hasOwnProperty('clearkeys')) {
-                                    const initData = {kids: Object.keys(protData.clearkeys)};
-                                    supportedKS[ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
+                                    const initData = { kids: Object.keys(protData.clearkeys) };
+                                    pendingNeedKeyData[i][ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
                                 }
                             }
-                            if (supportedKS[ksIdx].sessionId) {
+                            if (pendingNeedKeyData[i][ksIdx].sessionId) {
                                 // Load MediaKeySession with sessionId
-                                loadKeySession(supportedKS[ksIdx].sessionId, supportedKS[ksIdx].initData);
-                            } else if (supportedKS[ksIdx].initData) {
+                                loadKeySession(pendingNeedKeyData[i][ksIdx].sessionId, pendingNeedKeyData[i][ksIdx].initData);
+                            } else if (pendingNeedKeyData[i][ksIdx].initData !== null) {
                                 // Create new MediaKeySession with initData
-                                createKeySession(supportedKS[ksIdx].initData, supportedKS[ksIdx].cdmData);
+                                createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
                             }
-                        }
-                    };
-                    eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
-                    protectionModel.requestKeySystemAccess(requestedKeySystems);
-                    break;
-                }
-            }
-        } else if (keySystem === undefined) {
-            // First time through, so we need to select a key system
-            keySystem = null;
-            pendingNeedKeyData.push(supportedKS);
-
-            // Add all key systems to our request list since we have yet to select a key system
-            for (let i = 0; i < supportedKS.length; i++) {
-                requestedKeySystems.push({
-                    ks: supportedKS[i].ks,
-                    configs: [getKeySystemConfiguration(supportedKS[i].ks)]
-                });
-            }
-
-            let keySystemAccess;
-            const onKeySystemAccessComplete = function (event) {
-                eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
-                if (event.error) {
-                    keySystem = undefined;
-                    eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
-                    if (!fromManifest) {
-                        eventBus.trigger(events.KEY_SYSTEM_SELECTED, {
-                            data: null,
-                            error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + event.error)
-                        });
-                    }
-                } else {
-                    keySystemAccess = event.data;
-                    logger.info('DRM: KeySystem Access Granted (' + keySystemAccess.keySystem.systemString + ')!  Selecting key system...');
-                    protectionModel.selectKeySystem(keySystemAccess);
-                }
-            };
-            var onKeySystemSelected = function (event) {
-                eventBus.off(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
-                eventBus.off(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
-                if (!event.error) {
-                    if (!protectionModel) {
-                        return;
-                    }
-                    keySystem = protectionModel.getKeySystem();
-                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, { data: keySystemAccess });
-                    // Set server certificate from protData
-                    const protData = getProtData(keySystem);
-                    if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
-                        protectionModel.setServerCertificate(BASE64.decodeArray(protData.serverCertificate).buffer);
-                    }
-                    for (let i = 0; i < pendingNeedKeyData.length; i++) {
-                        for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
-                            if (keySystem === pendingNeedKeyData[i][ksIdx].ks) {
-                                if (protectionKeyController.isClearKey(keySystem)) {
-                                    // For Clearkey: if parameters for generating init data was provided by the user, use them for generating
-                                    // initData and overwrite possible initData indicated in encrypted event (EME)
-                                    if (protData && protData.hasOwnProperty('clearkeys')) {
-                                        const initData = {kids: Object.keys(protData.clearkeys)};
-                                        pendingNeedKeyData[i][ksIdx].initData = new TextEncoder().encode(JSON.stringify(initData));
-                                    }
-                                }
-                                if (pendingNeedKeyData[i][ksIdx].sessionId) {
-                                    // Load MediaKeySession with sessionId
-                                    loadKeySession(pendingNeedKeyData[i][ksIdx].sessionId, pendingNeedKeyData[i][ksIdx].initData);
-                                } else if (pendingNeedKeyData[i][ksIdx].initData !== null) {
-                                    // Create new MediaKeySession with initData
-                                    createKeySession(pendingNeedKeyData[i][ksIdx].initData, pendingNeedKeyData[i][ksIdx].cdmData);
-                                }
-                                break;
-                            }
+                            break;
                         }
                     }
-                } else {
-                    keySystem = undefined;
-                    if (!fromManifest) {
-                        eventBus.trigger(events.KEY_SYSTEM_SELECTED, {
-                            data: null,
-                            error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + 'Error selecting key system! -- ' + event.error)
-                        });
-                    }
                 }
-            };
-            eventBus.on(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
-            eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
-            protectionModel.requestKeySystemAccess(requestedKeySystems);
-        } else {
-            // We are in the process of selecting a key system, so just save the data
-            pendingNeedKeyData.push(supportedKS);
-        }
+            } else {
+                keySystem = undefined;
+                if (!fromManifest) {
+                    eventBus.trigger(events.KEY_SYSTEM_SELECTED, {
+                        data: null,
+                        error: new DashJSError(ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_CODE, ProtectionErrors.KEY_SYSTEM_ACCESS_DENIED_ERROR_MESSAGE + 'Error selecting key system! -- ' + event.error)
+                    });
+                }
+            }
+        };
+
+        eventBus.on(events.INTERNAL_KEY_SYSTEM_SELECTED, onKeySystemSelected, self);
+        eventBus.on(events.KEY_SYSTEM_ACCESS_COMPLETE, onKeySystemAccessComplete, self);
+        protectionModel.requestKeySystemAccess(requestedKeySystems);
     }
 
     function sendLicenseRequestCompleteEvent(data, error) {
@@ -575,7 +641,7 @@ function ProtectionController(config) {
         const protData = getProtData(keySystem);
         const keySystemString = keySystem ? keySystem.systemString : null;
         const licenseServerData = protectionKeyController.getLicenseServer(keySystem, protData, messageType);
-        const eventData = {sessionToken: sessionToken, messageType: messageType};
+        const eventData = { sessionToken: sessionToken, messageType: messageType };
 
         // Ensure message from CDM is not empty
         if (!message || message.byteLength === 0) {
@@ -827,6 +893,7 @@ function ProtectionController(config) {
 
     instance = {
         initializeForMedia: initializeForMedia,
+        clearMediaInfoArrayByStreamId,
         createKeySession: createKeySession,
         loadKeySession: loadKeySession,
         removeKeySession: removeKeySession,

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -476,15 +476,15 @@ function ProtectionController(config) {
             return entry.ks === keySystem;
         });
 
-        if (ksIdx !== -1) {
+        if (ksIdx !== -1 && supportedKS[ksIdx].initData) {
+
             //  we only need to call this if the init data has changed
-            if (supportedKS[ksIdx].initData) {
-                const initDataForKs = CommonEncryption.getPSSHForKeySystem(keySystem, supportedKS[ksIdx].initData);
-                if (_isInitDataDuplicate(initDataForKs)) {
-                    logger.info('DRM: Ignoring initData because we have already seen it!');
-                    return;
-                }
+            const initDataForKs = CommonEncryption.getPSSHForKeySystem(keySystem, supportedKS[ksIdx].initData);
+            if (_isInitDataDuplicate(initDataForKs)) {
+                logger.info('DRM: Ignoring initData because we have already seen it!');
+                return;
             }
+
 
             requestedKeySystems.push({
                 ks: supportedKS[ksIdx].ks,


### PR DESCRIPTION
This PR aims to fix #3490 

- Move logic for initial key system selection (no keysystem selected yet) and handling of key system selection after MPD updates (keysystem has already been selected) to separate functions: `_selectInitialKeySystem` and `_selectWithExistingKeySystem`
- Reduce `mediaInfoArr` to the latest mediaInfos for a specific stream id
- `_selectWithExistingKeySystem` is only applied when init data has changed to avoid unnecessary calls to `requestMediaKeySystemAccess`