### PR TITLE
Check TypeScript type declaration file on every build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "3.1.4",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13532,6 +13532,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/es5/index.js",
   "types": "build/typings/index.d.ts",
   "scripts": {
-    "build": "grunt",
+    "build": "npx typescript && grunt",
     "debug-mocha": "iron-node node_modules/mocha/bin/_mocha --require mochahook",
     "test": "mocha test/unit --require mochahook",
     "test-functional": "node test/functional/runTests.js --selenium=remote --app=remote",
@@ -54,6 +54,7 @@
     "mocha": "^2.3.4",
     "sinon": "^7.3.2",
     "time-grunt": "^2.0.0",
+    "typescript": "^4.1.5",
     "uglify-js": "^3.6.0",
     "yargs": "16.0.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    "index.d.ts"
+  ],
+  "compilerOptions": {
+    "noImplicitAny": true
+  }
+}


### PR DESCRIPTION
This should help to check the type declaration file to prevent errors being merged which in turn could compromise the build processes of some strictly types projects.

Should avoid such [problems](https://github.com/Dash-Industry-Forum/dash.js/pull/3551).