### PR TITLE
Fix a bug that lead to starting the the schedule timer twice. 

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -652,6 +652,7 @@ function StreamProcessor(config) {
         }
 
         if (e.error && e.request.serviceLocation) {
+            logger.info(`Fragment loading completed with an error`);
             setExplicitBufferingTime(e.request.startTime + (e.request.duration / 2));
             scheduleController.startScheduleTimer(0);
         }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -942,8 +942,7 @@ function BufferController(config) {
             }
 
             return totalBufferedTime;
-        }
-        catch(e) {
+        } catch (e) {
             return 0;
         }
     }


### PR DESCRIPTION
When the quality is changed as part of the scheduling logic the ScheduleController.js should not call _getNextFragment