### PR TITLE
Fix the error of the arguments of the DashMetrics.addManifestUpdate when it is calling

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -112,7 +112,7 @@ function HTTPLoader(cfg) {
                     success ? traces : null);
 
                 if (request.type === HTTPRequest.MPD_TYPE) {
-                    dashMetrics.addManifestUpdate(request.type, request.requestStartDate, request.requestEndDate);
+                    dashMetrics.addManifestUpdate(request);
                 }
             }
         };


### PR DESCRIPTION
**Related commit**: [2b6d778](https://github.com/Dash-Industry-Forum/dash.js/commit/2b6d778f0366a192ab4a7e18bece67e0e926a569#diff-37a9697c7cc9fba419e4d7d616e9a631133b28dabef5ed236f9160b5d1b342a5R249)

This is my first pull request, I have signed up to [the dash.js feedback agreement](https://groups.google.com/g/dashjs/c/r6KWiL_VbKM).