### PR TITLE
Fixed image subtitle caption container not clearing

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -623,6 +623,7 @@ function TextTracks(config) {
             resizeObserver = null;
         }
         currentTrackIdx = -1;
+        captionContainer = null;
         clearCaptionContainer.call(this);
     }
 


### PR DESCRIPTION
Setting captionContainer = null at the end of "deleteAllTextTracks() fixed the issue, seeking and switching seems to work without problems.