### PR TITLE
Refactor protection and fix key rotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,9 +45,9 @@ declare namespace dashjs {
 
         clearMediaInfoArray(): void;
 
-        createKeySession(initData: ArrayBuffer, cdmData: Uint8Array): void;
+        createKeySession(ksInfo: KeySystemInfo): void;
 
-        loadKeySession(sessionId: string, initData: ArrayBuffer): void;
+        loadKeySession(ksInfo: KeySystemInfo): void;
 
         removeKeySession(session: SessionToken): void;
 
@@ -63,7 +63,7 @@ declare namespace dashjs {
 
         setProtectionData(protDataSet: ProtectionDataSet): void;
 
-        getSupportedKeySystemsFromContentProtection(cps: any[]): SupportedKeySystem[];
+        getSupportedKeySystemsFromContentProtection(cps: any[]): KeySystemInfo[];
 
         getKeySystems(): KeySystem[];
 
@@ -1362,16 +1362,17 @@ declare namespace dashjs {
 
         getLicenseServerURLFromInitData(initData: ArrayBuffer): string | null;
 
-        getCDMData(): ArrayBuffer | null;
-
-        getSessionId(): string | null;
+        getCDMData(cdmData: string | null): ArrayBuffer | null;
     }
 
-    export interface SupportedKeySystem {
+    export interface KeySystemInfo {
         ks: KeySystem;
-        initData: ArrayBuffer;
-        cdmData: ArrayBuffer | null;
-        sessionId: string | null;
+        sessionId?: string,
+        sessionType?: string,
+        keyId?: string,
+        initData?: ArrayBuffer;
+        cdmData?: ArrayBuffer;
+        protData?: ProtectionData
     }
 
     export interface LicenseRequest {

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1026,9 +1026,12 @@ function DashAdapter() {
         mediaInfo.selectionPriority = dashManifestModel.getSelectionPriority(realAdaptation);
 
         if (mediaInfo.contentProtection) {
-            mediaInfo.contentProtection.forEach(function (item) {
-                item.KID = dashManifestModel.getKID(item);
-            });
+            // Get the default key ID and apply it to all key systems
+            const keyIds = mediaInfo.contentProtection.map(cp => dashManifestModel.getKID(cp)).filter(kid => kid !== null);
+            if (keyIds.length) {
+                const keyId = keyIds[0];
+                mediaInfo.contentProtection.forEach(cp => { cp.keyId = keyId; });
+            }
         }
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -181,7 +181,7 @@ function ProtectionController(config) {
 
         // Add all key systems to our request list since we have yet to select a key system
         for (let i = 0; i < supportedKS.length; i++) {
-            const keySystemConfiguration = _getKeySystemConfiguration(supportedKS[i].ks);
+            const keySystemConfiguration = _getKeySystemConfiguration(supportedKS[i]);
             requestedKeySystems.push({
                 ks: supportedKS[i].ks,
                 configs: [keySystemConfiguration]
@@ -321,7 +321,6 @@ function ProtectionController(config) {
      */
     function createKeySession(keySystemInfo) {
         const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo.initData);
-        // const protData = _getProtDataForKeySystem(selectedKeySystem);
 
         if (initDataForKS) {
 
@@ -369,18 +368,6 @@ function ProtectionController(config) {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns the session type either from the protData or as defined via setSessionType()
-     * @param keySystem
-     * @return {*}
-     * @private
-     */
-    function _getSessionType(keySystem) {
-        const protData = _getProtDataForKeySystem(keySystem);
-
-        return (protData && protData.sessionType) ? protData.sessionType : sessionType;
     }
 
     /**
@@ -627,13 +614,13 @@ function ProtectionController(config) {
      * @return {KeySystemConfiguration}
      * @private
      */
-    function _getKeySystemConfiguration(keySystem) {
-        const protData = _getProtDataForKeySystem(keySystem);
+    function _getKeySystemConfiguration(keySystemData) {
+        const protData = keySystemData;
         const audioCapabilities = [];
         const videoCapabilities = [];
         const audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;
         const videoRobustness = (protData && protData.videoRobustness && protData.videoRobustness.length > 0) ? protData.videoRobustness : robustnessLevel;
-        const ksSessionType = _getSessionType(keySystem);
+        const ksSessionType = keySystemData.sessionType;
         const distinctiveIdentifier = (protData && protData.distinctiveIdentifier) ? protData.distinctiveIdentifier : 'optional';
         const persistentState = (protData && protData.persistentState) ? protData.persistentState : (ksSessionType === 'temporary') ? 'optional' : 'required';
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -320,7 +320,7 @@ function ProtectionController(config) {
      * @ignore
      */
     function createKeySession(keySystemInfo) {
-        const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo.initData);
+        const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo ? keySystemInfo.initData : null);
 
         if (initDataForKS) {
 
@@ -343,7 +343,7 @@ function ProtectionController(config) {
                     error: new DashJSError(ProtectionErrors.KEY_SESSION_CREATED_ERROR_CODE, ProtectionErrors.KEY_SESSION_CREATED_ERROR_MESSAGE + error.message)
                 });
             }
-        } else if (keySystemInfo.initData) {
+        } else if (keySystemInfo && keySystemInfo.initData) {
             protectionModel.createKeySession(keySystemInfo);
         } else {
             eventBus.trigger(events.KEY_SESSION_CREATED, {

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -251,18 +251,6 @@ function ProtectionController(config) {
             return;
         }
 
-
-        //  we only need to create or load a new key session if the key id has changed
-        if (_isKeyIdDuplicate(current.keyId)) {
-            return;
-        }
-
-        //  we only need to create or load a new key session if the init data has changed
-        const initDataForKs = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, current.initData);
-        if (_isInitDataDuplicate(initDataForKs)) {
-            return;
-        }
-
         _loadOrCreateKeySession(current);
     }
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -615,7 +615,7 @@ function ProtectionController(config) {
      * @private
      */
     function _getKeySystemConfiguration(keySystemData) {
-        const protData = keySystemData;
+        const protData = keySystemData.protData;
         const audioCapabilities = [];
         const videoCapabilities = [];
         const audioRobustness = (protData && protData.audioRobustness && protData.audioRobustness.length > 0) ? protData.audioRobustness : robustnessLevel;

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -129,7 +129,7 @@ function ProtectionController(config) {
 
         // ContentProtection elements are specified at the AdaptationSet level, so the CP for audio
         // and video will be the same. Just use one valid MediaInfo object
-        let supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection);
+        let supportedKS = protectionKeyController.getSupportedKeySystemsFromContentProtection(mediaInfo.contentProtection, protDataSet, sessionType);
 
         // Reorder key systems according to priority order provided in protectionData
         supportedKS = supportedKS.sort((ksA, ksB) => {
@@ -218,7 +218,7 @@ function ProtectionController(config) {
                     for (ksIdx = 0; ksIdx < pendingKeySystemData[i].length; ksIdx++) {
                         if (selectedKeySystem === pendingKeySystemData[i][ksIdx].ks) {
                             const current = pendingKeySystemData[i][ksIdx]
-                            _loadOrCreateKeySession(protData, current)
+                            _loadOrCreateKeySession(current)
                             break;
                         }
                     }
@@ -241,7 +241,7 @@ function ProtectionController(config) {
      * @param {array} supportedKS
      * @private
      */
-    function _initiateWithExistingKeySystem(supportedKS,) {
+    function _initiateWithExistingKeySystem(supportedKS) {
         const ksIdx = supportedKS.findIndex((entry) => {
             return entry.ks === selectedKeySystem;
         });
@@ -251,29 +251,33 @@ function ProtectionController(config) {
             return;
         }
 
+
+        //  we only need to create or load a new key session if the key id has changed
+        if (_isKeyIdDuplicate(current.keyId)) {
+            return;
+        }
+
         //  we only need to create or load a new key session if the init data has changed
         const initDataForKs = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, current.initData);
         if (_isInitDataDuplicate(initDataForKs)) {
             return;
         }
 
-        const protData = _getProtDataForKeySystem(selectedKeySystem);
-        _loadOrCreateKeySession(protData, current);
+        _loadOrCreateKeySession(current);
     }
 
     /**
      * Loads an existing key session if we already have a session id. Otherwise we create a new key session
-     * @param {object} protData
      * @param {object} keySystemInfo
      * @private
      */
-    function _loadOrCreateKeySession(protData, keySystemInfo) {
+    function _loadOrCreateKeySession(keySystemInfo) {
         // Clearkey
         if (protectionKeyController.isClearKey(selectedKeySystem)) {
             // For Clearkey: if parameters for generating init data was provided by the user, use them for generating
             // initData and overwrite possible initData indicated in encrypted event (EME)
-            if (protData && protData.hasOwnProperty('clearkeys')) {
-                const initData = { kids: Object.keys(protData.clearkeys) };
+            if (keySystemInfo.protData && keySystemInfo.protData.hasOwnProperty('clearkeys')) {
+                const initData = { kids: Object.keys(keySystemInfo.protData.clearkeys) };
                 keySystemInfo.initData = new TextEncoder().encode(JSON.stringify(initData));
             }
         }
@@ -281,29 +285,28 @@ function ProtectionController(config) {
         // Reuse existing KeySession
         if (keySystemInfo.sessionId) {
             // Load MediaKeySession with sessionId
-            loadKeySession(keySystemInfo.sessionId, keySystemInfo.initData);
+            loadKeySession(keySystemInfo);
         }
 
         // Create a new KeySession
         else if (keySystemInfo.initData !== null) {
             // Create new MediaKeySession with initData
-            createKeySession(keySystemInfo.initData, keySystemInfo.cdmData);
+            createKeySession(keySystemInfo);
         }
     }
 
     /**
      * Loads a key session with the given session ID from persistent storage.  This essentially creates a new key session
      *
-     * @param {string} sessionID
-     * @param {string} initData
+     * @param {object} ksInfo
      * @memberof module:ProtectionController
      * @instance
      * @fires ProtectionController#KeySessionCreated
      * @ignore
      */
-    function loadKeySession(sessionID, initData) {
+    function loadKeySession(keySystemInfo) {
         checkConfig();
-        protectionModel.loadKeySession(sessionID, initData, _getSessionType(selectedKeySystem));
+        protectionModel.loadKeySession(keySystemInfo);
     }
 
     /**
@@ -316,11 +319,16 @@ function ProtectionController(config) {
      * @fires ProtectionController#KeySessionCreated
      * @ignore
      */
-    function createKeySession(initData, cdmData) {
-        const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, initData);
-        const protData = _getProtDataForKeySystem(selectedKeySystem);
+    function createKeySession(keySystemInfo) {
+        const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo.initData);
+        // const protData = _getProtDataForKeySystem(selectedKeySystem);
 
         if (initDataForKS) {
+
+            // Check for duplicate key id
+            if (_isKeyIdDuplicate(keySystemInfo.keyId)) {
+                return;
+            }
 
             // Check for duplicate initData
             if (_isInitDataDuplicate(initDataForKS)) {
@@ -328,17 +336,16 @@ function ProtectionController(config) {
             }
 
             try {
-                const sessionType = _getSessionType(selectedKeySystem)
-                protectionModel.createKeySession(initDataForKS, protData, sessionType, cdmData);
+                keySystemInfo.initData = initDataForKS;
+                protectionModel.createKeySession(keySystemInfo);
             } catch (error) {
                 eventBus.trigger(events.KEY_SESSION_CREATED, {
                     data: null,
                     error: new DashJSError(ProtectionErrors.KEY_SESSION_CREATED_ERROR_CODE, ProtectionErrors.KEY_SESSION_CREATED_ERROR_MESSAGE + error.message)
                 });
             }
-        } else if (initData) {
-            const sessionType = _getSessionType(selectedKeySystem)
-            protectionModel.createKeySession(initData, protData, sessionType, cdmData);
+        } else if (keySystemInfo.initData) {
+            protectionModel.createKeySession(keySystemInfo);
         } else {
             eventBus.trigger(events.KEY_SESSION_CREATED, {
                 data: null,
@@ -400,7 +407,32 @@ function ProtectionController(config) {
      */
     function getSupportedKeySystemsFromContentProtection(cps) {
         checkConfig();
-        return protectionKeyController.getSupportedKeySystemsFromContentProtection(cps);
+        return protectionKeyController.getSupportedKeySystemsFromContentProtection(cps, protDataSet, sessionType);
+    }
+
+    /**
+     * Checks if a session has already created for the provided key id
+     * @param {string} keyId
+     * @return {boolean}
+     * @private
+     */
+     function _isKeyIdDuplicate(keyId) {
+
+        if (!keyId) {
+            return false;
+        }
+
+        try {
+            const sessions = protectionModel.getSessions();
+            for (let i = 0; i < sessions.length; i++) {
+                if (sessions[i].getKeyId() === keyId) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (e) {
+            return false;
+        }
     }
 
     /**
@@ -658,7 +690,7 @@ function ProtectionController(config) {
 
         // Message not destined for license server
         if (!licenseServerModelInstance) {
-            logger.debug('DRM: License server request not required for this message (type = ' + e.data.messageType + ').  Session ID = ' + sessionToken.getSessionID());
+            logger.debug('DRM: License server request not required for this message (type = ' + e.data.messageType + ').  Session ID = ' + sessionToken.getSessionId());
             _sendLicenseRequestCompleteEvent(eventData);
             return;
         }
@@ -770,7 +802,7 @@ function ProtectionController(config) {
         const reqMethod = licenseServerData.getHTTPMethod(messageType);
         const responseType = licenseServerData.getResponseType(keySystemString, messageType);
         const timeout = protData && !isNaN(protData.httpTimeout) ? protData.httpTimeout : LICENSE_SERVER_REQUEST_DEFAULT_TIMEOUT;
-        const sessionId = sessionToken.getSessionID() || null;
+        const sessionId = sessionToken.getSessionId() || null;
 
         let licenseRequest = new LicenseRequest(url, reqMethod, responseType, reqHeaders, withCredentials, messageType, sessionId, reqPayload);
         const retryAttempts = !isNaN(settings.get().streaming.retryAttempts[HTTPRequest.LICENSE]) ? settings.get().streaming.retryAttempts[HTTPRequest.LICENSE] : LICENSE_SERVER_REQUEST_RETRIES;
@@ -1021,7 +1053,7 @@ function ProtectionController(config) {
 
             logger.debug('DRM: initData:', String.fromCharCode.apply(null, new Uint8Array(abInitData)));
 
-            const supportedKS = protectionKeyController.getSupportedKeySystems(abInitData, protDataSet);
+            const supportedKS = protectionKeyController.getSupportedKeySystems(abInitData, protDataSet, sessionType);
             if (supportedKS.length === 0) {
                 logger.debug('DRM: Received needkey event with initData, but we don\'t support any of the key systems!');
                 return;

--- a/src/streaming/protection/drm/KeySystemClearKey.js
+++ b/src/streaming/protection/drm/KeySystemClearKey.js
@@ -118,11 +118,7 @@ function KeySystemClearKey(config) {
         return null;
     }
 
-    function getCDMData() {
-        return null;
-    }
-
-    function getSessionId(/*cp*/) {
+    function getCDMData(/*cdmData*/) {
         return null;
     }
 
@@ -135,7 +131,6 @@ function KeySystemClearKey(config) {
         getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData,
         getCDMData,
-        getSessionId,
         getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemPlayReady.js
+++ b/src/streaming/protection/drm/KeySystemPlayReady.js
@@ -42,7 +42,6 @@ const uuid = '9a04f079-9840-4286-ab92-e65be0885f95';
 const systemString = ProtectionConstants.PLAYREADY_KEYSTEM_STRING;
 const schemeIdURI = 'urn:uuid:' + uuid;
 const PRCDMData = '<PlayReadyCDMData type="LicenseAcquisition"><LicenseAcquisition version="1.0" Proactive="false"><CustomData encoding="base64encoded">%CUSTOMDATA%</CustomData></LicenseAcquisition></PlayReadyCDMData>';
-let protData;
 
 function KeySystemPlayReady(config) {
 
@@ -236,63 +235,40 @@ function KeySystemPlayReady(config) {
     }
 
     /**
-     * Initialize the Key system with protection data
-     * @param {Object} protectionData the protection data
-     */
-    function init(protectionData) {
-        if (protectionData) {
-            protData = protectionData;
-        }
-    }
-
-
-    /**
      * Get Playready Custom data
      */
-    function getCDMData() {
+    function getCDMData(_cdmData) {
         let customData,
             cdmData,
             cdmDataBytes,
             i;
 
         checkConfig();
-        if (protData && protData.cdmData) {
-            // Convert custom data into multibyte string
-            customData = [];
-            for (i = 0; i < protData.cdmData.length; ++i) {
-                customData.push(protData.cdmData.charCodeAt(i));
-                customData.push(0);
-            }
-            customData = String.fromCharCode.apply(null, customData);
+        if (!_cdmData) return null;
 
-            // Encode in Base 64 the custom data string
-            customData = BASE64.encode(customData);
+        // Convert custom data into multibyte string
+        customData = [];
+        for (i = 0; i < _cdmData.length; ++i) {
+            customData.push(_cdmData.charCodeAt(i));
+            customData.push(0);
+        }
+        customData = String.fromCharCode.apply(null, customData);
 
-            // Initialize CDM data with Base 64 encoded custom data
-            // (see https://msdn.microsoft.com/en-us/library/dn457361.aspx)
-            cdmData = PRCDMData.replace('%CUSTOMDATA%', customData);
+        // Encode in Base 64 the custom data string
+        customData = BASE64.encode(customData);
 
-            // Convert CDM data into multibyte characters
-            cdmDataBytes = [];
-            for (i = 0; i < cdmData.length; ++i) {
-                cdmDataBytes.push(cdmData.charCodeAt(i));
-                cdmDataBytes.push(0);
-            }
+        // Initialize CDM data with Base 64 encoded custom data
+        // (see https://msdn.microsoft.com/en-us/library/dn457361.aspx)
+        cdmData = PRCDMData.replace('%CUSTOMDATA%', customData);
 
-            return new Uint8Array(cdmDataBytes).buffer;
+        // Convert CDM data into multibyte characters
+        cdmDataBytes = [];
+        for (i = 0; i < cdmData.length; ++i) {
+            cdmDataBytes.push(cdmData.charCodeAt(i));
+            cdmDataBytes.push(0);
         }
 
-        return null;
-    }
-
-    function getSessionId(cp) {
-        // Get sessionId from protectionData or from manifest
-        if (protData && protData.sessionId) {
-            return protData.sessionId;
-        } else if (cp && cp.sessionId) {
-            return cp.sessionId;
-        }
-        return null;
+        return new Uint8Array(cdmDataBytes).buffer;
     }
 
     instance = {
@@ -304,9 +280,7 @@ function KeySystemPlayReady(config) {
         getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData,
         getCDMData,
-        getSessionId,
-        setPlayReadyMessageFormat,
-        init
+        setPlayReadyMessageFormat
     };
 
     return instance;

--- a/src/streaming/protection/drm/KeySystemW3CClearKey.js
+++ b/src/streaming/protection/drm/KeySystemW3CClearKey.js
@@ -91,11 +91,7 @@ function KeySystemW3CClearKey(config) {
         return null;
     }
 
-    function getCDMData() {
-        return null;
-    }
-
-    function getSessionId(/*cp*/) {
+    function getCDMData(/*cdmData*/) {
         return null;
     }
 
@@ -108,7 +104,6 @@ function KeySystemW3CClearKey(config) {
         getLicenseRequestFromMessage: getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData: getLicenseServerURLFromInitData,
         getCDMData: getCDMData,
-        getSessionId: getSessionId,
         getClearKeysFromProtectionData: getClearKeysFromProtectionData
     };
 

--- a/src/streaming/protection/drm/KeySystemWidevine.js
+++ b/src/streaming/protection/drm/KeySystemWidevine.js
@@ -47,14 +47,7 @@ function KeySystemWidevine(config) {
 
     config = config || {};
     let instance;
-    let protData = null;
     const BASE64 = config.BASE64;
-
-    function init(protectionData) {
-        if (protectionData) {
-            protData = protectionData;
-        }
-    }
 
     function getInitData(cp) {
         return CommonEncryption.parseInitDataFromContentProtection(cp, BASE64);
@@ -72,17 +65,7 @@ function KeySystemWidevine(config) {
         return null;
     }
 
-    function getCDMData() {
-        return null;
-    }
-
-    function getSessionId(cp) {
-        // Get sessionId from protectionData or from manifest
-        if (protData && protData.sessionId) {
-            return protData.sessionId;
-        } else if (cp && cp.sessionId) {
-            return cp.sessionId;
-        }
+    function getCDMData(/*cdmData*/) {
         return null;
     }
 
@@ -90,13 +73,11 @@ function KeySystemWidevine(config) {
         uuid,
         schemeIdURI,
         systemString,
-        init,
         getInitData,
         getRequestHeadersFromMessage,
         getLicenseRequestFromMessage,
         getLicenseServerURLFromInitData,
-        getCDMData,
-        getSessionId
+        getCDMData
     };
 
     return instance;

--- a/src/streaming/protection/models/ProtectionModel.js
+++ b/src/streaming/protection/models/ProtectionModel.js
@@ -135,7 +135,7 @@ const ProtectionModel = function () { };
  */
 
 /**
- * Loads the persisted key session data associated with the given sessionID
+ * Loads the persisted key session data associated with the given sessionId
  * into a new session.  Sends KEY_SESSION_CREATED event with
  * {@MediaPlayer.vo.protection.SessionToken} as data.
  *

--- a/src/streaming/protection/vo/SessionToken.js
+++ b/src/streaming/protection/vo/SessionToken.js
@@ -55,7 +55,7 @@ class SessionToken {}
  * Returns the unique session ID designated to this session
  *
  * @function
- * @name SessionToken#getSessionID
+ * @name SessionToken#getSessionId
  * @return {string} the session ID or the empty string if the implementation
  * does not support session IDs or the sessionID has not yet been established
  */

--- a/test/unit/streaming.protection.drm.KeySystemPlayReady.js
+++ b/test/unit/streaming.protection.drm.KeySystemPlayReady.js
@@ -71,11 +71,6 @@ describe('KeySystemPlayready', function () {
             expect(keySystem.setPlayReadyMessageFormat.bind(keySystem, 'utf-8')).not.to.throw('Specified message format is not one of "utf-8" or "utf-16"');
         });
 
-        it('should return null when getSessionId is called and protData is undefined', function () {
-            const sessionId = keySystem.getSessionId();
-            expect(sessionId).to.be.null;   // jshint ignore:line
-        });
-
         it('should return null when getCDMData is called and protData is undefined', function () {
             const cdmData = keySystem.getCDMData();
             expect(cdmData).to.be.null;   // jshint ignore:line
@@ -102,8 +97,7 @@ describe('KeySystemPlayready', function () {
         });
 
         it('should return the correct cdmData', function () {
-            keySystem.init(protData);
-            cdmData = keySystem.getCDMData();
+            cdmData = keySystem.getCDMData(protData.cdmData);
             expect(keySystem).to.be.defined;   // jshint ignore:line
             expect(cdmData).to.be.not.null;   // jshint ignore:line
             expect(cdmData).to.be.instanceOf(ArrayBuffer);


### PR DESCRIPTION
The goal of this PR is to fix key rotation in order to rely on key id updates instead of initData updates.
Some live streams may have initData being updated in manifest updates but with same key id, thus this PR would avoid requesting unnecessarily a new license.

This required some refactoring in order to store key ids and then to simplify API protection models API (load/createSession).

Still in progress:
- in case of 'encrypted' event, shall we extract key id from pssh in order to compare it?
- then shall we remove completely initData duplication checking?