### PR TITLE
Replacing arrow function with regular functions in samples

### DIFF
--- a/samples/chromecast/receiver/js/DashPlayerService.js
+++ b/samples/chromecast/receiver/js/DashPlayerService.js
@@ -127,7 +127,7 @@ angular.module('DashCastReceiverApp.services', [])
                 numBitratesValue: numBitratesValue,
                 bufferLengthValue: bufferLengthValue,
                 droppedFramesValue: droppedFramesValue
-            }
+            };
         }
         else {
             return null;
@@ -188,12 +188,12 @@ angular.module('DashCastReceiverApp.services', [])
           for (let i = 0; i < 2; i++) {
             if (activeTrackIds[i] !== undefined) {
               let audioTracks = player.getTracksFor('audio');
-              audioTrack = audioTracks.find(function (track) { return track.index === activeTrackIds[i] });
+              audioTrack = audioTracks.find(function (track) { return track.index === activeTrackIds[i]; });
               if (audioTrack) {
                 player.setCurrentTrack(audioTrack);
               } else {
                 let textTracks = player.getTracksFor('fragmentedText');
-                textTrack = textTracks.find(function (track) { return track.index === activeTrackIds[i] });
+                textTrack = textTracks.find(function (track) { return track.index === activeTrackIds[i]; });
                 if (textTrack) {
                   player.enableText(true);
                   textEnable = true;
@@ -215,7 +215,7 @@ angular.module('DashCastReceiverApp.services', [])
           return 0;
         }
       },
-      
+
       getDurationSec () {
         if (player) {
           return player.duration();
@@ -284,7 +284,7 @@ angular.module('DashCastReceiverApp.services', [])
 
       setVolume (volume) {
         videoElt.volume = volume.level;
-        videoElt.muted = volume.muted; 
+        videoElt.muted = volume.muted;
       },
 
       unregisterEndedCallback (callback) {

--- a/samples/chromecast/receiver/js/DashPlayerService.js
+++ b/samples/chromecast/receiver/js/DashPlayerService.js
@@ -8,7 +8,7 @@ angular.module('DashCastReceiverApp.services', [])
     let player;
     let initialized = false;
 
-    const noop = () => {};
+    const noop = function () {};
     let _loadCallback = noop;
     let _errorCallback = noop;
     let _endedCallback = noop;
@@ -139,10 +139,10 @@ angular.module('DashCastReceiverApp.services', [])
         if (player && initialized) {
           let audioTracks = player.getTracksFor('audio');
           let textTracks = player.getTracksFor('fragmentedText');
-          audioTracks.forEach(track => {
+          audioTracks.forEach(function (track) {
               allTracks.push(_convertTrack(track, cast.receiver.media.TrackType.AUDIO));
           });
-          textTracks.forEach(track => {
+          textTracks.forEach(function (track) {
               allTracks.push(_convertTrack(track, cast.receiver.media.TrackType.TEXT));
           });
         }
@@ -188,12 +188,12 @@ angular.module('DashCastReceiverApp.services', [])
           for (let i = 0; i < 2; i++) {
             if (activeTrackIds[i] !== undefined) {
               let audioTracks = player.getTracksFor('audio');
-              audioTrack = audioTracks.find(track => track.index === activeTrackIds[i]);
+              audioTrack = audioTracks.find(function (track) { return track.index === activeTrackIds[i] });
               if (audioTrack) {
                 player.setCurrentTrack(audioTrack);
               } else {
                 let textTracks = player.getTracksFor('fragmentedText');
-                textTrack = textTracks.find(track => track.index === activeTrackIds[i]);
+                textTrack = textTracks.find(function (track) { return track.index === activeTrackIds[i] });
                 if (textTrack) {
                   player.enableText(true);
                   textEnable = true;

--- a/samples/chromecast/sender/js/CastSenderController.js
+++ b/samples/chromecast/sender/js/CastSenderController.js
@@ -426,7 +426,7 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
 
     this.resumeMediaSession = function (mediaSession) {
         if (mediaSession.media) {
-            $scope.setStream($scope.availableStreams.find(item => item.url == mediaSession.media.contentId));
+            $scope.setStream($scope.availableStreams.find(function (item) { return item.url == mediaSession.media.contentId }));
             $scope.state = STATE_CASTING;
             $scope.playing = mediaSession.playerState === 'PLAYING';
             $scope.muted = mediaSession.volume.muted;

--- a/samples/chromecast/sender/js/CastSenderController.js
+++ b/samples/chromecast/sender/js/CastSenderController.js
@@ -313,7 +313,7 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
 
     $scope.setStream = function (item) {
         $scope.selectedItem = item;
-    }
+    };
 
 
     // -----------------------------------
@@ -324,17 +324,17 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
         $scope.state = STATE_CASTING;
         caster.loadMedia($scope.selectedItem.url, $scope.selectedItem.isLive);
         $scope.playing = true;
-    }
+    };
 
     $scope.stopCast = function () {
         $scope.state = STATE_READY;
         caster.stopPlayback();
         $scope.playing = false;
-    }
+    };
 
     $scope.togglePlayback = function () {
         caster.playOrPause();
-    }
+    };
 
     $scope.doSeek = function () {
         var x = event.layerX,
@@ -342,11 +342,11 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
             p = x / w,
             v = $scope.duration * p;
         caster.seekMedia(v);
-    }
+    };
 
     $scope.toggleMute = function () {
         caster.muteOrUnmute();
-    }
+    };
 
     $scope.turnVolumeDown = function () {
         $scope.volume -= 0.1;
@@ -354,7 +354,7 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
             $scope.volume = 0;
         }
         caster.setMediaVolume($scope.volume);
-    }
+    };
 
     $scope.turnVolumeUp = function () {
         $scope.volume += 0.1;
@@ -362,11 +362,11 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
             $scope.volume = 1;
         }
         caster.setMediaVolume($scope.volume);
-    }
+    };
 
     $scope.toggleStats = function () {
         caster.toggleStats();
-    }
+    };
 
     // -----------------------------------
     // Initialization
@@ -395,42 +395,42 @@ app.controller('CastSenderController', ['$scope', '$window', 'caster', function(
             $scope.state = STATE_READY;
         }
         $scope.$apply();
-    }
+    };
 
     this.onTimeUpdate = function (time) {
         $scope.currentTime = time;
         var scrubber = document.getElementById("scrubber-content");
         var p = ($scope.currentTime / $scope.duration) * 100;
         angular.element(scrubber).width(p + "%");
-    }
+    };
 
     this.onDurationChange = function (duration) {
         $scope.duration = duration;
-    }
+    };
 
     this.onPausedChange = function (isPaused) {
         $scope.playing = !isPaused;
-    }
+    };
 
     this.onMutedChange = function (isMuted) {
         $scope.muted = isMuted;
-    }
+    };
 
     this.onVolumeChange = function (level) {
         $scope.volume = level;
-    }
+    };
 
     this.onEnded = function () {
 
-    }
+    };
 
     this.resumeMediaSession = function (mediaSession) {
         if (mediaSession.media) {
-            $scope.setStream($scope.availableStreams.find(function (item) { return item.url == mediaSession.media.contentId }));
+            $scope.setStream($scope.availableStreams.find(function (item) { return item.url == mediaSession.media.contentId; }));
             $scope.state = STATE_CASTING;
             $scope.playing = mediaSession.playerState === 'PLAYING';
             $scope.muted = mediaSession.volume.muted;
             $scope.$apply();
         }
-    }
+    };
 }]);

--- a/samples/chromecast/sender/js/CastSenderService.js
+++ b/samples/chromecast/sender/js/CastSenderService.js
@@ -17,32 +17,32 @@ angular.module('DashCastSenderApp.services', [])
         },
 
         addListeners = function() {
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.CURRENT_TIME_CHANGED, e => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.CURRENT_TIME_CHANGED, function (e) {
                 if (remotePlayer && remotePlayer.isMediaLoaded) {
                     delegate.onTimeUpdate(remotePlayer.currentTime);
                 }
             });
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.DURATION_CHANGED, () => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.DURATION_CHANGED, function () {
                 if (remotePlayer && remotePlayer.duration) {
                     delegate.onDurationChange(remotePlayer.duration);
                 }
             });
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.MEDIA_INFO_CHANGED, () => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.MEDIA_INFO_CHANGED, function () {
                 if (remotePlayer && remotePlayer.mediaInfo) {
                     delegate.onDurationChange(remotePlayer.mediaInfo.duration);
                 }
             });
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.IS_PAUSED_CHANGED, () => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.IS_PAUSED_CHANGED, function () {
                 if (remotePlayer) {
                     delegate.onPausedChange(remotePlayer.isPaused);
                 }
             });
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.IS_MUTED_CHANGED, () => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.IS_MUTED_CHANGED, function () {
                 if (remotePlayer) {
                     delegate.onMutedChange(remotePlayer.isMuted);
                 }
             });
-            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.VOLUME_LEVEL_CHANGED, () => {
+            remotePlayerController.addEventListener(cast.framework.RemotePlayerEventType.VOLUME_LEVEL_CHANGED, function () {
                 if (remotePlayer) {
                     delegate.onVolumeChange(remotePlayer.volumeLevel);
                 }
@@ -53,7 +53,7 @@ angular.module('DashCastSenderApp.services', [])
             if (castSession) {
                 castSession.sendMessage(NAMESPACE, {
                     type: 'TOGGLE_STATS'
-                }).then(err => {
+                }).then(function (err) {
                     onMessageSent(err);
                 });
             }
@@ -124,7 +124,7 @@ angular.module('DashCastSenderApp.services', [])
               receiverApplicationId: APP_ID,
               autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED
             });
-            castContext.addEventListener(cast.framework.CastContextEventType.CAST_STATE_CHANGED, e => {
+            castContext.addEventListener(cast.framework.CastContextEventType.CAST_STATE_CHANGED, function (e) {
                 console.log('[Cast]', e);
                 if (e.castState === cast.framework.CastState.CONNECTED && onReady) {
                     onReady();
@@ -133,11 +133,11 @@ angular.module('DashCastSenderApp.services', [])
                         let mediaSession = castSession.getMediaSession();
                         if (mediaSession) {
                             // call getStatus in order to retrieve data of the media when the session is resumed
-                            mediaSession.getStatus(null, () => {
+                            mediaSession.getStatus(null, function () {
                                 if (mediaSession.media) {
                                     delegate.resumeMediaSession(mediaSession);
                                 }
-                            }, (err) => {
+                            }, function (err) {
                                 console.error('Error getting status', err);
                             });
                         }

--- a/samples/low-latency/l2all_index.html
+++ b/samples/low-latency/l2all_index.html
@@ -167,7 +167,7 @@
         const player = init();
         const video = document.querySelector("video")
         let stallingAt = null;
-        const CMA = () => {
+        const CMA = function () {
             let average = 0;
             let count = 0;
 
@@ -200,11 +200,11 @@
             document.getElementById("catchup-threshold-tag").innerHTML = settings.streaming.liveCatchup.latencyThreshold + " secs";
         }, 200);
 
-        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, (e) => {
+        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, function (e) {
             console.warn('Quality changed requested', e);
         });
 
-        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, (e) => {
+        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) {
             if (e.mediaType === 'video') {
                 console.warn('Quality changed', e);
                 const quality = player.getBitrateInfoListFor('video')[e.newQuality];
@@ -215,7 +215,7 @@
             }
         });
 
-        window.startRecording = () => {
+        window.startRecording = function () {
             console.info('Begin recording');
 
             const latencyCMA = CMA();
@@ -231,7 +231,7 @@
             recordSwitch(player.getBitrateInfoListFor('video')[player.getQualityFor('video')]);
 
             let pollInterval = -1;
-            window.stopRecording = () => {
+            window.stopRecording = function () {
                 clearInterval(pollInterval);
                 checkStallResolution();
                 const lastQuality = history.switchHistory[history.switchHistory.length - 1];
@@ -250,15 +250,15 @@
             }, 200);
 
 
-            player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, (e) => {
+            player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) {
                 recordSwitch(player.getBitrateInfoListFor('video')[e.newQuality]);
             });
 
-            video.addEventListener('waiting', (e) => {
+            video.addEventListener('waiting', function (e) {
                 stallingAt = performance.now();
             });
 
-            video.addEventListener('timeupdate', () => {
+            video.addEventListener('timeupdate', function () {
                 checkStallResolution();
             });
 

--- a/samples/low-latency/lolp_index.html
+++ b/samples/low-latency/lolp_index.html
@@ -217,7 +217,7 @@
         const player = init();
         const video = document.querySelector('video')
         let stallingAt = null;
-        const CMA = () => {
+        const CMA = function () {
             let average = 0;
             let count = 0;
 
@@ -251,11 +251,11 @@
             document.getElementById('buffer-tag').innerHTML = currentBuffer + ' secs';
         }, 200);
 
-        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, (e) => {
+        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, function (e) {
             console.warn('Quality changed requested', e);
         });
 
-        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, (e) => {
+        player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) {
             if (e.mediaType === 'video') {
                 console.warn('Quality changed', e);
                 const quality = player.getBitrateInfoListFor('video')[e.newQuality];
@@ -266,7 +266,7 @@
             }
         });
 
-        window.startRecording = () => {
+        window.startRecording = function () {
             console.info('Begin recording');
 
             const latencyCMA = CMA();
@@ -282,7 +282,7 @@
             recordSwitch(player.getBitrateInfoListFor('video')[player.getQualityFor('video')]);
 
             let pollInterval = -1;
-            window.stopRecording = () => {
+            window.stopRecording = function () {
                 clearInterval(pollInterval);
                 checkStallResolution();
                 const lastQuality = history.switchHistory[history.switchHistory.length - 1];
@@ -300,15 +300,15 @@
             }, 200);
 
 
-            player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, (e) => {
+            player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) {
                 recordSwitch(player.getBitrateInfoListFor('video')[e.newQuality]);
             });
 
-            video.addEventListener('waiting', (e) => {
+            video.addEventListener('waiting', function (e) {
                 stallingAt = performance.now();
             });
 
-            video.addEventListener('timeupdate', () => {
+            video.addEventListener('timeupdate', function () {
                 checkStallResolution();
             });
 

--- a/samples/offline/app/main.js
+++ b/samples/offline/app/main.js
@@ -1084,9 +1084,8 @@ app.controller('DashController', function ($scope, $timeout, $q, sources, contri
             }
         });
         representations.fragmentedText = [];
-        var self = this;
         $('input[type="checkbox"][name="fragmentedText"]:checked').each(function () {
-            representations.fragmentedText.push($(self).attr('value'));
+            representations.fragmentedText.push($(this).attr('value'));
         });
 
         return representations;

--- a/samples/offline/app/main.js
+++ b/samples/offline/app/main.js
@@ -1064,28 +1064,29 @@ app.controller('DashController', function ($scope, $timeout, $q, sources, contri
     $scope.getSelectedRepresentations = function () {
         let representations = {};
         representations.video = [];
-        $scope.downloadableRepresentations.video.forEach((item) => {
+        $scope.downloadableRepresentations.video.forEach(function (item) {
             if (item.selected) {
                 representations.video.push(item);
             }
         });
 
         representations.audio = [];
-        $scope.downloadableRepresentations.audio.forEach((item) => {
+        $scope.downloadableRepresentations.audio.forEach(function (item) {
             if (item.selected) {
                 representations.audio.push(item);
             }
         });
 
         representations.text = [];
-        $scope.downloadableRepresentations.text.forEach((item) => {
+        $scope.downloadableRepresentations.text.forEach(function (item) {
             if (item.selected) {
                 representations.text.push(item);
             }
         });
         representations.fragmentedText = [];
+        var self = this;
         $('input[type="checkbox"][name="fragmentedText"]:checked').each(function () {
-            representations.fragmentedText.push($(this).attr('value'));
+            representations.fragmentedText.push($(self).attr('value'));
         });
 
         return representations;
@@ -1093,9 +1094,9 @@ app.controller('DashController', function ($scope, $timeout, $q, sources, contri
 
     $scope.getSelectedMediaInfos = function () {
         let mediaInfos = [];
-        $scope.mediaInfos.forEach(mediaInfo => {
+        $scope.mediaInfos.forEach(function (mediaInfo) {
             let selected = false;
-            mediaInfo.bitrateList = mediaInfo.bitrateList.filter(bitrate => {
+            mediaInfo.bitrateList = mediaInfo.bitrateList.filter(function (bitrate) {
                 selected = selected || bitrate.selected;
                 return bitrate.selected;
             });

--- a/samples/offline/app/offline/services/downloadService.js
+++ b/samples/offline/app/offline/services/downloadService.js
@@ -9,7 +9,7 @@ service('DownloadService', function () {
     let records = [];
 
     this.getRecord = function (id) {
-        let element = records.find((record) => {
+        let element = records.find(function (record) {
             return record.id === id;
         });
 
@@ -23,23 +23,24 @@ service('DownloadService', function () {
     this.init = function (playerInstance) {
         player = playerInstance;
         offlineController = player.getOfflineController();
+        var self = this;
 
-        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_STARTED, (e) => {
-            let record = this.getRecord(e.id);
+        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_STARTED, function (e) {
+            let record = self.getRecord(e.id);
             if (record) {
                 record.status = 'started';
             }
         }, this);
 
-        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_FINISHED, (e) => {
-            let record = this.getRecord(e.id);
+        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_FINISHED, function (e) {
+            let record = self.getRecord(e.id);
             if (record) {
                 record.status = 'finished';
             }
         }, this);
 
-        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_STOPPED, (e) => {
-            let record = this.getRecord(e.id);
+        player.on(dashjs.MediaPlayer.events.OFFLINE_RECORD_STOPPED, function (e) {
+            let record = self.getRecord(e.id);
             if (record) {
                 record.status = 'stopped';
             }
@@ -69,29 +70,31 @@ service('DownloadService', function () {
             }
         }, this);
 
-        offlineController.loadRecordsFromStorage().then(() => {
-            this.getAllRecords();
+        offlineController.loadRecordsFromStorage().then(function () {
+            self.getAllRecords();
         });
     };
 
     this.getAllRecords = function () {
         records.splice(0, records.length);
-        offlineController.getAllRecords().forEach(element => {
+        offlineController.getAllRecords().forEach(function (element) {
             records.push(element);
         });
     };
 
     this.doDownload = function (url) {
-        offlineController.createRecord(url).then((id) => {
+        var self = this;
+        offlineController.createRecord(url).then(function (id) {
             id = id;
             // new record has been created, let's refresh record list
-            this.getAllRecords();
+            self.getAllRecords();
         });
     };
 
     this.doDeleteRecord = function (id) {
-        offlineController.deleteRecord(id).then(() => {
-            this.getAllRecords();
+        var self = this;
+        offlineController.deleteRecord(id).then(function () {
+            self.getAllRecords();
         });
     };
 

--- a/samples/offline/app/rules/DownloadRatioRule.js
+++ b/samples/offline/app/rules/DownloadRatioRule.js
@@ -52,7 +52,7 @@ function DownloadRatioRuleClass() {
     }
 
     function getBytesLength(request) {
-        return request.trace.reduce((a, b) => a + b.b[0], 0);
+        return request.trace.reduce(function (a, b) { return a + b.b[0] }, 0);
     }
 
     function getMaxIndex(rulesContext) {


### PR DESCRIPTION
Removing arrow functions from samples as they are not supported by IE11

#3542 