### PR TITLE
Run functional tests by groupname

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,14 +69,14 @@ commands:
             protocol:
                 default: "https"
                 type: string
-            streams:
-                default: "all"
+            groupname:
+                default: ""
                 type: string
         steps:
             - run:
-                name: Run functional tests (<<parameters.browser>> / <<parameters.protocol>>) <<parameters.streams>>
+                name: Run functional tests (<<parameters.browser>> / <<parameters.protocol>>) <<parameters.groupname>>
                 command:
-                    node test/functional/runTests.js --selenium=remote --reporters=junit --app=remote --browsers=<<parameters.browser>> --protocol=<<parameters.protocol>> --streams="<<parameters.streams>>"
+                    node test/functional/runTests.js --selenium=remote --reporters=junit --app=remote --browsers=<<parameters.browser>> --protocol=<<parameters.protocol>> --groupname="<<parameters.groupname>>"
 jobs:
     build-and-unit-test:
         executor: dashjs-executor
@@ -142,11 +142,11 @@ jobs:
         steps:
             - functional_steps
             - run_test_suite:
-                streams: VOD (Static MPD)
+                groupname: VOD (Static MPD)
             - run_test_suite:
-                streams: LIVE (Dynamic MPD)
+                groupname: LIVE (Dynamic MPD)
             - run_test_suite:
-                streams: Live Low Latency
+                groupname: Live Low Latency
             - store_test_results:
                 path: test/functional/reports
 
@@ -155,9 +155,9 @@ jobs:
         steps:
             - functional_steps
             - run_test_suite:
-                streams: DRM (modern)
+                groupname: DRM (modern)
             - run_test_suite:
-                streams: DRM Content (conservative/legacy)
+                groupname: DRM Content (conservative/legacy)
             - store_test_results:
                 path: test/functional/reports
 
@@ -166,13 +166,13 @@ jobs:
         steps:
             - functional_steps
             - run_test_suite:
-                streams: Subtitles and Captions
+                groupname: Subtitles and Captions
             - run_test_suite:
-                streams: Thumbnails
+                groupname: Thumbnails
             - run_test_suite:
-                streams: Audio-only
+                groupname: Audio-only
             - run_test_suite:
-                streams: Smooth Streaming
+                groupname: Smooth Streaming
             
             - store_test_results:
                 path: test/functional/reports

--- a/test/functional/runTests.js
+++ b/test/functional/runTests.js
@@ -59,6 +59,10 @@ var args = yargs
             describe: 'Output log/debug messages',
             type: 'boolean',
             default: 'false'
+        },
+        'groupname': {
+            describe: 'Group name that the stream needs to belong to. Only applied if a groupname is present such as in the list of reference vectors.',
+            default: ''
         }
     })
     .parse();
@@ -197,6 +201,10 @@ if (args.streams !== 'all') {
 
 if (args.mpd !== '') {
     config.mpd = args.mpd;
+}
+
+if (args.groupname !== '') {
+    config.groupname = args.groupname;
 }
 
 config.source = args.source;

--- a/test/functional/streams.js
+++ b/test/functional/streams.js
@@ -16,6 +16,7 @@ module.exports.getStreams = function () {
             if(stream.url.substr(0,2) === '//') {
                 stream.url = intern.config.protocol + ':' + stream.url;
             }
+            stream.groupName = groupName;
             streams.push(stream);
         }
     }
@@ -27,6 +28,13 @@ module.exports.getStreams = function () {
     if (intern.config.streams) {
         streams = streams.filter(stream => {
             return stream.name.indexOf(intern.config.streams) !== -1;
+        });
+    }
+
+    // Filter streams if groupname is set
+    if (intern.config.groupname) {
+        streams = streams.filter(stream => {
+            return intern.config.groupname == stream.groupName;
         });
     }
 


### PR DESCRIPTION
We need to add a groupname attribute to the functional tests to run only the testvectors that belong to a certain category for the default list of reference streams. By combining name and groupname as we did before we test the same testvectors multiple times.