### PR TITLE
Fix text track enabling for MSS live streams

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -168,11 +168,11 @@ function MediaController() {
         const id = streamInfo.id;
         const current = getCurrentTrackFor(type, id);
 
-        if (!tracks[id] || !tracks[id][type] || isTracksEqual(track, current)) return;
+        if (!tracks[id] || !tracks[id][type]) return;
 
         tracks[id][type].current = track;
 
-        if (tracks[id][type].current && (type !== Constants.TEXT || (type === Constants.TEXT && track.isFragmented))) {
+        if (tracks[id][type].current && ((type !== Constants.TEXT && !isTracksEqual(track, current)) || (type === Constants.TEXT && track.isFragmented))) {
             eventBus.trigger(Events.CURRENT_TRACK_CHANGED, {
                 oldMediaInfo: current,
                 newMediaInfo: track,


### PR DESCRIPTION
This PR is fixing an issue when enabling text track for live MSS streams.
For live MSS streams, when switching audio or text track, manifest has to be updated in order to obtain current segment timeline of new selected track.
When, after playback has started and went over initial DVR window, enabling a text track that has been internally selected by default (to create text buffer controller), or when re-enabling a text track  that has been previously selected, then this is not considered as a track change and therefore CURRENT_TRACK_CHANGED event is not triggered and manifest is not updated.

With this PR, CURRENT_TRACK_CHANGED is always triggered when switching text track or when (re-)enabling previously selected text track.