### PR TITLE
Exclude text StreamProcessor when checking buffer level for initial playback

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -642,14 +642,21 @@ function PlaybackController() {
         return settings.get().streaming.liveCatchup.enabled || settings.get().streaming.lowLatencyEnabled;
     }
 
-    function getBufferLevel() {
+    /**
+     * Returns the combined minimum buffer level of all StreamProcessors. If a filter list is provided the types specified in the filter list are excluded.
+     * @param {array} filterList StreamProcessor types to exclude
+     * @return {null}
+     */
+    function getBufferLevel(filterList = null) {
         let bufferLevel = null;
         streamController.getActiveStreamProcessors().forEach(p => {
-            const bl = p.getBufferLevel();
-            if (bufferLevel === null) {
-                bufferLevel = bl;
-            } else {
-                bufferLevel = Math.min(bufferLevel, bl);
+            if (!filterList || filterList.length === 0 || filterList.indexOf(p.getType()) === -1) {
+                const bl = p.getBufferLevel();
+                if (bufferLevel === null) {
+                    bufferLevel = bl;
+                } else {
+                    bufferLevel = Math.min(bufferLevel, bl);
+                }
             }
         });
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -694,8 +694,8 @@ function StreamController() {
         // check if this is the initial playback and we reached the buffer target. If autoplay is true we start playback
         if (initialPlayback && autoPlay) {
             const initialBufferLevel = mediaPlayerModel.getInitialBufferLevel();
-
-            if (isNaN(initialBufferLevel) || initialBufferLevel <= playbackController.getBufferLevel() || (adapter.getIsDynamic() && initialBufferLevel > playbackController.getLiveDelay())) {
+            const excludedStreamProcessors = [Constants.TEXT];
+            if (isNaN(initialBufferLevel) || initialBufferLevel <= playbackController.getBufferLevel(excludedStreamProcessors) || (adapter.getIsDynamic() && initialBufferLevel > playbackController.getLiveDelay())) {
                 initialPlayback = false;
                 _createPlaylistMetrics(PlayList.INITIAL_PLAYOUT_START_REASON);
                 playbackController.play();


### PR DESCRIPTION
This is a potential fix for #3850 