### PR TITLE
Activate gap jumping when seeking close to the end of a period.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -178,10 +178,6 @@ declare namespace dashjs {
             },
             buffer?: {
                 enableSeekDecorrelationFix?: boolean,
-                seekGapFix?: {
-                    enabled?: boolean,
-                    threshold?: number
-                },
                 fastSwitchEnabled?: boolean,
                 flushBufferAtTrackSwitch?: boolean,
                 reuseExistingSourceBuffers?: boolean,
@@ -200,7 +196,8 @@ declare namespace dashjs {
                 jumpGaps?: boolean,
                 jumpLargeGaps?: boolean,
                 smallGapLimit?: number,
-                threshold?: number
+                threshold?: number,
+                enableSeekFix?: boolean
             },
             utcSynchronization?: {
                 useManifestDateHeaderTimeSource?: boolean,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -85,11 +85,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *                keepProtectionMediaKeys: false
  *            },
  *            buffer: {
- *                 enableSeekDecorrelationFix: true,
- *                 seekGapFix: {
- *                   enabled: false,
- *                   threshold: 1
- *                },
+ *                enableSeekDecorrelationFix: true,
  *                fastSwitchEnabled: true,
  *                flushBufferAtTrackSwitch: false,
  *                reuseExistingSourceBuffers: true,
@@ -250,9 +246,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * It is necessary because some browsers do not support setting currentTime on video element to a value that is outside of current buffer.
  *
  * If you experience unexpected seeking triggered by BufferController, you can try setting this value to false.
- * @property {object} [seekGapFix={enabled=true,threshold=1}]
- * Enables the adjustment of the seek target once no valid segment request could be generated for a specific seek time. This can happen if the user seeks to a position for which there is a gap in the timeline.
- *
+
  * @property {boolean} [fastSwitchEnabled=true]
  * When enabled, after an ABR up-switch in quality, instead of requesting and appending the next fragment at the end of the current buffer range it is requested and appended closer to the current time.
  *
@@ -377,6 +371,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Threshold at which the gap handling is executed. If currentRangeEnd - currentTime < threshold the gap jump will be triggered.
  * For live stream the jump might be delayed to keep a consistent live edge.
  * Note that the amount of buffer at which platforms automatically stall might differ.
+ * @property {boolean} [enableSeekFix=false]
+ * Enables the adjustment of the seek target once no valid segment request could be generated for a specific seek time. This can happen if the user seeks to a position for which there is a gap in the timeline.
  */
 
 /**
@@ -780,10 +776,6 @@ function Settings() {
             },
             buffer: {
                 enableSeekDecorrelationFix: false,
-                seekGapFix: {
-                    enabled: false,
-                    threshold: 1
-                },
                 fastSwitchEnabled: true,
                 flushBufferAtTrackSwitch: false,
                 reuseExistingSourceBuffers: true,
@@ -802,7 +794,8 @@ function Settings() {
                 jumpGaps: true,
                 jumpLargeGaps: true,
                 smallGapLimit: 1.5,
-                threshold: 0.3
+                threshold: 0.3,
+                enableSeekFix: false,
             },
             utcSynchronization: {
                 useManifestDateHeaderTimeSource: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -104,7 +104,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *                jumpGaps: true,
  *                jumpLargeGaps: true,
  *                smallGapLimit: 1.5,
- *                threshold: 0.3
+ *                threshold: 0.3,
+ *                enableSeekFix: false
  *            },
  *            utcSynchronization: {
  *                useManifestDateHeaderTimeSource: true,
@@ -365,7 +366,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Sets whether player should jump small gaps (discontinuities) in the buffer.
  * @property {boolean} [jumpLargeGaps=true]
  * Sets whether player should jump large gaps (discontinuities) in the buffer.
- * @property {number} [smallGapLimit=1.8]
+ * @property {number} [smallGapLimit=1.5]
  * Time in seconds for a gap to be considered small.
  * @property {number} [threshold=0.3]
  * Threshold at which the gap handling is executed. If currentRangeEnd - currentTime < threshold the gap jump will be triggered.

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -442,8 +442,8 @@ function StreamProcessor(config) {
 
         // If  this statement is true we are stuck. A static manifest does not change and we did not find a valid request for the target time
         // There is no point in trying again. We need to adjust the time in order to find a valid request. This can happen if the user/app seeked into a gap.
-        if (settings.get().streaming.buffer.seekGapFix.enabled && !isDynamic && shouldUseExplicitTimeForRequest && playbackController.isSeeking()) {
-            const adjustedTime = dashHandler.getValidSeekTimeCloseToTargetTime(bufferingTime, mediaInfo, representation, settings.get().streaming.buffer.seekGapFix.threshold);
+        if (settings.get().streaming.gaps.enableSeekFix && !isDynamic && shouldUseExplicitTimeForRequest && playbackController.isSeeking()) {
+            const adjustedTime = dashHandler.getValidSeekTimeCloseToTargetTime(bufferingTime, mediaInfo, representation, settings.get().streaming.gaps.threshold);
             if (!isNaN(adjustedTime)) {
                 playbackController.seek(adjustedTime, false, false);
                 return;

--- a/src/streaming/controllers/GapController.js
+++ b/src/streaming/controllers/GapController.js
@@ -55,7 +55,7 @@ function GapController() {
         logger;
 
     function initialize() {
-        registerEvents();
+        _registerEvents();
     }
 
     function setup() {
@@ -65,8 +65,8 @@ function GapController() {
     }
 
     function reset() {
-        stopGapHandler();
-        unregisterEvents();
+        _stopGapHandler();
+        _unregisterEvents();
         resetInitialSettings();
     }
 
@@ -96,7 +96,7 @@ function GapController() {
         }
     }
 
-    function registerEvents() {
+    function _registerEvents() {
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, this);
         eventBus.on(Events.INITIAL_STREAM_SWITCH, _onInitialStreamSwitch, this);
         eventBus.on(Events.PLAYBACK_SEEKING, _onPlaybackSeeking, this);
@@ -104,7 +104,7 @@ function GapController() {
         eventBus.on(Events.TRACK_CHANGE_RENDERED, _onBufferReplacementEnded, instance);
     }
 
-    function unregisterEvents() {
+    function _unregisterEvents() {
         eventBus.off(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, this);
         eventBus.off(Events.INITIAL_STREAM_SWITCH, _onInitialStreamSwitch, this);
         eventBus.off(Events.PLAYBACK_SEEKING, _onPlaybackSeeking, this);
@@ -112,6 +112,10 @@ function GapController() {
         eventBus.off(Events.TRACK_CHANGE_RENDERED, _onBufferReplacementEnded, instance);
     }
 
+    /**
+     * Clear scheduled gap jump when seeking
+     * @private
+     */
     function _onPlaybackSeeking() {
         if (jumpTimeoutHandler) {
             clearTimeout(jumpTimeoutHandler);
@@ -139,6 +143,11 @@ function GapController() {
         }
     }
 
+    /**
+     * Activate gap jumping again once segment of target type has been appended
+     * @param {object} e
+     * @private
+     */
     function _onBufferReplacementEnded(e) {
         if (!e || !e.mediaType) {
             return;
@@ -147,14 +156,22 @@ function GapController() {
         trackSwitchByMediaType[e.mediaType] = false;
     }
 
+    /**
+     * Activate the gap handler after the first stream switch
+     * @private
+     */
     function _onInitialStreamSwitch() {
         if (!gapHandlerInterval) {
-            startGapHandler();
+            _startGapHandler();
         }
     }
 
+    /**
+     * Callback handler for when the wallclock time has been updated
+     * @private
+     */
     function _onWallclockTimeUpdated(/*e*/) {
-        if (!_shouldCheckForGaps()) {
+        if (!_shouldCheckForGaps(settings.get().streaming.gaps.enableSeekFix)) {
             return;
         }
 
@@ -162,7 +179,7 @@ function GapController() {
         if (wallclockTicked >= THRESHOLD_TO_STALLS) {
             const currentTime = playbackController.getTime();
             if (lastPlaybackTime === currentTime) {
-                jumpGap(currentTime, true);
+                _jumpGap(currentTime, true);
             } else {
                 lastPlaybackTime = currentTime;
                 lastGapJumpPosition = NaN;
@@ -171,16 +188,42 @@ function GapController() {
         }
     }
 
-    function _shouldCheckForGaps() {
+    /**
+     * Returns if we are supposed to check for gaps
+     * @param {boolean} checkSeekingState - Usually we are not checking for gaps in the videolement is in seeking state. If this flag is set to true we check for a potential exceptions of this rule.
+     * @return {boolean}
+     * @private
+     */
+    function _shouldCheckForGaps(checkSeekingState = false) {
         const trackSwitchInProgress = Object.keys(trackSwitchByMediaType).some((key) => {
             return trackSwitchByMediaType[key];
         });
+        const shouldIgnoreSeekingState = checkSeekingState ? _shouldIgnoreSeekingState() : false;
 
-        return !trackSwitchInProgress && settings.get().streaming.gaps.jumpGaps && streamController.getActiveStreamProcessors().length > 0 && !playbackController.isSeeking() && !playbackController.isPaused() && !streamController.getIsStreamSwitchInProgress() &&
+        return !trackSwitchInProgress && settings.get().streaming.gaps.jumpGaps && streamController.getActiveStreamProcessors().length > 0 && (!playbackController.isSeeking() || shouldIgnoreSeekingState) && !playbackController.isPaused() && !streamController.getIsStreamSwitchInProgress() &&
             !streamController.getHasMediaOrInitialisationError();
     }
 
-    function getNextRangeIndex(ranges, currentTime) {
+    /**
+     * There are cases in which we never transition out of the seeking state and still need to jump a gap. For instance if the user seeks right before a gap and video element will not transition out of the seeking state.
+     * For now limit this to period boundaries. In this case the current period is completely buffered and we are right before the end of the period.
+     * @private
+     */
+    function _shouldIgnoreSeekingState() {
+        const activeStream = streamController.getActiveStream();
+        const streamEnd = parseFloat((activeStream.getStartTime().toFixed(5) + activeStream.getDuration()).toFixed(5))
+
+        return playbackController.getTime() + settings.get().streaming.gaps.threshold >= streamEnd;
+    }
+
+    /**
+     * Returns the index of the range object that comes after the current time
+     * @param {object} ranges
+     * @param {number} currentTime
+     * @private
+     * @return {null|number}
+     */
+    function _getNextRangeIndex(ranges, currentTime) {
         try {
 
             if (!ranges || (ranges.length <= 1 && currentTime > 0)) {
@@ -203,8 +246,11 @@ function GapController() {
         }
     }
 
-
-    function startGapHandler() {
+    /**
+     * Starts the interval that checks for gaps
+     * @private
+     */
+    function _startGapHandler() {
         try {
             if (!gapHandlerInterval) {
                 logger.debug('Starting the gap controller');
@@ -213,7 +259,7 @@ function GapController() {
                         return;
                     }
                     const currentTime = playbackController.getTime();
-                    jumpGap(currentTime);
+                    _jumpGap(currentTime);
 
                 }, GAP_HANDLER_INTERVAL);
             }
@@ -221,7 +267,11 @@ function GapController() {
         }
     }
 
-    function stopGapHandler() {
+    /**
+     * Clears the gap interval handler
+     * @private
+     */
+    function _stopGapHandler() {
         logger.debug('Stopping the gap controller');
         if (gapHandlerInterval) {
             clearInterval(gapHandlerInterval);
@@ -229,7 +279,13 @@ function GapController() {
         }
     }
 
-    function jumpGap(currentTime, playbackStalled = false) {
+    /**
+     * Jump a gap
+     * @param {number} currentTime
+     * @param {boolean} playbackStalled
+     * @private
+     */
+    function _jumpGap(currentTime, playbackStalled = false) {
         const smallGapLimit = settings.get().streaming.gaps.smallGapLimit;
         const jumpLargeGaps = settings.get().streaming.gaps.jumpLargeGaps;
         const ranges = videoModel.getBufferRange();
@@ -239,7 +295,7 @@ function GapController() {
 
 
         // Get the range just after current time position
-        nextRangeIndex = getNextRangeIndex(ranges, currentTime);
+        nextRangeIndex = _getNextRangeIndex(ranges, currentTime);
 
         if (!isNaN(nextRangeIndex)) {
             const start = ranges.start(nextRangeIndex);


### PR DESCRIPTION
This PR enables gap jumping when seeking close to the end of a period. This is supposed to solve #3713, cases in which there is a gap right before the end of the period and the user seeks very close to this gap. In that case the video element will remain in seeking state although there is data in the buffer.