### PR TITLE
Fix BOLA rule on track switch

### DIFF
--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -258,14 +258,13 @@ function BolaRule(config) {
         checkBolaStateStableBufferTime(bolaState, mediaType);
     }
 
-    function onBufferEmpty() {
+    function onBufferEmpty(e) {
         // if we rebuffer, we don't want the placeholder buffer to artificially raise BOLA quality
-        for (const mediaType in bolaStateDict) {
-            if (bolaStateDict.hasOwnProperty(mediaType) && bolaStateDict[mediaType].state === BOLA_STATE_STEADY) {
-                bolaStateDict[mediaType].placeholderBuffer = 0;
-            }
+        const mediaType = e.mediaType;
+        if (bolaStateDict.hasOwnProperty(mediaType) && bolaStateDict[mediaType].state === BOLA_STATE_STEADY) {
+            bolaStateDict[mediaType].placeholderBuffer = 0;
         }
-    }
+}
 
     function onPlaybackSeeking() {
         // TODO: 1. Verify what happens if we seek mid-fragment.

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -39,6 +39,7 @@ import EventBus from '../../../core/EventBus';
 import Events from '../../../core/events/Events';
 import Debug from '../../../core/Debug';
 import MediaPlayerEvents from '../../MediaPlayerEvents';
+import Constants from '../../constants/Constants';
 
 // BOLA_STATE_ONE_BITRATE   : If there is only one bitrate (or initialization failed), always return NO_CHANGE.
 // BOLA_STATE_STARTUP       : Set placeholder buffer such that we download fragments at most recently measured throughput.
@@ -261,10 +262,14 @@ function BolaRule(config) {
     function onBufferEmpty(e) {
         // if we rebuffer, we don't want the placeholder buffer to artificially raise BOLA quality
         const mediaType = e.mediaType;
-        if (bolaStateDict.hasOwnProperty(mediaType) && bolaStateDict[mediaType].state === BOLA_STATE_STEADY) {
-            bolaStateDict[mediaType].placeholderBuffer = 0;
+        // if audio buffer runs empty (due to track switch for example) then reset placeholder buffer only for audio (to avoid decrease video BOLA quality)
+        const stateDict = mediaType === Constants.AUDIO ? [Constants.AUDIO] : bolaStateDict;
+        for (const mediaType in stateDict) {
+            if (bolaStateDict.hasOwnProperty(mediaType) && bolaStateDict[mediaType].state === BOLA_STATE_STEADY) {
+                bolaStateDict[mediaType].placeholderBuffer = 0;
+            }
         }
-}
+    }
 
     function onPlaybackSeeking() {
         // TODO: 1. Verify what happens if we seek mid-fragment.


### PR DESCRIPTION
On audio track switch, if trackSwitchMode is set to TRACK_SWITCH_MODE_ALWAYS_REPLACE for audio, then audio buffer becomes empty and BOLA rule resets the placeholderbuffer level to 0, for BOTH audio and video.
Therefore, a quality switch to lowest level may be performed on video track when switching audio track.
This PR is fixing this issues by resetting the placeholderbuffer only for the media type which buffer is empty.