### PR TITLE
Ensure manifest loadedTime updated when patch applied

### DIFF
--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -163,7 +163,7 @@ function ManifestUpdater() {
             // successful update with no content implies existing manifest remains valid
             manifest = manifestModel.getValue();
 
-            // override load time to avoid invalid latency tracking
+            // override load time to avoid invalid latency tracking and ensure update cadence
             manifest.loadedTime = new Date();
         } else if (adapter.getIsPatch(manifest)) {
             // with patches the in-memory manifest is our base
@@ -194,6 +194,9 @@ function ManifestUpdater() {
                 refreshManifest(true);
                 return;
             }
+
+            // override load time to avoid invalid latency tracking and ensure update cadence
+            manifest.loadedTime = new Date();
         }
 
         // See DASH-IF IOP v4.3 section 4.6.4 "Transition Phase between Live and On-Demand"

--- a/test/unit/streaming.ManifestUpdater.js
+++ b/test/unit/streaming.ManifestUpdater.js
@@ -107,6 +107,7 @@ describe('ManifestUpdater', function () {
         eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {manifest: patch});
 
         expect(manifestModelMock.getValue()).to.equal(inMemoryManifest);
+        expect(inMemoryManifest.loadedTime).to.not.equal(originalTime);
         expect(patchCheckStub.called).to.be.true; // jshint ignore:line
         expect(isPatchValidStub.called).to.be.true; // jshint ignore:line
         expect(applyPatchStub.calledWith(inMemoryManifest, patch)).to.be.true; // jshint ignore:line


### PR DESCRIPTION
When patch is applied the manifest object `loadedTime` needs to be updated to ensure the update poll is set properly, otherwise the player will attempt a full reload immediately. Was originally in a test case and missed in the publish time change enforcement refactor.