### PR TITLE
Fix live seeking

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -354,12 +354,10 @@ function BufferController(config) {
             if (seekTarget <= range.end) {
                 // Seek video element to seek target or range start if appended buffer starts after seek target (segments timeline/template tolerance)
                 playbackController.seek(Math.max(seekTarget, range.start), false, true);
-                seekTarget = NaN;
             }
         } else if (currentTime < range.start) {
             // If appended buffer starts after seek target (segments timeline/template tolerance) then seek to range start
             playbackController.seek(range.start, false, true);
-            seekTarget = NaN;
         }
     }
 


### PR DESCRIPTION
Thie PR fixes live seeking for some embedded devices on which we can't set video element time at unavalaible range in audio AND video buffers.

This fixes following scenario:
- set seek target to ST=4
- download and append video buffer from 4 to 6
- _adjustSeekTarget() set video model current time to 4 and video seekTarget is set to NaN, but video model is still equal to 0 since no audio buffer at time ST
- download and append audio buffer from 2,1 to 4,1 
- _adjustSeekTarget() set video model current time to 2,1 since video model current time is still equals to 0
- download and append video buffer from 6 et 8
- since video seekTarget is set to NaN we don't adjust anymore video model current time => playback never starts
