### PR TITLE
chore: Add MANIFEST_LOADING_STARTED event

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -58,6 +58,7 @@ class CoreEvents extends EventsBase {
         this.LOADING_PROGRESS = 'loadingProgress';
         this.LOADING_DATA_PROGRESS = 'loadingDataProgress';
         this.LOADING_ABANDONED = 'loadingAborted';
+        this.MANIFEST_LOADING_STARTED = 'manifestLoadingStarted';
         this.MANIFEST_UPDATED = 'manifestUpdated';
         this.MEDIA_FRAGMENT_LOADED = 'mediaFragmentLoaded';
         this.MEDIA_FRAGMENT_NEEDED = 'mediaFragmentNeeded';

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -110,6 +110,8 @@ function ManifestLoader(config) {
 
         const request = new TextRequest(url, HTTPRequest.MPD_TYPE);
 
+        eventBus.trigger(Events.MANIFEST_LOADING_STARTED, { request: request });
+
         urlLoader.load({
             request: request,
             success: function (data, textStatus, responseURL) {


### PR DESCRIPTION
We have a requirement to refresh the CDN token on the manifest URL. We found that updating the URL using attachSource() added a black screen for about a second, so we are now using this event in conjunction with RequestModifier.