### PR TITLE
Fix: #3769 - Handle all 2XX status codes on license request 

### DIFF
--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -846,7 +846,7 @@ function ProtectionController(config) {
         };
 
         xhr.onload = function () {
-            if (this.status === 200 || retriesCount <= 0) {
+            if (this.status === 200 || this.status === 201 || retriesCount <= 0) {
                 onLoad(this);
             } else {
                 logger.warn('License request failed (' + this.status + '). Retrying it... Pending retries: ' + retriesCount);

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -748,7 +748,7 @@ function ProtectionController(config) {
                 return;
             }
 
-            if (xhr.status === 200) {
+            if (xhr.status >= 200 && xhr.status <= 299) {
                 let licenseResponse = new LicenseResponse(xhr.responseURL, Utils.parseHttpHeaders(xhr.getAllResponseHeaders ? xhr.getAllResponseHeaders() : null), xhr.response);
                 applyFilters(licenseResponseFilters, licenseResponse).then(() => {
                     const licenseMessage = licenseServerData.getLicenseMessage(licenseResponse.data, keySystemString, messageType);
@@ -846,7 +846,7 @@ function ProtectionController(config) {
         };
 
         xhr.onload = function () {
-            if (this.status === 200 || this.status === 201 || retriesCount <= 0) {
+            if (this.status >= 200 && this.status <= 299 || retriesCount <= 0) {
                 onLoad(this);
             } else {
                 logger.warn('License request failed (' + this.status + '). Retrying it... Pending retries: ' + retriesCount);


### PR DESCRIPTION
This pull request fixes issue: [#3769](https://github.com/Dash-Industry-Forum/dash.js/issues/3769)

Some DRM license providers are using different response codes, however it seems that dash.js is failing if response status code is not 200. Since most of the 2XX HTTP are success codes, we should not consider license request as failed.

If you have any ideas or comments how we can improve it, just let me know and I will be more than happy to fix it.