### PR TITLE
Pass url to RequestModifier.modifyRequestHeader (#3995)

### DIFF
--- a/samples/advanced/extend.html
+++ b/samples/advanced/extend.html
@@ -29,7 +29,7 @@
             /* Extend RequestModifier class and implement our own behaviour */
             player.extend("RequestModifier", function () {
                 return {
-                    modifyRequestHeader: function (xhr) {
+                    modifyRequestHeader: function (xhr, {url}) {
                         /* Add custom header. Requires to set up Access-Control-Allow-Headers in your */
                         /* response header in the server side. Reference: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader */
                         /* xhr.setRequestHeader('DASH-CUSTOM-HEADER', 'MyValue'); */

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -86,6 +86,8 @@ function FetchLoader(cfg) {
                 setRequestHeader: function (header, value) {
                     headers.append(header, value);
                 }
+            }, {
+                url: httpRequest.url
             });
         }
 

--- a/src/streaming/net/XHRLoader.js
+++ b/src/streaming/net/XHRLoader.js
@@ -65,7 +65,9 @@ function XHRLoader(cfg) {
         }
 
         if (requestModifier) {
-            xhr = requestModifier.modifyRequestHeader(xhr);
+            xhr = requestModifier.modifyRequestHeader(xhr, {
+                url: httpRequest.url
+            });
         }
 
         if (httpRequest.headers) {

--- a/src/streaming/utils/RequestModifier.js
+++ b/src/streaming/utils/RequestModifier.js
@@ -39,7 +39,8 @@ function RequestModifier() {
         return url;
     }
 
-    function modifyRequestHeader(request) {
+    // eslint-disable-next-line no-unused-vars
+    function modifyRequestHeader(request, {url}) {
         return request;
     }
 


### PR DESCRIPTION
Solution proposal for #3995. I've added an object as a secondary argument of `modifyRequestHeader` so that it is easily extensible in the future if someone wanted to add e.g. `method` or other XHR parameters.