### PR TITLE
Updated _applyServiceDescription(): only enable LL on critical SupplementalProperty, correct min/maxDrift 

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -870,29 +870,34 @@ function PlaybackController() {
             if (llsd) {
                 if (mediaInfo && mediaInfo.supplementalProperties &&
                     mediaInfo.supplementalProperties[Constants.SUPPLEMENTAL_PROPERTY_LL_SCHEME] === 'true') {
-                    if (llsd.latency && llsd.latency.target > 0) {
-                        logger.debug('Apply LL properties coming from service description. Target Latency (ms):', llsd.latency.target);
+                        logger.debug('Low Latency critical SupplementalProperty set: Enabling low Latency');
                         settings.update({
                             streaming: {
-                                lowLatencyEnabled: true,
-                                liveDelay: llsd.latency.target / 1000,
-                                liveCatchup: {
-                                    minDrift: llsd.latency.max > llsd.latency.target ? (llsd.latency.max - llsd.latency.target) / 1000 : undefined
-                                }
+                                lowLatencyEnabled: true
                             }
                         });
-                    }
-                    if (llsd.playbackRate && llsd.playbackRate.max > 1.0) {
-                        logger.debug('Apply LL properties coming from service description. Max PlaybackRate:', llsd.playbackRate.max);
-                        settings.update({
-                            streaming: {
-                                lowLatencyEnabled: true,
-                                liveCatchup: {
-                                    playbackRate: llsd.playbackRate.max - 1.0
-                                }
+                }
+                if (llsd.latency && llsd.latency.target > 0) {
+                    logger.debug('Apply LL properties coming from service description. Target Latency (ms):', llsd.latency.target);
+                    settings.update({
+                        streaming: {
+                            liveDelay: llsd.latency.target / 1000,
+                            liveCatchup: {
+                                minDrift: (llsd.latency.target + 500) / 1000,
+                                maxDrift: llsd.latency.max > llsd.latency.target ? (llsd.latency.max - llsd.latency.target) / 1000 : undefined
                             }
-                        });
-                    }
+                        }
+                    });
+                }
+                if (llsd.playbackRate && llsd.playbackRate.max > 1.0) {
+                    logger.debug('Apply LL properties coming from service description. Max PlaybackRate:', llsd.playbackRate.max);
+                    settings.update({
+                        streaming: {
+                            liveCatchup: {
+                                playbackRate: llsd.playbackRate.max - 1.0
+                            }
+                        }
+                    });
                 }
             }
         }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -881,7 +881,9 @@ function PlaybackController() {
                     logger.debug('Apply LL properties coming from service description. Target Latency (ms):', llsd.latency.target);
                     settings.update({
                         streaming: {
-                            liveDelay: llsd.latency.target / 1000,
+                            delay: {
+                                liveDelay: llsd.latency.target / 1000,
+                            },
                             liveCatchup: {
                                 minDrift: (llsd.latency.target + 500) / 1000,
                                 maxDrift: llsd.latency.max > llsd.latency.target ? (llsd.latency.max - llsd.latency.target) / 1000 : undefined

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -299,16 +299,15 @@ function TextController(config) {
                     textTracks[streamId].deleteCuesFromTrackIdx(oldTrackIdx);
                     mediaController.setTrack(mediaInfo);
                     textSourceBuffers[streamId].setCurrentFragmentedTrackIdx(i);
+                }  else if (oldTrackIdx === -1) {
+                    //in fragmented use case, if the user selects the older track (the one selected before disabled text track)
+                    //no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
+                    // For that reason we reactivate the StreamProcessor and the ScheduleController
+                    eventBus.trigger(Events.SET_FRAGMENTED_TEXT_AFTER_DISABLED, {}, {
+                        streamId,
+                        mediaType: Constants.FRAGMENTED_TEXT
+                    });
                 }
-            } else if (oldTrackIdx === -1) {
-                //in fragmented use case, if the user selects the older track (the one selected before disabled text track)
-                //no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
-                // For that reason we reactivate the StreamProcessor and the ScheduleController
-                eventBus.trigger(Events.SET_FRAGMENTED_TEXT_AFTER_DISABLED, {}, {
-                    streamId,
-                    mediaType: Constants.FRAGMENTED_TEXT
-                });
-
             }
         }
     }


### PR DESCRIPTION
Currently the code only makes any settings updates from ServiceDescription on presence of critical SupplementalProperty so this PR corrects the behaviour according to the DVB DASH spec:
- Only enable Low latency on presence of `urn:dvb:dash:lowlatency:critical:2019` SupplementalProperty (according to DVB DASH spec S10.20.5 - It is also mentioned in the spec that LL can be enabled due to two other conditions in the spec so these could also be added at a later date)
- On presence of Service Description set the low latency parameters in `settings`
- Correct setting of `maxDrift`, and `minDrift` according to DVB DASH spec (S10.20.6)