### PR TITLE
Fix issue on text track selection

### DIFF
--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -297,12 +297,12 @@ function TextController(config) {
             if (currentTrackInfo.lang === mediaInfo.lang &&
                 (mediaInfo.id ? currentTrackInfo.id === mediaInfo.id : currentTrackInfo.index === mediaInfo.index)) {
                 let currentFragTrack = mediaController.getCurrentTrackFor(Constants.TEXT, streamId);
-                if (mediaInfo !== currentFragTrack) {
+                if (mediaInfo.id ? currentFragTrack.id !== mediaInfo.id : currentFragTrack.index !== mediaInfo.index) {
                     textTracks[streamId].deleteCuesFromTrackIdx(oldTrackIdx);
                     textSourceBuffers[streamId].setCurrentFragmentedTrackIdx(i);
                 }  else if (oldTrackIdx === -1) {
-                    //in fragmented use case, if the user selects the older track (the one selected before disabled text track)
-                    //no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
+                    // in fragmented use case, if the user selects the older track (the one selected before disabled text track)
+                    // no CURRENT_TRACK_CHANGED event will be triggered because the mediaInfo in the StreamProcessor is equal to the one we are selecting
                     // For that reason we reactivate the StreamProcessor and the ScheduleController
                     eventBus.trigger(Events.SET_FRAGMENTED_TEXT_AFTER_DISABLED, {}, {
                         streamId,


### PR DESCRIPTION
This PR fixes an issue regarding text track selection.

Steps to reproduce the issue:
1. launch playback of content with multiple fragmented (TTML) text tracks
2. select one text track
3. disable text
4. re-select previously selected text track

As a result, scheduling of text fragments is not restarted and therefore no subtitles are displayed