### PR TITLE
Fix segmented text track selection

### DIFF
--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -299,16 +299,15 @@ function TextController(config) {
                     textTracks[streamId].deleteCuesFromTrackIdx(oldTrackIdx);
                     mediaController.setTrack(mediaInfo);
                     textSourceBuffers[streamId].setCurrentFragmentedTrackIdx(i);
+                }  else if (oldTrackIdx === -1) {
+                    //in fragmented use case, if the user selects the older track (the one selected before disabled text track)
+                    //no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
+                    // For that reason we reactivate the StreamProcessor and the ScheduleController
+                    eventBus.trigger(Events.SET_FRAGMENTED_TEXT_AFTER_DISABLED, {}, {
+                        streamId,
+                        mediaType: Constants.FRAGMENTED_TEXT
+                    });
                 }
-            } else if (oldTrackIdx === -1) {
-                //in fragmented use case, if the user selects the older track (the one selected before disabled text track)
-                //no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
-                // For that reason we reactivate the StreamProcessor and the ScheduleController
-                eventBus.trigger(Events.SET_FRAGMENTED_TEXT_AFTER_DISABLED, {}, {
-                    streamId,
-                    mediaType: Constants.FRAGMENTED_TEXT
-                });
-
             }
         }
     }


### PR DESCRIPTION
Fix a bug/regression for (segmented) text track selection.
Bug detected in stream "[Unified Streaming] Subtitles in multi period live" (https://pl8q5ug7b6.execute-api.eu-central-1.amazonaws.com/2.mpd), after disabled then enabled text track, text track is not enabled (segments not downloaded)