### PR TITLE
add missing TypeScript type signature for destroy method 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -358,6 +358,7 @@ declare namespace dashjs {
         getCurrentTextTrackIndex(): number;
         preload(): void;
         reset(): void;
+        destroy(): void;
         addABRCustomRule(type: string, rulename: string, rule: object): void;
         removeABRCustomRule(rulename: string): void;
         removeAllABRCustomRule(): void;


### PR DESCRIPTION
Hey, 
destroy method was added in #3432, but is missing in dashjs TypeScript typings.