### PR TITLE
DVB Metrics Reporting 'withCredentials'

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2094,6 +2094,7 @@ function MediaPlayer() {
                 mediaElement: getVideoElement(),
                 adapter: adapter,
                 dashMetrics: dashMetrics,
+                mediaPlayerModel: mediaPlayerModel,
                 events: Events,
                 constants: Constants,
                 metricsConstants: MetricsConstants

--- a/src/streaming/constants/MetricsConstants.js
+++ b/src/streaming/constants/MetricsConstants.js
@@ -55,6 +55,7 @@ class MetricsConstants {
         this.MANIFEST_UPDATE_TRACK_INFO = 'ManifestUpdateRepresentationInfo';
         this.PLAY_LIST = 'PlayList';
         this.DVB_ERRORS = 'DVBErrors';
+        this.HTTP_REQUEST_DVB_REPORTING_TYPE = 'DVBReporting';
     }
 
     constructor() {

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -53,7 +53,8 @@ function MetricsController(config) {
 
             reportingController = ReportingController(context).create({
                 debug: config.debug,
-                metricsConstants: config.metricsConstants
+                metricsConstants: config.metricsConstants,
+                mediaPlayerModel: config.mediaPlayerModel
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -42,13 +42,15 @@ function ReportingFactory(config) {
     let instance;
     const logger = config.debug ? config.debug.getLogger(instance) : {};
     const metricsConstants = config.metricsConstants;
+    const mediaPlayerModel = config.mediaPlayerModel || {};
 
     function create(entry, rangeController) {
         let reporting;
 
         try {
             reporting = knownReportingSchemeIdUris[entry.schemeIdUri](context).create({
-                metricsConstants: metricsConstants
+                metricsConstants: metricsConstants,
+                mediaPlayerModel: mediaPlayerModel
             });
 
             reporting.initialize(entry, rangeController);

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -60,7 +60,7 @@ function DVBReporting(config) {
 
     function doGetRequest(url, successCB, failureCB) {
         let req = new XMLHttpRequest();
-        req.withCredentials = mediaPlayerModel.getXHRWithCredentialsForType('DVBReporting');
+        req.withCredentials = mediaPlayerModel.getXHRWithCredentialsForType(metricsConstants.HTTP_REQUEST_DVB_REPORTING_TYPE);
         const oncomplete = function () {
             let reqIndex = pendingRequests.indexOf(req);
 

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -49,6 +49,7 @@ function DVBReporting(config) {
     let pendingRequests = [];
 
     const metricsConstants = config.metricsConstants;
+    const mediaPlayerModel = config.mediaPlayerModel;
 
     function setup() {
         metricSerialiser = MetricSerialiser(context).getInstance();
@@ -59,6 +60,7 @@ function DVBReporting(config) {
 
     function doGetRequest(url, successCB, failureCB) {
         let req = new XMLHttpRequest();
+        req.withCredentials = mediaPlayerModel.getXHRWithCredentialsForType('DVBReporting');
         const oncomplete = function () {
             let reqIndex = pendingRequests.indexOf(req);
 

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -172,6 +172,7 @@ HTTPRequest.INDEX_SEGMENT_TYPE = 'IndexSegment';
 HTTPRequest.MEDIA_SEGMENT_TYPE = 'MediaSegment';
 HTTPRequest.BITSTREAM_SWITCHING_SEGMENT_TYPE = 'BitstreamSwitchingSegment';
 HTTPRequest.MSS_FRAGMENT_INFO_SEGMENT_TYPE = 'FragmentInfoSegment';
+HTTPRequest.DVB_REPORTING_TYPE = 'DVBReporting';
 HTTPRequest.LICENSE = 'license';
 HTTPRequest.OTHER_TYPE = 'other';
 

--- a/test/unit/streaming.constants.MetricsConstants.js
+++ b/test/unit/streaming.constants.MetricsConstants.js
@@ -19,5 +19,6 @@ describe('MetricsConstants', function () {
         expect(MetricsConstants.MANIFEST_UPDATE_TRACK_INFO).to.equal('ManifestUpdateRepresentationInfo');
         expect(MetricsConstants.PLAY_LIST).to.equal('PlayList');
         expect(MetricsConstants.DVB_ERRORS).to.equal('DVBErrors');
+        expect(MetricsConstants.HTTP_REQUEST_DVB_REPORTING_TYPE).to.equal('DVBReporting');
     });
 });


### PR DESCRIPTION
See #3897 for more context.

Provides a way of setting a 'withCredentials' true/false on DVB Metrics Reporting requests. Uses getXHRWithCredentialsForType() and setXHRWithCredentialsForType() in MediaPlayer to achieve this.