### PR TITLE
Fix issue in GapContoller when reset playback

### DIFF
--- a/src/streaming/controllers/GapController.js
+++ b/src/streaming/controllers/GapController.js
@@ -195,6 +195,9 @@ function GapController() {
      * @private
      */
     function _shouldCheckForGaps(checkSeekingState = false) {
+        if (!streamController.getActiveStream()) {
+            return false;
+        }
         const trackSwitchInProgress = Object.keys(trackSwitchByMediaType).some((key) => {
             return trackSwitchByMediaType[key];
         });


### PR DESCRIPTION
Since StreamController is reset before GapController, activeStream may be null on wall clock time update.

In a more general view, reset process may raise such issues due to cross references betwenn StreamController and PlaybackController, and the use of timers (such as WALLCLOCK_TIME_UPDATED) 