### PR TITLE
Add support for multiple system strings for a single key system

### DIFF
--- a/samples/drm/clearkey.html
+++ b/samples/drm/clearkey.html
@@ -28,7 +28,7 @@
             };
             var video,
                 player,
-                url = "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_ClearKey.mpd";
+                url = "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd";
 
             video = document.querySelector("video");
             player = dashjs.MediaPlayer().create();

--- a/samples/drm/mpds/laurl.mpd
+++ b/samples/drm/mpds/laurl.mpd
@@ -1,7 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Version information:
+Axinom.MediaProcessing v3.0.0 targeting General Purpose Media Format specification v7
+ffmpeg version N-81423-g61fac0e Copyright (c) 2000-2016 the FFmpeg developers
+x265 [info]: HEVC encoder version 2.0+12-49a0d1176aef5bc6
+x264 0.148.2705 3f5ed56
+MP4Box - GPAC version 0.6.2-DEV-rev683-g7b29fbe-master
+MediaInfoLib - v0.7.87
+
+For more info about this video, see https://github.com/Axinom/dash-test-vectors
+-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static"
      mediaPresentationDuration="PT0H12M14.000S" maxSegmentDuration="PT0H0M4.000S"
      profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264"
-     xmlns:cenc="urn:mpeg:cenc:2013" xmlns:dashif="https://dashif.org/">
+     xmlns:dashif="https://dashif.org/"
+     xmlns:cenc="urn:mpeg:cenc:2013">
     <Period duration="PT0H12M14.000S">
         <BaseURL>https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/</BaseURL>
         <AdaptationSet segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9"
@@ -15,7 +28,7 @@
                 <pro xmlns="urn:microsoft:playready">
                     xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARABRAFcAMABuAGsAdgBrAEEAawBpAFQATABpAGYAWABVAEkAUABpAFoAZwA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=
                 </pro>
-                <dashif:Laurl>https://drm-widevine-licensing.axtest.net/AcquireLicense</dashif:Laurl>
+                <dashif:Laurl>https://drm-playready-licensing.axtest.net/AcquireLicense</dashif:Laurl>
             </ContentProtection>
             <ContentProtection value="Widevine" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
                 <dashif:Laurl>https://drm-widevine-licensing.axtest.net/AcquireLicense</dashif:Laurl>
@@ -45,20 +58,30 @@
                 <pro xmlns="urn:microsoft:playready">
                     xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARABRAFcAMABuAGsAdgBrAEEAawBpAFQATABpAGYAWABVAEkAUABpAFoAZwA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=
                 </pro>
-                <dashif:Laurl>https://drm-widevine-licensing.axtest.net/AcquireLicense</dashif:Laurl>
+                <dashif:Laurl>https://drm-playready-licensing.axtest.net/AcquireLicense</dashif:Laurl>
             </ContentProtection>
             <ContentProtection value="Widevine" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
-                <cenc:pssh>AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQnrQFDeRLSAKTLifXUIPiZg==</cenc:pssh>
                 <dashif:Laurl>https://drm-widevine-licensing.axtest.net/AcquireLicense</dashif:Laurl>
+                <cenc:pssh>AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQnrQFDeRLSAKTLifXUIPiZg==</cenc:pssh>
             </ContentProtection>
             <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
             <SegmentTemplate timescale="24000" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1"
-                             duration="95232" initialization="$RepresentationID$/init.mp4"/>
+                             duration="95232"
+                             initialization="$RepresentationID$/init.mp4"/>
             <Representation id="15" mimeType="audio/mp4" codecs="mp4a.40.29" audioSamplingRate="48000" startWithSAP="1"
                             bandwidth="134642">
                 <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
                                            value="2"/>
             </Representation>
+        </AdaptationSet>
+        <AdaptationSet segmentAlignment="true" group="3" lang="en">
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle"/>
+            <SegmentTemplate timescale="1000" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1"
+                             duration="4000"
+                             initialization="$RepresentationID$/init.mp4"/>
+            <Representation id="18" mimeType="application/mp4" codecs="wvtt" startWithSAP="1"
+                            bandwidth="428"></Representation>
         </AdaptationSet>
     </Period>
 </MPD>

--- a/samples/drm/system-string-priority.html
+++ b/samples/drm/system-string-priority.html
@@ -30,7 +30,7 @@
                 },
                 'com.microsoft.playready': {
                     'serverURL': 'https://drm-playready-licensing.axtest.net/AcquireLicense',
-                    'systemStringPriority': ['com.microsoft.playready.something', 'com.microsoft.playready', 'com.microsoft.playready.hardware', 'com.microsoft.playready'],
+                    'systemStringPriority': ['com.microsoft.playready.something', 'com.microsoft.playready.recommendation', 'com.microsoft.playready.hardware', 'com.microsoft.playready'],
                     'priority': 1,
                     'httpRequestHeaders': {
                         'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImZpcnN0X3BsYXlfZXhwaXJhdGlvbiI6NjAsInBsYXlyZWFkeSI6eyJyZWFsX3RpbWVfZXhwaXJhdGlvbiI6dHJ1ZX0sImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.FAbIiPxX8BHi9RwfzD7Yn-wugU19ghrkBFKsaCPrZmU'

--- a/samples/drm/system-string-priority.html
+++ b/samples/drm/system-string-priority.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>DRM system string priority example</title>
+
+    <script src="../../dist/dash.all.debug.js"></script>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../lib/main.css" rel="stylesheet">
+
+    <style>
+        video {
+            width: 640px;
+            height: 360px;
+        }
+    </style>
+
+    <script class="code">
+        function init() {
+            var protData = {
+                'com.widevine.alpha': {
+                    'serverURL': 'https://drm-widevine-licensing.axtest.net/AcquireLicense',
+                    'systemStringPriority': ['com.widevine.something', 'com.widevine.alpha'],
+                    'priority': 2,
+                    'httpRequestHeaders': {
+                        'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImZpcnN0X3BsYXlfZXhwaXJhdGlvbiI6NjAsInBsYXlyZWFkeSI6eyJyZWFsX3RpbWVfZXhwaXJhdGlvbiI6dHJ1ZX0sImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.FAbIiPxX8BHi9RwfzD7Yn-wugU19ghrkBFKsaCPrZmU'
+                    }
+                },
+                'com.microsoft.playready': {
+                    'serverURL': 'https://drm-playready-licensing.axtest.net/AcquireLicense',
+                    'systemStringPriority': ['com.microsoft.playready.something', 'com.microsoft.playready.recommendation', 'com.microsoft.playready.hardware', 'com.microsoft.playready'],
+                    'priority': 1,
+                    'httpRequestHeaders': {
+                        'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiMDg3Mjc4NmUtZjllNy00NjVmLWEzYTItNGU1YjBlZjhmYTQ1IiwiZW5jcnlwdGVkX2tleSI6IlB3NitlRVlOY3ZqWWJmc2gzWDNmbWc9PSJ9LHsiaWQiOiJjMTRmMDcwOS1mMmI5LTQ0MjctOTE2Yi02MWI1MjU4NjUwNmEiLCJlbmNyeXB0ZWRfa2V5IjoiLzErZk5paDM4bXFSdjR5Y1l6bnQvdz09In0seyJpZCI6IjhiMDI5ZTUxLWQ1NmEtNDRiZC05MTBmLWQ0YjVmZDkwZmJhMiIsImVuY3J5cHRlZF9rZXkiOiJrcTBKdVpFanBGTjhzYVRtdDU2ME9nPT0ifSx7ImlkIjoiMmQ2ZTkzODctNjBjYS00MTQ1LWFlYzItYzQwODM3YjRiMDI2IiwiZW5jcnlwdGVkX2tleSI6IlRjUlFlQld4RW9IT0tIcmFkNFNlVlE9PSJ9LHsiaWQiOiJkZTAyZjA3Zi1hMDk4LTRlZTAtYjU1Ni05MDdjMGQxN2ZiYmMiLCJlbmNyeXB0ZWRfa2V5IjoicG9lbmNTN0dnbWVHRmVvSjZQRUFUUT09In0seyJpZCI6IjkxNGU2OWY0LTBhYjMtNDUzNC05ZTlmLTk4NTM2MTVlMjZmNiIsImVuY3J5cHRlZF9rZXkiOiJlaUkvTXNsbHJRNHdDbFJUL0xObUNBPT0ifSx7ImlkIjoiZGE0NDQ1YzItZGI1ZS00OGVmLWIwOTYtM2VmMzQ3YjE2YzdmIiwiZW5jcnlwdGVkX2tleSI6IjJ3K3pkdnFycERWM3hSMGJKeTR1Z3c9PSJ9LHsiaWQiOiIyOWYwNWU4Zi1hMWFlLTQ2ZTQtODBlOS0yMmRjZDQ0Y2Q3YTEiLCJlbmNyeXB0ZWRfa2V5IjoiL3hsU0hweHdxdTNnby9nbHBtU2dhUT09In0seyJpZCI6IjY5ZmU3MDc3LWRhZGQtNGI1NS05NmNkLWMzZWRiMzk5MTg1MyIsImVuY3J5cHRlZF9rZXkiOiJ6dTZpdXpOMnBzaTBaU3hRaUFUa1JRPT0ifV19fQ.BXr93Et1krYMVs-CUnf7F3ywJWFRtxYdkR7Qn4w3-to'
+                    }
+                }
+            };
+            var video,
+                player,
+                url = 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p.mpd';
+
+            video = document.querySelector('video');
+            player = dashjs.MediaPlayer().create();
+            player.updateSettings({
+                debug: {
+                    logLevel: 5
+                }
+            });
+            player.initialize(video, url, true);
+            player.setProtectionData(protData);
+        }
+
+        function check() {
+            if (location.protocol === 'http:' && location.hostname !== 'localhost') {
+                var out = 'This page has been loaded under http. This might result in the EME APIs not being available to the player and any DRM-protected content will fail to play. ' +
+                    'If you wish to test manifest URLs that require EME support, then <a href=\'https:' + window.location.href.substring(window.location.protocol.length) + '\'>reload this page under https</a>.'
+                var div = document.getElementById('http-warning');
+                div.innerHTML = out;
+                div.style.display = ''
+            }
+        }
+    </script>
+</head>
+<body>
+
+<main>
+    <div class="container py-4">
+        <header class="pb-3 mb-4 border-bottom">
+            <img class=""
+                 src="../lib/img/dashjs-logo.png"
+                 width="200">
+        </header>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="alert alert-danger" role="alert" style="display: none" id="http-warning">
+
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-4">
+                <div class="h-100 p-5 bg-light border rounded-3">
+                    <h3>DRM system string priority example</h3>
+                    <p>This example shows how to specify the system string priority for the call to
+                        requestMediaKeySystemAccess for the same DRM system. For example, Playready might be supported
+                        with the system strings "com.microsoft.playready.recommendation" and
+                        "com.microsoft.playready". </p>
+                    <p>For a detailed explanation on DRM playback in dash.js checkout the
+                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
+                           target="_blank">Wiki</a>.</p>
+                </div>
+            </div>
+            <div class="col-md-8">
+                <video controls="true"></video>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div id="code-output"></div>
+            </div>
+        </div>
+        <footer class="pt-3 mt-4 text-muted border-top">
+            &copy; DASH-IF
+        </footer>
+    </div>
+</main>
+
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        check();
+        init();
+    });
+</script>
+<script src="../highlighter.js"></script>
+</body>
+</html>

--- a/samples/drm/system-string-priority.html
+++ b/samples/drm/system-string-priority.html
@@ -30,10 +30,10 @@
                 },
                 'com.microsoft.playready': {
                     'serverURL': 'https://drm-playready-licensing.axtest.net/AcquireLicense',
-                    'systemStringPriority': ['com.microsoft.playready.something', 'com.microsoft.playready.recommendation', 'com.microsoft.playready.hardware', 'com.microsoft.playready'],
+                    'systemStringPriority': ['com.microsoft.playready.something', 'com.microsoft.playready', 'com.microsoft.playready.hardware', 'com.microsoft.playready'],
                     'priority': 1,
                     'httpRequestHeaders': {
-                        'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiMDg3Mjc4NmUtZjllNy00NjVmLWEzYTItNGU1YjBlZjhmYTQ1IiwiZW5jcnlwdGVkX2tleSI6IlB3NitlRVlOY3ZqWWJmc2gzWDNmbWc9PSJ9LHsiaWQiOiJjMTRmMDcwOS1mMmI5LTQ0MjctOTE2Yi02MWI1MjU4NjUwNmEiLCJlbmNyeXB0ZWRfa2V5IjoiLzErZk5paDM4bXFSdjR5Y1l6bnQvdz09In0seyJpZCI6IjhiMDI5ZTUxLWQ1NmEtNDRiZC05MTBmLWQ0YjVmZDkwZmJhMiIsImVuY3J5cHRlZF9rZXkiOiJrcTBKdVpFanBGTjhzYVRtdDU2ME9nPT0ifSx7ImlkIjoiMmQ2ZTkzODctNjBjYS00MTQ1LWFlYzItYzQwODM3YjRiMDI2IiwiZW5jcnlwdGVkX2tleSI6IlRjUlFlQld4RW9IT0tIcmFkNFNlVlE9PSJ9LHsiaWQiOiJkZTAyZjA3Zi1hMDk4LTRlZTAtYjU1Ni05MDdjMGQxN2ZiYmMiLCJlbmNyeXB0ZWRfa2V5IjoicG9lbmNTN0dnbWVHRmVvSjZQRUFUUT09In0seyJpZCI6IjkxNGU2OWY0LTBhYjMtNDUzNC05ZTlmLTk4NTM2MTVlMjZmNiIsImVuY3J5cHRlZF9rZXkiOiJlaUkvTXNsbHJRNHdDbFJUL0xObUNBPT0ifSx7ImlkIjoiZGE0NDQ1YzItZGI1ZS00OGVmLWIwOTYtM2VmMzQ3YjE2YzdmIiwiZW5jcnlwdGVkX2tleSI6IjJ3K3pkdnFycERWM3hSMGJKeTR1Z3c9PSJ9LHsiaWQiOiIyOWYwNWU4Zi1hMWFlLTQ2ZTQtODBlOS0yMmRjZDQ0Y2Q3YTEiLCJlbmNyeXB0ZWRfa2V5IjoiL3hsU0hweHdxdTNnby9nbHBtU2dhUT09In0seyJpZCI6IjY5ZmU3MDc3LWRhZGQtNGI1NS05NmNkLWMzZWRiMzk5MTg1MyIsImVuY3J5cHRlZF9rZXkiOiJ6dTZpdXpOMnBzaTBaU3hRaUFUa1JRPT0ifV19fQ.BXr93Et1krYMVs-CUnf7F3ywJWFRtxYdkR7Qn4w3-to'
+                        'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImZpcnN0X3BsYXlfZXhwaXJhdGlvbiI6NjAsInBsYXlyZWFkeSI6eyJyZWFsX3RpbWVfZXhwaXJhdGlvbiI6dHJ1ZX0sImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.FAbIiPxX8BHi9RwfzD7Yn-wugU19ghrkBFKsaCPrZmU'
                     }
                 }
             };

--- a/samples/drm/system-string-priority.html
+++ b/samples/drm/system-string-priority.html
@@ -84,7 +84,7 @@
                 <div class="h-100 p-5 bg-light border rounded-3">
                     <h3>DRM system string priority example</h3>
                     <p>This example shows how to specify the system string priority for the call to
-                        requestMediaKeySystemAccess for the same DRM system. For example, Playready might be supported
+                        requestMediaKeySystemAccess. For example, Playready might be supported
                         with the system strings "com.microsoft.playready.recommendation" and
                         "com.microsoft.playready". </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -413,6 +413,20 @@
                 ]
             },
             {
+                "title": "Keysystem string priority",
+                "description": "This example shows how to specify the system string priority for the call to requestMediaKeySystemAccess for the same DRM system. For example, Playready might be supported with the system strings \"com.microsoft.playready.recommendation\" and \"com.microsoft.playready\". ",
+                "href": "drm/system-string-priority.html",
+                "image": "lib/img/tos-1.jpg",
+                "labels": [
+                    "VoD",
+                    "DRM",
+                    "Widevine",
+                    "Playready",
+                    "Video",
+                    "Audio"
+                ]
+            },
+            {
                 "title": "License server via MPD",
                 "description": "This example shows how to specify the license server url as part of the MPD using 'dashif:laurl'",
                 "href": "drm/dashif-laurl.html",

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -414,7 +414,7 @@
             },
             {
                 "title": "Keysystem string priority",
-                "description": "This example shows how to specify the system string priority for the call to requestMediaKeySystemAccess for the same DRM system. For example, Playready might be supported with the system strings \"com.microsoft.playready.recommendation\" and \"com.microsoft.playready\". ",
+                "description": "This example shows how to specify the system string priority for the call to requestMediaKeySystemAccess. For example, Playready might be supported with the system strings \"com.microsoft.playready.recommendation\" and \"com.microsoft.playready\". ",
                 "href": "drm/system-string-priority.html",
                 "image": "lib/img/tos-1.jpg",
                 "labels": [

--- a/src/streaming/constants/ProtectionConstants.js
+++ b/src/streaming/constants/ProtectionConstants.js
@@ -40,6 +40,7 @@ class ProtectionConstants {
         this.CLEARKEY_KEYSTEM_STRING = 'org.w3.clearkey';
         this.WIDEVINE_KEYSTEM_STRING = 'com.widevine.alpha';
         this.PLAYREADY_KEYSTEM_STRING = 'com.microsoft.playready';
+        this.PLAYREADY_RECOMMENDATION_KEYSTEM_STRING = 'com.microsoft.playready.recommendation';
         this.INITIALIZATION_DATA_TYPE_CENC = 'cenc';
         this.INITIALIZATION_DATA_TYPE_KEYIDS = 'keyids'
         this.INITIALIZATION_DATA_TYPE_WEBM = 'webm'

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -184,7 +184,8 @@ function ProtectionController(config) {
             const keySystemConfiguration = _getKeySystemConfiguration(supportedKS[i]);
             requestedKeySystems.push({
                 ks: supportedKS[i].ks,
-                configs: [keySystemConfiguration]
+                configs: [keySystemConfiguration],
+                protData: supportedKS[i].protData
             });
         }
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -194,7 +194,8 @@ function ProtectionController(config) {
         protectionModel.requestKeySystemAccess(requestedKeySystems)
             .then((event) => {
                 keySystemAccess = event.data;
-                logger.info('DRM: KeySystem Access Granted (' + keySystemAccess.keySystem.systemString + ')!  Selecting key system...');
+                let selectedSystemString = keySystemAccess.mksa && keySystemAccess.mksa.selectedSystemString ? keySystemAccess.mksa.selectedSystemString : keySystemAccess.keySystem.systemString;
+                logger.info('DRM: KeySystem Access Granted for system string (' + selectedSystemString + ')!  Selecting key system...');
                 return protectionModel.selectKeySystem(keySystemAccess);
             })
             .then((keySystem) => {

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -45,6 +45,11 @@ import KeyMessage from '../vo/KeyMessage';
 import KeySystemAccess from '../vo/KeySystemAccess';
 import ProtectionConstants from '../../constants/ProtectionConstants';
 
+const SYSTEM_STRING_PRIORITY = {};
+SYSTEM_STRING_PRIORITY[ProtectionConstants.PLAYREADY_KEYSTEM_STRING] = [ProtectionConstants.PLAYREADY_RECOMMENDATION_KEYSTEM_STRING, ProtectionConstants.PLAYREADY_KEYSTEM_STRING];
+SYSTEM_STRING_PRIORITY[ProtectionConstants.WIDEVINE_KEYSTEM_STRING] = [ProtectionConstants.WIDEVINE_KEYSTEM_STRING];
+SYSTEM_STRING_PRIORITY[ProtectionConstants.CLEARKEY_KEYSTEM_STRING] = [ProtectionConstants.CLEARKEY_KEYSTEM_STRING];
+
 function ProtectionModel_21Jan2015(config) {
 
     config = config || {};
@@ -170,13 +175,8 @@ function ProtectionModel_21Jan2015(config) {
         const currentKeySystem = ksConfigurations[idx].ks;
         let systemString = currentKeySystem.systemString;
 
-        // Patch to support persistent licenses on Edge browser (see issue #2658). Only apply when protData does not define a systemStringPriority
-        if (!protDataSystemStringPriority && systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING && configs[0].persistentState === 'required') {
-            systemString += '.recommendation';
-        }
-
-        // Use the default system string in case no values are provided by the application
-        const systemStringsToApply = protDataSystemStringPriority ? protDataSystemStringPriority : [systemString];
+        // Use the default values in case no values are provided by the application
+        const systemStringsToApply = protDataSystemStringPriority ? protDataSystemStringPriority : SYSTEM_STRING_PRIORITY[systemString] ? SYSTEM_STRING_PRIORITY[systemString] : [systemString];
 
         // Check all the available system strings and the available configurations for support
         _checkAccessForKeySystem(systemStringsToApply, configs)
@@ -224,6 +224,8 @@ function ProtectionModel_21Jan2015(config) {
      */
     function _checkAccessForSystemStrings(systemStringsToApply, configs, idx, resolve, reject) {
         const systemString = systemStringsToApply[idx];
+
+        logger.debug(`Requesting key system access for system string ${systemString}`);
 
         navigator.requestMediaKeySystemAccess(systemString, configs)
             .then((mediaKeySystemAccess) => {

--- a/src/streaming/protection/models/ProtectionModel_21Jan2015.js
+++ b/src/streaming/protection/models/ProtectionModel_21Jan2015.js
@@ -229,6 +229,7 @@ function ProtectionModel_21Jan2015(config) {
 
         navigator.requestMediaKeySystemAccess(systemString, configs)
             .then((mediaKeySystemAccess) => {
+                mediaKeySystemAccess.selectedSystemString = systemString;
                 resolve(mediaKeySystemAccess);
             })
             .catch((e) => {

--- a/test/functional/config/smokeVectors.json
+++ b/test/functional/config/smokeVectors.json
@@ -37,6 +37,28 @@
                     "url": "https://dash.akamaized.net/dash264/TestCases/5a/nomor/1.mpd",
                     "name": "Multiperiod with presentationTimeOffset",
                     "description": "Multiperiod with presentationTimeOffset"
+                },
+                {
+                    "name": "1080p with PlayReady and Widevine DRM, single key",
+                    "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p.mpd",
+                    "protData": {
+                        "com.widevine.alpha": {
+                            "serverURL": "https://drm-widevine-licensing.axtest.net/AcquireLicense",
+                            "httpRequestHeaders": {
+                                "X-AxDRM-Message": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.4lWwW46k-oWcah8oN18LPj5OLS5ZU-_AQv7fe0JhNjA"
+                            },
+                            "httpTimeout": 5000
+                        },
+                        "com.microsoft.playready": {
+                            "serverURL": "https://drm-playready-licensing.axtest.net/AcquireLicense",
+                            "httpRequestHeaders": {
+                                "X-AxDRM-Message": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.4lWwW46k-oWcah8oN18LPj5OLS5ZU-_AQv7fe0JhNjA"
+                            },
+                            "httpTimeout": 5000
+                        }
+                    },
+                    "moreInfo": "https://github.com/Axinom/dash-test-vectors",
+                    "provider": "axinom"
                 }
             ]
         },


### PR DESCRIPTION
The idea of this PR is to support different system strings when calling `requestMediaKeySystemAccess` for the same DRM system. As an example, Playready can be initialized with `com.microsoft.playready`, `com.microsoft.playready.recommendation` or `com.microsoft.playready.hardware` . 

To be backwards compliant with previous dash.js versions, we introduce a new field `systemStringPriority` in `protData`. If this field is present and contains values then we use these values instead of the default system string. If the field is absent we use the default system string.

````javascript
"protData": {
    "com.widevine.alpha": {
        "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/?specConform=true",
        "systemStringPriority": ["com.widevine.something", "com.widevine.alpha"]
    },
    "com.microsoft.playready": {
        "serverURL": "https://lic.staging.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx",
        "systemStringPriority": ["com.microsoft.playready.recommendation", "com.microsoft.playready.hardware","com.microsoft.playready"]
    }
},
````