### PR TITLE
Feature/dash handler optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -232,7 +232,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
 
 /**
  * @typedef {Object} Buffer
- * @property {boolean} [fastSwitchEnabled=false]
+ * @property {boolean} [fastSwitchEnabled=true]
  * When enabled, after an ABR up-switch in quality, instead of requesting and appending the next fragment at the end of the current buffer range it is requested and appended closer to the current time.
  *
  * When enabled, The maximum time to render a higher quality is current time + (1.5 * fragment duration).

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -197,13 +197,9 @@ function DashHandler(config) {
     }
 
     function isMediaFinished(representation, bufferingTime) {
-        let isFinished = false;
+        if (!representation || !lastSegment) return false;
 
-        if (!representation || !lastSegment) return isFinished;
-
-        // if the buffer is filled up we are done
-
-        // we are replacing existing stuff.
+        // we are replacing existing stuff in the buffer for instance after a track switch
         if (lastSegment.presentationStartTime + lastSegment.duration > bufferingTime) {
             return false;
         }
@@ -213,8 +209,9 @@ function DashHandler(config) {
             return true;
         }
 
+        // Transition from dynamic to static was done
         if (isDynamicManifest && dynamicStreamCompleted) {
-            isFinished = true;
+            return true;
         } else if (lastSegment) {
             const time = parseFloat((lastSegment.presentationStartTime - representation.adaptation.period.start).toFixed(5));
             const endTime = lastSegment.duration > 0 ? time + lastSegment.duration : time;
@@ -223,7 +220,7 @@ function DashHandler(config) {
             return isFinite(duration) && endTime >= duration - 0.05;
         }
 
-        return isFinished;
+        return false;
     }
 
     function getSegmentRequestForTime(mediaInfo, representation, time) {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -209,7 +209,7 @@ function DashHandler(config) {
         }
 
         // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled
-        if (!isNaN(representation.availableSegmentsNumber) && segmentIndex >= representation.availableSegmentsNumber && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
+        if (!isNaN(representation.numberOfSegments) && segmentIndex >= (representation.numberOfSegments - 1) && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
             return true;
         }
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -208,11 +208,10 @@ function DashHandler(config) {
             return false;
         }
 
-        representation.availableSegmentsNumber = _calculateAvailableSegments();
+        representation.availableSegmentsNumber = _calculateAvailableSegments(representation);
 
         // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled
         if (!isNaN(representation.availableSegmentsNumber) && segmentIndex >= representation.availableSegmentsNumber && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
-            console.log()
             return true;
         }
 
@@ -230,7 +229,7 @@ function DashHandler(config) {
     }
 
     function _calculateAvailableSegments(representation) {
-        segmentsController.getAvailableSegments(representation)
+        return segmentsController.getAvailableSegments(representation)
     }
 
     function getSegmentRequestForTime(mediaInfo, representation, time) {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -208,8 +208,6 @@ function DashHandler(config) {
             return false;
         }
 
-        representation.availableSegmentsNumber = _calculateAvailableSegments(representation);
-
         // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled
         if (!isNaN(representation.availableSegmentsNumber) && segmentIndex >= representation.availableSegmentsNumber && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
             return true;
@@ -226,10 +224,6 @@ function DashHandler(config) {
         }
 
         return isFinished;
-    }
-
-    function _calculateAvailableSegments(representation) {
-        return segmentsController.getAvailableSegments(representation)
     }
 
     function getSegmentRequestForTime(mediaInfo, representation, time) {
@@ -293,7 +287,7 @@ function DashHandler(config) {
 
         // check that there is a segment in this index
         const segment = segmentsController.getSegmentByIndex(representation, indexToRequest, lastSegment ? lastSegment.mediaStartTime : -1);
-        if (!segment && isEndlessMedia(representation) && !dynamicStreamCompleted) {
+        if (!segment && !isFinite(representation.adaptation.period.duration) && !dynamicStreamCompleted) {
             logger.debug(getType() + ' No segment found at index: ' + indexToRequest + '. Wait for next loop');
             return null;
         } else {
@@ -314,10 +308,6 @@ function DashHandler(config) {
         }
 
         return request;
-    }
-
-    function isEndlessMedia(representation) {
-        return !isFinite(representation.adaptation.period.duration);
     }
 
     function onDynamicToStatic() {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -208,6 +208,13 @@ function DashHandler(config) {
             return false;
         }
 
+        representation.availableSegmentsNumber = _calculateAvailableSegments();
+
+        // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled
+        if (!isNaN(representation.availableSegmentsNumber) && segmentIndex >= representation.availableSegmentsNumber && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
+            console.log()
+            return true;
+        }
 
         if (isDynamicManifest && dynamicStreamCompleted) {
             isFinished = true;
@@ -220,6 +227,10 @@ function DashHandler(config) {
         }
 
         return isFinished;
+    }
+
+    function _calculateAvailableSegments(representation) {
+        segmentsController.getAvailableSegments(representation)
     }
 
     function getSegmentRequestForTime(mediaInfo, representation, time) {

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -222,7 +222,7 @@ function DashHandler(config) {
         // For dynamic SegmentTimeline manifests we need to check if the next period is already signaled and the segment we fetched before is the last one that is signaled.
         // We can not simply use the index, as numberOfSegments might have decreased after an MPD update
         return !!(isDynamicManifest && representation.adaptation.period.nextPeriodId && representation.segmentInfoType === DashConstants.SEGMENT_TIMELINE && representation.mediaFinishedInformation &&
-            !isNaN(representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment) && lastSegment && !isNaN(lastSegment.mediaStartTime) && !isNaN(lastSegment.duration) && lastSegment.mediaStartTime + lastSegment.duration >= representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment);
+            !isNaN(representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment) && lastSegment && !isNaN(lastSegment.mediaStartTime) && !isNaN(lastSegment.duration) && lastSegment.mediaStartTime + lastSegment.duration >= (representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment - 0.05));
     }
 
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -208,7 +208,7 @@ function DashHandler(config) {
             return false;
         }
 
-        // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled
+        // last segment of that period in a static manifest || last segment of that period in a dynamic manifest and the next period is already signaled. Account for -1 based segmentIndex by subtracting one from numberOfSegments
         if (!isNaN(representation.numberOfSegments) && segmentIndex >= (representation.numberOfSegments - 1) && (!isDynamicManifest || representation.adaptation.period.nextPeriodId)) {
             return true;
         }

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -192,7 +192,6 @@ function RepresentationController(config) {
         }
 
         if (segments.length > 0) {
-            representation.availableSegmentsNumber = segments.length;
             representation.segments = segments;
         }
 

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -142,7 +142,7 @@ function RepresentationController(config) {
                     if (data[1] && !data[1].error) {
                         currentRep = _onSegmentsLoaded(currentRep, data[1]);
                     }
-                    _calculateAvailableSegments(currentRep);
+                    _setMediaFinishedInformation(currentRep);
                     _onRepresentationUpdated(currentRep);
                     resolve();
                 })
@@ -152,8 +152,8 @@ function RepresentationController(config) {
         });
     }
 
-    function _calculateAvailableSegments(representation) {
-        representation.numberOfSegments = segmentsController.getNumberOfSegments(representation);
+    function _setMediaFinishedInformation(representation) {
+        representation.mediaFinishedInformation = segmentsController.getMediaFinishedInformation(representation);
     }
 
     function _onInitLoaded(representation, e) {

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -153,7 +153,7 @@ function RepresentationController(config) {
     }
 
     function _calculateAvailableSegments(representation) {
-        representation.availableSegmentsNumber = segmentsController.getAvailableSegments(representation);
+        representation.numberOfSegments = segmentsController.getNumberOfSegments(representation);
     }
 
     function _onInitLoaded(representation, e) {

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -142,6 +142,7 @@ function RepresentationController(config) {
                     if (data[1] && !data[1].error) {
                         currentRep = _onSegmentsLoaded(currentRep, data[1]);
                     }
+                    _calculateAvailableSegments(currentRep);
                     _onRepresentationUpdated(currentRep);
                     resolve();
                 })
@@ -149,6 +150,10 @@ function RepresentationController(config) {
                     reject(e);
                 });
         });
+    }
+
+    function _calculateAvailableSegments(representation) {
+        representation.availableSegmentsNumber = segmentsController.getAvailableSegments(representation);
     }
 
     function _onInitLoaded(representation, e) {

--- a/src/dash/controllers/SegmentsController.js
+++ b/src/dash/controllers/SegmentsController.js
@@ -91,9 +91,9 @@ function SegmentsController(config) {
         return getter ? getter.getSegmentByTime(representation, time) : null;
     }
 
-    function getAvailableSegments(representation) {
+    function getNumberOfSegments(representation) {
         const getter = getSegmentsGetter(representation);
-        return getter ? getter.getAvailableSegments(representation) : 0;
+        return getter ? getter.getNumberOfSegments(representation) : 0;
     }
 
     instance = {
@@ -102,7 +102,7 @@ function SegmentsController(config) {
         updateSegmentData,
         getSegmentByIndex,
         getSegmentByTime,
-        getAvailableSegments
+        getNumberOfSegments
     };
 
     setup();

--- a/src/dash/controllers/SegmentsController.js
+++ b/src/dash/controllers/SegmentsController.js
@@ -93,7 +93,7 @@ function SegmentsController(config) {
 
     function getAvailableSegments(representation) {
         const getter = getSegmentsGetter(representation);
-        getter.getAvailableSegments(representation);
+        return getter ? getter.getAvailableSegments(representation) : 0;
     }
 
     instance = {

--- a/src/dash/controllers/SegmentsController.js
+++ b/src/dash/controllers/SegmentsController.js
@@ -91,9 +91,12 @@ function SegmentsController(config) {
         return getter ? getter.getSegmentByTime(representation, time) : null;
     }
 
-    function getNumberOfSegments(representation) {
+    function getMediaFinishedInformation(representation) {
         const getter = getSegmentsGetter(representation);
-        return getter ? getter.getNumberOfSegments(representation) : 0;
+        return getter ? getter.getMediaFinishedInformation(representation) : {
+            numberOfSegments: 0,
+            mediaTimeOfLastSignaledSegment: NaN
+        };
     }
 
     instance = {
@@ -102,7 +105,7 @@ function SegmentsController(config) {
         updateSegmentData,
         getSegmentByIndex,
         getSegmentByTime,
-        getNumberOfSegments
+        getMediaFinishedInformation
     };
 
     setup();

--- a/src/dash/controllers/SegmentsController.js
+++ b/src/dash/controllers/SegmentsController.js
@@ -91,12 +91,18 @@ function SegmentsController(config) {
         return getter ? getter.getSegmentByTime(representation, time) : null;
     }
 
+    function getAvailableSegments(representation) {
+        const getter = getSegmentsGetter(representation);
+        getter.getAvailableSegments(representation);
+    }
+
     instance = {
         initialize,
         updateInitData,
         updateSegmentData,
         getSegmentByIndex,
-        getSegmentByTime
+        getSegmentByTime,
+        getAvailableSegments
     };
 
     setup();

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -689,6 +689,10 @@ function DashManifestModel() {
                     voPeriod.duration = realPeriod.duration;
                 }
 
+                if (voPreviousPeriod) {
+                    voPreviousPeriod.nextPeriodId = voPeriod.id;
+                }
+
                 voPeriods.push(voPeriod);
                 realPreviousPeriod = realPeriod;
                 voPreviousPeriod = voPeriod;

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -582,6 +582,9 @@ function DashManifestModel() {
     }
 
     function calcSegmentDuration(segmentTimeline) {
+        if (!segmentTimeline || !segmentTimeline.S_asArray) {
+            return NaN;
+        }
         let s0 = segmentTimeline.S_asArray[0];
         let s1 = segmentTimeline.S_asArray[1];
         return s0.hasOwnProperty('d') ? s0.d : (s1.t - s0.t);

--- a/src/dash/utils/ListSegmentsGetter.js
+++ b/src/dash/utils/ListSegmentsGetter.js
@@ -47,13 +47,20 @@ function ListSegmentsGetter(config, isDynamic) {
         }
     }
 
-    function getNumberOfSegments(representation) {
+    function getMediaFinishedInformation(representation) {
+        const mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN }
+
         if (!representation) {
-            return 0;
+            return mediaFinishedInformation;
         }
 
         const list = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentList;
-        return list.SegmentURL_asArray.length;
+        const startNumber = representation && !isNaN(representation.startNumber) ? representation.startNumber : 1;
+        const offset = Math.max(startNumber - 1, 0);
+
+        mediaFinishedInformation.numberOfSegments = offset + list.SegmentURL_asArray.length;
+
+        return mediaFinishedInformation
     }
 
     function getSegmentByIndex(representation, index) {
@@ -80,7 +87,6 @@ function ListSegmentsGetter(config, isDynamic) {
                 segment.replacementTime = (startNumber + index - 1) * representation.segmentDuration;
                 segment.media = s.media ? s.media : '';
                 segment.mediaRange = s.mediaRange;
-                segment.index = index;
                 segment.indexRange = s.indexRange;
             }
         }
@@ -110,7 +116,7 @@ function ListSegmentsGetter(config, isDynamic) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getNumberOfSegments
+        getMediaFinishedInformation
     };
 
     return instance;

--- a/src/dash/utils/ListSegmentsGetter.js
+++ b/src/dash/utils/ListSegmentsGetter.js
@@ -47,7 +47,7 @@ function ListSegmentsGetter(config, isDynamic) {
         }
     }
 
-    function getAvailableSegments(representation) {
+    function getNumberOfSegments(representation) {
         if (!representation) {
             return 0;
         }
@@ -110,7 +110,7 @@ function ListSegmentsGetter(config, isDynamic) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getAvailableSegments
+        getNumberOfSegments
     };
 
     return instance;

--- a/src/dash/utils/ListSegmentsGetter.js
+++ b/src/dash/utils/ListSegmentsGetter.js
@@ -85,8 +85,6 @@ function ListSegmentsGetter(config, isDynamic) {
             }
         }
 
-        representation.availableSegmentsNumber = len;
-
         return segment;
     }
 
@@ -110,8 +108,9 @@ function ListSegmentsGetter(config, isDynamic) {
     }
 
     instance = {
-        getSegmentByIndex: getSegmentByIndex,
-        getSegmentByTime: getSegmentByTime
+        getSegmentByIndex,
+        getSegmentByTime,
+        getAvailableSegments
     };
 
     return instance;

--- a/src/dash/utils/ListSegmentsGetter.js
+++ b/src/dash/utils/ListSegmentsGetter.js
@@ -47,6 +47,15 @@ function ListSegmentsGetter(config, isDynamic) {
         }
     }
 
+    function getAvailableSegments(representation) {
+        if (!representation) {
+            return 0;
+        }
+
+        const list = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentList;
+        return list.SegmentURL_asArray.length;
+    }
+
     function getSegmentByIndex(representation, index) {
         checkConfig();
 

--- a/src/dash/utils/SegmentBaseGetter.js
+++ b/src/dash/utils/SegmentBaseGetter.js
@@ -46,6 +46,14 @@ function SegmentBaseGetter(config) {
         }
     }
 
+    function getAvailableSegments(representation) {
+        if (!representation || !representation.segments) {
+            return 0;
+        }
+
+        return representation.segments.length;
+    }
+
     function getSegmentByIndex(representation, index) {
         checkConfig();
 
@@ -115,8 +123,9 @@ function SegmentBaseGetter(config) {
     }
 
     instance = {
-        getSegmentByIndex: getSegmentByIndex,
-        getSegmentByTime: getSegmentByTime
+        getSegmentByIndex,
+        getSegmentByTime,
+        getAvailableSegments
     };
 
     return instance;

--- a/src/dash/utils/SegmentBaseGetter.js
+++ b/src/dash/utils/SegmentBaseGetter.js
@@ -46,12 +46,16 @@ function SegmentBaseGetter(config) {
         }
     }
 
-    function getNumberOfSegments(representation) {
+    function getMediaFinishedInformation(representation) {
+        const mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN }
+
         if (!representation || !representation.segments) {
-            return 0;
+            return mediaFinishedInformation
         }
 
-        return representation.segments.length;
+        mediaFinishedInformation.numberOfSegments = representation.segments.length;
+
+        return mediaFinishedInformation;
     }
 
     function getSegmentByIndex(representation, index) {
@@ -65,7 +69,7 @@ function SegmentBaseGetter(config) {
         let seg;
         if (index < len) {
             seg = representation.segments[index];
-            if (seg && seg.availabilityIdx === index) {
+            if (seg && seg.index === index) {
                 return seg;
             }
         }
@@ -73,7 +77,7 @@ function SegmentBaseGetter(config) {
         for (let i = 0; i < len; i++) {
             seg = representation.segments[i];
 
-            if (seg && seg.availabilityIdx === index) {
+            if (seg && seg.index === index) {
                 return seg;
             }
         }
@@ -99,21 +103,21 @@ function SegmentBaseGetter(config) {
 
         let idx = -1;
         let epsilon,
-            frag,
+            seg,
             ft,
             fd,
             i;
 
         if (segments && ln > 0) {
             for (i = 0; i < ln; i++) {
-                frag = segments[i];
-                ft = frag.presentationStartTime;
-                fd = frag.duration;
+                seg = segments[i];
+                ft = seg.presentationStartTime;
+                fd = seg.duration;
 
                 epsilon = fd / 2;
                 if ((time + epsilon) >= ft &&
                     (time - epsilon) < (ft + fd)) {
-                    idx = frag.availabilityIdx;
+                    idx = seg.index;
                     break;
                 }
             }
@@ -125,7 +129,7 @@ function SegmentBaseGetter(config) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getNumberOfSegments
+        getMediaFinishedInformation
     };
 
     return instance;

--- a/src/dash/utils/SegmentBaseGetter.js
+++ b/src/dash/utils/SegmentBaseGetter.js
@@ -46,7 +46,7 @@ function SegmentBaseGetter(config) {
         }
     }
 
-    function getAvailableSegments(representation) {
+    function getNumberOfSegments(representation) {
         if (!representation || !representation.segments) {
             return 0;
         }
@@ -125,7 +125,7 @@ function SegmentBaseGetter(config) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getAvailableSegments
+        getNumberOfSegments
     };
 
     return instance;

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -129,7 +129,7 @@ export function replaceTokenForTemplate(url, token, value) {
     }
 }
 
-function getSegment(representation, duration, presentationStartTime, mediaStartTime, availabilityStartTime,
+function getSegment(representation, duration, presentationStartTime, mediaStartTime,
                     timelineConverter, presentationEndTime, isDynamic, index) {
     let seg = new Segment();
 
@@ -137,11 +137,11 @@ function getSegment(representation, duration, presentationStartTime, mediaStartT
     seg.duration = duration;
     seg.presentationStartTime = presentationStartTime;
     seg.mediaStartTime = mediaStartTime;
-    seg.availabilityStartTime = availabilityStartTime;
+    seg.availabilityStartTime = timelineConverter.calcAvailabilityStartTimeFromPresentationTime(presentationEndTime, representation, isDynamic);
     seg.availabilityEndTime = timelineConverter.calcAvailabilityEndTimeFromPresentationTime(presentationEndTime + duration, representation, isDynamic);
     seg.wallStartTime = timelineConverter.calcWallTimeForSegment(seg, isDynamic);
     seg.replacementNumber = getNumberForSegment(seg, index);
-    seg.availabilityIdx = index;
+    seg.index = index;
 
     return seg;
 }
@@ -193,9 +193,8 @@ export function getIndexBasedSegment(timelineConverter, isDynamic, representatio
     presentationEndTime = parseFloat((presentationStartTime + duration).toFixed(5));
 
     const mediaTime = timelineConverter.calcMediaTimeFromPresentationTime(presentationStartTime, representation);
-    const availabilityStartTime = timelineConverter.calcAvailabilityStartTimeFromPresentationTime(presentationEndTime, representation, isDynamic);
 
-    const segment = getSegment(representation, duration, presentationStartTime, mediaTime, availabilityStartTime,
+    const segment = getSegment(representation, duration, presentationStartTime, mediaTime,
         timelineConverter, presentationEndTime, isDynamic, index);
 
     if (!isSegmentAvailable(timelineConverter, representation, segment, isDynamic)) {
@@ -216,11 +215,8 @@ export function getTimeBasedSegment(timelineConverter, isDynamic, representation
     presentationStartTime = timelineConverter.calcPresentationTimeFromMediaTime(scaledTime, representation);
     presentationEndTime = presentationStartTime + scaledDuration;
 
-    const availabilityStartTime = timelineConverter.calcAvailabilityStartTimeFromPresentationTime(presentationEndTime, representation, isDynamic);
-
     seg = getSegment(representation, scaledDuration, presentationStartTime,
         scaledTime,
-        availabilityStartTime,
         timelineConverter, presentationEndTime, isDynamic, index);
 
     if (!isSegmentAvailable(timelineConverter, representation, seg, isDynamic)) {

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -53,9 +53,9 @@ function TemplateSegmentsGetter(config, isDynamic) {
 
         const duration = representation.segmentDuration;
         if (isNaN(duration)) {
-            representation.availableSegmentsNumber = 1;
+            return 1;
         } else {
-            representation.availableSegmentsNumber = Math.ceil(representation.adaptation.period.duration / duration);
+            return Math.ceil(representation.adaptation.period.duration / duration);
         }
     }
 
@@ -104,7 +104,8 @@ function TemplateSegmentsGetter(config, isDynamic) {
 
     instance = {
         getSegmentByIndex,
-        getSegmentByTime
+        getSegmentByTime,
+        getAvailableSegments
     };
 
     return instance;

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -46,7 +46,7 @@ function TemplateSegmentsGetter(config, isDynamic) {
         }
     }
 
-    function getAvailableSegments(representation) {
+    function getNumberOfSegments(representation) {
         if (!representation) {
             return 0;
         }
@@ -105,7 +105,7 @@ function TemplateSegmentsGetter(config, isDynamic) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getAvailableSegments
+        getNumberOfSegments
     };
 
     return instance;

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -46,6 +46,19 @@ function TemplateSegmentsGetter(config, isDynamic) {
         }
     }
 
+    function getAvailableSegments(representation) {
+        if (!representation) {
+            return 0;
+        }
+
+        const duration = representation.segmentDuration;
+        if (isNaN(duration)) {
+            representation.availableSegmentsNumber = 1;
+        } else {
+            representation.availableSegmentsNumber = Math.ceil(representation.adaptation.period.duration / duration);
+        }
+    }
+
     function getSegmentByIndex(representation, index) {
         checkConfig();
 
@@ -65,14 +78,6 @@ function TemplateSegmentsGetter(config, isDynamic) {
             url = replaceTokenForTemplate(url, 'Number', seg.replacementNumber);
             url = replaceTokenForTemplate(url, 'Time', seg.replacementTime);
             seg.media = url;
-        }
-
-        const duration = representation.segmentDuration;
-
-        if (isNaN(duration)) {
-            representation.availableSegmentsNumber = 1;
-        } else {
-            representation.availableSegmentsNumber = Math.ceil(representation.adaptation.period.duration / duration);
         }
 
         return seg;

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -48,6 +48,83 @@ function TimelineSegmentsGetter(config, isDynamic) {
         }
     }
 
+    function getAvailableSegments(representation) {
+        if (!representation) {
+            return 0;
+        }
+
+        const base = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentTemplate ||
+            representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentList;
+        const timeline = base.SegmentTimeline;
+
+        let time = 0;
+        let scaledTime = 0;
+        let availableSegments = 0;
+
+        let fragments,
+            frag,
+            i,
+            len,
+            j,
+            repeat,
+            repeatEndTime,
+            nextFrag,
+            fTimescale;
+
+        fTimescale = representation.timescale;
+        fragments = timeline.S_asArray;
+
+        len = fragments.length;
+
+        for (i = 0; i < len; i++) {
+            frag = fragments[i];
+            repeat = 0;
+            if (frag.hasOwnProperty('r')) {
+                repeat = frag.r;
+            }
+
+            // For a repeated S element, t belongs only to the first segment
+            if (frag.hasOwnProperty('t')) {
+                time = frag.t;
+                scaledTime = time / fTimescale;
+            }
+
+            // This is a special case: "A negative value of the @r attribute of the S element indicates that the duration indicated in @d attribute repeats until the start of the next S element, the end of the Period or until the
+            // next MPD update."
+            if (repeat < 0) {
+                nextFrag = fragments[i + 1];
+
+                if (nextFrag && nextFrag.hasOwnProperty('t')) {
+                    repeatEndTime = nextFrag.t / fTimescale;
+                } else {
+                    try {
+                        let availabilityEnd = 0;
+                        if (!isNaN(representation.adaptation.period.start) && !isNaN(representation.adaptation.period.duration) && isFinite(representation.adaptation.period.duration)) {
+                            // use end of the Period
+                            availabilityEnd = representation.adaptation.period.start + representation.adaptation.period.duration;
+                        } else {
+                            // use DVR window
+                            const dvrWindow = dashMetrics.getCurrentDVRInfo();
+                            availabilityEnd = !isNaN(dvrWindow.end) ? dvrWindow.end : 0;
+                        }
+                        repeatEndTime = timelineConverter.calcMediaTimeFromPresentationTime(availabilityEnd, representation);
+                        representation.segmentDuration = frag.d / fTimescale;
+                    } catch (e) {
+                        repeatEndTime = 0;
+                    }
+                }
+
+                repeat = Math.max(Math.ceil((repeatEndTime - scaledTime) / (frag.d / fTimescale)) - 1, 0);
+            }
+
+            for (j = 0; j <= repeat; j++) {
+                availableSegments++;
+            }
+        }
+
+        return availableSegments;
+    }
+
     function iterateSegments(representation, iterFunc) {
         const base = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentTemplate ||
             representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentList;
@@ -134,8 +211,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
         }
 
         representation.availableSegmentsNumber = availabilityIdx;
-
-        console.log(`Available segments for ${representation.mimeType} ${representation.availableSegmentsNumber}`);
     }
 
     function getSegmentByIndex(representation, index, lastSegmentTime) {
@@ -232,8 +307,9 @@ function TimelineSegmentsGetter(config, isDynamic) {
 
 
     instance = {
-        getSegmentByIndex: getSegmentByIndex,
-        getSegmentByTime: getSegmentByTime
+        getSegmentByIndex,
+        getSegmentByTime,
+        getAvailableSegments
     };
 
     return instance;

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -134,6 +134,8 @@ function TimelineSegmentsGetter(config, isDynamic) {
         }
 
         representation.availableSegmentsNumber = availabilityIdx;
+
+        console.log(`Available segments for ${representation.mimeType} ${representation.availableSegmentsNumber}`);
     }
 
     function getSegmentByIndex(representation, index, lastSegmentTime) {

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -209,8 +209,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
                 scaledTime = time / fTimescale;
             }
         }
-
-        representation.availableSegmentsNumber = availabilityIdx;
     }
 
     function getSegmentByIndex(representation, index, lastSegmentTime) {

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -48,7 +48,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
         }
     }
 
-    function getAvailableSegments(representation) {
+    function getNumberOfSegments(representation) {
         if (!representation) {
             return 0;
         }
@@ -307,7 +307,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
     instance = {
         getSegmentByIndex,
         getSegmentByTime,
-        getAvailableSegments
+        getNumberOfSegments
     };
 
     return instance;

--- a/src/dash/vo/Period.js
+++ b/src/dash/vo/Period.js
@@ -39,6 +39,7 @@ class Period {
         this.duration = NaN;
         this.start = NaN;
         this.mpd = null;
+        this.nextPeriodId = null;
     }
 }
 

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -53,7 +53,8 @@ class Representation {
         this.presentationTimeOffset = 0;
         // Set the source buffer timeOffset to this
         this.MSETimeOffset = NaN;
-        this.numberOfSegments = 0;
+        // The information we need in the DashHandler to determine whether the last segment has been loaded
+        this.mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN };
         this.bandwidth = NaN;
         this.width = NaN;
         this.height = NaN;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -53,7 +53,7 @@ class Representation {
         this.presentationTimeOffset = 0;
         // Set the source buffer timeOffset to this
         this.MSETimeOffset = NaN;
-        this.availableSegmentsNumber = 0;
+        this.numberOfSegments = 0;
         this.bandwidth = NaN;
         this.width = NaN;
         this.height = NaN;

--- a/src/dash/vo/Segment.js
+++ b/src/dash/vo/Segment.js
@@ -35,6 +35,7 @@
 class Segment {
     constructor() {
         this.indexRange = null;
+        // The index of the segment in the list of segments. We start at 0
         this.index = null;
         this.mediaRange = null;
         this.media = null;
@@ -52,8 +53,6 @@ class Segment {
         this.availabilityStartTime = NaN;
         // Ignore and  discard this segment after
         this.availabilityEndTime = NaN;
-        // The index of the segment inside the availability window
-        this.availabilityIdx = NaN;
         // For dynamic mpd's, this is the wall clock time that the video
         // element currentTime should be presentationStartTime
         this.wallStartTime = NaN;

--- a/src/offline/OfflineStreamProcessor.js
+++ b/src/offline/OfflineStreamProcessor.js
@@ -333,7 +333,7 @@ function OfflineStreamProcessor(config) {
     }
 
     function getAvailableSegmentsNumber() {
-        return representationController.getCurrentRepresentation().availableSegmentsNumber + 1; // do not forget init segment
+        return representationController.getCurrentRepresentation().numberOfSegments + 1; // do not forget init segment
     }
 
     function updateProgression () {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -403,16 +403,17 @@ function StreamProcessor(config) {
         let request = null;
 
         const representation = representationController.getCurrentRepresentation();
-        const isMediaFinished = dashHandler.isMediaFinished(representation, bufferingTime);
+        const lastSegmentRequested = dashHandler.lastSegmentRequested(representation, bufferingTime);
 
         // Check if the media is finished. If so, no need to schedule another request
-        if (isMediaFinished) {
+        if (lastSegmentRequested) {
             const segmentIndex = dashHandler.getCurrentIndex();
             logger.debug(`Segment requesting for stream ${streamInfo.id} has finished`);
             eventBus.trigger(Events.STREAM_REQUESTING_COMPLETED, { segmentIndex }, {
                 streamId: streamInfo.id,
                 mediaType: type
             });
+            bufferController.segmentRequestingCompleted(segmentIndex);
             scheduleController.clearScheduleTimer();
             return;
         }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -100,7 +100,6 @@ function BufferController(config) {
 
         eventBus.on(Events.INIT_FRAGMENT_LOADED, _onInitFragmentLoaded, instance);
         eventBus.on(Events.MEDIA_FRAGMENT_LOADED, _onMediaFragmentLoaded, instance);
-        eventBus.on(Events.STREAM_REQUESTING_COMPLETED, _onStreamRequestingCompleted, instance);
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, instance);
 
         eventBus.on(MediaPlayerEvents.PLAYBACK_PLAYING, _onPlaybackPlaying, instance);
@@ -875,9 +874,9 @@ function BufferController(config) {
         return Promise.resolve();
     }
 
-    function _onStreamRequestingCompleted(e) {
-        if (!isNaN(e.segmentIndex)) {
-            maximumIndex = e.segmentIndex;
+    function segmentRequestingCompleted(segmentIndex) {
+        if (!isNaN(segmentIndex)) {
+            maximumIndex = segmentIndex;
             _checkIfBufferingCompleted();
         }
     }
@@ -1029,7 +1028,6 @@ function BufferController(config) {
         eventBus.off(Events.INIT_FRAGMENT_LOADED, _onInitFragmentLoaded, this);
         eventBus.off(Events.MEDIA_FRAGMENT_LOADED, _onMediaFragmentLoaded, this);
         eventBus.off(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, this);
-        eventBus.off(Events.STREAM_REQUESTING_COMPLETED, _onStreamRequestingCompleted, this);
 
         eventBus.off(MediaPlayerEvents.PLAYBACK_PLAYING, _onPlaybackPlaying, this);
         eventBus.off(MediaPlayerEvents.PLAYBACK_PROGRESS, _onPlaybackProgression, this);
@@ -1067,7 +1065,8 @@ function BufferController(config) {
         clearBuffers,
         pruneAllSafely,
         updateBufferTimestampOffset,
-        setSeekTarget
+        setSeekTarget,
+        segmentRequestingCompleted
     };
 
     setup();

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -200,6 +200,10 @@ function NotFragmentedTextBufferController(config) {
 
     }
 
+    function segmentRequestingCompleted() {
+
+    }
+
     function pruneAllSafely() {
         return Promise.resolve();
     }
@@ -233,7 +237,8 @@ function NotFragmentedTextBufferController(config) {
         setSeekTarget,
         updateAppendWindow,
         pruneAllSafely,
-        updateBufferTimestampOffset
+        updateBufferTimestampOffset,
+        segmentRequestingCompleted
     };
 
     setup();

--- a/test/unit/dash.utils.ListSegmentsGetter.js
+++ b/test/unit/dash.utils.ListSegmentsGetter.js
@@ -101,7 +101,7 @@ describe('ListSegmentsGetter', () => {
         it('should calculate representation segment range correctly', () => {
             const representation = createRepresentationMock();
 
-            const availableSegmentsNumber = listSegmentsGetter.getAvailableSegments(representation);
+            const availableSegmentsNumber = listSegmentsGetter.getNumberOfSegments(representation);
             expect(availableSegmentsNumber).to.equal(5);
         });
     });

--- a/test/unit/dash.utils.ListSegmentsGetter.js
+++ b/test/unit/dash.utils.ListSegmentsGetter.js
@@ -101,8 +101,8 @@ describe('ListSegmentsGetter', () => {
         it('should calculate representation segment range correctly', () => {
             const representation = createRepresentationMock();
 
-            listSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(representation.availableSegmentsNumber).to.equal(5);
+            const availableSegmentsNumber = listSegmentsGetter.getAvailableSegments(representation);
+            expect(availableSegmentsNumber).to.equal(5);
         });
     });
 

--- a/test/unit/dash.utils.ListSegmentsGetter.js
+++ b/test/unit/dash.utils.ListSegmentsGetter.js
@@ -97,12 +97,19 @@ describe('ListSegmentsGetter', () => {
         });
     });
 
-    describe('availableSegmentsNumber calculation', () => {
-        it('should calculate representation segment range correctly', () => {
+    describe('mediaFinishedInformation calculation', () => {
+        it('should calculate the right number of segments', () => {
             const representation = createRepresentationMock();
 
-            const availableSegmentsNumber = listSegmentsGetter.getNumberOfSegments(representation);
-            expect(availableSegmentsNumber).to.equal(5);
+            const mediaFinishedInformation = listSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.numberOfSegments).to.equal(5);
+        });
+
+        it('mediaTimeOfLastSignaledSegments should be NaN', () => {
+            const representation = createRepresentationMock();
+
+            const mediaFinishedInformation = listSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.mediaTimeOfLastSignaledSegment).to.be.NaN;
         });
     });
 
@@ -111,17 +118,17 @@ describe('ListSegmentsGetter', () => {
             const representation = createRepresentationMock();
 
             let seg = listSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(10);
 
             seg = listSegmentsGetter.getSegmentByIndex(representation, 1);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(10);
             expect(seg.duration).to.equal(10);
 
             seg = listSegmentsGetter.getSegmentByIndex(representation, 2);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(20);
             expect(seg.duration).to.equal(10);
         });
@@ -147,17 +154,17 @@ describe('ListSegmentsGetter', () => {
             const representation = createRepresentationMock();
 
             let seg = listSegmentsGetter.getSegmentByTime(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(10);
 
             seg = listSegmentsGetter.getSegmentByTime(representation, 22);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(20);
             expect(seg.duration).to.equal(10);
 
             seg = listSegmentsGetter.getSegmentByTime(representation, 32);
-            expect(seg.availabilityIdx).to.equal(3);
+            expect(seg.index).to.equal(3);
             expect(seg.presentationStartTime).to.equal(30);
             expect(seg.duration).to.equal(10);
         });

--- a/test/unit/dash.utils.SegmentBaseGetter.js
+++ b/test/unit/dash.utils.SegmentBaseGetter.js
@@ -12,7 +12,7 @@ function createRepresentationMock() {
 
     for (let i = 0; i < 5; i++) {
         representation.segments.push({
-            availabilityIdx: i,
+            index: i,
             duration: 5,
             mediaStartTime: i * 5,
             presentationStartTime: i * 5,
@@ -63,17 +63,17 @@ describe('SegmentBaseGetter', () => {
             const representation = createRepresentationMock();
 
             let seg = segmentBaseGetter.getSegmentByIndex(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(5);
 
             seg = segmentBaseGetter.getSegmentByIndex(representation, 1);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(5);
             expect(seg.duration).to.equal(5);
 
             seg = segmentBaseGetter.getSegmentByIndex(representation, 2);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(10);
             expect(seg.duration).to.equal(5);
         });
@@ -91,17 +91,17 @@ describe('SegmentBaseGetter', () => {
             const representation = createRepresentationMock();
 
             let seg = segmentBaseGetter.getSegmentByTime(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(5);
 
             seg = segmentBaseGetter.getSegmentByTime(representation, 6);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(5);
 
             seg = segmentBaseGetter.getSegmentByTime(representation, 12);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(5);
             expect(seg.duration).to.equal(5);
         });

--- a/test/unit/dash.utils.TemplateSegmentsGetter.js
+++ b/test/unit/dash.utils.TemplateSegmentsGetter.js
@@ -45,7 +45,7 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = undefined;
 
-            const availableSegmentsNumber = templateSegmentsGetter.getAvailableSegments(representation);
+            const availableSegmentsNumber = templateSegmentsGetter.getNumberOfSegments(representation);
             expect(availableSegmentsNumber).to.equal(1);
         });
 
@@ -54,7 +54,7 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = 5;
 
-            const availableSegmentsNumber = templateSegmentsGetter.getAvailableSegments(representation);
+            const availableSegmentsNumber = templateSegmentsGetter.getNumberOfSegments(representation);
             expect(availableSegmentsNumber).to.equal(20);
         });
     });

--- a/test/unit/dash.utils.TemplateSegmentsGetter.js
+++ b/test/unit/dash.utils.TemplateSegmentsGetter.js
@@ -45,18 +45,25 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = undefined;
 
-            const availableSegmentsNumber = templateSegmentsGetter.getNumberOfSegments(representation);
-            expect(availableSegmentsNumber).to.equal(1);
+            const mediaFinishedInformation = templateSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.numberOfSegments).to.equal(1);
         });
 
-        it('should calculate representation segment range correctly', () => {
+        it('should calculate availableSegmentsNumber correctly', () => {
             const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = 5;
 
-            const availableSegmentsNumber = templateSegmentsGetter.getNumberOfSegments(representation);
-            expect(availableSegmentsNumber).to.equal(20);
+            representation.segmentAvailabilityWindow = {start: 0, end: 100};
+            let mediaFinishedInformation = templateSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.numberOfSegments).to.equal(20);
+
+            representation.segmentAvailabilityWindow = {start: 0, end: 101};
+            representation.adaptation.period.duration = 101;
+            mediaFinishedInformation = templateSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.numberOfSegments).to.equal(21);
         });
+
+
     });
 
     describe('getSegmentByIndex', () => {
@@ -66,17 +73,17 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentDuration = 1;
 
             let seg = templateSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(1);
 
             seg = templateSegmentsGetter.getSegmentByIndex(representation, 1);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(1);
             expect(seg.duration).to.equal(1);
 
             seg = templateSegmentsGetter.getSegmentByIndex(representation, 2);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(2);
             expect(seg.duration).to.equal(1);
         });
@@ -107,22 +114,22 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentDuration = 5;
 
             let seg = templateSegmentsGetter.getSegmentByTime(representation, 0);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(5);
 
             seg = templateSegmentsGetter.getSegmentByTime(representation, 3);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(5);
 
             seg = templateSegmentsGetter.getSegmentByTime(representation, 12);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(10);
             expect(seg.duration).to.equal(5);
 
             seg = templateSegmentsGetter.getSegmentByTime(representation, 17);
-            expect(seg.availabilityIdx).to.equal(3);
+            expect(seg.index).to.equal(3);
             expect(seg.presentationStartTime).to.equal(15);
             expect(seg.duration).to.equal(5);
         });

--- a/test/unit/dash.utils.TemplateSegmentsGetter.js
+++ b/test/unit/dash.utils.TemplateSegmentsGetter.js
@@ -45,8 +45,8 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = undefined;
 
-            templateSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(representation.availableSegmentsNumber).to.equal(1);
+            const availableSegmentsNumber = templateSegmentsGetter.getAvailableSegments(representation);
+            expect(availableSegmentsNumber).to.equal(1);
         });
 
         it('should calculate representation segment range correctly', () => {
@@ -54,8 +54,8 @@ describe('TemplateSegmentsGetter', () => {
             representation.segmentAvailabilityWindow = {start: 0, end: 100};
             representation.segmentDuration = 5;
 
-            templateSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(representation.availableSegmentsNumber).to.equal(20);
+            const availableSegmentsNumber = templateSegmentsGetter.getAvailableSegments(representation);
+            expect(availableSegmentsNumber).to.equal(20);
         });
     });
 

--- a/test/unit/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/dash.utils.TimelineSegmentsGetter.js
@@ -80,11 +80,17 @@ describe('TimelineSegmentsGetter', () => {
     });
 
     describe('availableSegmentsNumber calculation', () => {
-        it('should calculate representation segment range correctly', () => {
+        it('should calculate the number of available segments correctly', () => {
             const representation = createRepresentationMock();
 
-            const availableSegmentsNumber = timelineSegmentsGetter.getNumberOfSegments(representation);
-            expect(availableSegmentsNumber).to.equal(26);
+            const mediaFinishedInformation = timelineSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.numberOfSegments).to.equal(26);
+        });
+        it('should calculate the media time of the last segment correctly', () => {
+            const representation = createRepresentationMock();
+
+            const mediaFinishedInformation = timelineSegmentsGetter.getMediaFinishedInformation(representation);
+            expect(mediaFinishedInformation.mediaTimeOfLastSignaledSegment).to.equal(101.1);
         });
     });
 
@@ -93,17 +99,17 @@ describe('TimelineSegmentsGetter', () => {
             const representation = createRepresentationMock();
 
             let seg = timelineSegmentsGetter.getSegmentByIndex(representation, 0, -1);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByIndex(representation, 1, 0);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(4.004);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByIndex(representation, 2, 4.004);
-            expect(seg.availabilityIdx).to.equal(2);
+            expect(seg.index).to.equal(2);
             expect(seg.presentationStartTime).to.equal(8.008);
             expect(seg.duration).to.equal(4.004);
         });
@@ -132,32 +138,32 @@ describe('TimelineSegmentsGetter', () => {
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 3);
-            expect(seg.availabilityIdx).to.equal(0);
+            expect(seg.index).to.equal(0);
             expect(seg.presentationStartTime).to.equal(0);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 5);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(4.004);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 22);
-            expect(seg.availabilityIdx).to.equal(5);
+            expect(seg.index).to.equal(5);
             expect(seg.presentationStartTime).to.equal(20.02);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 53);
-            expect(seg.availabilityIdx).to.equal(13);
+            expect(seg.index).to.equal(13);
             expect(seg.presentationStartTime).to.equal(52.052);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 4.004);
-            expect(seg.availabilityIdx).to.equal(1);
+            expect(seg.index).to.equal(1);
             expect(seg.presentationStartTime).to.equal(4.004);
             expect(seg.duration).to.equal(4.004);
 
             seg = timelineSegmentsGetter.getSegmentByTime(representation, 100.2);
-            expect(seg.availabilityIdx).to.equal(25);
+            expect(seg.index).to.equal(25);
             expect(seg.presentationStartTime).to.equal(100.1);
             expect(seg.duration).to.equal(1);
         });

--- a/test/unit/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/dash.utils.TimelineSegmentsGetter.js
@@ -83,8 +83,8 @@ describe('TimelineSegmentsGetter', () => {
         it('should calculate representation segment range correctly', () => {
             const representation = createRepresentationMock();
 
-            timelineSegmentsGetter.getSegmentByIndex(representation, 0);
-            expect(representation.availableSegmentsNumber).to.equal(25);
+            const availableSegmentsNumber = timelineSegmentsGetter.getAvailableSegments(representation);
+            expect(availableSegmentsNumber).to.equal(26);
         });
     });
 

--- a/test/unit/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/dash.utils.TimelineSegmentsGetter.js
@@ -83,7 +83,7 @@ describe('TimelineSegmentsGetter', () => {
         it('should calculate representation segment range correctly', () => {
             const representation = createRepresentationMock();
 
-            const availableSegmentsNumber = timelineSegmentsGetter.getAvailableSegments(representation);
+            const availableSegmentsNumber = timelineSegmentsGetter.getNumberOfSegments(representation);
             expect(availableSegmentsNumber).to.equal(26);
         });
     });


### PR DESCRIPTION
This PR aims to solve parts of #3713. It includes a new logic in the DashHandler to decide whether all segments of a period have been loaded:

* For static and dynamic(Template,List) manifests we compare the index of the last downloaded segment to the number of signaled segments
* For dynamic SegmentTimeline manifests the number of available segments changes with MPD updates. We compare the media time of the last signaled segment to the media time of the last downloaded segment. 
* For dynamic manifests we can rely on the fact that segments are only allowed to be added to the last period. Once a new period is signaled and the last segment of the current period has been fetched we can conclude that the last segment of the current period has been loaded
* We update the number of signaled segments after each MPD update
* In addition, there is still a buffer finished decision logic implemented in the `BufferController`. After appending each segment we check if the current buffer is >= the time until the end of the period.

The advantage of the new approach is that we start prebuffering new periods, even if not enough segments are signaled to fill the whole buffer for the current period.