### PR TITLE
Fix for a rounding error not allowing BUFFERING_COMPLETED to get fired

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -665,8 +665,7 @@ function BufferController(config) {
 
     function _checkIfBufferingCompleted() {
         const isLastIdxAppended = maxAppendedIndex >= maximumIndex - 1; // Handles 0 and non 0 based request index
-        const periodBuffered = playbackController.getTimeToStreamEnd(streamInfo) - bufferLevel <= 0;
-
+        const periodBuffered = playbackController.getTimeToStreamEnd(streamInfo) - parseFloat(bufferLevel.toFixed(5)) <= 0;
         if ((isLastIdxAppended || periodBuffered) && !isBufferingCompleted) {
             setIsBufferingCompleted(true);
             logger.debug(`checkIfBufferingCompleted trigger BUFFERING_COMPLETED for stream id ${streamInfo.id} and type ${type}`);

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -638,10 +638,10 @@ function BufferController(config) {
         let range,
             length;
 
-        // // Consider gap/discontinuity limit as tolerance
-        // if (settings.get().streaming.gaps.jumpGaps) {
-        //     tolerance = settings.get().streaming.gaps.smallGapLimit;
-        // }
+        // Consider gap/discontinuity limit as tolerance
+        if (settings.get().streaming.gaps.jumpGaps) {
+            tolerance = settings.get().streaming.gaps.smallGapLimit;
+        }
 
         range = getRangeAt(time, tolerance);
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -638,10 +638,10 @@ function BufferController(config) {
         let range,
             length;
 
-        // Consider gap/discontinuity limit as tolerance
-        if (settings.get().streaming.gaps.jumpGaps) {
-            tolerance = settings.get().streaming.gaps.smallGapLimit;
-        }
+        // // Consider gap/discontinuity limit as tolerance
+        // if (settings.get().streaming.gaps.jumpGaps) {
+        //     tolerance = settings.get().streaming.gaps.smallGapLimit;
+        // }
 
         range = getRangeAt(time, tolerance);
 
@@ -665,7 +665,8 @@ function BufferController(config) {
 
     function _checkIfBufferingCompleted() {
         const isLastIdxAppended = maxAppendedIndex >= maximumIndex - 1; // Handles 0 and non 0 based request index
-        const periodBuffered = playbackController.getTimeToStreamEnd(streamInfo) - parseFloat(bufferLevel.toFixed(5)) <= 0;
+        // To avoid rounding error when comparing, the stream time and buffer level only must be within 5 decimal places
+        const periodBuffered = playbackController.getTimeToStreamEnd(streamInfo) - bufferLevel < 0.00001;
         if ((isLastIdxAppended || periodBuffered) && !isBufferingCompleted) {
             setIsBufferingCompleted(true);
             logger.debug(`checkIfBufferingCompleted trigger BUFFERING_COMPLETED for stream id ${streamInfo.id} and type ${type}`);


### PR DESCRIPTION
The player may stall in certain cases due to a rounding difference when computing if a period is completely buffered or not. This is seen in multi-period scenarios, in our use case, server side ad insertion). The result is that the player does not start pulling segments for the next period and eventually stalls.

This was seen while testing the Pluto.Tv service. It is difficult for me to provide an example stream as our streams are dynamically generated and DRM protected.

The root cause is the comparison between a number that is rounded to 5 decimal places and a number that is not rounded inside of `BufferController.js`. `playbackController.getTimeToStreamEnd()` is rounded and `bufferLevel` is not rounded.

An example seen while testing:

`getTimeToStreamEnd()` result: `15.23113`
`bufferLevel`: `15.231126070022583`

In this case, `playbackController.getTimeToStreamEnd(streamInfo) - bufferLevel` evaluates to `0.00000393` and thus `periodBuffered` evaluates to `false` even though the period is actually completely buffered.

The fix provided rounds `bufferLevel` at the comparison site and limits the scope of the change. However, it might be better to round `bufferLevel` inside of the `getBufferLength()` function. Please advise.

With this fix, the example values above are both `15.23113` and `playbackController.getTimeToStreamEnd(streamInfo) - bufferLevel` evaluates to `0.00000`.