### PR TITLE
Fixes for discharging preloaded content

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -313,7 +313,14 @@ function BufferController(config) {
             triggerEvent(Events.SEEK_TARGET, {time: currentTime});
         }
 
-        if (appendedBytesInfo && (!dischargeFragments || dischargeFragments.indexOf(appendedBytesInfo) < 0)) {
+        let suppressAppendedEvent = false;
+        if (dischargeFragments) {
+            if (dischargeFragments.indexOf(appendedBytesInfo) > 0) {
+                suppressAppendedEvent = true;
+            }
+            dischargeFragments = null;
+        }
+        if (appendedBytesInfo && !suppressAppendedEvent) {
             triggerEvent(appendedBytesInfo.endFragment ? Events.BYTES_APPENDED_END_FRAGMENT : Events.BYTES_APPENDED, {
                 quality: appendedBytesInfo.quality,
                 startTime: appendedBytesInfo.start,
@@ -321,8 +328,6 @@ function BufferController(config) {
                 bufferedRanges: ranges,
                 mediaType: type
             });
-        } else {
-            dischargeFragments = null;
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -185,16 +185,18 @@ function BufferController(config) {
             let lastInit = null;
             for (let j = 0; j < chunks.length; j++) {
                 const chunk = chunks[j];
-                const initChunk = initCache.extract(chunk.streamId, chunk.representationId);
-                if (initChunk) {
-                    if (lastInit !== initChunk) {
-                        dischargeFragments.push(initChunk);
-                        buffer.append(initChunk);
-                        lastInit = initChunk;
+                if (chunk.segmentType !== 'InitializationSegment') {
+                    const initChunk = initCache.extract(chunk.streamId, chunk.representationId);
+                    if (initChunk) {
+                        if (lastInit !== initChunk) {
+                            dischargeFragments.push(initChunk);
+                            buffer.append(initChunk);
+                            lastInit = initChunk;
+                        }
                     }
-                    dischargeFragments.push(chunk);
-                    buffer.append(chunk);
                 }
+                dischargeFragments.push(chunk);
+                buffer.append(chunk);
             }
 
             dischargeBuffer.reset();


### PR DESCRIPTION
This PR fixes two issues with using the `preload()` function and discharging before it's filled up until buffer target:

1. If a video element is attached while it's still pre-loading content, the fragments appended from the discharge() function in BufferController send bytes_appended events out. This causes the scheduling loop to be triggered a second time, meaning remaining fragments will be downloaded 2 at time until buffer target is reached. To fix it, the fragments discharged from the PreBufferSink are tracked in array `dischargeFragments` and bytes_appended events are not sent out for those fragments.
2. If an init segment is discharged it is appended to the SourceBuffer twice. The discharge function checks the InitCache when `chunk` is an init segment. It returns the exact same init segment as `initChunk`, and so it gets appended twice to the source buffer.

You can reproduce both of these by calling preload and attaching a video element quickly after, before you reach the buffer target.