### PR TITLE
Fix calculation of thumbnail timestamp for multiple periods

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1683,8 +1683,7 @@ function MediaPlayer() {
             return;
         }
 
-        const timeInPeriod = streamController.getTimeRelativeToStreamId(s, stream.getId());
-        return thumbnailController.provide(timeInPeriod, callback);
+        return thumbnailController.provide(s, callback);
     }
 
     /*


### PR DESCRIPTION
Before this PR the timestamps for the Thumbnails were provided relative to period start. This lead to calculation of wrong urls or 404s on thumbnails