### PR TITLE
Fix TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1353,7 +1353,7 @@ declare namespace dashjs {
         uuid: string;
         schemeIdURI: string;
 
-        getInitData(cp: object): ArrayBuffer;
+        getInitData(cp: object): ArrayBuffer | null;
 
         getRequestHeadersFromMessage(message: ArrayBuffer): object | null;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1378,7 +1378,7 @@ declare namespace dashjs {
         url: string;
         method: string;
         responseType: string;
-        headers: object;
+        headers: {[key: string]: string};
         withCredentials: boolean;
         messageType: string;
         sessionId: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1491,4 +1491,28 @@ declare namespace dashjs {
 
     export function supportsMediaSource(): boolean;
 
+    export interface ClassConstructor {
+        __dashjs_factory_name: string
+    }
+
+    export type Factory = (context: object) => {
+        create: () => any
+    }
+
+    export type SingletonFactory = (context: object) => {
+        getInstance: () => any
+    }
+
+    export interface FactoryMaker {
+        extend(name: string, childInstance: object, override: boolean, context: object): void;
+        getSingletonInstance(context: object, className: string): any,
+        setSingletonInstance(context: object, className: string, instance: object): void;
+        deleteSingletonInstances(context: object): void;
+        getSingletonFactory(classConstructor: ClassConstructor): SingletonFactory,
+        getSingletonFactoryByName(name: string): SingletonFactory,
+        updateSingletonFactory(name: string, factory: SingletonFactory): void,
+        getClassFactory(classConstructor: ClassConstructor): Factory,
+        getClassFactoryByName(name: string): Factory,
+        updateClassFactory(name: string, factory: Factory): void,
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1353,7 +1353,7 @@ declare namespace dashjs {
         uuid: string;
         schemeIdURI: string;
 
-        getInitData(cp: object): ArrayBuffer | null;
+        getInitData(cp: object, cencContentProtection?: object | null): ArrayBuffer | null;
 
         getRequestHeadersFromMessage(message: ArrayBuffer): object | null;
 


### PR DESCRIPTION
- Allow KeySystem.getInitData to return null
- Add missing parameter type to getInitData
- Type LicenseRequest.headers as a dictionary
- Add typings for FactoryMaker

See #3834.