### PR TITLE
avoid error when using getCurrentTrackFor with unknown type 

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -135,7 +135,7 @@ function MediaController() {
      * @memberof MediaController#
      */
     function getCurrentTrackFor(type, streamId) {
-        if (!type || !tracks[streamId]) return null;
+        if (!type || !tracks[streamId] || !tracks[streamId][type]) return null;
         return tracks[streamId][type].current;
     }
 


### PR DESCRIPTION
for example with fragmentedText type that is not used anymore. It is for calls with the public API getCurrentTrackFor