### PR TITLE
Overwrite manifest mediaPresentationDuration if duration mismatch

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -194,6 +194,16 @@ function ManifestLoader(config) {
                         logger.debug('BaseURI set by Location to: ' + baseUri);
                     }
 
+                    // If there is a mismatch between the manifest's specified duration and the total duration of all periods,
+                    // overwrite the manifest's duration attribute. This is a patch for if a manifest is generated incorrectly.
+                    if (manifest.mediaPresentationDuration && manifest.Period.length > 1) {
+                        const sumPeriodDurations = manifest.Period.reduce((totalDuration, period) => totalDuration + period.duration, 0);
+                        if (manifest.mediaPresentationDuration - sumPeriodDurations) {
+                            logger.warn('Media presentation duration does not match duration of all periods. Setting duration to total period duration');
+                            manifest.mediaPresentationDuration = sumPeriodDurations;
+                        }
+                    }
+
                     manifest.baseUri = baseUri;
                     manifest.loadedTime = new Date();
                     xlinkController.resolveManifestOnLoad(manifest);


### PR DESCRIPTION
Relates to issue https://github.com/Dash-Industry-Forum/dash.js/issues/3962

Test stream that has ~1.5 seconds of mismatch: https://aow.im/dash/manifest.mpd

I have the signed feedback agreement, where can I send it?