### PR TITLE
Fix setting MediaSource's duration

### DIFF
--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -70,11 +70,15 @@ function MediaSourceController() {
     }
 
     function setDuration(source, value) {
+        if (!source || source.readyState !== 'open') return;
+        if (source.duration === value) return;
 
-        if (source.duration != value)
+        if (!isBufferUpdating(source)) {
+            logger.info('Set MediaSource duration:' + value);
             source.duration = value;
-
-        return source.duration;
+        } else {
+            setTimeout(setDuration.bind(null, source, value), 50);
+        }
     }
 
     function setSeekable(source, start, end) {
@@ -102,6 +106,16 @@ function MediaSourceController() {
         }
         logger.info('call to mediaSource endOfStream');
         source.endOfStream();
+    }
+
+    function isBufferUpdating(source) {
+        let buffers = source.sourceBuffers;
+        for (let i = 0; i < buffers.length; i++) {
+            if (buffers[i].updating) {
+                return true;
+            }
+        }
+        return false;
     }
 
     instance = {

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -71,6 +71,7 @@ function MediaSourceController() {
 
     function setDuration(source, value) {
         if (!source || source.readyState !== 'open') return;
+        if (value === null && isNaN(value)) return;
         if (source.duration === value) return;
 
         if (!isBufferUpdating(source)) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -636,10 +636,7 @@ function StreamController() {
 
     function setMediaDuration(duration) {
         const manifestDuration = duration ? duration : getActiveStreamInfo().manifestInfo.duration;
-
-        if (manifestDuration && !isNaN(manifestDuration)) {
-            mediaSourceController.setDuration(mediaSource, manifestDuration);
-        }
+        mediaSourceController.setDuration(mediaSource, manifestDuration);
     }
 
     function getComposedStream(streamInfo) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -638,8 +638,7 @@ function StreamController() {
         const manifestDuration = duration ? duration : getActiveStreamInfo().manifestInfo.duration;
 
         if (manifestDuration && !isNaN(manifestDuration)) {
-            const mediaDuration = mediaSourceController.setDuration(mediaSource, manifestDuration);
-            logger.debug('Duration successfully set to: ' + mediaDuration);
+            mediaSourceController.setDuration(mediaSource, manifestDuration);
         }
     }
 

--- a/test/unit/streaming.controllers.MediaSourceController.js
+++ b/test/unit/streaming.controllers.MediaSourceController.js
@@ -86,9 +86,13 @@ describe('MediaSourceController', function () {
 
         it('should update source duration', function () {
 
-            let source = {};
-            let duration = mediaSourceController.setDuration(source, 'duration');
-            expect(duration).to.equal('duration');
+            let source = {
+                readyState: 'open',
+                sourceBuffers: [],
+                duration: NaN
+            };
+            mediaSourceController.setDuration(source, 'duration');
+            expect(source.duration).to.equal('duration');
 
         });
 


### PR DESCRIPTION
When setting duration on MediaSource, if any SourceBuffer is updating it throws an `InvalidStateError` exception:

`Uncaught DOMException: Failed to set the 'duration' property on 'MediaSource': The 'updating' attribute is true on one or more of this MediaSource's SourceBuffers`

This PR fixes this issue by check if no SourceBuffer is updating when setting MediaSource duration