### PR TITLE
Fix EventController._triggerRemainingEvents not doing anything

### DIFF
--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -337,7 +337,7 @@ function EventController() {
 
             };
 
-            _iterateAndTriggerCallback(events, callback());
+            _iterateAndTriggerCallback(events, callback);
 
         } catch (e) {
 


### PR DESCRIPTION
EventController apparently was meant to trigger pending events on stop, but this was not happening because of what seems like a silly typo.

This in fact raised an exception which was consumed by an empty `catch` clause. This also does not seem intentional.