### PR TITLE
[MSS] Do not update manifest if already updating at tracks switching for live streams

### DIFF
--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -136,7 +136,6 @@ function ManifestUpdater() {
     }
 
     function refreshManifest(ignorePatch = false) {
-        if (isUpdating) return;
         isUpdating = true;
         const manifest = manifestModel.getValue();
 
@@ -265,10 +264,15 @@ function ManifestUpdater() {
         isUpdating = false;
     }
 
+    function getIsUpdating() {
+        return isUpdating;
+    }
+
     instance = {
         initialize: initialize,
         setManifest: setManifest,
         refreshManifest: refreshManifest,
+        getIsUpdating: getIsUpdating,
         setConfig: setConfig,
         reset: reset
     };

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -136,6 +136,7 @@ function ManifestUpdater() {
     }
 
     function refreshManifest(ignorePatch = false) {
+        if (isUpdating) return;
         isUpdating = true;
         const manifest = manifestModel.getValue();
 

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -670,9 +670,11 @@ function Stream(config) {
 
         // Applies only for MSS streams
         if (manifest.refreshManifestOnSwitchTrack) {
-            logger.debug('Stream -  Refreshing manifest for switch track');
             trackChangedEvents.push(e);
-            manifestUpdater.refreshManifest();
+            if (!manifestUpdater.getIsUpdating()) {
+                logger.debug('Stream -  Refreshing manifest for switch track');
+                manifestUpdater.refreshManifest();
+            }
         } else {
             processor.selectMediaInfo(mediaInfo)
                 .then(() => {


### PR DESCRIPTION
In case of live MSS, manifest needs to be refreshed when switching audio or text track.
This PR avoids requesting twice the manifest when simultaneoulsy switching audio and text track