### PR TITLE
Fix concurrent internal seeks

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -494,6 +494,7 @@ function PlaybackController() {
 
     function _onPlaybackPlaying() {
         logger.info('Native video element event: playing');
+        internalSeek = false;
         eventBus.trigger(Events.PLAYBACK_PLAYING, { playingTime: getTime() });
     }
 
@@ -505,7 +506,6 @@ function PlaybackController() {
     function _onPlaybackSeeking() {
         // Check if internal seeking to be ignored
         if (internalSeek) {
-            internalSeek = false;
             return;
         }
 
@@ -527,6 +527,7 @@ function PlaybackController() {
 
     function _onPlaybackSeeked() {
         logger.info('Native video element event: seeked');
+        internalSeek = false;
         eventBus.trigger(Events.PLAYBACK_SEEKED);
     }
 


### PR DESCRIPTION
This PR fixes an issue in case of concurrent internal seeks, for example when seeking live streams and audio and video buffers attempt to perform an internal seek in parallel, at the same time. In that case one of the seeks would not be considered as an internal seek.