### PR TITLE
Fix VideoModel currentTime and seeking

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -96,6 +96,7 @@ function VideoModel() {
                 // We don't set the same currentTime because it can cause firing unexpected Pause event in IE11
                 // providing playbackRate property equals to zero.
                 if (element.currentTime === _currentTime) {
+                    _currentTime = NaN;
                     return;
                 }
 

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -48,6 +48,7 @@ function VideoModel() {
     let instance,
         logger,
         element,
+        seekingTime,
         TTMLRenderingDiv,
         previousPlaybackRate;
 
@@ -59,6 +60,7 @@ function VideoModel() {
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
+        seekingTime = NaN;
     }
 
     function initialize() {
@@ -88,6 +90,7 @@ function VideoModel() {
 
     //TODO Move the DVR window calculations from MediaPlayer to Here.
     function setCurrentTime(currentTime, stickToBuffered) {
+        seekingTime = currentTime;
         waitForReadyState(Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA, () => {
             if (element) {
                 //_currentTime = currentTime;
@@ -106,6 +109,7 @@ function VideoModel() {
                 try {
                     currentTime = stickToBuffered ? stickTimeToBuffered(currentTime) : currentTime;
                     element.currentTime = currentTime;
+                    seekingTime = NaN;
                 } catch (e) {
                     if (element.readyState === 0 && e.code === e.INVALID_STATE_ERR) {
                         setTimeout(function () {
@@ -287,11 +291,11 @@ function VideoModel() {
     }
 
     function isSeeking() {
-        return element ? element.seeking : null;
+        return element ? (element.seeking || !isNaN(seekingTime)) : null;
     }
 
     function getTime() {
-        return element ? element.currentTime : null;
+        return element ? (!isNaN(seekingTime) ? seekingTime : element.currentTime) : null;
     }
 
     function getPlaybackRate() {


### PR DESCRIPTION
This PR is fixing an issue when getting video model current time and seeking state, after setting current time but while waiting for video element ready state to have metadata.

One example of issue with current version is track selection once 'loadedmetadata' event is received for live streams (or on demand with start time > 0):
- edit reference sample application main file, and add the following code:

```
$scope.player.on(dashjs.MediaPlayer.events.PLAYBACK_METADATA_LOADED, function (e) { /* jshint ignore:line */
    $scope.player.enableText(true);
    $scope.player.setTextTrack(2);
}, $scope);
```
 
- load reference sample application
- edit options and disable "Enable Text At Loading"
- load content "Subtitles and Captions / [DASH-IF] TTML Segmented Subtitles Live (livesim)"

The player shall select and stream text track of index 2 (on 'loadedmetadata' event), but track switch is performed at current playback time which is not yet corresponding to the initial live seeking time. Therefore player is trying to get first text fragment at a time before text segments timeline. No fragment is downloaded.