### PR TITLE
feat: Preserve cdata on manifest parsing and expose on dash event messageData

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -869,6 +869,7 @@ function DashManifestModel() {
                         // string representation'.
                         event.messageData =
                             currentMpdEvent.messageData ||
+                            currentMpdEvent.__cdata ||
                             currentMpdEvent.__text;
                     }
 


### PR DESCRIPTION
In order to parse Content Programme Metadata as specified in DVB DASH spec in section 9.1.2, the XML parser and Dash Events need to support CDATA in the payload.

This PR preserves CDATA when the manifest is parsed and assigns the CDATA to the `event.messageData` if the attribute exists.

Would welcome feedback on whether preserving CDATA should be driven from a player settings configuration.

There doesn't seem to be any specific existing test coverage in these areas, but the whole suite continues to pass and I have tested access to the CDATA within a player event using scheme `urn:dvb:iptv:cpm:2014`.

As this is my first dash.js contribution, I've also uploaded a feedback agreement to the mailing list.

