### PR TITLE
Avoid uncaught exception on SourceBuffer.abort()

### DIFF
--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -403,10 +403,14 @@ function SourceBufferSink(config) {
                 appendQueue = [];
                 if (mediaSource.readyState === 'open') {
                     _waitForUpdateEnd(() => {
-                        if (buffer) {
-                            buffer.abort();
+                        try {
+                            if (buffer) {
+                                buffer.abort();
+                            }
+                            resolve();
+                        } catch (e) {
+                            resolve();
                         }
-                        resolve();
                     });
                 } else if (buffer && buffer.setTextTrack && mediaSource.readyState === 'ended') {
                     buffer.abort(); //The cues need to be removed from the TextSourceBuffer via a call to abort()
@@ -418,7 +422,6 @@ function SourceBufferSink(config) {
                 resolve();
             }
         });
-
     }
 
     function _executeCallback() {


### PR DESCRIPTION
Sometimes when resetting a stream playback we may encounter javascript error:
`Uncaught DOMException: Failed to execute 'abort' on 'SourceBuffer': This SourceBuffer has been removed from the parent media source.`
This PR is fixing this issue.