### PR TITLE
Fix execution of local functional tests on mac

### DIFF
--- a/test/functional/config/browsers.json
+++ b/test/functional/config/browsers.json
@@ -46,6 +46,9 @@
                 "com.widevine.alpha": true,
                 "com.microsoft.playready": false,
                 "org.w3.clearkey": true
+            },
+            "goog:chromeOptions": {
+                "w3c": false
             }
         },
         "firefox": {


### PR DESCRIPTION
Currently only for windows the config chromeOptions.w3c:false is set. This was missing for mac config, causing local tests using chromedriver and chrome browser terminating with 'unknown command: Cannot call non W3C standard command while in W3C mode' error message.