### PR TITLE
Add parameter in MediaPlayer.setQualityFor() to force quality switch

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -53,6 +53,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
     var videoControllerVisibleTimeout = 0;
     var liveThresholdSecs = 12;
     var textTrackList = {};
+    var forceQuality = false;
     var video,
         videoContainer,
         videoController,
@@ -845,7 +846,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
                             if (item.index > 0) {
                                 cfg.streaming.abr.autoSwitchBitrate[item.mediaType] = false;
                                 self.player.updateSettings(cfg);
-                                self.player.setQualityFor(item.mediaType, item.index - 1);
+                                self.player.setQualityFor(item.mediaType, item.index - 1, forceQuality);
                             } else {
                                 cfg.streaming.abr.autoSwitchBitrate[item.mediaType] = true;
                                 self.player.updateSettings(cfg);
@@ -1013,6 +1014,10 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
 
         enable: function () {
             videoController.classList.remove('disable');
+        },
+
+        forceQualitySwitch: function (value) {
+            forceQuality = value;
         },
 
         resetSelectionMenus: function () {

--- a/index.d.ts
+++ b/index.d.ts
@@ -464,7 +464,7 @@ declare namespace dashjs {
 
         getQualityFor(type: MediaType): number;
 
-        setQualityFor(type: MediaType, value: number): void;
+        setQualityFor(type: MediaType, value: number, replace?: boolean): void;
 
         updatePortalSize(): void;
 

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -227,6 +227,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.jumpGapsSelected = true;
     $scope.fastSwitchSelected = true;
     $scope.videoAutoSwitchSelected = true;
+    $scope.forceQualitySwitchSelected = false;
     $scope.videoQualities = [];
     $scope.ABRStrategy = 'abrDynamic';
 
@@ -535,6 +536,10 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                 }
             }
         });
+    };
+
+    $scope.toggleForceQualitySwitch = function () {
+        $scope.controlbar.forceQualitySwitch($scope.forceQualitySwitchSelected);
     };
 
     $scope.toggleScheduleWhilePaused = function () {

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -247,6 +247,12 @@
                     Video Auto Switch
                 </label>
                 <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                       title="Forces quality switch to be immediatly effective">
+                    <input type="checkbox" id="forceQualitySwitchCB" ng-model="forceQualitySwitchSelected"
+                           ng-change="toggleForceQualitySwitch()" ng-checked="forceQualitySwitchSelected">
+                    Force Quality Switch
+                </label>
+                <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
                        title="ABR - Use custom ABR rules">
                     <input type="checkbox" id="customABRRules" ng-model="customABRRulesSelected"
                            ng-change="toggleUseCustomABRRules()" ng-checked="customABRRulesSelected">

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -868,13 +868,14 @@ function MediaPlayer() {
      *
      * @param {MediaType} type - 'video', 'audio' or 'image'
      * @param {number} value - the quality index, 0 corresponding to the lowest bitrate
+     * @param {boolean} replace - true if segments have to be replaced by segments of the new quality
      * @memberof module:MediaPlayer
      * @see {@link module:MediaPlayer#setAutoSwitchQualityFor setAutoSwitchQualityFor()}
      * @see {@link module:MediaPlayer#getQualityFor getQualityFor()}
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
      * @instance
      */
-    function setQualityFor(type, value) {
+    function setQualityFor(type, value, replace = false) {
         if (!streamingInitialized) {
             throw STREAMING_NOT_INITIALIZED_ERROR;
         }
@@ -888,7 +889,7 @@ function MediaPlayer() {
                 thumbnailController.setTrackByIndex(value);
             }
         }
-        abrController.setPlaybackQuality(type, streamController.getActiveStreamInfo(), value);
+        abrController.setPlaybackQuality(type, streamController.getActiveStreamInfo(), value, { replace: replace });
     }
 
     /**

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -414,6 +414,25 @@ function BufferController(config) {
         });
     }
 
+    function prepareForReplacementQualitySwitch() {
+        return new Promise((resolve, reject) => {
+            sourceBufferSink.abort()
+                .then(() => {
+                    return updateAppendWindow();
+                })
+                .then(() => {
+                    return pruneAllSafely();
+                })
+                .then(() => {
+                    setIsBufferingCompleted(false);
+                    resolve();
+                })
+                .catch((e) => {
+                    reject(e);
+                });
+        });
+    }
+
     function prepareForNonReplacementTrackSwitch(codec) {
         return new Promise((resolve, reject) => {
             updateAppendWindow()
@@ -1052,6 +1071,7 @@ function BufferController(config) {
         prepareForQualityChange,
         prepareForReplacementTrackSwitch,
         prepareForNonReplacementTrackSwitch,
+        prepareForReplacementQualitySwitch,
         updateAppendWindow,
         getAllRangesWithSafetyFactor,
         getContinuousBufferTimeForTargetTime,


### PR DESCRIPTION
This PR adds a parameter '`replace`' in `MediaPlayer.setQualityFor()` to force quality switch, i.e. to force segments to be immediatly replaced by segments of the new selected quality.

An option has been added in sample app to test this functionnality (set to false by default).