### PR TITLE
Fix SourceBufferSink reset process

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -1025,14 +1025,14 @@ function BufferController(config) {
         seekTarget = NaN;
 
         if (sourceBufferSink) {
+            let tmpSourceBufferSinkToReset = sourceBufferSink;
+            sourceBufferSink = null;
             if (!errored && !keepBuffers) {
-                sourceBufferSink.abort()
+                tmpSourceBufferSinkToReset.abort()
                     .then(() => {
-                        sourceBufferSink.reset(keepBuffers);
-                        sourceBufferSink = null;
+                        tmpSourceBufferSinkToReset.reset(keepBuffers);
+                        tmpSourceBufferSinkToReset = null;
                     });
-            } else {
-                sourceBufferSink = null;
             }
         }
 


### PR DESCRIPTION
This PR is fixing errors when stopping playback.

When resetting BufferController and aborting then removing source buffers from MediaSource, we can face the following error, due to asynchronous processes:

`[SourceBufferSink][video] getAllBufferRanges exception: Failed to read the 'buffered' property from 'SourceBuffer': This SourceBuffer has been removed from the parent media source. 
`