### PR TITLE
Adding optional error to KeyStatusesChangedEvent type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,12 @@ declare namespace dashjs {
         setCalleeNameVisible(flag: boolean): void;
     }
 
+    interface DashJSError {
+        code: number | null;
+        message: string | null;
+        data: unknown | null;
+    }
+
     interface VideoModel { }
 
     interface ProtectionController {
@@ -689,13 +695,13 @@ declare namespace dashjs {
     export interface KeySessionEvent extends Event {
         type: MediaPlayerEvents['KEY_SESSION_CREATED'];
         data: SessionToken | null;
-        error?: string;
+        error?: DashJSError;
     }
 
     export interface KeyStatusesChangedEvent extends Event {
         type: MediaPlayerEvents['KEY_STATUSES_CHANGED'];
         data: SessionToken;
-        error?: string;
+        error?: DashJSError;
     }
 
     export interface KeySystemSelectedEvent extends Event {
@@ -710,7 +716,7 @@ declare namespace dashjs {
             sessionToken: SessionToken;
             messageType: string;
         };
-        error?: string;
+        error?: DashJSError;
     }
 
     export interface LogEvent extends Event {

--- a/index.d.ts
+++ b/index.d.ts
@@ -695,6 +695,7 @@ declare namespace dashjs {
     export interface KeyStatusesChangedEvent extends Event {
         type: MediaPlayerEvents['KEY_STATUSES_CHANGED'];
         data: SessionToken;
+        error?: string;
     }
 
     export interface KeySystemSelectedEvent extends Event {


### PR DESCRIPTION
The `ProtectionController` can emit this event with an error, when the current license expires: 
1. https://github.com/Dash-Industry-Forum/dash.js/blob/75cf1a5535bcb5777a55f5b51a034be6022378e5/src/streaming/protection/controllers/ProtectionController.js#L635