### PR TITLE
Fix MSS live seeking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,6 +187,7 @@ declare namespace dashjs {
                 'InitializationSegment'?:     number;
                 'BitstreamSwitchingSegment'?: number;
                 'IndexSegment'?:              number;
+                'FragmentInfoSegment'?:       number;
                 'other'?:                     number;
                 'lowLatencyReductionFactor'?:  number;
             };
@@ -197,6 +198,7 @@ declare namespace dashjs {
                 'InitializationSegment'?:     number;
                 'BitstreamSwitchingSegment'?: number;
                 'IndexSegment'?:              number;
+                'FragmentInfoSegment'?:       number;
                 'other'?:                     number;
                 'lowLatencyMultiplyFactor'?:  number;
             };

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -121,6 +121,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *              IndexSegment: 1000,
  *              MediaSegment: 1000,
  *              BitstreamSwitchingSegment: 1000,
+ *              FragmentInfoSegment: 1000,
  *              other: 1000,
  *              lowLatencyReductionFactor: 10
  *          },
@@ -131,6 +132,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *              IndexSegment: 3,
  *              MediaSegment: 3,
  *              BitstreamSwitchingSegment: 3,
+ *              FragmentInfoSegment: 3,
  *              other: 3,
  *              lowLatencyMultiplyFactor: 5
  *          },

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -462,6 +462,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Request to retrieve a media segment (video/audio/image/text chunk).
  * @property {number} [BitstreamSwitchingSegment]
  * Bitrate stream switching type of request.
+ * @property {number} [FragmentInfoSegment]
+ * Request to retrieve a FragmentInfo segment (specific to Smooth Streaming live streams).
  * @property {number} [other]
  * Other type of request.
  * @property {number} [lowLatencyReductionFactor]
@@ -672,6 +674,7 @@ function Settings() {
                 [HTTPRequest.INIT_SEGMENT_TYPE]: 1000,
                 [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: 1000,
                 [HTTPRequest.INDEX_SEGMENT_TYPE]: 1000,
+                [HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE]: 1000,
                 [HTTPRequest.OTHER_TYPE]: 1000,
                 lowLatencyReductionFactor: 10
             },
@@ -682,6 +685,7 @@ function Settings() {
                 [HTTPRequest.INIT_SEGMENT_TYPE]: 3,
                 [HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE]: 3,
                 [HTTPRequest.INDEX_SEGMENT_TYPE]: 3,
+                [HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE]: 3,
                 [HTTPRequest.OTHER_TYPE]: 3,
                 lowLatencyMultiplyFactor: 5
             },

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -724,6 +724,8 @@ function Settings() {
                     } else {
                         dest[n] = Utils.clone(source[n]);
                     }
+                } else {
+                    dest[n] = Utils.clone(source[n]);
                 }
             }
         }

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -728,8 +728,6 @@ function Settings() {
                     } else {
                         dest[n] = Utils.clone(source[n]);
                     }
-                } else {
-                    dest[n] = Utils.clone(source[n]);
                 }
             }
         }

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -30,6 +30,7 @@
  */
 
 import FragmentRequest from '../streaming/vo/FragmentRequest';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 
 function MssFragmentInfoController(config) {
 
@@ -113,7 +114,7 @@ function MssFragmentInfoController(config) {
         let request = new FragmentRequest();
 
         request.mediaType = type;
-        request.type = 'FragmentInfoSegment';
+        request.type = HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE;
         // request.range = segment.mediaRange;
         request.startTime = segment.t / timescale;
         request.duration = segment.d / timescale;

--- a/src/mss/MssFragmentInfoController.js
+++ b/src/mss/MssFragmentInfoController.js
@@ -69,7 +69,6 @@ function MssFragmentInfoController(config) {
         logger.debug('Start');
 
         started = true;
-        startTime = new Date().getTime();
         index = 0;
 
         loadNextFragmentInfo();
@@ -167,6 +166,10 @@ function MssFragmentInfoController(config) {
             delay;
 
         // logger.debug('FragmentInfo loaded: ', request.url);
+
+        if (startTime === null) {
+            startTime = new Date().getTime();
+        }
 
         if (!startFragmentTime) {
             startFragmentTime = request.startTime;

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -163,7 +163,7 @@ function MssFragmentMoofProcessor(config) {
 
                 // Remove segments prior to availability start time
                 segment = segments[0];
-                while (Math.round(segment.t / timescale) < availabilityStartTime) {
+                while (Math.round((segment.t + segment.d) / timescale) < availabilityStartTime) {
                     // logger.debug('Remove segment  - t = ' + (segment.t / timescale));
                     segments.splice(0, 1);
                     segment = segments[0];

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -183,6 +183,7 @@ function MssFragmentMoofProcessor(config) {
     }
 
     function updateDVR(type, range, manifestInfo) {
+        if (type !== 'video' && type !== 'audio') return;
         const dvrInfos = dashMetrics.getCurrentDVRInfo(type);
         if (!dvrInfos || (range.end > dvrInfos.range.end)) {
             logger.debug('Update DVR range: [' + range.start + ' - ' + range.end + ']');

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -187,6 +187,7 @@ function MssFragmentMoofProcessor(config) {
         if (!dvrInfos || (range.end > dvrInfos.range.end)) {
             logger.debug('Update DVR range: [' + range.start + ' - ' + range.end + ']');
             dashMetrics.addDVRInfo(type, playbackController.getTime(), manifestInfo, range);
+            playbackController.updateCurrentTime(type);
         }
     }
 

--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -84,6 +84,7 @@ function MssFragmentMoofProcessor(config) {
             range;
         let segment = null;
         let t = 0;
+        let endTime;
         let availabilityStartTime = null;
 
         if (entries.length === 0) {
@@ -144,9 +145,9 @@ function MssFragmentMoofProcessor(config) {
         if (manifest.type === 'static') {
             if (type === 'video') {
                 segment = segments[segments.length - 1];
-                var end = (segment.t + segment.d) / timescale;
-                if (end > representation.adaptation.period.duration) {
-                    eventBus.trigger(Events.MANIFEST_VALIDITY_CHANGED, { sender: this, newDuration: end });
+                endTime = (segment.t + segment.d) / timescale;
+                if (endTime > representation.adaptation.period.duration) {
+                    eventBus.trigger(Events.MANIFEST_VALIDITY_CHANGED, { sender: this, newDuration: endTime });
                 }
             }
             return;
@@ -159,14 +160,20 @@ function MssFragmentMoofProcessor(config) {
                 t = segment.t;
 
                 // Determine the segments' availability start time
-                availabilityStartTime = Math.round((t - (manifest.timeShiftBufferDepth * timescale)) / timescale);
+                availabilityStartTime = (t - (manifest.timeShiftBufferDepth * timescale)) / timescale;
 
                 // Remove segments prior to availability start time
                 segment = segments[0];
-                while (Math.round((segment.t + segment.d) / timescale) < availabilityStartTime) {
+                endTime = (segment.t + segment.d) / timescale;
+                while (endTime < availabilityStartTime) {
+                    // Check if not currently playing the segment to be removed
+                    if (!playbackController.isPaused() && playbackController.getTime() < endTime) {
+                        break;
+                    }
                     // logger.debug('Remove segment  - t = ' + (segment.t / timescale));
                     segments.splice(0, 1);
                     segment = segments[0];
+                    endTime =  (segment.t + segment.d) / timescale;
                 }
             }
 

--- a/src/mss/MssFragmentProcessor.js
+++ b/src/mss/MssFragmentProcessor.js
@@ -31,6 +31,8 @@
 
 import MssFragmentMoofProcessor from './MssFragmentMoofProcessor';
 import MssFragmentMoovProcessor from './MssFragmentMoovProcessor';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
+
 
 // Add specific box processors not provided by codem-isoboxer library
 
@@ -163,7 +165,7 @@ function MssFragmentProcessor(config) {
             // MediaSegment => convert to Smooth Streaming moof format
             mssFragmentMoofProcessor.convertFragment(e, streamProcessor);
 
-        } else if (e.request.type === 'FragmentInfoSegment') {
+        } else if (e.request.type === HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE) {
             // FragmentInfo (live) => update segments list
             mssFragmentMoofProcessor.updateSegmentList(e, streamProcessor);
 

--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -37,6 +37,7 @@ import MssParser from './parser/MssParser';
 import MssErrors from './errors/MssErrors';
 import DashJSError from '../streaming/vo/DashJSError';
 import InitCache from '../streaming/utils/InitCache';
+import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 
 function MssHandler(config) {
 
@@ -176,7 +177,7 @@ function MssHandler(config) {
         // Process moof to transcode it from MSS to DASH (or to update segment timeline for SegmentInfo fragments)
         mssFragmentProcessor.processFragment(e, streamProcessor);
 
-        if (e.request.type === 'FragmentInfoSegment') {
+        if (e.request.type === HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE) {
             // If FragmentInfo loaded, then notify corresponding MssFragmentInfoController
             let fragmentInfoController = getFragmentInfoController(e.request.mediaType);
             if (fragmentInfoController) {

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -592,7 +592,7 @@ function MssParser(config) {
         return widevineCP;
     }
 
-    function processManifest(xmlDoc/*, manifestLoadedTime*/) {
+    function processManifest(xmlDoc) {
         const manifest = {};
         const contentProtections = [];
         const smoothStreamingMedia = xmlDoc.getElementsByTagName('SmoothStreamingMedia')[0];

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -751,13 +751,7 @@ function MssParser(config) {
                     'liveDelay': liveDelay,
                     'stableBufferTime': bufferTime,
                     'bufferTimeAtTopQuality': bufferTime,
-                    'bufferTimeAtTopQualityLongForm': bufferTime,
-                    'retryAttempts': {
-                        'FragmentInfoSegment': 3
-                    },
-                    'retryIntervals': {
-                        'FragmentInfoSegment': 1000
-                    }
+                    'bufferTimeAtTopQualityLongForm': bufferTime
                 }
             });
         }

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -592,7 +592,7 @@ function MssParser(config) {
         return widevineCP;
     }
 
-    function processManifest(xmlDoc, manifestLoadedTime) {
+    function processManifest(xmlDoc/*, manifestLoadedTime*/) {
         const manifest = {};
         const contentProtections = [];
         const smoothStreamingMedia = xmlDoc.getElementsByTagName('SmoothStreamingMedia')[0];
@@ -706,11 +706,6 @@ function MssParser(config) {
                 manifest.minBufferTime = segmentDuration;
 
                 if (manifest.type === 'dynamic' ) {
-                    // Set availabilityStartTime
-                    segments = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray;
-                    let endTime = (segments[segments.length - 1].t + segments[segments.length - 1].d) / adaptations[i].SegmentTemplate.timescale * 1000;
-                    manifest.availabilityStartTime = new Date(manifestLoadedTime.getTime() - endTime);
-
                     // Match timeShiftBufferDepth to video segment timeline duration
                     if (manifest.timeShiftBufferDepth > 0 &&
                         manifest.timeShiftBufferDepth !== Infinity &&

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -722,6 +722,7 @@ function MssParser(config) {
         // In case of live streams:
         // 1- configure player buffering properties according to target live delay
         // 2- adapt live delay and then buffers length in case timeShiftBufferDepth is too small compared to target live delay (see PlaybackController.computeLiveDelay())
+        // 3- Set retry attempts and intervals for FragmentInfo requests
         if (manifest.type === 'dynamic') {
             let targetLiveDelay = mediaPlayerModel.getLiveDelay();
             if (!targetLiveDelay) {
@@ -750,7 +751,13 @@ function MssParser(config) {
                     'liveDelay': liveDelay,
                     'stableBufferTime': bufferTime,
                     'bufferTimeAtTopQuality': bufferTime,
-                    'bufferTimeAtTopQualityLongForm': bufferTime
+                    'bufferTimeAtTopQualityLongForm': bufferTime,
+                    'retryAttempts': {
+                        'FragmentInfoSegment': 3
+                    },
+                    'retryIntervals': {
+                        'FragmentInfoSegment': 1000
+                    }
                 }
             });
         }

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -225,6 +225,10 @@ function ManifestLoader(config) {
     function reset() {
         eventBus.off(Events.XLINK_READY, onXlinkReady, instance);
 
+        if (mssHandler) {
+            mssHandler.reset();
+        }
+
         if (xlinkController) {
             xlinkController.reset();
             xlinkController = null;
@@ -233,10 +237,6 @@ function ManifestLoader(config) {
         if (urlLoader) {
             urlLoader.abort();
             urlLoader = null;
-        }
-
-        if (mssHandler) {
-            mssHandler.reset();
         }
     }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -386,8 +386,8 @@ function PlaybackController() {
         return startTime;
     }
 
-    function getActualPresentationTime(currentTime) {
-        const DVRMetrics = dashMetrics.getCurrentDVRInfo();
+    function getActualPresentationTime(currentTime, mediatype) {
+        const DVRMetrics = dashMetrics.getCurrentDVRInfo(mediatype);
         const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
         let actualTime;
 
@@ -430,10 +430,10 @@ function PlaybackController() {
         wallclockTimeIntervalId = null;
     }
 
-    function updateCurrentTime() {
+    function updateCurrentTime(mediaType) {
         if (isPaused() || !isDynamic || videoModel.getReadyState() === 0) return;
         const currentTime = getNormalizedTime();
-        const actualTime = getActualPresentationTime(currentTime);
+        const actualTime = getActualPresentationTime(currentTime, mediaType);
         const timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
         if (timeChanged) {
             logger.debug(`UpdateCurrentTime: Seek to actual time: ${actualTime} from currentTime: ${currentTime}`);
@@ -977,6 +977,7 @@ function PlaybackController() {
         isSeeking: isSeeking,
         getStreamEndTime,
         seek: seek,
+        updateCurrentTime: updateCurrentTime,
         reset: reset
     };
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -435,7 +435,7 @@ function PlaybackController() {
         const currentTime = getNormalizedTime();
         const actualTime = getActualPresentationTime(currentTime, mediaType);
         const timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
-        if (timeChanged) {
+        if (timeChanged && !isSeeking()) {
             logger.debug(`UpdateCurrentTime: Seek to actual time: ${actualTime} from currentTime: ${currentTime}`);
             seek(actualTime);
         }

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -159,7 +159,7 @@ function HTTPLoader(cfg) {
                         internalLoad(config, remainingAttempts);
                     }, mediaPlayerModel.getRetryIntervalsForType(request.type));
                 } else {
-                    if (request.type === 'FragmentInfoSegment') {
+                    if (request.type === HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE) {
                         return;
                     }
 
@@ -360,7 +360,7 @@ function HTTPLoader(cfg) {
 
         requests.forEach(x => {
             // MSS patch: ignore FragmentInfo requests
-            if (x.request.type === 'FragmentInfoSegment') {
+            if (x.request.type === HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE) {
                 return;
             }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -355,6 +355,11 @@ function HTTPLoader(cfg) {
         delayedRequests = [];
 
         requests.forEach(x => {
+            // MSS patch: ignore FragmentInfo requests
+            if (x.request.type === 'FragmentInfoSegment') {
+                return;
+            }
+
             // abort will trigger onloadend which we don't want
             // when deliberately aborting inflight requests -
             // set them to undefined so they are not called

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -159,6 +159,10 @@ function HTTPLoader(cfg) {
                         internalLoad(config, remainingAttempts);
                     }, mediaPlayerModel.getRetryIntervalsForType(request.type));
                 } else {
+                    if (request.type === 'FragmentInfoSegment') {
+                        return;
+                    }
+
                     errHandler.error(new DashJSError(downloadErrorToRequestTypeMap[request.type], request.url + ' is not available', {
                         request: request,
                         response: httpRequest.response

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -166,6 +166,7 @@ HTTPRequest.INIT_SEGMENT_TYPE = 'InitializationSegment';
 HTTPRequest.INDEX_SEGMENT_TYPE = 'IndexSegment';
 HTTPRequest.MEDIA_SEGMENT_TYPE = 'MediaSegment';
 HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'BitstreamSwitchingSegment';
+HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE = 'FragmentInfoSegment';
 HTTPRequest.LICENSE = 'license';
 HTTPRequest.OTHER_TYPE = 'other';
 


### PR DESCRIPTION
This PR is fixing a bug when seeking MSS live streams to DVR window range start.
While seeking to range start, segment timeline could be updated at the same time, thus having first segments to be removed from timeline.
This PR is fixing also an issue regarding SegmentInfo requests that could be aborted when seeking.