### PR TITLE
Fix multi audio and timeline

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -688,7 +688,7 @@ function Settings() {
             eventControllerRefreshDelay: 150,
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,
-                fallbackToSegmentTimeline: false
+                fallbackToSegmentTimeline: true
             },
             metrics: {
                 maxListDepth: 100

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -197,13 +197,14 @@ function DashAdapter() {
         }
 
         const sameId = mInfoOne.id === mInfoTwo.id;
+        const sameCodec = mInfoOne.codec === mInfoTwo.codec;
         const sameViewpoint = mInfoOne.viewpoint === mInfoTwo.viewpoint;
         const sameLang = mInfoOne.lang === mInfoTwo.lang;
         const sameRoles = mInfoOne.roles.toString() === mInfoTwo.roles.toString();
         const sameAccessibility = mInfoOne.accessibility.toString() === mInfoTwo.accessibility.toString();
         const sameAudioChannelConfiguration = mInfoOne.audioChannelConfiguration.toString() === mInfoTwo.audioChannelConfiguration.toString();
 
-        return (sameId && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
+        return (sameId && sameCodec && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
     }
 
     /**
@@ -1170,6 +1171,7 @@ function DashAdapter() {
         setCurrentMediaInfo,
         isPatchValid,
         applyPatchToManifest,
+        areMediaInfosEqual,
         reset
     };
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -817,16 +817,16 @@ function Stream(config) {
         for (let i = 0, ln = streamProcessors.length; i < ln; i++) {
             let streamProcessor = streamProcessors[i];
             const currentMediaInfo = streamProcessor.getMediaInfo();
-            const currentMediaInfoId = currentMediaInfo ? currentMediaInfo.id : null;
             streamProcessor.updateStreamInfo(streamInfo);
             let allMediaForType = adapter.getAllMediaInfoForType(streamInfo, streamProcessor.getType());
             // Check if AdaptationSet has not been removed in MPD update
             if (allMediaForType) {
-                for (let i = 0; i < allMediaForType.length; i++) {
-                    streamProcessor.addMediaInfo(allMediaForType[i]);
-                    if (allMediaForType[i].id === currentMediaInfoId) {
-                        abrController.updateTopQualityIndex(allMediaForType[i]);
-                        streamProcessor.selectMediaInfo(allMediaForType[i])
+                for (let j = 0; j < allMediaForType.length; j++) {
+                    const mInfo = allMediaForType[j];
+                    streamProcessor.addMediaInfo(allMediaForType[j]);
+                    if (adapter.areMediaInfosEqual(currentMediaInfo, mInfo)) {
+                        abrController.updateTopQualityIndex(mInfo);
+                        streamProcessor.selectMediaInfo(mInfo)
                     }
                 }
             }


### PR DESCRIPTION
- Fix a bug in calculation of the DVR window when fallbackToSegmentTimeline is activated. Only set the timelineAnchorAvailabilityOffset if DVR window is calculated based on SegmentTimeline
- Fix a bug for streams with multiple AdaptationSets and no id attribute specified