### PR TITLE
feat: Trigger event when AdaptationSet is removed due to all represen…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -438,8 +438,11 @@ declare namespace dashjs {
 
         on(type: TtmlToParseEvent['type'], listener: (e: TtmlToParseEvent) => void, scope?: object): void;
 
+        on(type: AdaptationSetRemovedNoCapabilitiesEvent['type'], listener: (e: AdaptationSetRemovedNoCapabilitiesEvent) => void, scope?: object): void;
+        
         on(type: string, listener: (e: Event) => void, scope?: object): void;
 
+        
         off(type: string, listener: (e: any) => void, scope?: object): void;
 
         extend(parentNameString: string, childInstance: object, override: boolean): void;
@@ -728,6 +731,7 @@ declare namespace dashjs {
         OFFLINE_RECORD_STOPPED: 'public_offlineRecordStopped';
         PERIOD_SWITCH_STARTED: 'periodSwitchStarted';
         PERIOD_SWITCH_COMPLETED: 'periodSwitchCompleted';
+        ADAPTATION_SET_REMOVED_NO_CAPABILITIES: 'adaptationSetRemovedNoCapabilities';
         PLAYBACK_ENDED: 'playbackEnded';
         PLAYBACK_ERROR: 'playbackError';
         PLAYBACK_LOADED_DATA: 'playbackLoadedData';
@@ -1015,6 +1019,11 @@ declare namespace dashjs {
         type: MediaPlayerEvents['PERIOD_SWITCH_COMPLETED' | 'PERIOD_SWITCH_STARTED'];
         toStreamInfo: StreamInfo | null;
         fromStreamInfo?: StreamInfo | null;
+    }
+
+    export interface AdaptationSetRemovedNoCapabilitiesEvent extends Event {
+        type: MediaPlayerEvents['ADAPTATION_SET_REMOVED_NO_CAPABILITIES'];
+        adaptationSet: object;
     }
 
     export interface PlaybackErrorEvent extends Event {

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -396,6 +396,12 @@ class MediaPlayerEvents extends EventsBase {
          * @event MediaPlayerEvents#REPRESENTATION_SWITCH
          */
         this.REPRESENTATION_SWITCH = 'representationSwitch';
+
+        /**
+         * Event that is dispatched whenever an adaptation set is removed due to all representations not being supported.
+         * @event MediaPlayerEvents#ADAPTATION_SET_REMOVED_NO_CAPABILITIES
+         */
+        this.ADAPTATION_SET_REMOVED_NO_CAPABILITIES = 'adaptationSetRemovedNoCapabilities';
     }
 }
 

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -1,9 +1,14 @@
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import Constants from '../constants/Constants';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
 
 function CapabilitiesFilter() {
+
     const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+
     let instance,
         adapter,
         capabilities,
@@ -91,6 +96,9 @@ function CapabilitiesFilter() {
                         const supported = as.Representation_asArray && as.Representation_asArray.length > 0;
 
                         if (!supported) {
+                            eventBus.trigger(Events.ADAPTATION_SET_REMOVED_NO_CAPABILITIES, {
+                                adaptationSet: as
+                            });
                             logger.warn(`AdaptationSet has been removed because of no supported Representation`);
                         }
 


### PR DESCRIPTION
…tations being incompatible

This event allows us to detect when the manifest no longer has any AdaptationSets of the same content type and present an error slate to the user.

Prior to this change, we could see a warning in the log, but the player would just show a blank screen.