### PR TITLE
Fix a bug that lead to undefined customParametersModel after calling …

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -422,7 +422,6 @@ function MediaPlayer() {
         }
         if (customParametersModel) {
             customParametersModel.reset();
-            customParametersModel = null;
         }
 
         settings.reset();


### PR DESCRIPTION
…Mediaplayer.reset() . Fixes #3975 