### PR TITLE
Fix multiperiod switching

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -374,6 +374,7 @@ function BufferController(config) {
     // START Buffer Level, State & Sufficiency Handling.
     //**********************************************************************
     function onPlaybackSeeking(e) {
+        if (!buffer) return;
         seekTarget = e.seekTime;
         if (isBufferingCompleted) {
             seekClearedBufferingCompleted = true;
@@ -395,6 +396,7 @@ function BufferController(config) {
 
     // Prune full buffer but what is around current time position
     function pruneAllSafely() {
+        if (!buffer) return;
         buffer.waitForUpdateEnd(() => {
             const ranges = getAllRangesWithSafetyFactor();
             if (!ranges || ranges.length === 0) {
@@ -406,6 +408,7 @@ function BufferController(config) {
 
     // Get all buffer ranges but a range around current time position
     function getAllRangesWithSafetyFactor() {
+        if (!buffer) return;
         const clearRanges = [];
         const ranges = buffer.getAllBufferRanges();
         if (!ranges || ranges.length === 0) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -542,7 +542,9 @@ function PlaybackController() {
         logger.info('Native video element event: ended');
         pause();
         stopUpdatingWallclockTime();
-        eventBus.trigger(Events.PLAYBACK_ENDED, { 'isLast': streamController.getActiveStreamInfo().isLast });
+        const streamInfo = streamController ? streamController.getActiveStreamInfo() : null;
+        if (!streamInfo) return;
+        eventBus.trigger(Events.PLAYBACK_ENDED, { 'isLast': streamInfo.isLast });
     }
 
     // Handle DASH PLAYBACK_ENDED event

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -49,7 +49,6 @@ function ScheduleController(config) {
     const abrController = config.abrController;
     const playbackController = config.playbackController;
     const textController = config.textController;
-    const streamInfo = config.streamInfo;
     const type = config.type;
     const mimeType = config.mimeType;
     const mediaController = config.mediaController;
@@ -57,6 +56,7 @@ function ScheduleController(config) {
     const settings = config.settings;
 
     let instance,
+        streamInfo,
         logger,
         currentRepresentationInfo,
         initialRequest,
@@ -80,6 +80,7 @@ function ScheduleController(config) {
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
         resetInitialSettings();
+        streamInfo = config.streamInfo;
     }
 
     function initialize(_hasVideoTrack) {
@@ -126,6 +127,7 @@ function ScheduleController(config) {
     }
 
     function start() {
+        if (!streamInfo) return;
         if (isStarted()) return;
         if (!currentRepresentationInfo || bufferController.getIsBufferingCompleted()) return;
 
@@ -163,6 +165,7 @@ function ScheduleController(config) {
     }
 
     function schedule() {
+        if (!streamInfo) return;
         if (isStopped || isFragmentProcessingInProgress ||
             (playbackController.isPaused() && !settings.get().streaming.scheduleWhilePaused) ||
             ((type === Constants.FRAGMENTED_TEXT || type === Constants.TEXT) && !textController.isTextEnabled()) ||
@@ -443,6 +446,7 @@ function ScheduleController(config) {
     }
 
     function onPlaybackSeeking(e) {
+        if (!streamInfo) return;
         setSeekTarget(e.seekTime);
         setTimeToLoadDelay(0);
 
@@ -524,6 +528,7 @@ function ScheduleController(config) {
         stop();
         completeQualityChange(false);
         resetInitialSettings();
+        streamInfo = null;
     }
 
     function getPlaybackController() {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -454,7 +454,7 @@ function ScheduleController(config) {
             start();
         }
 
-        const latency = currentRepresentationInfo.DVRWindow && playbackController ? currentRepresentationInfo.DVRWindow.end - playbackController.getTime() : NaN;
+        const latency = currentRepresentationInfo && currentRepresentationInfo.DVRWindow && playbackController ? currentRepresentationInfo.DVRWindow.end - playbackController.getTime() : NaN;
         dashMetrics.updateManifestUpdateInfo({
             latency: latency
         });


### PR DESCRIPTION
This PR is fixing some issues when switching periods, due to controllers lifecycle and seeking event handler.
For example it fixes the following javascript error when switching period:

```
BufferController.js:398 Uncaught TypeError: Cannot read property 'waitForUpdateEnd' of null
    at pruneAllSafely (BufferController.js:398)
    at Object.onPlaybackSeeking (BufferController.js:386)
    at EventBus.js:124
    at Array.forEach (<anonymous>)
    at Object.trigger (EventBus.js:124)
    at HTMLVideoElement.onPlaybackSeeking (PlaybackController.js:499)
```