### PR TITLE
Enable gap seek fix by default

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -801,7 +801,7 @@ function Settings() {
                 jumpLargeGaps: true,
                 smallGapLimit: 1.5,
                 threshold: 0.3,
-                enableSeekFix: false
+                enableSeekFix: true
             },
             utcSynchronization: {
                 enabled: true,


### PR DESCRIPTION
#3823 changes the calculation in `TimelineSegmentsGetter.js`. In order to seek over gaps at playback start we need to enable `enableSeekFix`