### PR TITLE
Fix #3701 - use prepare rather than postinstall so dashjs can be used as a dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "mocha test/unit --require mochahook",
         "test-browserunit": "karma start build/karma.conf.js",
         "test-functional": "node test/functional/runTests.js --selenium=remote --app=remote",
-        "postinstall": "node githook.js",
+        "prepare": "node githook.js",
         "prepack": "npm run build"
     },
     "devDependencies": {


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v7/using-npm/scripts

`prepare` only runs when npm install is run locally without any arguments ie when called, rather than after every install. This means the pre-commit hook is installed for those developing the library, but not those for who it is installed as a dependancy.