### PR TITLE
Fix events without presentation time and id

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -849,9 +849,10 @@ function DashManifestModel() {
 
                     if (currentMpdEvent.hasOwnProperty(DashConstants.PRESENTATION_TIME)) {
                         event.presentationTime = currentMpdEvent.presentationTime;
-                        const presentationTimeOffset = eventStream.presentationTimeOffset ? eventStream.presentationTimeOffset / eventStream.timescale : 0;
-                        event.calculatedPresentationTime = event.presentationTime / eventStream.timescale + period.start - presentationTimeOffset;
                     }
+                    const presentationTimeOffset = eventStream.presentationTimeOffset ? eventStream.presentationTimeOffset / eventStream.timescale : 0;
+                    event.calculatedPresentationTime = event.presentationTime / eventStream.timescale + period.start - presentationTimeOffset;
+
                     if (currentMpdEvent.hasOwnProperty(DashConstants.DURATION)) {
                         event.duration = currentMpdEvent.duration / eventStream.timescale;
                     }

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -858,6 +858,8 @@ function DashManifestModel() {
                     }
                     if (currentMpdEvent.hasOwnProperty(DashConstants.ID)) {
                         event.id = currentMpdEvent.id;
+                    } else {
+                        event.id = null;
                     }
 
                     if (currentMpdEvent.Signal && currentMpdEvent.Signal.Binary) {

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -454,7 +454,7 @@ function EventController() {
         const id = event.id;
 
         events[schemeIdUri] = events[schemeIdUri].filter((e) => {
-            return (value && e.eventStream.value && e.eventStream.value !== value) || (e.id !== id && (!isNaN(e.id) || !isNaN(id)));
+            return (value && e.eventStream.value && e.eventStream.value !== value) || e.id !== id;
         });
 
         if (events[schemeIdUri].length === 0) {

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -454,7 +454,7 @@ function EventController() {
         const id = event.id;
 
         events[schemeIdUri] = events[schemeIdUri].filter((e) => {
-            return (value && e.eventStream.value && e.eventStream.value !== value) || (e.id !== id);
+            return (value && e.eventStream.value && e.eventStream.value !== value) || (e.id !== id && (!isNaN(e.id) || !isNaN(id)));
         });
 
         if (events[schemeIdUri].length === 0) {


### PR DESCRIPTION
This PR fixes a memory leak for inline events without id and presentation time. Before this PR the events were not removed from the list of outdated events leading to large memory consumption for longtime playback.