### PR TITLE
Adding AACH in the list of supported codecs for mssparser

### DIFF
--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -47,7 +47,7 @@ function MssParser(config) {
     const settings = config.settings;
 
     const DEFAULT_TIME_SCALE = 10000000.0;
-    const SUPPORTED_CODECS = ['AAC', 'AACL', 'AVC1', 'H264', 'TTML', 'DFXP'];
+    const SUPPORTED_CODECS = ['AAC', 'AACL', 'AACH', 'AVC1', 'H264', 'TTML', 'DFXP'];
     // MPEG-DASH Role and accessibility mapping for text tracks according to ETSI TS 103 285 v1.1.1 (section 7.1.2)
     const ROLE = {
         'CAPT': 'main',

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -47,7 +47,7 @@ function MssParser(config) {
     const settings = config.settings;
 
     const DEFAULT_TIME_SCALE = 10000000.0;
-    const SUPPORTED_CODECS = ['AAC', 'AACL', 'AACH', 'AVC1', 'H264', 'TTML', 'DFXP'];
+    const SUPPORTED_CODECS = ['AAC', 'AACL', 'AACH', 'AACP', 'AVC1', 'H264', 'TTML', 'DFXP'];
     // MPEG-DASH Role and accessibility mapping for text tracks according to ETSI TS 103 285 v1.1.1 (section 7.1.2)
     const ROLE = {
         'CAPT': 'main',


### PR DESCRIPTION
MSS manifest with audio codec value fourCC="AACH" is not converted into dash by MSSParser.js.
Supported codecs list does not have 'AACH'.
Audio was not playing because of this.

Adding AACH to SUPPORTED_CODECS list plays audio fine.