### PR TITLE
Fix transition from live to static

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -181,7 +181,7 @@ function DashHandler(config) {
         }
     }
 
-    function lastSegmentRequested(representation, bufferingTime) {
+    function isLastSegmentRequested(representation, bufferingTime) {
         if (!representation || !lastSegment) {
             return false;
         }
@@ -314,7 +314,7 @@ function DashHandler(config) {
         getSegmentRequestForTime,
         getCurrentIndex,
         getNextSegmentRequest,
-        lastSegmentRequested,
+        isLastSegmentRequested,
         reset,
         getNextSegmentRequestIdempotent
     };


### PR DESCRIPTION
Only check if the stream is completed if no request could be generated. Otherwise we stop buffering to early after a transition from dynamic to static manifests.