### PR TITLE
fix implicit "any" type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -347,10 +347,10 @@ declare namespace dashjs {
         getProtectionController(): ProtectionController;
         attachProtectionController(value: ProtectionController): void;
         setProtectionData(value: ProtectionDataSet): void;
-        registerLicenseRequestFilter(filter: RequestFilter),
-        registerLicenseResponseFilter(filter: ResponseFilter),
-        unregisterLicenseRequestFilter(filter: RequestFilter),
-        unregisterLicenseResponseFilter(filter: ResponseFilter),
+        registerLicenseRequestFilter(filter: RequestFilter): void,
+        registerLicenseResponseFilter(filter: ResponseFilter): void,
+        unregisterLicenseRequestFilter(filter: RequestFilter): void,
+        unregisterLicenseResponseFilter(filter: ResponseFilter): void,
         getOfflineController(): OfflineController;
         enableManifestDateHeaderTimeSource(value: boolean): void;
         displayCaptionsOnTop(value: boolean): void;


### PR DESCRIPTION
These functions need an explicit response type to prevent warnings like the following:

index.d.ts (350,9): 'registerLicenseRequestFilter', which lacks return-type annotation, implicitly has an 'any' return type.
index.d.ts (351,9): 'registerLicenseResponseFilter', which lacks return-type annotation, implicitly has an 'any' return type.
index.d.ts (352,9): 'unregisterLicenseRequestFilter', which lacks return-type annotation, implicitly has an 'any' return type.
index.d.ts (353,9): 'unregisterLicenseResponseFilter', which lacks return-type annotation, implicitly has an 'any' return type