### PR TITLE
fix: #3568 validateExecutedFragmentRequest while removing buffer may causes playback stall

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -228,6 +228,7 @@ function ScheduleController(config) {
     }
 
     function validateExecutedFragmentRequest() {
+        if (!isNaN(seekTarget)) return;
         // Validate that the fragment request executed and appended into the source buffer is as
         // good of quality as the current quality and is the correct media track.
         const time = playbackController.getTime();


### PR DESCRIPTION
#3568

checks `seekTarget` equals to `NaN` before executing `validateExecutedFragmentRequest`