### PR TITLE
Do not clear entire buffer when seeking to 0

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -469,7 +469,7 @@ function BufferController(config) {
         }
 
         // if no target time is provided we clear everyhing
-        if (!seekTime || isNaN(seekTime)) {
+        if ((!seekTime && seekTime !== 0) || isNaN(seekTime)) {
             clearRanges.push({
                 start: ranges.start(0),
                 end: ranges.end(ranges.length - 1) + BUFFER_END_THRESHOLD


### PR DESCRIPTION
This fixes issue #3705.

Changes proposed in this PR are the safest way to not make any regression. I'm not sure it this function is supposed to support strings such as `'10'` or not. If not - then I'd rather change this conditional to:
```js
if (typeof seekTime !== 'number' || isNaN(seekTime)) {
```