### PR TITLE
Fix/cmcd nor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -270,8 +270,7 @@ function CmcdModel() {
 
         if (nextRequest) {
             if (request.url !== nextRequest.url) {
-                let url = new URL(nextRequest.url);
-                data.nor = url.pathname;
+                data.nor = Utils.getRelativeUrl(request.url, nextRequest.url);
             } else if (nextRequest.range) {
                 data.nrr = nextRequest.range;
             }

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -270,7 +270,7 @@ function CmcdModel() {
 
         if (nextRequest) {
             if (request.url !== nextRequest.url) {
-                data.nor = Utils.getRelativeUrl(request.url, nextRequest.url);
+                data.nor = encodeURIComponent(Utils.getRelativeUrl(request.url, nextRequest.url));
             } else if (nextRequest.range) {
                 data.nrr = nextRequest.range;
             }

--- a/test/unit/core.Utils.js
+++ b/test/unit/core.Utils.js
@@ -14,14 +14,14 @@ describe('Utils', () => {
             const a = 'https://localhost:3000/a/b/c.mp4';
             const b = 'https://localhost:3000/d/e/f.mp4';
 
-            expect(Utils.getRelativeUrl(a,b)).to.be.equal('d/e/f.mp4');
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('/d/e/f.mp4');
         })
 
         it('Should return relative url if strings are similar up to one element before filename', () => {
             const a = 'https://localhost:3000/a/b/c.mp4';
             const b = 'https://localhost:3000/a/c/f.mp4';
 
-            expect(Utils.getRelativeUrl(a,b)).to.be.equal('c/f.mp4');
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('../c/f.mp4');
         })
 
         it('Should return relative url if strings are similar up to filename', () => {
@@ -38,25 +38,53 @@ describe('Utils', () => {
             expect(Utils.getRelativeUrl(a,b)).to.be.equal('https://loca:3000/a/b/f.mp4');
         })
 
+        it('Should return filename if origin differs in terms of SSL', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'http://localhost:3000/a/b/e.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('e.mp4');
+        })
+
         it('Should return relative url if part of the pathnames are not equal', () => {
             const a = 'https://localhost:3000/a/b/c.mp4';
             const b = 'https://localhost:3000/ab/b/f.mp4';
 
-            expect(Utils.getRelativeUrl(a,b)).to.be.equal('ab/b/f.mp4');
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('/ab/b/f.mp4');
         })
 
         it('Should return relative url if target pathname is longer than source pathname ', () => {
             const a = 'https://localhost:3000/a/b/f.mp4';
             const b = 'https://localhost:3000/a/b/f/e/c.mp4';
 
-            expect(Utils.getRelativeUrl(a,b)).to.be.equal('/f/e/c.mp4');
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('f/e/c.mp4');
         })
 
         it('Should return relative url if source pathname is longer than target pathname ', () => {
             const a = 'https://localhost:3000/a/b/f/e/c.mp4';
             const b = 'https://localhost:3000/a/b/f.mp4';
 
-            expect(Utils.getRelativeUrl(a,b)).to.be.equal('../../f.mp4');
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('/a/b/f.mp4');
+        })
+
+        it('Should return relative url if source contains slash in the end ', () => {
+            const a = 'https://localhost:3000/a/';
+            const b = 'https://localhost:3000/a/b.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('b.mp4');
+        })
+
+        it('Should return relative url if source pathnames are exceptionally long ', () => {
+            const a = 'https://localhost:3000/a/b/c/d/e/f/g/h/1.mp4';
+            const b = 'https://localhost:3000/a/b/c/d/e/change/i/j/k/l/m/n/2.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('../../../change/i/j/k/l/m/n/2.mp4');
+        })
+
+        it('Should return relative url if source contains slash in the end and multiple elements in the path', () => {
+            const a = 'https://localhost:3000/a/b/c/';
+            const b = 'https://localhost:3000/a/b/x/c.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('../x/c.mp4');
         })
     })
 })

--- a/test/unit/core.Utils.js
+++ b/test/unit/core.Utils.js
@@ -1,0 +1,62 @@
+import Utils from '../../src/core/Utils'
+import {expect} from 'chai';
+
+describe('Utils', () => {
+    describe('getRelativeUrl', () => {
+
+        it('Should return complete url if no original url is given', () => {
+            const b = 'https://localhost:3000/d/e/f.mp4';
+
+            expect(Utils.getRelativeUrl(undefined,b)).to.be.equal('https://localhost:3000/d/e/f.mp4');
+        })
+
+        it('Should return relative url if strings are different after server name', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'https://localhost:3000/d/e/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('d/e/f.mp4');
+        })
+
+        it('Should return relative url if strings are similar up to one element before filename', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'https://localhost:3000/a/c/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('c/f.mp4');
+        })
+
+        it('Should return relative url if strings are similar up to filename', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'https://localhost:3000/a/b/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('f.mp4');
+        })
+
+        it('Should return complete url if origin is different', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'https://loca:3000/a/b/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('https://loca:3000/a/b/f.mp4');
+        })
+
+        it('Should return relative url if part of the pathnames are not equal', () => {
+            const a = 'https://localhost:3000/a/b/c.mp4';
+            const b = 'https://localhost:3000/ab/b/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('ab/b/f.mp4');
+        })
+
+        it('Should return relative url if target pathname is longer than source pathname ', () => {
+            const a = 'https://localhost:3000/a/b/f.mp4';
+            const b = 'https://localhost:3000/a/b/f/e/c.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('/f/e/c.mp4');
+        })
+
+        it('Should return relative url if source pathname is longer than target pathname ', () => {
+            const a = 'https://localhost:3000/a/b/f/e/c.mp4';
+            const b = 'https://localhost:3000/a/b/f.mp4';
+
+            expect(Utils.getRelativeUrl(a,b)).to.be.equal('../../f.mp4');
+        })
+    })
+})

--- a/test/unit/streaming.models.CmcdModel.js
+++ b/test/unit/streaming.models.CmcdModel.js
@@ -121,7 +121,7 @@ describe('CmcdModel', function () {
             const MEASURED_THROUGHPUT = 8327641;
             const BUFFER_LEVEL = parseInt(dashMetricsMock.getCurrentBufferLevel() * 10) * 100;
             const VIDEO_OBJECT_TYPE = 'v';
-            const NEXT_OBJECT_URL = '/next_object';
+            const NEXT_OBJECT_URL = 'next_object';
             const NEXT_OBJECT_RANGE = '100-500';
 
             abrControllerMock.setTopBitrateInfo({bitrate: TOP_BITRATE});
@@ -135,7 +135,8 @@ describe('CmcdModel', function () {
                 mediaType: MEDIA_TYPE,
                 quality: 0,
                 mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
-                duration: DURATION
+                duration: DURATION,
+                url: 'http://test.url/firstRequest'
             };
 
             let headers = cmcdModel.getHeaderParameters(request);
@@ -430,7 +431,7 @@ describe('CmcdModel', function () {
             const MEASURED_THROUGHPUT = 8327641;
             const BUFFER_LEVEL = parseInt(dashMetricsMock.getCurrentBufferLevel() * 10) * 100;
             const VIDEO_OBJECT_TYPE = 'v';
-            const NEXT_OBJECT_URL = '/next_object';
+            const NEXT_OBJECT_URL = 'next_object';
             const NEXT_OBJECT_RANGE = '100-500';
 
             abrControllerMock.setTopBitrateInfo({bitrate: TOP_BITRATE});
@@ -444,7 +445,8 @@ describe('CmcdModel', function () {
                 mediaType: MEDIA_TYPE,
                 quality: 0,
                 mediaInfo: {bitrateList: [{bandwidth: BITRATE}]},
-                duration: DURATION
+                duration: DURATION,
+                url: 'http://test.url/firstRequest'
             };
 
             let parameters = cmcdModel.getQueryParameter(request);


### PR DESCRIPTION
This PR fixes two issues with the CMCD nor attribute as described in #3741 
- `nor` shall be relative to the current request url
- `nor` shall be URI encoded