### PR TITLE
Remove non-standard `t` metric from HttpList reports

### DIFF
--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -122,7 +122,7 @@ function MetricsModel(config) {
         vo.s = s;
         vo.d = d;
         vo.b = b;
-        vo.t = t;
+        vo._t = t;
 
         httpRequest.trace.push(vo);
 

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -93,7 +93,7 @@ function ThroughputHistory(config) {
         if (settings.get().streaming.lowLatencyEnabled) {
             const calculationMode = settings.get().streaming.abr.fetchThroughputCalculationMode;
             if (calculationMode === Constants.ABR_FETCH_THROUGHPUT_CALCULATION_MOOF_PARSING) {
-                const sumOfThroughputValues = httpRequest.trace.reduce((a, b) => a + b.t, 0);
+                const sumOfThroughputValues = httpRequest.trace.reduce((a, b) => a + b._t, 0);
                 throughput = Math.round(sumOfThroughputValues / httpRequest.trace.length);
             }
             if (throughput === 0) {

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -159,7 +159,7 @@ class HTTPRequestTrace {
          * Measurement throughput in kbits/s
          * @public
          */
-         this.t = null;
+         this._t = null;
     }
 }
 


### PR DESCRIPTION
The `t` metric should not be included in the reported HttpList metrics as it is not part of the MPEG-DASH specified set of reported metrics. The metrics `t` variable has been renamed to `_t` to indicate that it should not be included in reported metrics. 