### PR TITLE
Fix webpack IE11 support 

### DIFF
--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const ESLintPlugin = require('eslint-webpack-plugin');
 const pkg = require('../package.json');
 
 const out_dir = '../dist';
@@ -36,12 +35,6 @@ const config = {
         ]
     },
     plugins: [
-        new ESLintPlugin({
-            files: [
-                'src/**/*.js',
-                'test/unit/mocks/*.js',
-                'test/unit/*.js'
-            ]
         })
     ]
 }

--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const path = require('path');
 const pkg = require('../package.json');
 
@@ -35,6 +36,8 @@ const config = {
         ]
     },
     plugins: [
+        new webpack.ProvidePlugin({
+            Promise: 'es6-promise-promise',
         })
     ]
 }

--- a/build/webpack.prod.js
+++ b/build/webpack.prod.js
@@ -1,5 +1,6 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.base.js').config;
+const ESLintPlugin = require('eslint-webpack-plugin');
 
 const entries = {
     'dash.all': './index.js',
@@ -24,7 +25,16 @@ const configProd = merge(common, {
     output: {
         filename: '[name].min.js'
     },
-    performance: { hints: false }
+    performance: { hints: false },
+    plugins: [
+        new ESLintPlugin({
+            files: [
+                'src/**/*.js',
+                'test/unit/mocks/*.js',
+                'test/unit/*.js'
+            ]
+        })
+    ]
 });
 
 module.exports = [configDev, configProd];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7327,6 +7327,21 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
+    },
+    "es6-promise-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-promise/-/es6-promise-promise-1.0.0.tgz",
+      "integrity": "sha1-OpHyNf3SsIxEkrVzTf0fQXKJuZQ=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.2.1"
+      }
+    },
     "escalade": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-env": "^1.7.0",
     "chai": "^3.4.1",
     "chai-spies": "^1.0.0",
+    "es6-promise-promise": "1.0.0",
     "eslint": "^7.23.0",
     "eslint-webpack-plugin": "^2.5.3",
     "ftp-deploy": "^2.4.1",


### PR DESCRIPTION
Fix issue #3619 by adding polyfill for ES6 Promise.
This PR also modifies webpack configuration to enable eslint only for production mode