### PR TITLE
Remove getNormalizedTime

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -193,19 +193,6 @@ function PlaybackController() {
         return streamInfo && videoModel ? videoModel.getTime() : null;
     }
 
-    function getNormalizedTime() {
-        let t = getTime();
-
-        if (isDynamic && !isNaN(availabilityStartTime)) {
-            const timeOffset = availabilityStartTime / 1000;
-            // Fix current time for firefox and safari (returned as an absolute time)
-            if (t > timeOffset) {
-                t -= timeOffset;
-            }
-        }
-        return t;
-    }
-
     function getPlaybackRate() {
         return streamInfo && videoModel ? videoModel.getPlaybackRate() : null;
     }
@@ -340,7 +327,7 @@ function PlaybackController() {
         if (!isDynamic || isNaN(availabilityStartTime)) {
             return NaN;
         }
-        let currentTime = getNormalizedTime();
+        let currentTime = getTime();
         if (isNaN(currentTime) || currentTime === 0) {
             return 0;
         }
@@ -462,7 +449,7 @@ function PlaybackController() {
             mediaType = streamController.hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO;
         }
         // Compare the current time of the video element against the range defined in the DVR window.
-        const currentTime = getNormalizedTime();
+        const currentTime = getTime();
         const actualTime = getActualPresentationTime(currentTime, mediaType);
         const timeChanged = (!isNaN(actualTime) && actualTime !== currentTime);
         if (timeChanged && !isSeeking() && (isStalled() || playbackStalled || videoModel.getReadyState() === 1)) {
@@ -1033,7 +1020,6 @@ function PlaybackController() {
         getTimeToStreamEnd,
         getBufferLevel,
         getTime,
-        getNormalizedTime,
         getIsManifestUpdateInProgress,
         getPlaybackRate,
         getPlayedRanges,

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -69,10 +69,6 @@ class PlaybackControllerMock {
         this.time = time;
     }
 
-    getNormalizedTime() {
-        return null;
-    }
-
     getPlaybackRate() {
         return null;
     }

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -257,11 +257,6 @@ describe('PlaybackController', function () {
                 expect(playbackController.getTime()).to.equal(videoModelMock.time);
             });
 
-            it('should return current normalized video time', function () {
-                videoModelMock.time = 5;
-                expect(playbackController.getNormalizedTime()).to.equal(videoModelMock.time);
-            });
-
             it('should return video playback rate', function () {
                 videoModelMock.playbackRate = 2;
                 expect(playbackController.getPlaybackRate()).to.equal(videoModelMock.playbackRate);


### PR DESCRIPTION
- The original issue https://github.com/Dash-Industry-Forum/dash.js/issues/2796 no longer occurs
   * We reran the test using the same test stream (https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd) on the same OS (MAC 10.13.6) and browser version (FF62, also tested FF62.0.1, FF61) - we used the v2.9.1 dash reference player with low latency enabled - and could not reproduce the error. Maybe the stream has changed?
- The function leads to incorrect `currentLiveLatency` calculation with streams where the current media time is greater than the AST - particularly when AST is small but non zero.
- We have successfully tested this PR on current browsers (FF96.0.3& Chrome98 on MacOS11.6.2&MacOS10.13.6, Chrome 97.0.4692.99 and Firefox 91.6.0esr in Windows 10) with the test stream (https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd) and others.