### PR TITLE
Refactor/protection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare namespace dashjs {
     interface ProtectionController {
         initializeForMedia(mediaInfo: ProtectionMediaInfo): void;
 
-        clearMediaInfoArrayByStreamId(streamId: string): void;
+        clearMediaInfoArray(): void;
 
         createKeySession(initData: ArrayBuffer, cdmData: Uint8Array): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,7 @@ declare namespace dashjs {
             },
             protection?: {
                 keepProtectionMediaKeys?: boolean,
+                ignoreEmeEncryptedEvent?: boolean
             },
             buffer?: {
                 enableSeekDecorrelationFix?: boolean,

--- a/samples/drm/dashif-laurl.html
+++ b/samples/drm/dashif-laurl.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>License server via MPD example</title>
+
+    <script src="../../dist/dash.all.debug.js"></script>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../lib/main.css" rel="stylesheet">
+
+    <style>
+        video {
+            width: 640px;
+            height: 360px;
+        }
+    </style>
+
+    <script class="code">
+        function init() {
+            var protData = {
+                "com.widevine.alpha": {
+                    "httpRequestHeaders": {
+                        "X-AxDRM-Message": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImZpcnN0X3BsYXlfZXhwaXJhdGlvbiI6NjAsInBsYXlyZWFkeSI6eyJyZWFsX3RpbWVfZXhwaXJhdGlvbiI6dHJ1ZX0sImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.FAbIiPxX8BHi9RwfzD7Yn-wugU19ghrkBFKsaCPrZmU"
+                    },
+                    priority: 0
+                },
+                "com.microsoft.playready": {
+                    "httpRequestHeaders": {
+                        "X-AxDRM-Message": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImZpcnN0X3BsYXlfZXhwaXJhdGlvbiI6NjAsInBsYXlyZWFkeSI6eyJyZWFsX3RpbWVfZXhwaXJhdGlvbiI6dHJ1ZX0sImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.FAbIiPxX8BHi9RwfzD7Yn-wugU19ghrkBFKsaCPrZmU"
+                    },
+                    priority: 0
+                }
+            };
+            var video,
+                player,
+                url = "mpds/laurl.mpd";
+
+            video = document.querySelector("video");
+            player = dashjs.MediaPlayer().create();
+            player.updateSettings({
+                debug: {
+                    logLevel: 5
+                }
+            })
+            player.initialize(video, url, true);
+            player.setProtectionData(protData);
+        }
+    </script>
+</head>
+<body>
+
+<main>
+    <div class="container py-4">
+        <header class="pb-3 mb-4 border-bottom">
+            <img class=""
+                 src="../lib/img/dashjs-logo.png"
+                 width="200">
+        </header>
+        <div class="row">
+            <div class="col-md-4">
+                <div class="h-100 p-5 bg-light border rounded-3">
+                    <h3>Widevine DRM instantiation example</h3>
+                    <p>This example shows how to specify the license server url as part of the MPD using
+                        'dashif:laurl'. </p>
+                    <p>For a detailed explanation on this checkout the
+                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition#licenser-server-url-via-mpd"
+                           target="_blank">Wiki</a>.</p>
+                </div>
+            </div>
+            <div class="col-md-8">
+                <video controls="true"></video>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div id="code-output"></div>
+            </div>
+        </div>
+        <footer class="pt-3 mt-4 text-muted border-top">
+            &copy; DASH-IF
+        </footer>
+    </div>
+</main>
+
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        init();
+    });
+</script>
+<script src="../highlighter.js"></script>
+</body>
+</html>

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -389,7 +389,22 @@
                     "Video",
                     "Audio"
                 ]
+            },
+            {
+                "title": "License server via MPD",
+                "description": "This example shows how to specify the license server url as part of the MPD using 'dashif:laurl'",
+                "href": "drm/dashif-laurl.html",
+                "image": "lib/img/tos-3.jpg",
+                "labels": [
+                    "VoD",
+                    "DRM",
+                    "Widevine",
+                    "Playready",
+                    "Video",
+                    "Audio"
+                ]
             }
+            
         ]
     },
     {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -521,6 +521,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Set the value for the ProtectionController and MediaKeys life cycle.
  *
  * If true, the ProtectionController and then created MediaKeys and MediaKeySessions will be preserved during the MediaPlayer lifetime.
+ * @property {boolean} ignoreEmeEncryptedEvent
+ * If set to true the player will ignore "encrypted" and "needkey" events thrown by the EME.
  */
 
 /**
@@ -773,7 +775,8 @@ function Settings() {
                 applyServiceDescription: true
             },
             protection: {
-                keepProtectionMediaKeys: false
+                keepProtectionMediaKeys: false,
+                ignoreEmeEncryptedEvent: false
             },
             buffer: {
                 enableSeekDecorrelationFix: false,

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -715,7 +715,7 @@ function Stream(config) {
         if (protectionController) {
             // Need to check if streamProcessors exists because streamProcessors
             // could be cleared in case an error is detected while initializing DRM keysystem
-            protectionController.clearMediaInfoArrayByStreamId(getId());
+            protectionController.clearMediaInfoArray();
             for (let i = 0; i < ln && streamProcessors[i]; i++) {
                 const type = streamProcessors[i].getType();
                 const mediaInfo = streamProcessors[i].getMediaInfo();

--- a/src/streaming/constants/ProtectionConstants.js
+++ b/src/streaming/constants/ProtectionConstants.js
@@ -40,6 +40,9 @@ class ProtectionConstants {
         this.CLEARKEY_KEYSTEM_STRING = 'org.w3.clearkey';
         this.WIDEVINE_KEYSTEM_STRING = 'com.widevine.alpha';
         this.PLAYREADY_KEYSTEM_STRING = 'com.microsoft.playready';
+        this.INITIALIZATION_DATA_TYPE_CENC = 'cenc';
+        this.INITIALIZATION_DATA_TYPE_KEYIDS = 'keyids'
+        this.INITIALIZATION_DATA_TYPE_WEBM = 'webm'
     }
 
     constructor () {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -114,7 +114,7 @@ function StreamController() {
     }
 
     function initialize(autoPl, protData) {
-        checkConfig();
+        _checkConfig();
 
         autoPlay = autoPl;
         protectionData = protData;
@@ -496,7 +496,7 @@ function StreamController() {
             _handleOuterPeriodSeek(e, seekToStream);
         }
 
-        createPlaylistMetrics(PlayList.SEEK_START_REASON);
+        _createPlaylistMetrics(PlayList.SEEK_START_REASON);
     }
 
     /**
@@ -698,7 +698,7 @@ function StreamController() {
 
             if (isNaN(initialBufferLevel) || initialBufferLevel <= playbackController.getBufferLevel() || (adapter.getIsDynamic() && initialBufferLevel > playbackController.getLiveDelay())) {
                 initialPlayback = false;
-                createPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
+                _createPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
                 playbackController.play();
             }
         }
@@ -755,7 +755,7 @@ function StreamController() {
         logger.debug('[onPlaybackStarted]');
         if (!initialPlayback && isPaused) {
             isPaused = false;
-            createPlaylistMetrics(PlayList.RESUME_FROM_PAUSE_START_REASON);
+            _createPlaylistMetrics(PlayList.RESUME_FROM_PAUSE_START_REASON);
         }
     }
 
@@ -1214,7 +1214,7 @@ function StreamController() {
         dashMetrics.addPlayList();
     }
 
-    function createPlaylistMetrics(startReason) {
+    function _createPlaylistMetrics(startReason) {
         dashMetrics.createPlaylistMetrics(playbackController.getTime() * 1000, startReason);
     }
 
@@ -1305,7 +1305,7 @@ function StreamController() {
         return null;
     }
 
-    function checkConfig() {
+    function _checkConfig() {
         if (!manifestLoader || !manifestLoader.hasOwnProperty('load') || !timelineConverter || !timelineConverter.hasOwnProperty('initialize') ||
             !timelineConverter.hasOwnProperty('reset') || !timelineConverter.hasOwnProperty('getClientTimeOffset') || !manifestModel || !errHandler ||
             !dashMetrics || !playbackController) {
@@ -1313,19 +1313,19 @@ function StreamController() {
         }
     }
 
-    function checkInitialize() {
+    function _checkInitialize() {
         if (!manifestUpdater || !manifestUpdater.hasOwnProperty('setManifest')) {
             throw new Error('initialize function has to be called previously');
         }
     }
 
     function load(url) {
-        checkConfig();
+        _checkConfig();
         manifestLoader.load(url);
     }
 
     function loadWithManifest(manifest) {
-        checkInitialize();
+        _checkInitialize();
         manifestUpdater.setManifest(manifest);
     }
 
@@ -1427,7 +1427,7 @@ function StreamController() {
     }
 
     function reset() {
-        checkConfig();
+        _checkConfig();
 
         timeSyncController.reset();
 

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -29,6 +29,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+const LICENSE_SERVER_MANIFEST_CONFIGURATIONS = {
+    attributes: ['Laurl','laurl'],
+    prefixes: ['clearkey', 'dashif']
+};
+
 /**
  * @class
  * @ignore
@@ -210,6 +215,54 @@ class CommonEncryption {
         }
 
         return pssh;
+    }
+
+    static getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri) {
+        try {
+
+            if (!mediaInfo || mediaInfo.length === 0) {
+                return null;
+            }
+
+            let i = 0;
+            let licenseServer = null;
+
+            while (i < mediaInfo.length && !licenseServer) {
+                const info = mediaInfo[i];
+
+                if (info && info.contentProtection && info.contentProtection.length > 0) {
+                    const targetProtectionData = info.contentProtection.filter((cp) => {
+                        return cp.schemeIdUri && cp.schemeIdUri === schemeIdUri;
+                    });
+
+                    if (targetProtectionData && targetProtectionData.length > 0) {
+                        let j = 0;
+                        while (j < targetProtectionData.length && !licenseServer) {
+                            const ckData = targetProtectionData[j];
+                            let k = 0;
+                            while (k < LICENSE_SERVER_MANIFEST_CONFIGURATIONS.attributes.length && !licenseServer) {
+                                let l = 0;
+                                const attribute = LICENSE_SERVER_MANIFEST_CONFIGURATIONS.attributes[k];
+                                while (l < LICENSE_SERVER_MANIFEST_CONFIGURATIONS.prefixes.length && !licenseServer) {
+                                    const prefix = LICENSE_SERVER_MANIFEST_CONFIGURATIONS.prefixes[l];
+                                    if (ckData[attribute] && ckData[attribute].__prefix && ckData[attribute].__prefix === prefix && ckData[attribute].__text) {
+                                        licenseServer = ckData[attribute].__text;
+                                    }
+                                    l += 1;
+                                }
+                                k += 1;
+                            }
+                            j += 1;
+                        }
+                    }
+                }
+                i += 1;
+            }
+            return licenseServer;
+        } catch
+            (e) {
+            return null;
+        }
     }
 }
 

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -119,7 +119,7 @@ function Protection() {
         protectionKeyController.setConfig({ debug: config.debug, BASE64: config.BASE64 });
         protectionKeyController.initialize();
 
-        let protectionModel =  getProtectionModel(config);
+        let protectionModel =  _getProtectionModel(config);
 
         if (!controller && protectionModel) {//TODO add ability to set external controller if still needed at all?
             controller = ProtectionController(context).create({
@@ -138,7 +138,7 @@ function Protection() {
         return controller;
     }
 
-    function getProtectionModel(config) {
+    function _getProtectionModel(config) {
         const debug = config.debug;
         const logger = debug.getLogger(instance);
         const eventBus = config.eventBus;
@@ -149,19 +149,19 @@ function Protection() {
             (!videoElement || videoElement.mediaKeys !== undefined)) {
             logger.info('EME detected on this user agent! (ProtectionModel_21Jan2015)');
             return ProtectionModel_21Jan2015(context).create({ debug: debug, eventBus: eventBus, events: config.events });
-        } else if (getAPI(videoElement, APIS_ProtectionModel_3Feb2014)) {
+        } else if (_getAPI(videoElement, APIS_ProtectionModel_3Feb2014)) {
             logger.info('EME detected on this user agent! (ProtectionModel_3Feb2014)');
-            return ProtectionModel_3Feb2014(context).create({ debug: debug, eventBus: eventBus, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_3Feb2014) });
-        } else if (getAPI(videoElement, APIS_ProtectionModel_01b)) {
+            return ProtectionModel_3Feb2014(context).create({ debug: debug, eventBus: eventBus, events: config.events, api: _getAPI(videoElement, APIS_ProtectionModel_3Feb2014) });
+        } else if (_getAPI(videoElement, APIS_ProtectionModel_01b)) {
             logger.info('EME detected on this user agent! (ProtectionModel_01b)');
-            return ProtectionModel_01b(context).create({ debug: debug, eventBus: eventBus, errHandler: errHandler, events: config.events, api: getAPI(videoElement, APIS_ProtectionModel_01b) });
+            return ProtectionModel_01b(context).create({ debug: debug, eventBus: eventBus, errHandler: errHandler, events: config.events, api: _getAPI(videoElement, APIS_ProtectionModel_01b) });
         } else {
             logger.warn('No supported version of EME detected on this user agent! - Attempts to play encrypted content will fail!');
             return null;
         }
     }
 
-    function getAPI(videoElement, apis) {
+    function _getAPI(videoElement, apis) {
         for (let i = 0; i < apis.length; i++) {
             const api = apis[i];
             // detect if api is supported by browser
@@ -177,7 +177,7 @@ function Protection() {
     }
 
     instance = {
-        createProtectionSystem: createProtectionSystem
+        createProtectionSystem
     };
 
     return instance;

--- a/src/streaming/protection/ProtectionEvents.js
+++ b/src/streaming/protection/ProtectionEvents.js
@@ -50,13 +50,6 @@ class ProtectionEvents extends EventsBase {
         this.INTERNAL_KEY_MESSAGE = 'internalKeyMessage';
 
         /**
-         * Event ID for events delivered when a key system selection procedure
-         * completes
-         * @ignore
-         */
-        this.INTERNAL_KEY_SYSTEM_SELECTED = 'internalKeySystemSelected';
-
-        /**
          * Event ID for events delivered when the status of one decryption keys has changed
          * @ignore
          */

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -39,6 +39,7 @@ import LicenseResponse from '../vo/LicenseResponse';
 import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import Utils from '../../../core/Utils';
 import Constants from '../../constants/Constants';
+import FactoryMaker from '../../../core/FactoryMaker';
 
 const NEEDKEY_BEFORE_INITIALIZE_RETRIES = 5;
 const NEEDKEY_BEFORE_INITIALIZE_TIMEOUT = 500;
@@ -489,10 +490,10 @@ function ProtectionController(config) {
         checkConfig();
         if (element) {
             protectionModel.setMediaElement(element);
-            eventBus.on(events.NEED_KEY, _onNeedKey, this);
+            eventBus.on(events.NEED_KEY, _onNeedKey, instance);
         } else if (element === null) {
             protectionModel.setMediaElement(element);
-            eventBus.off(events.NEED_KEY, _onNeedKey, this);
+            eventBus.off(events.NEED_KEY, _onNeedKey, instance);
         }
     }
 
@@ -559,13 +560,13 @@ function ProtectionController(config) {
      * @ignore
      */
     function reset() {
+        eventBus.off(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, instance);
+        eventBus.off(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, instance);
+
         checkConfig();
 
         licenseRequestFilters = [];
         licenseResponseFilters = [];
-
-        eventBus.off(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, instance);
-        eventBus.off(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, instance);
 
         setMediaElement(null);
 
@@ -1076,4 +1077,4 @@ function ProtectionController(config) {
 }
 
 ProtectionController.__dashjs_factory_name = 'ProtectionController';
-export default dashjs.FactoryMaker.getClassFactory(ProtectionController); /* jshint ignore:line */
+export default FactoryMaker.getClassFactory(ProtectionController); /* jshint ignore:line */

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -78,7 +78,7 @@ function ProtectionController(config) {
 
     let instance,
         logger,
-        pendingNeedKeyData,
+        pendingKeySystemData,
         mediaInfoArr,
         protDataSet,
         sessionType,
@@ -90,7 +90,7 @@ function ProtectionController(config) {
 
     function setup() {
         logger = debug.getLogger(instance);
-        pendingNeedKeyData = [];
+        pendingKeySystemData = [];
         mediaInfoArr = [];
         sessionType = 'temporary';
         robustnessLevel = '';
@@ -127,7 +127,7 @@ function ProtectionController(config) {
         mediaInfoArr.push(mediaInfo);
 
         // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
-        // and video will be the same.  Just use one valid MediaInfo object
+        // and video will be the same. Just use one valid MediaInfo object
         let supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection);
 
         // Reorder key systems according to priority order provided in protectionData
@@ -152,7 +152,7 @@ function ProtectionController(config) {
 
         // We are in the process of selecting a key system, so just save the data which might be coming from additional AdaptationSets.
         if (keySystemSelectionInProgress) {
-            pendingNeedKeyData.push(supportedKS);
+            pendingKeySystemData.push(supportedKS);
         }
 
         // First time, so we need to select a key system
@@ -170,7 +170,7 @@ function ProtectionController(config) {
         keySystemSelectionInProgress = true;
         const requestedKeySystems = [];
 
-        pendingNeedKeyData.push(supportedKS);
+        pendingKeySystemData.push(supportedKS);
 
         // Add all key systems to our request list since we have yet to select a key system
         for (let i = 0; i < supportedKS.length; i++) {
@@ -207,10 +207,10 @@ function ProtectionController(config) {
 
                 // Create key sessions for the different AdaptationSets
                 let ksIdx;
-                for (let i = 0; i < pendingNeedKeyData.length; i++) {
-                    for (ksIdx = 0; ksIdx < pendingNeedKeyData[i].length; ksIdx++) {
-                        if (selectedKeySystem === pendingNeedKeyData[i][ksIdx].ks) {
-                            const current = pendingNeedKeyData[i][ksIdx]
+                for (let i = 0; i < pendingKeySystemData.length; i++) {
+                    for (ksIdx = 0; ksIdx < pendingKeySystemData[i].length; ksIdx++) {
+                        if (selectedKeySystem === pendingKeySystemData[i][ksIdx].ks) {
+                            const current = pendingKeySystemData[i][ksIdx]
                             _loadOrCreateKeySession(protData, current)
                             break;
                         }
@@ -599,6 +599,7 @@ function ProtectionController(config) {
         needkeyRetries = [];
 
         mediaInfoArr = [];
+        pendingKeySystemData = [];
     }
 
     /**

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -96,6 +96,8 @@ function ProtectionController(config) {
         robustnessLevel = '';
         licenseRequestFilters = [];
         licenseResponseFilters = [];
+        eventBus.on(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, instance);
+        eventBus.on(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, instance);
     }
 
     function checkConfig() {
@@ -122,8 +124,6 @@ function ProtectionController(config) {
 
         checkConfig();
 
-        eventBus.on(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, this);
-        eventBus.on(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, this);
         mediaInfoArr.push(mediaInfo);
 
         // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
@@ -582,8 +582,8 @@ function ProtectionController(config) {
         licenseRequestFilters = [];
         licenseResponseFilters = [];
 
-        eventBus.off(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, this);
-        eventBus.off(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, this);
+        eventBus.off(events.INTERNAL_KEY_MESSAGE, _onKeyMessage, instance);
+        eventBus.off(events.INTERNAL_KEY_STATUS_CHANGED, _onKeyStatusChanged, instance);
 
         setMediaElement(null);
 

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -279,7 +279,7 @@ function ProtectionKeyController() {
      * @instance
      *
      */
-    function getLicenseServer(keySystem, protData, messageType) {
+    function getLicenseServerModelInstance(keySystem, protData, messageType) {
 
         // Our default server implementations do not do anything with "license-release" or
         // "individualization-request" messages, so we just send a success event
@@ -340,18 +340,18 @@ function ProtectionKeyController() {
     }
 
     instance = {
-        initialize: initialize,
-        setProtectionData: setProtectionData,
-        isClearKey: isClearKey,
-        initDataEquals: initDataEquals,
-        getKeySystems: getKeySystems,
-        setKeySystems: setKeySystems,
-        getKeySystemBySystemString: getKeySystemBySystemString,
-        getSupportedKeySystemsFromContentProtection: getSupportedKeySystemsFromContentProtection,
-        getSupportedKeySystems: getSupportedKeySystems,
-        getLicenseServer: getLicenseServer,
-        processClearKeyLicenseRequest: processClearKeyLicenseRequest,
-        setConfig: setConfig
+        initialize,
+        setProtectionData,
+        isClearKey,
+        initDataEquals,
+        getKeySystems,
+        setKeySystems,
+        getKeySystemBySystemString,
+        getSupportedKeySystemsFromContentProtection,
+        getSupportedKeySystems,
+        getLicenseServerModelInstance,
+        processClearKeyLicenseRequest,
+        setConfig
     };
 
     return instance;

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -174,17 +174,17 @@ function KeySystemClearKey(config) {
     }
 
     instance = {
-        uuid: uuid,
-        schemeIdURI: schemeIdURI,
-        systemString: systemString,
-        getInitData: getInitData,
-        getRequestHeadersFromMessage: getRequestHeadersFromMessage,
-        getLicenseRequestFromMessage: getLicenseRequestFromMessage,
-        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
-        getCDMData: getCDMData,
-        getSessionId: getSessionId,
+        uuid,
+        schemeIdURI,
+        systemString,
+        getInitData,
+        getRequestHeadersFromMessage,
+        getLicenseRequestFromMessage,
+        getLicenseServerURLFromInitData,
+        getCDMData,
+        getSessionId,
         getLicenseServerUrlFromMediaInfo,
-        getClearKeysFromProtectionData: getClearKeysFromProtectionData
+        getClearKeysFromProtectionData
     };
 
     return instance;

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -43,10 +43,6 @@ function KeySystemClearKey(config) {
     config = config || {};
     let instance;
     const BASE64 = config.BASE64;
-    const LICENSE_SERVER_MANIFEST_CONFIGURATIONS = {
-        attributes: ['Laurl', 'laurl'],
-        prefixes: ['clearkey', 'dashif']
-    };
 
     /**
      * Returns desired clearkeys (as specified in the CDM message) from protection data
@@ -122,49 +118,6 @@ function KeySystemClearKey(config) {
         return null;
     }
 
-    function getLicenseServerUrlFromMediaInfo(mediaInfo) {
-        try {
-            if (!mediaInfo || mediaInfo.length === 0) {
-                return null;
-            }
-            let i = 0;
-            let licenseServer = null;
-            while (i < mediaInfo.length && !licenseServer) {
-                const info = mediaInfo[i];
-                if (info && info.contentProtection && info.contentProtection.length > 0) {
-                    const clearkeyProtData = info.contentProtection.filter((cp) => {
-                        return cp.schemeIdUri && cp.schemeIdUri === schemeIdURI;
-                    });
-                    if (clearkeyProtData && clearkeyProtData.length > 0) {
-                        let j = 0;
-                        while (j < clearkeyProtData.length && !licenseServer) {
-                            const ckData = clearkeyProtData[j];
-                            let k = 0;
-                            while (k < LICENSE_SERVER_MANIFEST_CONFIGURATIONS.attributes.length && !licenseServer) {
-                                let l = 0;
-                                const attribute = LICENSE_SERVER_MANIFEST_CONFIGURATIONS.attributes[k];
-                                while (l < LICENSE_SERVER_MANIFEST_CONFIGURATIONS.prefixes.length && !licenseServer) {
-                                    const prefix = LICENSE_SERVER_MANIFEST_CONFIGURATIONS.prefixes[l];
-                                    if (ckData[attribute] && ckData[attribute].__prefix && ckData[attribute].__prefix === prefix && ckData[attribute].__text) {
-                                        licenseServer = ckData[attribute].__text;
-                                    }
-                                    l += 1;
-                                }
-                                k += 1;
-                            }
-                            j += 1;
-                        }
-                    }
-                }
-                i += 1;
-            }
-            return licenseServer;
-        } catch
-            (e) {
-            return null;
-        }
-    }
-
     function getCDMData() {
         return null;
     }
@@ -183,7 +136,6 @@ function KeySystemClearKey(config) {
         getLicenseServerURLFromInitData,
         getCDMData,
         getSessionId,
-        getLicenseServerUrlFromMediaInfo,
         getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -296,17 +296,17 @@ function KeySystemPlayReady(config) {
     }
 
     instance = {
-        uuid: uuid,
-        schemeIdURI: schemeIdURI,
-        systemString: systemString,
-        getInitData: getInitData,
-        getRequestHeadersFromMessage: getRequestHeadersFromMessage,
-        getLicenseRequestFromMessage: getLicenseRequestFromMessage,
-        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
-        getCDMData: getCDMData,
-        getSessionId: getSessionId,
-        setPlayReadyMessageFormat: setPlayReadyMessageFormat,
-        init: init
+        uuid,
+        schemeIdURI,
+        systemString,
+        getInitData,
+        getRequestHeadersFromMessage,
+        getLicenseRequestFromMessage,
+        getLicenseServerURLFromInitData,
+        getCDMData,
+        getSessionId,
+        setPlayReadyMessageFormat,
+        init
     };
 
     return instance;

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -87,16 +87,16 @@ function KeySystemWidevine(config) {
     }
 
     instance = {
-        uuid: uuid,
-        schemeIdURI: schemeIdURI,
-        systemString: systemString,
-        init: init,
-        getInitData: getInitData,
-        getRequestHeadersFromMessage: getRequestHeadersFromMessage,
-        getLicenseRequestFromMessage: getLicenseRequestFromMessage,
-        getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
-        getCDMData: getCDMData,
-        getSessionId: getSessionId
+        uuid,
+        schemeIdURI,
+        systemString,
+        init,
+        getInitData,
+        getRequestHeadersFromMessage,
+        getLicenseRequestFromMessage,
+        getLicenseServerURLFromInitData,
+        getCDMData,
+        getSessionId
     };
 
     return instance;

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -172,7 +172,7 @@ function ProtectionModel_01b(config) {
 
     function selectKeySystem(keySystemAccess) {
         keySystem = keySystemAccess.keySystem;
-        eventBus.trigger(events.INTERNAL_KEY_SYSTEM_SELECTED);
+        return Promise.resolve();
     }
 
     function setMediaElement(mediaElement) {
@@ -411,19 +411,19 @@ function ProtectionModel_01b(config) {
     }
 
     instance = {
-        getAllInitData: getAllInitData,
-        requestKeySystemAccess: requestKeySystemAccess,
-        getKeySystem: getKeySystem,
-        selectKeySystem: selectKeySystem,
-        setMediaElement: setMediaElement,
-        createKeySession: createKeySession,
-        updateKeySession: updateKeySession,
-        closeKeySession: closeKeySession,
-        setServerCertificate: setServerCertificate,
-        loadKeySession: loadKeySession,
-        removeKeySession: removeKeySession,
+        getAllInitData,
+        requestKeySystemAccess,
+        getKeySystem,
+        selectKeySystem,
+        setMediaElement,
+        createKeySession,
+        updateKeySession,
+        closeKeySession,
+        setServerCertificate,
+        loadKeySession,
+        removeKeySession,
         stop: reset,
-        reset: reset
+        reset
     };
 
     setup();

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -100,7 +100,7 @@ function ProtectionModel_21Jan2015(config) {
                     });
                     // Close the session and handle errors, otherwise promise
                     // resolver above will be called
-                    closeKeySessionInternal(session).catch(function () {
+                    _closeKeySessionInternal(session).catch(function () {
                         done(s);
                     });
 
@@ -117,15 +117,11 @@ function ProtectionModel_21Jan2015(config) {
         for (let i = 0; i < sessions.length; i++) {
             session = sessions[i];
             if (!session.getUsable()) {
-                closeKeySessionInternal(session).catch(function () {
+                _closeKeySessionInternal(session).catch(function () {
                     removeSession(session);
                 });
             }
         }
-    }
-
-    function getKeySystem() {
-        return keySystem;
     }
 
     function getAllInitData() {
@@ -139,9 +135,63 @@ function ProtectionModel_21Jan2015(config) {
     }
 
     function requestKeySystemAccess(ksConfigurations) {
-        requestKeySystemAccessInternal(ksConfigurations, 0);
+        return new Promise((resolve, reject) => {
+            _requestKeySystemAccessInternal(ksConfigurations, 0, resolve, reject);
+        })
     }
 
+    /**
+     * Initializes access to a key system. Once we found a valid configuration we get a mediaKeySystemAccess object
+     * @param ksConfigurations
+     * @param idx
+     * @param resolve
+     * @param reject
+     * @private
+     */
+    function _requestKeySystemAccessInternal(ksConfigurations, idx, resolve, reject) {
+        if (navigator.requestMediaKeySystemAccess === undefined ||
+            typeof navigator.requestMediaKeySystemAccess !== 'function') {
+            const msg = 'Insecure origins are not allowed';
+            eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, { error: msg });
+            reject({ error: msg });
+            return;
+        }
+
+        const keySystem = ksConfigurations[idx].ks;
+        const configs = ksConfigurations[idx].configs;
+        let systemString = keySystem.systemString;
+
+        // Patch to support persistent licenses on Edge browser (see issue #2658)
+        if (systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING && configs[0].persistentState === 'required') {
+            systemString += '.recommendation';
+        }
+
+        navigator.requestMediaKeySystemAccess(systemString, configs)
+            .then((mediaKeySystemAccess) => {
+                const configuration = (typeof mediaKeySystemAccess.getConfiguration === 'function') ?
+                    mediaKeySystemAccess.getConfiguration() : null;
+                const keySystemAccess = new KeySystemAccess(keySystem, configuration);
+
+                keySystemAccess.mksa = mediaKeySystemAccess;
+                eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, { data: keySystemAccess });
+                resolve({ data: keySystemAccess });
+            })
+            .catch((error) => {
+                if (idx + 1 < ksConfigurations.length) {
+                    _requestKeySystemAccessInternal(ksConfigurations, idx + 1, resolve, reject);
+                } else {
+                    const errorMessage = 'Key system access denied! ';
+                    eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, { error: errorMessage + error.message });
+                    reject({ error: errorMessage + error.message });
+                }
+            });
+    }
+
+    /**
+     * Selects a key system by creating the mediaKeys and adding them to the video element
+     * @param keySystemAccess
+     * @return {Promise<unknown>}
+     */
     function selectKeySystem(keySystemAccess) {
         return new Promise((resolve, reject) => {
             keySystemAccess.mksa.createMediaKeys()
@@ -155,7 +205,7 @@ function ProtectionModel_21Jan2015(config) {
                     }
                 })
                 .then(() => {
-                    resolve();
+                    resolve(keySystem);
                 })
                 .catch(function () {
                     reject({ error: 'Error selecting keys system (' + keySystemAccess.keySystem.systemString + ')! Could not create MediaKeys -- TODO' });
@@ -198,6 +248,12 @@ function ProtectionModel_21Jan2015(config) {
         });
     }
 
+    /**
+     * Create a key session, a session token and initialize a request by calling generateRequest
+     * @param initData
+     * @param protData
+     * @param sessionType
+     */
     function createKeySession(initData, protData, sessionType) {
         if (!keySystem || !mediaKeys) {
             throw new Error('Can not create sessions until you have selected a key system');
@@ -205,16 +261,15 @@ function ProtectionModel_21Jan2015(config) {
 
         const session = mediaKeys.createSession(sessionType);
         const sessionToken = createSessionToken(session, initData, sessionType);
-        const ks = this.getKeySystem();
 
-        // Generate initial key request.
-        // keyids type is used for clearkey when keys are provided directly in the protection data and then request to a license server is not needed
-        const dataType = ks.systemString === ProtectionConstants.CLEARKEY_KEYSTEM_STRING && (initData || (protData && protData.clearkeys)) ? 'keyids' : 'cenc';
+
+        // The "keyids" type is used for Clearkey when keys are provided directly in the protection data and a request to a license server is not needed
+        const dataType = keySystem.systemString === ProtectionConstants.CLEARKEY_KEYSTEM_STRING && (initData || (protData && protData.clearkeys)) ? ProtectionConstants.INITIALIZATION_DATA_TYPE_KEYIDS : ProtectionConstants.INITIALIZATION_DATA_TYPE_CENC;
+
         session.generateRequest(dataType, initData).then(function () {
             logger.debug('DRM: Session created.  SessionID = ' + sessionToken.getSessionID());
             eventBus.trigger(events.KEY_SESSION_CREATED, { data: sessionToken });
         }).catch(function (error) {
-            // TODO: Better error string
             removeSession(sessionToken);
             eventBus.trigger(events.KEY_SESSION_CREATED, {
                 data: null,
@@ -293,7 +348,7 @@ function ProtectionModel_21Jan2015(config) {
 
     function closeKeySession(sessionToken) {
         // Send our request to the key session
-        closeKeySessionInternal(sessionToken).catch(function (error) {
+        _closeKeySessionInternal(sessionToken).catch(function (error) {
             removeSession(sessionToken);
             eventBus.trigger(events.KEY_SESSION_CLOSED, {
                 data: null,
@@ -302,45 +357,7 @@ function ProtectionModel_21Jan2015(config) {
         });
     }
 
-    function requestKeySystemAccessInternal(ksConfigurations, idx) {
-        return new Promise((resolve, reject) => {
-
-            if (navigator.requestMediaKeySystemAccess === undefined ||
-                typeof navigator.requestMediaKeySystemAccess !== 'function') {
-                reject({ error: 'Insecure origins are not allowed' });
-                return;
-            }
-
-            (function (i) {
-                const keySystem = ksConfigurations[i].ks;
-                const configs = ksConfigurations[i].configs;
-                let systemString = keySystem.systemString;
-
-                // PATCH to support persistent licenses on Edge browser (see issue #2658)
-                if (systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING && configs[0].persistentState === 'required') {
-                    systemString += '.recommendation';
-                }
-
-                navigator.requestMediaKeySystemAccess(systemString, configs).then(function (mediaKeySystemAccess) {
-                    // Chrome 40 does not currently implement MediaKeySystemAccess.getConfiguration()
-                    const configuration = (typeof mediaKeySystemAccess.getConfiguration === 'function') ?
-                        mediaKeySystemAccess.getConfiguration() : null;
-                    const keySystemAccess = new KeySystemAccess(keySystem, configuration);
-                    keySystemAccess.mksa = mediaKeySystemAccess;
-                    eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, { data: keySystemAccess });
-
-                }).catch(function (error) {
-                    if (++i < ksConfigurations.length) {
-                        requestKeySystemAccessInternal(ksConfigurations, i);
-                    } else {
-                        eventBus.trigger(events.KEY_SYSTEM_ACCESS_COMPLETE, { error: 'Key system access denied! ' + error.message });
-                    }
-                });
-            })(idx);
-        })
-    }
-
-    function closeKeySessionInternal(sessionToken) {
+    function _closeKeySessionInternal(sessionToken) {
         const session = sessionToken.session;
 
         // Remove event listeners
@@ -473,7 +490,7 @@ function ProtectionModel_21Jan2015(config) {
         session.addEventListener('message', token);
 
         // Register callback for session closed Promise
-        session.closed.then(function () {
+        session.closed.then(() => {
             removeSession(token);
             logger.debug('DRM: Session closed.  SessionID = ' + token.getSessionID());
             eventBus.trigger(events.KEY_SESSION_CLOSED, { data: token.getSessionID() });
@@ -488,7 +505,6 @@ function ProtectionModel_21Jan2015(config) {
     instance = {
         getAllInitData,
         requestKeySystemAccess,
-        getKeySystem,
         selectKeySystem,
         setMediaElement,
         setServerCertificate,

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -161,17 +161,20 @@ function ProtectionModel_3Feb2014(config) {
     }
 
     function selectKeySystem(ksAccess) {
-        try {
-            mediaKeys = ksAccess.mediaKeys = new window[api.MediaKeys](ksAccess.keySystem.systemString);
-            keySystem = ksAccess.keySystem;
-            keySystemAccess = ksAccess;
-            if (videoElement) {
-                setMediaKeys();
+        return new Promise((resolve, reject) => {
+            try {
+                mediaKeys = ksAccess.mediaKeys = new window[api.MediaKeys](ksAccess.keySystem.systemString);
+                keySystem = ksAccess.keySystem;
+                keySystemAccess = ksAccess;
+                if (videoElement) {
+                    setMediaKeys();
+                }
+                resolve();
+            } catch (error) {
+                reject({ error: 'Error selecting keys system (' + keySystem.systemString + ')! Could not create MediaKeys -- TODO' });
+
             }
-            eventBus.trigger(events.INTERNAL_KEY_SYSTEM_SELECTED);
-        } catch (error) {
-            eventBus.trigger(events.INTERNAL_KEY_SYSTEM_SELECTED, { error: 'Error selecting keys system (' + keySystem.systemString + ')! Could not create MediaKeys -- TODO' });
-        }
+        })
     }
 
     function setMediaElement(mediaElement) {
@@ -273,9 +276,14 @@ function ProtectionModel_3Feb2014(config) {
         session[api.release]();
     }
 
-    function setServerCertificate(/*serverCertificate*/) { /* Not supported */ }
-    function loadKeySession(/*sessionID*/) { /* Not supported */ }
-    function removeKeySession(/*sessionToken*/) { /* Not supported */ }
+    function setServerCertificate(/*serverCertificate*/) { /* Not supported */
+    }
+
+    function loadKeySession(/*sessionID*/) { /* Not supported */
+    }
+
+    function removeKeySession(/*sessionToken*/) { /* Not supported */
+    }
 
 
     function createEventHandler() {

--- a/src/streaming/protection/servers/ClearKey.js
+++ b/src/streaming/protection/servers/ClearKey.js
@@ -77,11 +77,11 @@ function ClearKey() {
     }
 
     instance = {
-        getServerURLFromMessage: getServerURLFromMessage,
-        getHTTPMethod: getHTTPMethod,
-        getResponseType: getResponseType,
-        getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse
+        getServerURLFromMessage,
+        getHTTPMethod,
+        getResponseType,
+        getLicenseMessage,
+        getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/DRMToday.js
+++ b/src/streaming/protection/servers/DRMToday.js
@@ -93,11 +93,11 @@ function DRMToday(config) {
     }
 
     instance = {
-        getServerURLFromMessage: getServerURLFromMessage,
-        getHTTPMethod: getHTTPMethod,
-        getResponseType: getResponseType,
-        getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse
+        getServerURLFromMessage,
+        getHTTPMethod,
+        getResponseType,
+        getLicenseMessage,
+        getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/PlayReady.js
+++ b/src/streaming/protection/servers/PlayReady.js
@@ -134,11 +134,11 @@ function PlayReady() {
     }
 
     instance = {
-        getServerURLFromMessage: getServerURLFromMessage,
-        getHTTPMethod: getHTTPMethod,
-        getResponseType: getResponseType,
-        getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse
+        getServerURLFromMessage,
+        getHTTPMethod,
+        getResponseType,
+        getLicenseMessage,
+        getErrorResponse
     };
 
     return instance;

--- a/src/streaming/protection/servers/Widevine.js
+++ b/src/streaming/protection/servers/Widevine.js
@@ -57,11 +57,11 @@ function Widevine() {
     }
 
     instance = {
-        getServerURLFromMessage: getServerURLFromMessage,
-        getHTTPMethod: getHTTPMethod,
-        getResponseType: getResponseType,
-        getLicenseMessage: getLicenseMessage,
-        getErrorResponse: getErrorResponse
+        getServerURLFromMessage,
+        getHTTPMethod,
+        getResponseType,
+        getLicenseMessage,
+        getErrorResponse
     };
 
     return instance;

--- a/test/unit/mocks/ProtectionKeyControllerMock.js
+++ b/test/unit/mocks/ProtectionKeyControllerMock.js
@@ -11,6 +11,10 @@ function ProtectionKeyControllerMock () {
     this.getLicenseServer = function () {
         return null;
     };
+
+    this.getLicenseServerModelInstance = function () {
+        return {};
+    }
 }
 
 export default ProtectionKeyControllerMock;

--- a/test/unit/mocks/ProtectionModelMock.js
+++ b/test/unit/mocks/ProtectionModelMock.js
@@ -14,6 +14,7 @@ function ProtectionModelMock (config) {
     };
 
     this.requestKeySystemAccess = function () {
+        return Promise.resolve();
     };
 }
 

--- a/test/unit/streaming.protection.CommonEncryption.js
+++ b/test/unit/streaming.protection.CommonEncryption.js
@@ -4,7 +4,7 @@ import Base64 from '../../externals/base64';
 const expect = require('chai').expect;
 let cpData;
 
-describe('CommonEncryption',  () => {
+describe('CommonEncryption', () => {
 
     beforeEach(() => {
         cpData = {
@@ -21,13 +21,13 @@ describe('CommonEncryption',  () => {
 
         it('should return null if no init data is available in the ContentProtection element', () => {
             cpData = {};
-            const result = CommonEncryption.parseInitDataFromContentProtection(cpData,Base64);
+            const result = CommonEncryption.parseInitDataFromContentProtection(cpData, Base64);
 
             expect(result).to.be.null; // jshint ignore:line
         });
 
         it('should return base64 decoded string if init data is available in the ContentProtection element', () => {
-            const result = CommonEncryption.parseInitDataFromContentProtection(cpData,Base64);
+            const result = CommonEncryption.parseInitDataFromContentProtection(cpData, Base64);
             const expectedByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
 
             expect(result.byteLength).to.equal(expectedByteLength);
@@ -37,7 +37,7 @@ describe('CommonEncryption',  () => {
             const expectedByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
             cpData.pssh.__text = '\nAAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARABGgZlbHV2aW8iBmVsdXZpbw==\n';
             const originalByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
-            const result = CommonEncryption.parseInitDataFromContentProtection(cpData,Base64);
+            const result = CommonEncryption.parseInitDataFromContentProtection(cpData, Base64);
 
             expect(originalByteLength).to.not.equal(result.byteLength);
             expect(result.byteLength).to.equal(expectedByteLength);
@@ -47,7 +47,7 @@ describe('CommonEncryption',  () => {
             const expectedByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
             cpData.pssh.__text = 'AAAANHBzc2gAAAAA7e+LqXnWSs6jy          Cfc1R0h7QAAABQIARABGgZlbHV2aW8iBmVsdXZpbw==';
             const originalByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
-            const result = CommonEncryption.parseInitDataFromContentProtection(cpData,Base64);
+            const result = CommonEncryption.parseInitDataFromContentProtection(cpData, Base64);
 
             expect(originalByteLength).to.not.equal(result.byteLength);
             expect(result.byteLength).to.equal(expectedByteLength);
@@ -57,7 +57,7 @@ describe('CommonEncryption',  () => {
             const expectedByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
             cpData.pssh.__text = '\n\n\nAAAANHBzc2gAAAAA7e+LqXnWSs6jy          Cfc1R0h7QAAABQIARABGgZlbHV2aW8iBmVsdXZpbw==\n\n';
             const originalByteLength = Base64.decodeArray(cpData.pssh.__text).buffer.byteLength;
-            const result = CommonEncryption.parseInitDataFromContentProtection(cpData,Base64);
+            const result = CommonEncryption.parseInitDataFromContentProtection(cpData, Base64);
 
             expect(originalByteLength).to.not.equal(result.byteLength);
             expect(result.byteLength).to.equal(expectedByteLength);
@@ -65,4 +65,63 @@ describe('CommonEncryption',  () => {
 
     });
 
-});
+    describe('getLicenseServerUrlFromMediaInfo', () => {
+        let mediaInfo;
+        let schemeIdUri = 'abcd-efgh';
+
+        beforeEach(() => {
+            mediaInfo = [{
+                contentProtection: [
+                    {
+                        schemeIdUri: schemeIdUri,
+                        laurl: {
+                            __prefix: 'dashif',
+                            __text: 'license-server-url'
+                        }
+                    }
+                ]
+            }]
+        });
+
+        it('should return null in case the schemeIdUri does not match', () => {
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, 'nomatch');
+
+            expect(result).to.be.null;
+        });
+
+        it('should return null if license server url is empty', () => {
+            mediaInfo[0].contentProtection[0].laurl.__text = '';
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri);
+
+            expect(result).to.be.null;
+        })
+
+        it('should return null if wrong prefix', () => {
+            mediaInfo[0].contentProtection[0].laurl.__prefix = 'wrongprefix';
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri);
+
+            expect(result).to.be.null;
+        })
+
+        it('should return null if wrong attribute', () => {
+            delete mediaInfo[0].contentProtection[0].laurl;
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri);
+
+            expect(result).to.be.null;
+        })
+
+        it('should return valid license server for dashif:laurl', () => {
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri);
+
+            expect(result).to.be.equal('license-server-url');
+        })
+
+        it('should return valid license server for dashif:Laurl', () => {
+            delete mediaInfo[0].contentProtection[0].laurl;
+            mediaInfo[0].contentProtection[0].Laurl = { __prefix: 'dashif', __text: 'license-server-url' };
+            const result = CommonEncryption.getLicenseServerUrlFromMediaInfo(mediaInfo, schemeIdUri);
+
+            expect(result).to.be.equal('license-server-url');
+        })
+    });
+})


### PR DESCRIPTION
The goal of this PR is to refactor the DRM handling in dash.js. It also adds a new settings flag to disable the encrypted/needkey event

- Add promises if possible to control async functions. The previous usage of events was messy, made the content hard to maintain and was not required for most of the functions (except for keymessage and needkey). 
- Add `ignoreEmeEncryptedEvent` to ignore pssh from init and media segments, implements #3423
- Removed call to `protectionModel.requestKeySystemAccess` in case a new key session is created after the keysystem has already been selected.
- Clear and update  `mediaInfo` in `ProtectionController` after each MPD update
- Implement #3801 
- Updated https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition