### PR TITLE
Feature capabilities filter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -133,6 +133,7 @@ declare namespace dashjs {
             useAppendWindow?: boolean,
             manifestUpdateRetryInterval?: number;
             stallThreshold?: number;
+            filterUnsupportedEssentialProperties?: true
             liveCatchup?: {
                 minDrift?: number;
                 maxDrift?: number;

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -298,6 +298,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * downloading the next manifest once the minimumUpdatePeriod time has
  * @property {number} [stallThreshold=0.5]
  * Stall threshold used in BufferController.js to determine whether a track should still be changed and which buffer range to prune.
+ * @property {boolean} [filterUnsupportedEssentialProperties=true]
+ * Enable to filter all the AdaptationSets and Representations which contain an unsupported <EssentialProperty> element
  * @property {module:Settings~CachingInfoSettings} [lastBitrateCachingInfo={enabled: true, ttl: 360000}]
  * Set to false if you would like to disable the last known bit rate from being stored during playback and used
  * to set the initial bit rate for subsequent playback within the expiration window.
@@ -447,6 +449,7 @@ function Settings() {
             useAppendWindow: true,
             manifestUpdateRetryInterval: 100,
             stallThreshold: 0.5,
+            filterUnsupportedEssentialProperties: true,
             liveCatchup: {
                 minDrift: 0.02,
                 maxDrift: 0,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -378,6 +378,10 @@ function DashAdapter() {
         return realAdaptation;
     }
 
+    function getRealPeriodByIndex(index) {
+        return dashManifestModel.getRealPeriodForIndex(index, voPeriods[0].mpd.manifest);
+    }
+
     /**
      * Returns all voRepresentations for a given mediaInfo
      * @param {object} mediaInfo
@@ -725,6 +729,10 @@ function DashAdapter() {
         return null;
     }
 
+    function getIsTypeOf(adaptation, type) {
+        return dashManifestModel.getIsTypeOf(adaptation, type);
+    }
+
     function reset() {
         voPeriods = [];
         voAdaptations = {};
@@ -940,6 +948,7 @@ function DashAdapter() {
         getAllMediaInfoForType: getAllMediaInfoForType,
         getAdaptationForType: getAdaptationForType,
         getRealAdaptation: getRealAdaptation,
+        getRealPeriodByIndex,
         getVoRepresentations: getVoRepresentations,
         getEventsFor: getEventsFor,
         getEvent: getEvent,
@@ -950,6 +959,7 @@ function DashAdapter() {
         getUTCTimingSources: getUTCTimingSources,
         getSuggestedPresentationDelay: getSuggestedPresentationDelay,
         getAvailabilityStartTime: getAvailabilityStartTime,
+        getIsTypeOf,
         getIsDynamic: getIsDynamic,
         getDuration: getDuration,
         getRegularPeriods: getRegularPeriods,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -378,6 +378,24 @@ function DashAdapter() {
         return realAdaptation;
     }
 
+    /**
+     * Return all EssentialProperties of a Representation
+     * @param {object} representation
+     * @return {array}
+     */
+    function getEssentialPropertiesForRepresentation(representation) {
+        try {
+            return dashManifestModel.getEssentialPropertiesForRepresentation(representation);
+        } catch (e) {
+            return [];
+        }
+    }
+
+    /**
+     * Returns the period by index
+     * @param {number} index
+     * @return {object}
+     */
     function getRealPeriodByIndex(index) {
         return dashManifestModel.getRealPeriodForIndex(index, voPeriods[0].mpd.manifest);
     }
@@ -949,6 +967,7 @@ function DashAdapter() {
         getAdaptationForType: getAdaptationForType,
         getRealAdaptation: getRealAdaptation,
         getRealPeriodByIndex,
+        getEssentialPropertiesForRepresentation,
         getVoRepresentations: getVoRepresentations,
         getEventsFor: getEventsFor,
         getEvent: getEvent,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -208,6 +208,19 @@ function DashManifestModel() {
         return manifest && manifest.Period_asArray && isInteger(periodIndex) ? manifest.Period_asArray[periodIndex] ? manifest.Period_asArray[periodIndex].AdaptationSet_asArray : [] : [];
     }
 
+    function getRealPeriods(manifest) {
+        return manifest && manifest.Period_asArray ? manifest.Period_asArray : [];
+    }
+
+    function getRealPeriodForIndex(index, manifest) {
+        const realPeriods = getRealPeriods(manifest);
+        if (realPeriods.length > 0 && isInteger(index)) {
+            return realPeriods[index];
+        } else {
+            return null;
+        }
+    }
+
     function getAdaptationForId(id, manifest, periodIndex) {
         const realAdaptations = getRealAdaptations(manifest, periodIndex);
         let i,
@@ -1114,6 +1127,8 @@ function DashManifestModel() {
         getIndexForAdaptation: getIndexForAdaptation,
         getAdaptationForId: getAdaptationForId,
         getAdaptationsForType: getAdaptationsForType,
+        getRealPeriods,
+        getRealPeriodForIndex,
         getCodec: getCodec,
         getMimeType: getMimeType,
         getKID: getKID,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -1147,6 +1147,7 @@ function DashManifestModel() {
         getRegularPeriods: getRegularPeriods,
         getMpd: getMpd,
         getEventsForPeriod: getEventsForPeriod,
+        getEssentialPropertiesForRepresentation,
         getEventStreamForAdaptationSet: getEventStreamForAdaptationSet,
         getEventStreamForRepresentation: getEventStreamForRepresentation,
         getUTCTimingSources: getUTCTimingSources,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -40,6 +40,7 @@ import BaseURLController from './controllers/BaseURLController';
 import ManifestLoader from './ManifestLoader';
 import ErrorHandler from './utils/ErrorHandler';
 import Capabilities from './utils/Capabilities';
+import CapabilitiesFilter from './utils/CapabilitiesFilter';
 import TextTracks from './text/TextTracks';
 import RequestModifier from './utils/RequestModifier';
 import TextController from './text/TextController';
@@ -61,7 +62,7 @@ import Settings from '../core/Settings';
 import {
     getVersionString
 }
-from './../core/Version';
+    from './../core/Version';
 
 //Dash
 import SegmentBaseController from '../dash/controllers/SegmentBaseController';
@@ -74,7 +75,7 @@ import {
 import BASE64 from '../../externals/base64';
 import ISOBoxer from 'codem-isoboxer';
 import DashJSError from './vo/DashJSError';
-import { checkParameterType } from './utils/SupervisorTools';
+import {checkParameterType} from './utils/SupervisorTools';
 import ManifestUpdater from './ManifestUpdater';
 import URLUtils from '../streaming/utils/URLUtils';
 import BoxParser from './utils/BoxParser';
@@ -84,6 +85,7 @@ import BoxParser from './utils/BoxParser';
  * The media types
  * @typedef {("video" | "audio" | "text" | "fragmentedText" | "embeddedText" | "image")} MediaType
  */
+
 /* jscs:enable */
 
 /**
@@ -94,35 +96,35 @@ import BoxParser from './utils/BoxParser';
  */
 function MediaPlayer() {
     /**
-    * @constant {string} STREAMING_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized
-    * @inner
-    */
+     * @constant {string} STREAMING_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized
+     * @inner
+     */
     const STREAMING_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a source before calling this method';
     /**
-    * @constant {string} PLAYBACK_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized
-    * @inner
-    */
+     * @constant {string} PLAYBACK_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized
+     * @inner
+     */
     const PLAYBACK_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a valid source and view before calling this method';
     /**
-    * @constant {string} ELEMENT_NOT_ATTACHED_ERROR error string thrown when a function is called before the dash.js has received a reference of an HTML5 video element
-    * @inner
-    */
+     * @constant {string} ELEMENT_NOT_ATTACHED_ERROR error string thrown when a function is called before the dash.js has received a reference of an HTML5 video element
+     * @inner
+     */
     const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
     /**
-    * @constant {string} SOURCE_NOT_ATTACHED_ERROR error string thrown when a function is called before the dash.js has received a valid source stream.
-    * @inner
-    */
+     * @constant {string} SOURCE_NOT_ATTACHED_ERROR error string thrown when a function is called before the dash.js has received a valid source stream.
+     * @inner
+     */
     const SOURCE_NOT_ATTACHED_ERROR = 'You must first call attachSource() with a valid source before calling this method';
     /**
-    * @constant {string} MEDIA_PLAYER_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized.
-    * @inner
-    */
+     * @constant {string} MEDIA_PLAYER_NOT_INITIALIZED_ERROR error string thrown when a function is called before the dash.js has been fully initialized.
+     * @inner
+     */
     const MEDIA_PLAYER_NOT_INITIALIZED_ERROR = 'MediaPlayer not initialized!';
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
     let settings = Settings(context).getInstance();
-    const debug = Debug(context).getInstance({settings: settings});
+    const debug = Debug(context).getInstance({ settings: settings });
 
     let instance,
         logger,
@@ -145,6 +147,7 @@ function MediaPlayer() {
         errHandler,
         baseURLController,
         capabilities,
+        capabilitiesFilter,
         streamController,
         gapController,
         playbackController,
@@ -195,6 +198,9 @@ function MediaPlayer() {
         if (config.capabilities) {
             capabilities = config.capabilities;
         }
+        if (config.capabilitiesFilter) {
+            capabilitiesFilter = config.capabilitiesFilter;
+        }
         if (config.streamController) {
             streamController = config.streamController;
         }
@@ -242,6 +248,7 @@ function MediaPlayer() {
         if (!capabilities) {
             capabilities = Capabilities(context).getInstance();
         }
+
         errHandler = ErrorHandler(context).getInstance();
 
         if (!capabilities.supportsMediaSource()) {
@@ -279,6 +286,10 @@ function MediaPlayer() {
 
         if (!gapController) {
             gapController = GapController(context).getInstance();
+        }
+
+        if (!capabilitiesFilter) {
+            capabilitiesFilter = CapabilitiesFilter(context).getInstance();
         }
 
         adapter = DashAdapter(context).getInstance();
@@ -1959,8 +1970,14 @@ function MediaPlayer() {
             streamController = StreamController(context).getInstance();
         }
 
+        capabilitiesFilter.setConfig({
+            capabilities,
+            adapter
+        });
+
         streamController.setConfig({
             capabilities: capabilities,
+            capabilitiesFilter,
             manifestLoader: manifestLoader,
             manifestModel: manifestModel,
             mediaPlayerModel: mediaPlayerModel,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1972,7 +1972,8 @@ function MediaPlayer() {
 
         capabilitiesFilter.setConfig({
             capabilities,
-            adapter
+            adapter,
+            settings
         });
 
         streamController.setConfig({

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -87,17 +87,6 @@ function Stream(config) {
         isEndedEventSignaled,
         trackChangedEvent;
 
-    const codecCompatibilityTable = [
-        {
-            'codec': 'avc1',
-            'compatibleCodecs': ['avc3']
-        },
-        {
-            'codec': 'avc3',
-            'compatibleCodecs': ['avc1']
-        }
-    ];
-
     function setup() {
         debug = Debug(context).getInstance();
         logger = debug.getLogger(instance);
@@ -845,25 +834,8 @@ function Stream(config) {
             return oldCodecs.indexOf(newCodec) > -1;
         });
 
-        const partialCodecMatch = newCodecs.some((newCodec) => oldCodecs.some((oldCodec) => codecRootCompatibleWithCodec(oldCodec, newCodec)));
+        const partialCodecMatch = newCodecs.some((newCodec) => oldCodecs.some((oldCodec) => capabilities.codecRootCompatibleWithCodec(oldCodec, newCodec)));
         return codecMatch || (partialCodecMatch && sameMimeType);
-    }
-
-    // Check if the root of the old codec is the same as the new one, or if it's declared as compatible in the compat table
-    function codecRootCompatibleWithCodec(codec1, codec2) {
-        const codecRoot = codec1.split('.')[0];
-        const rootCompatible = codec2.indexOf(codecRoot) === 0;
-        let compatTableCodec;
-        for (let i = 0; i < codecCompatibilityTable.length; i++) {
-            if (codecCompatibilityTable[i].codec === codecRoot) {
-                compatTableCodec = codecCompatibilityTable[i];
-                break;
-            }
-        }
-        if (compatTableCodec) {
-            return rootCompatible || compatTableCodec.compatibleCodecs.some((compatibleCodec) => codec2.indexOf(compatibleCodec) === 0);
-        }
-        return rootCompatible;
     }
 
     function setPreloaded(value) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -60,6 +60,7 @@ function StreamController() {
     let instance,
         logger,
         capabilities,
+        capabilitiesFilter,
         manifestUpdater,
         manifestLoader,
         manifestModel,
@@ -619,7 +620,7 @@ function StreamController() {
             if (!isNaN(seekTime)) {
                 // If the streamswitch has been triggered by a seek command there is no need to seek again. Still we need to trigger the seeking event in order for the controllers to adjust the new time
                 if (seekTime === playbackController.getTime()) {
-                    eventBus.trigger(Events.SEEK_TARGET, {time: seekTime}, {streamId: activeStream.getId()});
+                    eventBus.trigger(Events.SEEK_TARGET, { time: seekTime }, { streamId: activeStream.getId() });
                 } else {
                     playbackController.seek(seekTime);
                 }
@@ -699,6 +700,7 @@ function StreamController() {
                         adapter: adapter,
                         timelineConverter: timelineConverter,
                         capabilities: capabilities,
+                        capabilitiesFilter,
                         errHandler: errHandler,
                         baseURLController: baseURLController,
                         abrController: abrController,
@@ -990,6 +992,9 @@ function StreamController() {
 
         if (config.capabilities) {
             capabilities = config.capabilities;
+        }
+        if (config.capabilitiesFilter) {
+            capabilitiesFilter = config.capabilitiesFilter;
         }
         if (config.manifestLoader) {
             manifestLoader = config.manifestLoader;

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../../core/FactoryMaker';
+import {THUMBNAILS_SCHEME_ID_URIS} from '../../streaming/thumbnail/ThumbnailTracks';
 
 export function supportsMediaSource() {
     let hasWebKit = ('WebKitMediaSource' in window);
@@ -72,16 +73,26 @@ function Capabilities() {
         return false;
     }
 
+    function supportsEssentialProperty(ep) {
+        try {
+            return THUMBNAILS_SCHEME_ID_URIS.indexOf(ep.schemeIdUri);
+        } catch (e) {
+            return true;
+        }
+    }
+
     instance = {
-        supportsMediaSource: supportsMediaSource,
-        supportsEncryptedMedia: supportsEncryptedMedia,
-        supportsCodec: supportsCodec,
-        setEncryptedMediaSupported: setEncryptedMediaSupported
+        supportsMediaSource,
+        supportsEncryptedMedia,
+        supportsCodec,
+        setEncryptedMediaSupported,
+        supportsEssentialProperty
     };
 
     setup();
 
     return instance;
 }
+
 Capabilities.__dashjs_factory_name = 'Capabilities';
 export default FactoryMaker.getSingletonFactory(Capabilities);

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -75,7 +75,7 @@ function Capabilities() {
 
     function supportsEssentialProperty(ep) {
         try {
-            return THUMBNAILS_SCHEME_ID_URIS.indexOf(ep.schemeIdUri);
+            return THUMBNAILS_SCHEME_ID_URIS.indexOf(ep.schemeIdUri) !== -1;
         } catch (e) {
             return true;
         }

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -88,12 +88,14 @@ function CapabilitiesFilter() {
                 const essentialProperties = adapter.getEssentialPropertiesForRepresentation(rep);
 
                 if (essentialProperties && essentialProperties.length > 0) {
-                    essentialProperties.forEach((ep) => {
-                        if (!capabilities.supportsEssentialProperty(ep)) {
-                            logger.debug('[Stream] EssentialProperty not supported: ' + ep.schemeIdUri);
+                    let i = 0;
+                    while (i < essentialProperties.length) {
+                        if (!capabilities.supportsEssentialProperty(essentialProperties[i])) {
+                            logger.debug('[Stream] EssentialProperty not supported: ' + essentialProperties[i].schemeIdUri);
                             return false;
                         }
-                    });
+                        i += 1;
+                    }
                 }
 
                 return true;

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -1,0 +1,81 @@
+import FactoryMaker from '../../core/FactoryMaker';
+import Debug from '../../core/Debug';
+import Constants from '../constants/Constants';
+
+function CapabilitiesFilter() {
+    const context = this.context;
+    let instance,
+        adapter,
+        capabilities,
+        logger;
+
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+    }
+
+    function setConfig(config) {
+        if (!config) {
+            return;
+        }
+
+        if (config.adapter) {
+            adapter = config.adapter;
+        }
+
+        if (config.capabilities) {
+            capabilities = config.capabilities;
+        }
+
+    }
+
+    function filterUnsupportedFeaturesOfPeriod(streamInfo) {
+        _filterUnsupportedCodecs(Constants.VIDEO, streamInfo);
+        _filterUnsupportedCodecs(Constants.AUDIO, streamInfo);
+        _filterUnsupportedEssentialProperties(streamInfo);
+    }
+
+
+    function _filterUnsupportedCodecs(type, streamInfo) {
+        const realPeriod = adapter.getRealPeriodByIndex(streamInfo ? streamInfo.index : null, type);
+
+        if (!realPeriod || !realPeriod.AdaptationSet_asArray || realPeriod.AdaptationSet_asArray.length === 0) {
+            return;
+        }
+
+        realPeriod.AdaptationSet_asArray = realPeriod.AdaptationSet_asArray.filter((as) => {
+
+            if (!as.Representation_asArray || as.Representation_asArray.length === 0 || !adapter.getIsTypeOf(as, type)) {
+                return true;
+            }
+
+            as.Representation_asArray = as.Representation_asArray.filter((_, i) => {
+                const codec = adapter.getCodec(as, i, true);
+                if (!capabilities.supportsCodec(codec)) {
+                    logger.error('[Stream] codec not supported: ' + codec);
+                    return false;
+                }
+                return true;
+            });
+
+            return as.Representation_asArray && as.Representation_asArray.length > 0;
+        });
+
+    }
+
+    function _filterUnsupportedEssentialProperties() {
+
+    }
+
+    instance = {
+        setConfig,
+        filterUnsupportedFeaturesOfPeriod
+    };
+
+    setup();
+
+    return instance;
+}
+
+CapabilitiesFilter.__dashjs_factory_name = 'CapabilitiesFilter';
+export default FactoryMaker.getSingletonFactory(CapabilitiesFilter);

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -109,6 +109,43 @@ function AdapterMock () {
     this.convertDataToRepresentationInfo = function () {
         return null;
     };
+
+    this.getIsTypeOf = function () {
+        return true;
+    };
+
+    this.getCodec = function (adaptation, representationId, addResolutionInfo) {
+        let codec = null;
+
+        if (adaptation && adaptation.Representation_asArray && adaptation.Representation_asArray.length > 0) {
+            const representation = adaptation.Representation_asArray[representationId];
+            if (representation) {
+                codec = representation.mimeType + ';codecs="' + representation.codecs + '"';
+                if (addResolutionInfo && representation.width !== undefined && representation.height !== undefined) {
+                    codec += ';width="' + representation.width + '";height="' + representation.height + '"';
+                }
+            }
+        }
+
+        // If the codec contains a profiles parameter we remove it. Otherwise it will cause problems when checking for codec capabilities of the platform
+        if (codec) {
+            codec = codec.replace(/\sprofiles=[^;]*/g, '');
+        }
+
+        return codec;
+    };
+
+    this.getEssentialPropertiesForRepresentation = function (realRepresentation) {
+        if (!realRepresentation || !realRepresentation.EssentialProperty_asArray || !realRepresentation.EssentialProperty_asArray.length) return null;
+
+        return realRepresentation.EssentialProperty_asArray.map((prop) => {
+            return {
+                schemeIdUri: prop.schemeIdUri,
+                value: prop.value
+            };
+        });
+    };
+
 }
 
 export default AdapterMock;

--- a/test/unit/mocks/CapabilitiesFilterMock.js
+++ b/test/unit/mocks/CapabilitiesFilterMock.js
@@ -1,0 +1,8 @@
+class CapabilitiesFilterMock {
+
+    filterUnsupportedFeaturesOfPeriod() {
+
+    }
+}
+
+export default CapabilitiesFilterMock;

--- a/test/unit/streaming.Stream.js
+++ b/test/unit/streaming.Stream.js
@@ -16,6 +16,7 @@ import StreamMock from './mocks/StreamMock';
 import ManifestUpdaterMock from './mocks/ManifestUpdaterMock';
 import PlaybackControllerMock from './mocks/PlaybackControllerMock';
 import CapabilitiesMock from './mocks/CapabilitiesMock';
+import CapabilitiesFilterMock from './mocks/CapabilitiesFilterMock';
 import MediaControllerMock from './mocks/MediaControllerMock';
 import DashMetricsMock from './mocks/DashMetricsMock';
 import TextControllerMock from './mocks/TextControllerMock';
@@ -41,6 +42,7 @@ describe('Stream', function () {
     const manifestUpdaterMock = new ManifestUpdaterMock();
     const playbackControllerMock = new PlaybackControllerMock();
     const capabilitiesMock = new CapabilitiesMock();
+    const capabilitiesFilterMock = new CapabilitiesFilterMock();
     const mediaControllerMock = new MediaControllerMock();
     const dashMetricsMock = new DashMetricsMock();
     const textControllerMock = new TextControllerMock();
@@ -66,6 +68,7 @@ describe('Stream', function () {
                 manifestUpdater: manifestUpdaterMock,
                 playbackController: playbackControllerMock,
                 capabilities: capabilitiesMock,
+                capabilitiesFilter: capabilitiesFilterMock,
                 mediaController: mediaControllerMock,
                 timelineConverter: timelineConverter,
                 dashMetrics: dashMetricsMock,

--- a/test/unit/streaming.utils.CapabilitiesFilter.js
+++ b/test/unit/streaming.utils.CapabilitiesFilter.js
@@ -1,0 +1,304 @@
+import CapabilitiesFilter from '../../src/streaming/utils/CapabilitiesFilter';
+import AdapterMock from './mocks/AdapterMock';
+import CapabilitiesMock from './mocks/CapabilitiesMock';
+import Settings from '../../src/core/Settings';
+
+const expect = require('chai').expect;
+
+let adapterMock;
+let capabilitiesFilter;
+let settings;
+let capabilitiesMock;
+
+describe('CapabilitiesFilter', function () {
+
+
+    beforeEach(function () {
+        adapterMock = new AdapterMock();
+        settings = Settings({}).getInstance();
+        capabilitiesMock = new CapabilitiesMock();
+        capabilitiesFilter = CapabilitiesFilter({}).getInstance();
+        capabilitiesFilter.setConfig({
+            adapter: adapterMock,
+            capabilities: capabilitiesMock,
+            settings: settings
+        });
+    });
+
+    describe('filterUnsupportedFeaturesOfPeriod', function () {
+
+        describe('filter codecs', function () {
+
+            beforeEach(function () {
+                settings.update({ streaming: { filterUnsupportedEssentialProperties: false } });
+            });
+
+            it('should not filter AdaptationSets and Representations', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(1);
+                expect(periodAsArray.AdaptationSet_asArray[0].Representation_asArray).to.have.lengthOf(2);
+
+            });
+
+            it('should filter AdaptationSets', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsCodec', definition: function () {
+                        return false;
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(0);
+            });
+
+            it('should filter Representations', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.1',
+                                audioSamplingRate: '48000'
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsCodec', definition: function (codec) {
+                        return codec === 'audio/mp4;codecs="mp4a.40.2"';
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(1);
+                expect(periodAsArray.AdaptationSet_asArray[0].Representation_asArray).to.have.lengthOf(1);
+
+            });
+        });
+
+        describe('filter EssentialProperty values', function () {
+
+            beforeEach(function () {
+                settings.update({ streaming: { filterUnsupportedEssentialProperties: true } });
+            });
+
+            it('should not filter AdaptationSets and Representations if filterUnsupportedEssentialProperties is disabled', function () {
+                settings.update({ streaming: { filterUnsupportedEssentialProperties: false } });
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsEssentialProperty', definition: function () {
+                        return true;
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(1);
+                expect(periodAsArray.AdaptationSet_asArray[0].Representation_asArray).to.have.lengthOf(2);
+            });
+
+            it('should not filter AdaptationSets and Representations if EssentialProperties value is supported', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsEssentialProperty', definition: function () {
+                        return true;
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(1);
+                expect(periodAsArray.AdaptationSet_asArray[0].Representation_asArray).to.have.lengthOf(2);
+            });
+
+            it('should filter AdaptationSets if EssentialProperty value is not supported', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsEssentialProperty', definition: function () {
+                        return false;
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(0);
+            });
+
+            it('should filter a single Representation if EssentialProperty value is not supported', function () {
+                const periodAsArray = {
+                    AdaptationSet_asArray: [{
+                        mimeType: 'audio/mp4',
+                        Representation_asArray: [
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000',
+                                EssentialProperty_asArray: [{
+                                    schemeIdUri: 'http://dashif.org/thumbnail_tile',
+                                    value: 'somevalue'
+                                }]
+                            },
+                            {
+                                mimeType: 'audio/mp4',
+                                codecs: 'mp4a.40.2',
+                                audioSamplingRate: '48000'
+                            }
+                        ]
+                    }]
+                };
+                const streamInfo = { index: 0 };
+
+                prepareAdapterMock(periodAsArray);
+                prepareCapabilitiesMock({
+                    name: 'supportsEssentialProperty', definition: function () {
+                        return false;
+                    }
+                });
+                capabilitiesFilter.filterUnsupportedFeaturesOfPeriod(streamInfo);
+
+                expect(periodAsArray.AdaptationSet_asArray).to.have.lengthOf(1);
+                expect(periodAsArray.AdaptationSet_asArray[0].Representation_asArray).to.have.lengthOf(1);
+            });
+        });
+
+
+    });
+});
+
+function prepareAdapterMock(periodAsArray) {
+    adapterMock.getRealPeriodByIndex = function () {
+        return periodAsArray;
+    };
+}
+
+function prepareCapabilitiesMock(data) {
+    capabilitiesMock[data.name] = data.definition;
+}


### PR DESCRIPTION
This addresses issues #3510 and #3509

- Adds CapabilitiesFilter that filters Representations and Adaptations for each period(stream object)
  - Removes unsupported AS and Rep based on media codec
  - Removes unsupported AS and Rep based on EssentialProperty
- Can be disabled via Settings flag

The reason to add a new class here is to have a single point where all the necessary filtering is performed, prior to the initialization of the StreamProcessors. Additional filters might be added in the future