### PR TITLE
Set response.url to modifiedUrl

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -275,6 +275,7 @@ function HTTPLoader(cfg) {
                 headers = cmcdModel.getHeaderParameters(request);
             }
         }
+        request.url = modifiedUrl;
         const verb = request.checkExistenceOnly ? HTTPRequest.HEAD : HTTPRequest.GET;
         const withCredentials = mediaPlayerModel.getXHRWithCredentialsForType(request.type);
 


### PR DESCRIPTION
- Corrects reporting and logging of URL if modified (e.g. by CMCD)

The response.url is used by the logging and [DVB] reporting components (when activated) which only report the original url before any modifications have been made (e.g. by CMCD) so the used URL (i.e. including the query params) isn't correctly reported. This also fixes some issues with identification of redirection (#3721).