### PR TITLE
fix: jumping gap resulting in loop

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -801,7 +801,9 @@ function Settings() {
                 jumpLargeGaps: true,
                 smallGapLimit: 1.5,
                 threshold: 0.3,
-                enableSeekFix: true
+                enableSeekFix: true,
+                enableLoopFix: false,
+                loopSeek: 0.25
             },
             utcSynchronization: {
                 enabled: true,

--- a/src/streaming/controllers/GapController.js
+++ b/src/streaming/controllers/GapController.js
@@ -46,6 +46,7 @@ function GapController() {
         settings,
         wallclockTicked,
         gapHandlerInterval,
+        lastGapStartPosition,
         lastGapJumpPosition,
         playbackController,
         streamController,
@@ -72,6 +73,7 @@ function GapController() {
 
     function resetInitialSettings() {
         gapHandlerInterval = null;
+        lastGapStartPosition = NaN;
         lastGapJumpPosition = NaN;
         wallclockTicked = 0;
         jumpTimeoutHandler = null;
@@ -100,6 +102,7 @@ function GapController() {
         eventBus.on(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, this);
         eventBus.on(Events.INITIAL_STREAM_SWITCH, _onInitialStreamSwitch, this);
         eventBus.on(Events.PLAYBACK_SEEKING, _onPlaybackSeeking, this);
+        eventBus.on(Events.PLAYBACK_SEEKED, _onPlaybackSeeked, this);
         eventBus.on(Events.BUFFER_REPLACEMENT_STARTED, _onBufferReplacementStarted, instance);
         eventBus.on(Events.TRACK_CHANGE_RENDERED, _onBufferReplacementEnded, instance);
     }
@@ -108,6 +111,7 @@ function GapController() {
         eventBus.off(Events.WALLCLOCK_TIME_UPDATED, _onWallclockTimeUpdated, this);
         eventBus.off(Events.INITIAL_STREAM_SWITCH, _onInitialStreamSwitch, this);
         eventBus.off(Events.PLAYBACK_SEEKING, _onPlaybackSeeking, this);
+        eventBus.off(Events.PLAYBACK_SEEKED, _onPlaybackSeeking, this);
         eventBus.off(Events.BUFFER_REPLACEMENT_STARTED, _onBufferReplacementStarted, instance);
         eventBus.off(Events.TRACK_CHANGE_RENDERED, _onBufferReplacementEnded, instance);
     }
@@ -120,6 +124,22 @@ function GapController() {
         if (jumpTimeoutHandler) {
             clearTimeout(jumpTimeoutHandler);
             jumpTimeoutHandler = null;
+        }
+    }
+
+    function _onPlaybackSeeked() {
+        const enableLoopFix = settings.get().streaming.gaps.enableLoopFix;
+        const loopSeek = settings.get().streaming.gaps.loopSeek;
+
+        if (enableLoopFix) {
+            const currentTime = videoModel.getTime();
+            if (!isNaN(lastGapJumpPosition) && !isNaN(lastGapStartPosition) && currentTime <= lastGapStartPosition) {
+                logger.warn(`Jump from ${lastGapStartPosition} to ${lastGapJumpPosition} failed, it jumped to ${currentTime}. Jumping ${loopSeek}`);
+                lastGapJumpPosition = lastGapJumpPosition + loopSeek;
+                playbackController.seek(lastGapJumpPosition, true, true);
+            } else {
+                lastGapStartPosition = NaN;
+            }
         }
     }
 
@@ -182,6 +202,7 @@ function GapController() {
                 _jumpGap(currentTime, true);
             } else {
                 lastPlaybackTime = currentTime;
+                lastGapStartPosition = NaN;
                 lastGapJumpPosition = NaN;
             }
             wallclockTicked = 0;
@@ -335,6 +356,7 @@ function GapController() {
                     jumpTimeoutHandler = null;
                 }, timeToWait);
             }
+            lastGapStartPosition = currentTime;
             lastGapJumpPosition = seekToPosition;
         }
     }


### PR DESCRIPTION
**A gap occurs and the player ends up in an endlessly looping state.**

:wave:  This fixes a bug that happens when playing back MSS ( probably an issue with MPD as well ).
The reason this happens is because the Samsung TVs ( in this case ) won’t seek to the requested position but rather a few seconds before which causes it to end up in the gap… again.

Log of the behavior
```
[2/1/2022, 8:59:36 AM] [5196938][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:36 AM] [5196991][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:36 AM] [5196993][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:38 AM] [5198668][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:38 AM] [5198933][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:38 AM] [5198933][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:38 AM] [5198974][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:38 AM] [5198978][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:40 AM] [5200664][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:40 AM] [5200935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:40 AM] [5200936][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:40 AM] [5200995][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:40 AM] [5200996][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:42 AM] [5202681][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:42 AM] [5202932][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:42 AM] [5202933][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:42 AM] [5202974][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:42 AM] [5202976][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:44 AM] [5204666][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:44 AM] [5204935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:44 AM] [5204936][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:44 AM] [5204984][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:44 AM] [5204985][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:46 AM] [5206668][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:46 AM] [5206935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:46 AM] [5206936][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:46 AM] [5206990][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:46 AM] [5206992][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:48 AM] [5208665][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:48 AM] [5208932][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:48 AM] [5208933][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:48 AM] [5209016][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:48 AM] [5209017][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:50 AM] [5210702][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:50 AM] [5210935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:50 AM] [5210935][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:50 AM] [5210973][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:50 AM] [5210976][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:52 AM] [5212658][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:52 AM] [5212935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:52 AM] [5212935][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:52 AM] [5212988][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:52 AM] [5212991][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:54 AM] [5214670][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:54 AM] [5214935][PlaybackController] Requesting seek to time: 1643702229.013 (internal) 
[2/1/2022, 8:59:54 AM] [5214937][GapController] Jumping gap occuring in period defaultId_0 starting at 1643702228.779 and ending at 1643702229.013. Jumping by: 0.09999999999999998 
[2/1/2022, 8:59:54 AM] [5214986][PlaybackController] Native video element event: seeked 
[2/1/2022, 8:59:54 AM] [5214989][PlaybackController] Native video element event: playing 
[2/1/2022, 8:59:56 AM] [5216655][PlaybackController] Native video element event: waiting 
[2/1/2022, 8:59:56 AM] [5216935][PlaybackController] Requesting seek to time: 1643702229.013 (internal)
```

The solution is to detect that the seek didn't jump and simply increase the seek time slightly.