### PR TITLE
Explicitly match null status

### DIFF
--- a/src/streaming/metrics/utils/DVBErrorsTranslator.js
+++ b/src/streaming/metrics/utils/DVBErrorsTranslator.js
@@ -90,6 +90,7 @@ function DVBErrorsTranslator(config) {
 
     function handleHttpMetric(vo) {
         if ((vo.responsecode === 0) ||      // connection failure - unknown
+                (vo.responsecode == null) || // Generated on .catch() and when uninitialised
                 (vo.responsecode >= 400) || // HTTP error status code
                 (vo.responsecode < 100) ||  // unknown status codes
                 (vo.responsecode >= 600)) { // unknown status codes


### PR DESCRIPTION
This can be generated when a request fails with a catch(), though it can occur if the status is uninitialised or explicitly set to null.

Also it seems that the check for `>= 600` is redundant since it will be caught but the earlier `>= 400` check.