### PR TITLE
Throw new error in case of invalid settings

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -946,6 +946,8 @@ function Settings() {
                     } else {
                         dest[n] = Utils.clone(source[n]);
                     }
+                } else {
+                    throw new Error('Settings parameter ' + path + n + ' is not supported');
                 }
             }
         }


### PR DESCRIPTION
This PR enables throwing an error in case of invalid, non-existent setting parameter.
Since some settings parameters may be moved or renamed depending on the version, this would avoid issues during dash.js integration.