### PR TITLE
Fix/3808

### DIFF
--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -253,7 +253,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
             // In some cases when requiredMediaTime = actual end time of the last segment
             // it is possible that this time a bit exceeds the declared end time of the last segment.
             // in this case we still need to include the last segment in the segment list.
-            if (requiredMediaTime < (scaledTime + (frag.d / fTimescale))) {
+            if ((requiredMediaTime < (scaledTime + (frag.d / fTimescale))) && requiredMediaTime >= scaledTime) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -436,7 +436,7 @@ function StreamProcessor(config) {
 
         // If  this statement is true we are stuck. A static manifest does not change and we did not find a valid request for the target time
         // There is no point in trying again. We need to adjust the time in order to find a valid request. This can happen if the user/app seeked into a gap.
-        if (settings.get().streaming.gaps.enableSeekFix && !isDynamic && shouldUseExplicitTimeForRequest && playbackController.isSeeking()) {
+        if (settings.get().streaming.gaps.enableSeekFix && !isDynamic && shouldUseExplicitTimeForRequest && (playbackController.isSeeking() || playbackController.getTime() === 0)) {
             const adjustedTime = dashHandler.getValidSeekTimeCloseToTargetTime(bufferingTime, mediaInfo, representation, settings.get().streaming.gaps.threshold);
             if (!isNaN(adjustedTime)) {
                 playbackController.seek(adjustedTime, false, false);


### PR DESCRIPTION
Account for seek to 0 in _noMediaRequestGenerated and consider if the requiredMediaTime is larger than the start time of the segment