### PR TITLE
Updated text for PlayReady DRM

### DIFF
--- a/samples/samples.json
+++ b/samples/samples.json
@@ -126,7 +126,7 @@
             },
             {
                 "title": "PlayReady",
-                "description": "This example shows how to use dash.js to play streams with PlayReady DRM protection (Windows only).",
+                "description": "This example shows how to use dash.js to play streams with PlayReady DRM protection (Windows 10 Microsoft Chromium Edge only).",
                 "href": "drm/playready.html"
             },
             {


### PR DESCRIPTION
Doc updated for PlayReady DRM is supported only on Windows 10 on Microsoft Chromium Edge.