### PR TITLE
Treat HTTP headers case-insensitively

### DIFF
--- a/src/dash/DashMetrics.js
+++ b/src/dash/DashMetrics.js
@@ -411,6 +411,10 @@ function DashMetrics(config) {
      * @instance
      */
     function getLatestMPDRequestHeaderValueByID(id) {
+        if (!id) {
+            return null;
+        }
+
         let headers = {};
         let httpRequestList,
             httpRequest,
@@ -427,7 +431,8 @@ function DashMetrics(config) {
             }
         }
 
-        return headers[id] === undefined ? null :  headers[id];
+        const value = headers[id.toLowerCase()];
+        return value === undefined ? null : value;
     }
 
     /**
@@ -439,12 +444,18 @@ function DashMetrics(config) {
      * @instance
      */
     function getLatestFragmentRequestHeaderValueByID(mediaType, id) {
+        if (!id) {
+            return null;
+        }
+
         let headers = {};
-        let httpRequest = getCurrentHttpRequest(mediaType, true);
+        let httpRequest = getCurrentHttpRequest(mediaType);
         if (httpRequest) {
             headers = Utils.parseHttpHeaders(httpRequest._responseHeaders);
         }
-        return headers[id] === undefined ? null :  headers[id];
+
+        const value = headers[id.toLowerCase()];
+        return value === undefined ? null : value;
     }
 
     /**

--- a/test/unit/dash.DashMetrics.js
+++ b/test/unit/dash.DashMetrics.js
@@ -63,7 +63,19 @@ describe('DashMetrics', function () {
     });
 
     describe('getLatestMPDRequestHeaderValueByID', () => {
+        it('should treat headers case-insensitively', () => {
+            const metrics = { HttpList: [{type: 'MPD', _responseHeaders: 'date: mock'}]};
+            metricsModelMock.setMetrics(metrics);
+
+            const lowerCaseValue = dashMetrics.getLatestMPDRequestHeaderValueByID('date');
+            const upperCaseValue = dashMetrics.getLatestMPDRequestHeaderValueByID('Date');
+
+            expect(lowerCaseValue).to.equal('mock');
+            expect(upperCaseValue).to.equal('mock');
+        });
+
         it('should return null when getLatestMPDRequestHeaderValueByID is called and id is undefined', () => {
+            metricsModelMock.setMetrics({});
             const lastMpdRequestHeader = dashMetrics.getLatestMPDRequestHeaderValueByID();
 
             expect(lastMpdRequestHeader).to.be.null;  // jshint ignore:line
@@ -80,7 +92,19 @@ describe('DashMetrics', function () {
     });
 
     describe('getLatestFragmentRequestHeaderValueByID', () => {
+        it('should treat headers case-insensitively', () => {
+            const metrics = { HttpList: [{responsecode: 200, _responseHeaders: 'date: mock'}]};
+            metricsModelMock.setMetrics(metrics);
+
+            const lowerCaseValue = dashMetrics.getLatestFragmentRequestHeaderValueByID('stream', 'date');
+            const upperCaseValue = dashMetrics.getLatestFragmentRequestHeaderValueByID('stream', 'Date');
+
+            expect(lowerCaseValue).to.equal('mock');
+            expect(upperCaseValue).to.equal('mock');
+        });
+
         it('should return null when getLatestFragmentRequestHeaderValueByID is called and metrics, type and id are undefined', () => {
+            metricsModelMock.setMetrics({});
             const lastFragmentRequestHeader = dashMetrics.getLatestFragmentRequestHeaderValueByID();
 
             expect(lastFragmentRequestHeader).to.be.null;  // jshint ignore:line


### PR DESCRIPTION
HTTP headers are case-insensitive and `Headers` object keys are lowercase to accommodate for that.

`getLatestMPDRequestHeaderValueByID` is used only once within the project and it's called with a string `'Date'` which without being converted to lower case never matches any headers. This caused time synchronisation through `Date` header not to work.