### PR TITLE
Fix SegmentTimeline's  segment getter from requested time

### DIFF
--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -331,10 +331,10 @@ function TimelineConverter() {
             if (segment.hasOwnProperty('r')) {
                 repeat = segment.r;
             }
-            d += (segment.d / timescale) * (1 + repeat);
+            d += segment.d * (1 + repeat);
         }
 
-        range.end = range.start + d;
+        range.end = calcPresentationTimeFromMediaTime((segments[0].t + d) / timescale, voRepresentation);
 
         return range;
     }

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -113,7 +113,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
         const list = base.SegmentURL_asArray;
 
         let time = 0;
-        let scaledTime = 0;
         let relativeIdx = -1;
 
         let fragments,
@@ -139,27 +138,25 @@ function TimelineSegmentsGetter(config, isDynamic) {
             // For a repeated S element, t belongs only to the first segment
             if (frag.hasOwnProperty('t')) {
                 time = frag.t;
-                scaledTime = time / fTimescale;
             }
 
             // This is a special case: "A negative value of the @r attribute of the S element indicates that the duration indicated in @d attribute repeats until the start of the next S element, the end of the Period or until the
             // next MPD update."
             if (repeat < 0) {
                 const nextFrag = fragments[i + 1];
-                repeat = _calculateRepeatCountForNegativeR(representation, nextFrag, frag, fTimescale, scaledTime);
+                repeat = _calculateRepeatCountForNegativeR(representation, nextFrag, frag, fTimescale, time / fTimescale);
             }
 
             for (j = 0; j <= repeat && !breakIterator; j++) {
                 relativeIdx++;
 
-                breakIterator = iterFunc(time, scaledTime, base, list, frag, fTimescale, relativeIdx, i);
+                breakIterator = iterFunc(time, base, list, frag, fTimescale, relativeIdx, i);
 
                 if (breakIterator) {
                     representation.segmentDuration = frag.d / fTimescale;
                 }
 
                 time += frag.d;
-                scaledTime = time / fTimescale;
             }
         }
     }
@@ -201,7 +198,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
         let segment = null;
         let found = false;
 
-        iterateSegments(representation, function (time, scaledTime, base, list, frag, fTimescale, relativeIdx, i) {
+        iterateSegments(representation, function (time, base, list, frag, fTimescale, relativeIdx, i) {
             if (found || lastSegmentTime < 0) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;
@@ -224,8 +221,8 @@ function TimelineSegmentsGetter(config, isDynamic) {
                     frag.tManifest);
 
                 return true;
-            } else if (scaledTime >= lastSegmentTime - frag.d * 0.5 / fTimescale) { // same logic, if deviation is
-                // 50% of segment duration, segment is found if scaledTime is greater than or equal to (startTime of previous segment - half of the previous segment duration)
+            } else if (time >= (lastSegmentTime * fTimescale) - (frag.d * 0.5)) { // same logic, if deviation is
+                // 50% of segment duration, segment is found if time is greater than or equal to (startTime of previous segment - half of the previous segment duration)
                 found = true;
             }
 
@@ -249,11 +246,12 @@ function TimelineSegmentsGetter(config, isDynamic) {
         let segment = null;
         const requiredMediaTime = timelineConverter.calcMediaTimeFromPresentationTime(requestedTime, representation);
 
-        iterateSegments(representation, function (time, scaledTime, base, list, frag, fTimescale, relativeIdx, i) {
+        iterateSegments(representation, function (time, base, list, frag, fTimescale, relativeIdx, i) {
             // In some cases when requiredMediaTime = actual end time of the last segment
             // it is possible that this time a bit exceeds the declared end time of the last segment.
             // in this case we still need to include the last segment in the segment list.
-            if ((requiredMediaTime < (scaledTime + (frag.d / fTimescale))) && requiredMediaTime >= scaledTime) {
+            const scaledMediaTime = requiredMediaTime * fTimescale;
+            if (scaledMediaTime < (time + frag.d) && scaledMediaTime >= time) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;
 

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -250,7 +250,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
             // In some cases when requiredMediaTime = actual end time of the last segment
             // it is possible that this time a bit exceeds the declared end time of the last segment.
             // in this case we still need to include the last segment in the segment list.
-            const scaledMediaTime = requiredMediaTime * fTimescale;
+            const scaledMediaTime = precisionRound(requiredMediaTime * fTimescale);
             if (scaledMediaTime < (time + frag.d) && scaledMediaTime >= time) {
                 let media = base.media;
                 let mediaRange = frag.mediaRange;
@@ -281,6 +281,9 @@ function TimelineSegmentsGetter(config, isDynamic) {
         return segment;
     }
 
+    function precisionRound(number) {
+        return parseFloat(number.toPrecision(15));
+    }
 
     instance = {
         getSegmentByIndex,


### PR DESCRIPTION
This PR is fixing a bug when searching a segment in a SegmentTimeline from a requested media time.
In some cases, due to lost precision when applying timescale, requested media time may be a in "virtual" gap in the timeline introduced by the way the segments start and end time are calculated.

For example, with following timeline:
```
<SegmentTimeline>
  <S t="990366987247" d="1200" r="8" />
  <S d="1199" />
  <S d="1200" r="5" />
</SegmentTimeline>
```

If you seek and request segment at time `1650611665.40999` the TimelineSegmentsGetter will fail to find a segment while requested media is in timeline range.