### PR TITLE
Change precedence of ServiceDescription elements

### DIFF
--- a/src/streaming/controllers/ServiceDescriptionController.js
+++ b/src/streaming/controllers/ServiceDescriptionController.js
@@ -99,7 +99,7 @@ function ServiceDescriptionController() {
         }
 
         const supportedServiceDescriptions = manifestInfo.serviceDescriptions.filter(sd => SUPPORTED_SCHEMES.includes(sd.schemeIdUri));
-        const allClientsServiceDescriptions = manifestInfo.serviceDescriptions.filter(sd => !('schemeIdUri' in sd));
+        const allClientsServiceDescriptions = manifestInfo.serviceDescriptions.filter(sd => sd.schemeIdUri == null);
         let sd = (supportedServiceDescriptions.length > 0) 
             ? supportedServiceDescriptions[supportedServiceDescriptions.length - 1]
             : allClientsServiceDescriptions[allClientsServiceDescriptions.length - 1];

--- a/src/streaming/controllers/ServiceDescriptionController.js
+++ b/src/streaming/controllers/ServiceDescriptionController.js
@@ -86,27 +86,27 @@ function ServiceDescriptionController() {
             return;
         }
 
-        for (let i = 0; i < manifestInfo.serviceDescriptions.length; i++) {
-            const sd = manifestInfo.serviceDescriptions[i];
+        const supportedServiceDescriptions = manifestInfo.serviceDescriptions.filter(sd => SUPPORTED_SCHEMES.includes(sd.schemeIdUri));
+        const allClientsServiceDescriptions = manifestInfo.serviceDescriptions.filter(sd => !('schemeIdUri' in sd));
+        let sd = (supportedServiceDescriptions.length > 0) 
+            ? supportedServiceDescriptions[supportedServiceDescriptions.length - 1]
+            : allClientsServiceDescriptions[allClientsServiceDescriptions.length - 1];
+        if (!sd) return;
 
-            if (!sd.schemeIdUri || SUPPORTED_SCHEMES.includes(sd.schemeIdUri)) {
+        if (sd.latency && sd.latency.target > 0) {
+            _applyServiceDescriptionLatency(sd);
+        }
 
-                if (sd.latency && sd.latency.target > 0) {
-                    _applyServiceDescriptionLatency(sd);
-                }
+        if (sd.playbackRate && sd.playbackRate.max > 1.0) {
+            _applyServiceDescriptionPlaybackRate(sd);
+        }
 
-                if (sd.playbackRate && sd.playbackRate.max > 1.0) {
-                    _applyServiceDescriptionPlaybackRate(sd);
-                }
+        if (sd.operatingQuality) {
+            _applyServiceDescriptionOperatingQuality(sd);
+        }
 
-                if (sd.operatingQuality) {
-                    _applyServiceDescriptionOperatingQuality(sd);
-                }
-
-                if (sd.operatingBandwidth) {
-                    _applyServiceDescriptionOperatingBandwidth(sd);
-                }
-            }
+        if (sd.operatingBandwidth) {
+            _applyServiceDescriptionOperatingBandwidth(sd);
         }
     }
 

--- a/test/unit/streaming.controllers.ServiceDescriptionController.js
+++ b/test/unit/streaming.controllers.ServiceDescriptionController.js
@@ -55,6 +55,35 @@ describe('ServiceDescriptionController', () => {
             expect(currentSettings.initialBitrate).to.be.empty;
         })
 
+        it('Should use supported scheme in preference of no provided schemeIdUri', () => {
+            dummyManifestInfo.serviceDescriptions.push({
+                latency: {
+                    target: 10000,
+                }
+            });
+            serviceDescriptionController.applyServiceDescription(dummyManifestInfo);
+            const currentSettings = serviceDescriptionController.getServiceDescriptionSettings();
+            expect(currentSettings.liveDelay).to.be.equal(5);
+        })
+
+        it('Should use ServiceDescription that appears last if multiple applicable ServiceDescriptions', () => {
+            // Also ensures only parameters from a single ServiceDescription element are used
+            dummyManifestInfo.serviceDescriptions.push({
+                schemeIdUri: 'urn:dvb:dash:lowlatency:scope:2019',
+                latency: {
+                    target: 10000,
+                }
+            });
+            serviceDescriptionController.applyServiceDescription(dummyManifestInfo);
+            const currentSettings = serviceDescriptionController.getServiceDescriptionSettings();
+            expect(currentSettings.liveDelay).to.be.equal(10);
+            expect(currentSettings.liveCatchup.maxDrift).to.be.NaN;
+            expect(currentSettings.liveCatchup.playbackRate).to.be.NaN;
+            expect(currentSettings.minBitrate).to.be.empty;
+            expect(currentSettings.maxBitrate).to.be.empty;
+            expect(currentSettings.initialBitrate).to.be.empty;
+        });
+
         it('Should not update the latency if target latency is equal to 0', () => {
             dummyManifestInfo.serviceDescriptions[0].latency.target = 0;
             delete dummyManifestInfo.serviceDescriptions[0].playbackRate;


### PR DESCRIPTION
See #3922 for details.

- Only parameters from a single ServiceDescription element applied.
- `urn:dvb:dash:lowlatency:scope:2019` takes precedence.
- Use last listed ServiceDescription element if multiple applicable.