### PR TITLE
Fix AbrController's reference to StreamProcessor lost when switching period

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -214,7 +214,7 @@ function StreamProcessor(config) {
             liveEdgeFinder = null;
         }
 
-        if (abrController) {
+        if (abrController && !keepBuffers) {
             abrController.unRegisterStreamType(type);
         }
 


### PR DESCRIPTION
When a StreamProcessor for a first period is torn down, ABR stops working for the second period. The second period is fixed at whatever quality it's on when this occurs.

This is because `abrController.unRegisterStreamType` is called, but only after it's been set to the new period. The result is that the second period doesn't have a StreamProcessor and therefore `checkPlaybackQuality` doesn't get called. The solution here is not to call when keepBuffers is true, the StreamProcessor has already been overwritten.