### PR TITLE
JSDoc cleanup

### DIFF
--- a/build/jsdoc/README.md
+++ b/build/jsdoc/README.md
@@ -5,11 +5,11 @@
 
 ### Install Dependencies
 1. [install grunt-jsdoc](https://www.npmjs.org/package/grunt-jsdoc-plugin)
-    * npm install grunt-jsdoc-plugin
+    * `npm install jsdoc`
 
 ### Build JSDocs only
 ```
-grunt jsdoc
+npm run doc
 ```
 
 

--- a/build/jsdoc/jsdoc_conf.json
+++ b/build/jsdoc/jsdoc_conf.json
@@ -24,7 +24,7 @@
         "copyright": "<h3>DASH Industry Forum</h3>",
         "footer": "",
         "navType": "horizontal",
-        "theme": "sandstone",
+        "theme": "spacelab",
         "linenums": true,
         "collapseSymbols": true,
         "inverseNav": true,

--- a/build/jsdoc/jsdoc_conf.json
+++ b/build/jsdoc/jsdoc_conf.json
@@ -3,27 +3,32 @@
         "allowUnknownTags": true
     },
     "source": {
-        "include": ["./src/", "README.md"]
+        "include": [
+            "./src/",
+            "README.md"
+        ]
     },
-    "plugins": [ "plugins/markdown" ],
+    "plugins": [
+        "plugins/markdown"
+    ],
     "markdown": {
         "hardwrap": true
     },
     "templates": {
-		"cleverLinks"           : true,
-		"monospaceLinks"        : true,
-		"dateFormat"            : "ddd MMM Do YYYY",
-		"outputSourceFiles"     : true,
-		"outputSourcePath"      : true,
-		"systemName"            : "Dash JS",
-		"copyright"             : "<h3>Dash.js <a href=\"http://gruntjs.com/\"><img src=\"https://gruntjs.com/cdn/builtwith.png\" alt=\"Built with Grunt\"></a></h3>",
-		"footer"                : "",
-		"navType"               : "horizontal",
-		"theme"                 : "spacelab",
-		"linenums"              : true,
-		"collapseSymbols"       : false,
-		"inverseNav"            : true,
-        "highlightTutorialCode" : true
+        "cleverLinks": true,
+        "monospaceLinks": true,
+        "dateFormat": "ddd MMM Do YYYY",
+        "outputSourceFiles": true,
+        "outputSourcePath": true,
+        "systemName": "dash.js",
+        "copyright": "<h3>DASH Industry Forum</h3>",
+        "footer": "",
+        "navType": "horizontal",
+        "theme": "sandstone",
+        "linenums": true,
+        "collapseSymbols": true,
+        "inverseNav": true,
+        "highlightTutorialCode": true
     },
     "opts": {
         "template": "../../node_modules/ink-docstrap/template",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The initial idea of this work was to fix #3952. However I did not find a solution for the problem, the ToC overlaps the table with various different templates. Minor improvement is collapsing the content via `collapseSymbols`