### PR TITLE
Stream: do not reset() on protection error

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -647,7 +647,6 @@ function Stream(config) {
         if (event.error) {
             errHandler.error(event.error);
             logger.fatal(event.error.message);
-            reset();
         }
     }
 


### PR DESCRIPTION
As for every other error. 
This is up to the application to stop/reset the session.