### PR TITLE
Avoid creating one HTTPLoader instance per request

### DIFF
--- a/src/streaming/net/URLLoader.js
+++ b/src/streaming/net/URLLoader.js
@@ -49,21 +49,21 @@ function URLLoader(cfg) {
     schemeLoaderFactory = SchemeLoaderFactory(context).getInstance();
 
     function load(config) {
-
-        let loaderFactory = schemeLoaderFactory.getLoader(config && config.request ? config.request.url : null);
-        loader = loaderFactory(context).create({
-            errHandler: cfg.errHandler,
-            mediaPlayerModel: cfg.mediaPlayerModel,
-            requestModifier: cfg.requestModifier,
-            dashMetrics: cfg.dashMetrics,
-            boxParser: cfg.boxParser ? cfg.boxParser : null,
-            constants: cfg.constants ? cfg.constants : null,
-            dashConstants: cfg.dashConstants ? cfg.dashConstants : null,
-            urlUtils: cfg.urlUtils ? cfg.urlUtils : null,
-            requestTimeout: !isNaN(cfg.requestTimeout) ? cfg.requestTimeout : 0,
-            errors: cfg.errors
-        });
-
+        if (!loader) {
+            let loaderFactory = schemeLoaderFactory.getLoader(config && config.request ? config.request.url : null);
+            loader = loaderFactory(context).create({
+                errHandler: cfg.errHandler,
+                mediaPlayerModel: cfg.mediaPlayerModel,
+                requestModifier: cfg.requestModifier,
+                dashMetrics: cfg.dashMetrics,
+                boxParser: cfg.boxParser ? cfg.boxParser : null,
+                constants: cfg.constants ? cfg.constants : null,
+                dashConstants: cfg.dashConstants ? cfg.dashConstants : null,
+                urlUtils: cfg.urlUtils ? cfg.urlUtils : null,
+                requestTimeout: !isNaN(cfg.requestTimeout) ? cfg.requestTimeout : 0,
+                errors: cfg.errors
+            });
+        }
         loader.load(config);
     }
 


### PR DESCRIPTION
This PR fixes an issue introduced when added offline support with SchemeLoaderFactory.
It avoids creating one HTTPLoader instance per http request.
This may have side effects in case we are sending requests in parallel by the same FragmentLoader and want to abort them. First request therefore would not be aborted.
One use case is sending of MSS FragmentInfo requests in parallel of media segments.