### PR TITLE
Fix/abandon request

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -862,7 +862,7 @@ function Settings() {
                 video: Constants.TRACK_SWITCH_MODE_NEVER_REPLACE
             },
             selectionModeForInitialTrack: Constants.TRACK_SELECTION_MODE_HIGHEST_SELECTION_PRIORITY,
-            fragmentRequestTimeout: 10000,
+            fragmentRequestTimeout: 20000,
             retryIntervals: {
                 [HTTPRequest.MPD_TYPE]: 500,
                 [HTTPRequest.XLINK_EXPANSION_TYPE]: 500,
@@ -894,7 +894,7 @@ function Settings() {
                     insufficientBufferRule: true,
                     switchHistoryRule: true,
                     droppedFramesRule: true,
-                    abandonRequestsRule: false
+                    abandonRequestsRule: true
                 },
                 bandwidthSafetyFactor: 0.9,
                 useDefaultABRRules: true,

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -608,7 +608,7 @@ function StreamProcessor(config) {
         scheduleController.setCurrentRepresentation(representationInfo);
         representationController.prepareQualityChange(newQuality);
 
-        // Abort the current request to avoid inconsistencies. A quality switch can also be triggered manually by the application.
+        // Abort the current request to avoid inconsistencies and in case a rule such as AbandonRequestRule has forced a quality switch. A quality switch can also be triggered manually by the application.
         // If we update the buffer values now, or initialize a request to the new init segment, the currently downloading media segment might "work" with wrong values.
         // Everything that is already in the buffer queue is ok and will be handled by the corresponding function below depending on the switch mode.
         fragmentModel.abortRequests();
@@ -671,6 +671,7 @@ function StreamProcessor(config) {
             const bufferLevel = bufferController.getBufferLevel();
             const abandonmentState = abrController.getAbandonmentStateFor(streamInfo.id, type);
 
+            // The quality we originally requested was lower than the new quality
             if (request.quality < representationInfo.quality && bufferLevel >= safeBufferLevel && abandonmentState !== MetricsConstants.ABANDON_LOAD) {
                 const targetTime = time + safeBufferLevel;
                 setExplicitBufferingTime(targetTime);

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -299,7 +299,6 @@ function AbrController() {
                 index: e.request.index
             })[0];
             if (request) {
-                fragmentModel.abortRequests();
                 abandonmentStateDict[streamId][type].state = MetricsConstants.ABANDON_LOAD;
                 switchHistoryDict[streamId][type].reset();
                 switchHistoryDict[streamId][type].push({
@@ -625,7 +624,7 @@ function AbrController() {
 
             switchHistoryDict[streamId][type].push({ oldValue: oldQuality, newValue: newQuality });
 
-            if (newQuality > SwitchRequest.NO_CHANGE && newQuality !== oldQuality && (abandonmentStateDict[streamId][type].state === MetricsConstants.ALLOW_LOAD || newQuality > oldQuality)) {
+            if (newQuality > SwitchRequest.NO_CHANGE && newQuality !== oldQuality && (abandonmentStateDict[streamId][type].state === MetricsConstants.ALLOW_LOAD || newQuality < oldQuality)) {
                 _changeQuality(type, oldQuality, newQuality, maxIdx, switchRequest.reason, streamId);
                 return true;
             }


### PR DESCRIPTION
This PR applies the following changes:
* Enable the abandonRequestRule per default
* Fix a bug in the ABRController: Once a request has been abandoned  we need to block upswitches **not** downswitches.
* Remove the call to abort the request from the ABRController. Otherwise we run into an issue in the StreamProcessor that causes the ScheduleController to be started right away.