### PR TITLE
Fix `d` trace httpList metric reporting

### DIFF
--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -116,13 +116,12 @@ function MetricsModel(config) {
         }
     }
 
-    function appendHttpTrace(httpRequest, s, d, b, t) {
+    function appendHttpTrace(httpRequest, s, d, b) {
         let vo = new HTTPRequestTrace();
 
         vo.s = s;
         vo.d = d;
         vo.b = b;
-        vo._t = t;
 
         httpRequest.trace.push(vo);
 
@@ -188,7 +187,7 @@ function MetricsModel(config) {
 
         if (traces) {
             traces.forEach(trace => {
-                appendHttpTrace(vo, trace.s, trace.d, trace.b, trace.t);
+                appendHttpTrace(vo, trace.s, trace.d, trace.b);
             });
         } else {
             // The interval and trace shall be absent for redirect and failure records.

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -231,16 +231,22 @@ function FetchLoader(cfg) {
                                     // are correctly generated
                                     // Same structure as https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequestEventTarget/
                                     let calculatedThroughput = null;
+                                    let calculatedTime = null;
                                     if (calculationMode === Constants.ABR_FETCH_THROUGHPUT_CALCULATION_MOOF_PARSING) {
                                         calculatedThroughput = calculateThroughputByChunkData(startTimeData, endTimeData);
+                                        if (calculatedThroughput) {
+                                            calculatedTime = bytesReceived * 8 / calculatedThroughput;
+                                        }
+                                    }
+                                    else if (calculationMode === Constants.ABR_FETCH_THROUGHPUT_CALCULATION_DOWNLOADED_DATA) {
+                                        calculatedTime = calculateDownloadedTime(downloadedData, bytesReceived);
                                     }
 
                                     httpRequest.progress({
                                         loaded: bytesReceived,
                                         total: isNaN(totalBytes) ? bytesReceived : totalBytes,
                                         lengthComputable: true,
-                                        time: calculateDownloadedTime(downloadedData, bytesReceived),
-                                        throughput: calculatedThroughput,
+                                        time: calculatedTime,
                                         stream: true
                                     });
                                 }

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -208,8 +208,7 @@ function HTTPLoader(cfg) {
                 traces.push({
                     s: lastTraceTime,
                     d: event.time ? event.time : currentTime.getTime() - lastTraceTime.getTime(),
-                    b: [event.loaded ? event.loaded - lastTraceReceivedCount : 0],
-                    t: event.throughput
+                    b: [event.loaded ? event.loaded - lastTraceReceivedCount : 0]
                 });
 
                 lastTraceTime = currentTime;

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -91,14 +91,7 @@ function ThroughputHistory(config) {
         let throughputMeasureTime = 0, throughput = 0;
 
         if (httpRequest._fileLoaderType && httpRequest._fileLoaderType === Constants.FILE_LOADER_TYPES.FETCH) {
-            const calculationMode = settings.get().streaming.abr.fetchThroughputCalculationMode;
-            if (calculationMode === Constants.ABR_FETCH_THROUGHPUT_CALCULATION_MOOF_PARSING) {
-                const sumOfThroughputValues = httpRequest.trace.reduce((a, b) => a + b._t, 0);
-                throughput = Math.round(sumOfThroughputValues / httpRequest.trace.length);
-            }
-            if (throughput === 0) {
-                throughputMeasureTime = httpRequest.trace.reduce((a, b) => a + b.d, 0);
-            }
+            throughputMeasureTime = httpRequest.trace.reduce((a, b) => a + b.d, 0);
         } else {
             throughputMeasureTime = useDeadTimeLatency ? downloadTimeInMilliseconds : latencyTimeInMilliseconds + downloadTimeInMilliseconds;
         }

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -159,11 +159,6 @@ class HTTPRequestTrace {
          * @public
          */
         this.b = [];
-        /**
-         * Measurement throughput in kbits/s
-         * @public
-         */
-        this._t = null;
     }
 }
 


### PR DESCRIPTION
Currently the `d` trace httpList metric always contains the time calculated using the 'Data Chunks' Low Latency throughput calculation, regardless of the `fetchThroughputCalculationMode` setting. This means the httpList reporting contains the incorrect `d` value in the default situation where MOOF parsing mode is used. 
The addition of the 'throughput' (`t`) trace entry leads to other issues:
1) It is not currently taken account of in L2ARule (which this PR would fix): https://github.com/Dash-Industry-Forum/dash.js/blob/7fdbf4e54a9975f31818e18dc6a67cc44a5933eb/src/streaming/rules/abr/L2ARule.js#L388
2) It adds complication with metric reporting (addressed in #3883)

This PR aims to:
- Ensure 'd' (Measurement period duration) trace httpList metric reflects that used by ABR
- Limit use of the throughput metric to the FetchLoader
- Remove throughput metric from trace object
- Simplify ThroughputHistory rules