### PR TITLE
Fix issue after a track switch if enableSeekDecorrelationFix is enabled

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -335,15 +335,16 @@ function BufferController(config) {
 
         // Check if current buffered range already contains seek target (and current video element time)
         const currentTime = playbackController.getTime();
-        let range = getRangeAt(seekTarget, 0);
-        if (currentTime === seekTarget && range) {
+        const rangeAtCurrenTime = getRangeAt(currentTime, 0);
+        const rangeAtSeekTarget = getRangeAt(seekTarget, 0);
+        if (rangeAtCurrenTime && rangeAtSeekTarget && rangeAtCurrenTime.start === rangeAtSeekTarget.start) {
             seekTarget = NaN;
             return;
         }
 
         // Get buffered range corresponding to the seek target
         const segmentDuration = representationController.getCurrentRepresentation().segmentDuration;
-        range = getRangeAt(seekTarget, segmentDuration);
+        const range = getRangeAt(seekTarget, segmentDuration);
         if (!range) return;
 
         if (settings.get().streaming.buffer.enableSeekDecorrelationFix && Math.abs(currentTime - seekTarget) > segmentDuration) {


### PR DESCRIPTION
This PR is fixing the following issue:
if enableSeekDecorrelationFix is enabled, than after a track switch BufferController::_adjustSeekTarget may execute by mistake an internal seek (to buffered range start), since seekTarget may differ from playback currrent time (which may have progressed in the meantime)