### PR TITLE
Implement new catchup seeking/pausing logic as discussed during F2F

### DIFF
--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -359,7 +359,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
     };
 
     var seekLive = function () {
-        self.player.seekToLive();
+        self.player.seekToOriginalLive();
     };
 
     //************************************************************************************

--- a/contrib/akamai/controlbar/ControlBar.js
+++ b/contrib/akamai/controlbar/ControlBar.js
@@ -359,7 +359,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
     };
 
     var seekLive = function () {
-        self.player.seek(self.player.duration());
+        self.player.seekToLive();
     };
 
     //************************************************************************************

--- a/index.d.ts
+++ b/index.d.ts
@@ -228,7 +228,6 @@ declare namespace dashjs {
             liveCatchup?: {
                 maxDrift?: number;
                 playbackRate?: number;
-                latencyThreshold?: number,
                 playbackBufferMin?: number,
                 enabled?: boolean
                 mode?: string
@@ -466,6 +465,8 @@ declare namespace dashjs {
         isDynamic(): boolean;
 
         seek(value: number): void;
+
+        seekToLive(): void;
 
         setPlaybackRate(value: number): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -466,7 +466,7 @@ declare namespace dashjs {
 
         seek(value: number): void;
 
-        seekToLive(): void;
+        seekToOriginalLive(): void;
 
         setPlaybackRate(value: number): void;
 

--- a/samples/low-latency/testplayer/main.css
+++ b/samples/low-latency/testplayer/main.css
@@ -1,5 +1,11 @@
+.videoContainer{
+    position: relative;
+}
+
 video {
     width: 100%;
+    height: auto;
+    margin: auto;
 }
 
 #manifest {
@@ -29,4 +35,12 @@ video {
 #metric-chart {
     max-height: 400px;
     min-height: 400px;
+}
+
+.video-controller {
+    margin-top: -5px !important;
+}
+
+.dash-video-player {
+    background: #000000;
 }

--- a/samples/low-latency/testplayer/main.js
+++ b/samples/low-latency/testplayer/main.js
@@ -30,7 +30,6 @@ App.prototype._setDomElements = function () {
     this.domElements.settings.targetLatency = document.getElementById('target-latency');
     this.domElements.settings.maxDrift = document.getElementById('max-drift');
     this.domElements.settings.catchupPlaybackRate = document.getElementById('catchup-playback-rate');
-    this.domElements.settings.liveCatchupLatencyThreshold = document.getElementById('catchup-threshold');
     this.domElements.settings.abrAdditionalInsufficientBufferRule = document.getElementById('abr-additional-insufficient')
     this.domElements.settings.abrAdditionalDroppedFramesRule = document.getElementById('abr-additional-dropped');
     this.domElements.settings.abrAdditionalAbandonRequestRule = document.getElementById('abr-additional-abandon');
@@ -89,7 +88,6 @@ App.prototype._applyParameters = function () {
             liveCatchup: {
                 maxDrift: settings.maxDrift,
                 playbackRate: settings.catchupPlaybackRate,
-                latencyThreshold: settings.liveCatchupLatencyThreshold,
                 mode: settings.catchupMechanism
             },
             abr: {
@@ -133,9 +131,6 @@ App.prototype._adjustSettingsByUrlParameters = function () {
         if (params.catchupPlaybackRate !== undefined) {
             this.domElements.settings.catchupPlaybackRate.value = parseFloat(params.catchupPlaybackRate).toFixed(1);
         }
-        if (params.liveCatchupLatencyThreshold !== undefined) {
-            this.domElements.settings.liveCatchupLatencyThreshold.value = parseFloat(params.liveCatchupLatencyThreshold).toFixed(0);
-        }
         if (params.abrAdditionalInsufficientBufferRule !== undefined) {
             this.domElements.settings.abrAdditionalInsufficientBufferRule.checked = params.abrAdditionalInsufficientBufferRule === 'true';
         }
@@ -165,7 +160,6 @@ App.prototype._getCurrentSettings = function () {
     var targetLatency = parseFloat(this.domElements.settings.targetLatency.value, 10);
     var maxDrift = parseFloat(this.domElements.settings.maxDrift.value, 10);
     var catchupPlaybackRate = parseFloat(this.domElements.settings.catchupPlaybackRate.value, 10);
-    var liveCatchupLatencyThreshold = parseFloat(this.domElements.settings.liveCatchupLatencyThreshold.value, 10);
     var abrAdditionalInsufficientBufferRule = this.domElements.settings.abrAdditionalInsufficientBufferRule.checked;
     var abrAdditionalDroppedFramesRule = this.domElements.settings.abrAdditionalDroppedFramesRule.checked;
     var abrAdditionalAbandonRequestRule = this.domElements.settings.abrAdditionalAbandonRequestRule.checked;
@@ -178,7 +172,6 @@ App.prototype._getCurrentSettings = function () {
         targetLatency,
         maxDrift,
         catchupPlaybackRate,
-        liveCatchupLatencyThreshold,
         abrGeneral,
         abrAdditionalInsufficientBufferRule,
         abrAdditionalDroppedFramesRule,
@@ -343,8 +336,6 @@ App.prototype._startIntervalHandler = function () {
 
             var currentBuffer = dashMetrics.getCurrentBufferLevel('video');
             self.domElements.metrics.bufferTag.innerHTML = currentBuffer + ' secs';
-
-            self.domElements.metrics.catchupThresholdTag.innerHTML = settings.streaming.liveCatchup.latencyThreshold + ' secs';
 
             var d = new Date();
             var seconds = d.getSeconds();

--- a/samples/low-latency/testplayer/main.js
+++ b/samples/low-latency/testplayer/main.js
@@ -2,6 +2,7 @@ var METRIC_INTERVAL = 300;
 
 var App = function () {
     this.player = null;
+    this.controlbar = null;
     this.video = null;
     this.chart = null;
     this.domElements = {
@@ -45,7 +46,6 @@ App.prototype._setDomElements = function () {
     this.domElements.metrics.latencyTag = document.getElementById('latency-tag');
     this.domElements.metrics.playbackrateTag = document.getElementById('playbackrate-tag');
     this.domElements.metrics.bufferTag = document.getElementById('buffer-tag');
-    this.domElements.metrics.catchupThresholdTag = document.getElementById('catchup-threshold-tag');
     this.domElements.metrics.sec = document.getElementById('sec');
     this.domElements.metrics.min = document.getElementById('min');
     this.domElements.metrics.videoMaxIndex = document.getElementById('video-max-index');
@@ -70,6 +70,8 @@ App.prototype._load = function () {
     this._registerDashEventHandler();
     this._applyParameters();
     this.player.initialize(this.video, url, true);
+    this.controlbar = new ControlBar(this.player);
+    this.controlbar.initialize();
 }
 
 App.prototype._applyParameters = function () {

--- a/samples/low-latency/testplayer/testplayer.html
+++ b/samples/low-latency/testplayer/testplayer.html
@@ -4,14 +4,16 @@
     <meta charset="utf-8">
     <title>Low latency streaming - Testplayer</title>
 
-    <script src="../../../dist/dash.all.debug.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.3.2/dist/chart.min.js"></script>
-
     <!-- Bootstrap core CSS -->
     <link href="../../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="../../../contrib/akamai/controlbar/controlbar.css">
     <link href="../../lib/main.css" rel="stylesheet">
     <link href="main.css" rel="stylesheet">
+
+    <script src="../../../dist/dash.all.debug.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.3.2/dist/chart.min.js"></script>
+    <script src="../../../contrib/akamai/controlbar/Controlbar.js"></script>
 
 </head>
 <body>
@@ -70,11 +72,6 @@
                                         <span class="input-group-text">Catch-up playback rate</span>
                                         <input type="number" id="catchup-playback-rate" class="form-control" value="0.1"
                                                step="0.01" max="0.5" min="0.0">
-                                    </div>
-                                    <div class="input-group input-group-sm mb-3">
-                                        <span class="input-group-text"> Live catchup latency threshold (sec):</span>
-                                        <input type="number" class="form-control" value="60" min="0"
-                                               id="catchup-threshold">
                                     </div>
                                 </div>
                                 <div class="col-md-3">
@@ -243,8 +240,39 @@
             </div>
         </div>
         <div class="row mt-2">
-            <div class="col-md-7">
-                <video controls="true"></video>
+            <div class="col-md-7 dash-video-player">
+                <div id="videoContainer" class="videoContainer">
+                    <video></video>
+                    <div id="videoController" class="video-controller unselectable">
+                        <div id="playPauseBtn" class="btn-play-pause" title="Play/Pause">
+                            <span id="iconPlayPause" class="icon-play"></span>
+                        </div>
+                        <span id="videoTime" class="time-display">00:00:00</span>
+                        <div id="fullscreenBtn" class="btn-fullscreen control-icon-layout" title="Fullscreen">
+                            <span class="icon-fullscreen-enter"></span>
+                        </div>
+                        <div id="bitrateListBtn" class="control-icon-layout" title="Bitrate List">
+                            <span class="icon-bitrate"></span>
+                        </div>
+                        <input type="range" id="volumebar" class="volumebar" value="1" min="0" max="1" step=".01"/>
+                        <div id="muteBtn" class="btn-mute control-icon-layout" title="Mute">
+                            <span id="iconMute" class="icon-mute-off"></span>
+                        </div>
+                        <div id="trackSwitchBtn" class="control-icon-layout" title="A/V Tracks">
+                            <span class="icon-tracks"></span>
+                        </div>
+                        <div id="captionBtn" class="btn-caption control-icon-layout" title="Closed Caption">
+                            <span class="icon-caption"></span>
+                        </div>
+                        <span id="videoDuration" class="duration-display">00:00:00</span>
+                        <div class="seekContainer">
+                            <div id="seekbar" class="seekbar seekbar-complete">
+                                <div id="seekbar-buffer" class="seekbar seekbar-buffer"></div>
+                                <div id="seekbar-play" class="seekbar seekbar-play"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="col-md-5">
                 <div class="p-5 border rounded-3 mt-1">
@@ -267,9 +295,6 @@
                         <div><span class="metric-value"> Playback rate: </span><span
                             id="playbackrate-tag"></span>
                         </div>
-                        <div><span
-                            class="metric-value">Live catchup latency threshold: </span><span
-                            id="catchup-threshold-tag"></span></div>
                     </div>
                 </div>
             </div>

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -140,7 +140,6 @@ import Events from './events/Events';
  *                maxDrift: NaN,
  *                playbackRate: NaN,
  *                playbackBufferMin: 0.5,
- *                latencyThreshold: 60,
  *                enabled: false,
  *                mode: Constants.LIVE_CATCHUP_MODE_DEFAULT
  *            },
@@ -462,15 +461,6 @@ import Events from './events/Events';
  * Set it to NaN to turn off live catch up feature.
  *
  * Note: Catch-up mechanism is only applied when playing low latency live streams.
- * @property {number} [latencyThreshold=60]
- * Use this parameter to set the maximum threshold for which live catch up is applied.
- *
- * For instance, if this value is set to 8 seconds, then live catchup is only applied if the current live latency is equal or below 8 seconds.
- *
- * The reason behind this parameter is to avoid an increase of the playback rate if the user seeks within the DVR window.
- *
- * If no value is specified catchup mode will always be applied
- *
  * @property {number} [playbackBufferMin=NaN]
  * Use this parameter to specify the minimum buffer which is used for LoL+ based playback rate reduction.
  *
@@ -846,7 +836,6 @@ function Settings() {
                 playbackRate: NaN,
                 playbackBufferMin: 0.5,
                 enabled: null,
-                latencyThreshold: 60,
                 mode: Constants.LIVE_CATCHUP_MODE_DEFAULT
             },
             lastBitrateCachingInfo: {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -529,7 +529,7 @@ function MediaPlayer() {
             throw PLAYBACK_NOT_INITIALIZED_ERROR;
         }
         if (!autoPlay || (isPaused() && playbackInitialized)) {
-            playbackController.play();
+            playbackController.play(true);
         }
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -589,14 +589,14 @@ function MediaPlayer() {
     }
 
     /**
-     * Seeks back to the original live edge. Only applies to live streams, for VoD streams this call will be ignored.
+     * Seeks back to the original live edge (live edge as calculated at playback start). Only applies to live streams, for VoD streams this call will be ignored.
      */
-    function seekToLive() {
+    function seekToOriginalLive() {
         if (!playbackInitialized || !isDynamic()) {
             return;
         }
 
-        playbackController.seekToLive();
+        playbackController.seekToOriginalLive();
     }
 
     /**
@@ -2324,7 +2324,7 @@ function MediaPlayer() {
         isDynamic,
         getLowLatencyModeEnabled,
         seek,
-        seekToLive,
+        seekToOriginalLive,
         setPlaybackRate,
         getPlaybackRate,
         setMute,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2076,7 +2076,6 @@ function MediaPlayer() {
             streamController,
             playbackController,
             mediaPlayerModel,
-            dashMetrics,
             videoModel,
             settings
         })

--- a/src/streaming/controllers/CatchupController.js
+++ b/src/streaming/controllers/CatchupController.js
@@ -206,7 +206,7 @@ function CatchupController() {
                 deltaLatency > maxDrift) {
                 logger.info('[CatchupController]: Low Latency catchup mechanism. Latency too high, doing a seek to live point');
                 isCatchupSeekInProgress = true;
-                _seekToLive();
+                playbackController.seekToCurrentLive(true, false);
             }
 
             // try to reach the target latency by adjusting the playback rate
@@ -410,19 +410,6 @@ function CatchupController() {
         }
 
         return newRate
-    }
-
-    /**
-     * Seek to live edge
-     */
-    function _seekToLive() {
-        const type = streamController && streamController.hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO;
-        const DVRMetrics = dashMetrics.getCurrentDVRInfo(type);
-        const DVRWindow = DVRMetrics ? DVRMetrics.range : null;
-
-        if (DVRWindow && !isNaN(DVRWindow.end)) {
-            playbackController.seek(DVRWindow.end - playbackController.getLiveDelay(), true, false);
-        }
     }
 
     instance = {

--- a/src/streaming/controllers/CatchupController.js
+++ b/src/streaming/controllers/CatchupController.js
@@ -48,7 +48,6 @@ function CatchupController() {
         streamController,
         playbackController,
         mediaPlayerModel,
-        dashMetrics,
         playbackStalled,
         logger;
 
@@ -75,10 +74,6 @@ function CatchupController() {
 
         if (config.playbackController) {
             playbackController = config.playbackController;
-        }
-
-        if (config.dashMetrics) {
-            dashMetrics = config.dashMetrics;
         }
 
         if (config.mediaPlayerModel) {

--- a/src/streaming/controllers/CatchupController.js
+++ b/src/streaming/controllers/CatchupController.js
@@ -250,8 +250,7 @@ function CatchupController() {
      */
     function _shouldStartCatchUp() {
         try {
-            const latencyThreshold = mediaPlayerModel.getLiveCatchupLatencyThreshold();
-            if (!playbackController.getTime() > 0 || isCatchupSeekInProgress || (!isNaN(latencyThreshold) && playbackController.getCurrentLiveLatency() >= latencyThreshold)) {
+            if (!playbackController.getTime() > 0 || isCatchupSeekInProgress) {
                 return false;
             }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -177,8 +177,11 @@ function PlaybackController() {
     /**
      * Triggers play() on the video element
      */
-    function play() {
+    function play(adjustLiveDelay = false) {
         if (streamInfo && videoModel && videoModel.getElement()) {
+            if (adjustLiveDelay && isDynamic) {
+                _adjustLiveDelayAfterUserInteraction(getTime());
+            }
             videoModel.play();
         } else {
             playOnceInitialized = true;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -734,7 +734,7 @@ function StreamController() {
      * @private
      */
     function _onLiveDelaySettingUpdated() {
-        if (adapter.getIsDynamic() && playbackController.getLiveDelay() !== 0) {
+        if (adapter.getIsDynamic() && playbackController.getOriginalLiveDelay() !== 0) {
             const streamsInfo = adapter.getStreamsInfo()
             if (streamsInfo.length > 0) {
                 const manifestInfo = streamsInfo[0].manifestInfo;
@@ -1031,7 +1031,7 @@ function StreamController() {
             const dvrInfo = dashMetrics.getCurrentDVRInfo();
             const liveEdge = dvrInfo && dvrInfo.range ? dvrInfo.range.end : 0;
             // we are already in the right start period. so time should not be smaller than period@start and should not be larger than period@end
-            startTime = liveEdge - playbackController.getLiveDelay();
+            startTime = liveEdge - playbackController.getOriginalLiveDelay();
             // If start time in URI, take min value between live edge time and time from URI (capped by DVR window range)
             const dvrWindow = dvrInfo ? dvrInfo.range : null;
             if (dvrWindow) {

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -113,26 +113,6 @@ function MediaPlayerModel() {
     }
 
     /**
-     * Returns the threshold for which to apply the catchup logic
-     * @return {number}
-     */
-    function getLiveCatchupLatencyThreshold() {
-        try {
-            const liveCatchupLatencyThreshold = settings.get().streaming.liveCatchup.latencyThreshold;
-            const liveDelay = playbackController.getLiveDelay();
-
-            if (liveCatchupLatencyThreshold !== null && !isNaN(liveCatchupLatencyThreshold)) {
-                return Math.max(liveCatchupLatencyThreshold, liveDelay);
-            }
-
-            return NaN;
-
-        } catch (e) {
-            return NaN;
-        }
-    }
-
-    /**
      * Returns the min,max or initial bitrate for a specific media type.
      * @param {string} field
      * @param {string} mediaType
@@ -209,7 +189,6 @@ function MediaPlayerModel() {
     instance = {
         getCatchupMaxDrift,
         getCatchupModeEnabled,
-        getLiveCatchupLatencyThreshold,
         getStableBufferTime,
         getInitialBufferLevel,
         getRetryAttemptsForType,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -173,7 +173,7 @@ function MediaPlayerModel() {
     }
 
     /**
-     * Returns the retry interbal for a specific media type
+     * Returns the retry interval for a specific media type
      * @param type
      * @return {number}
      */

--- a/test/unit/mocks/PlaybackControllerMock.js
+++ b/test/unit/mocks/PlaybackControllerMock.js
@@ -106,6 +106,10 @@ class PlaybackControllerMock {
         return 15;
     }
 
+    getOriginalLiveDelay() {
+        return 15;
+    }
+
     reset() {
         this.setup();
     }


### PR DESCRIPTION
This PR implements the seeking catchup logic as discussed during the F2F in Berlin. The basic idea is to adjust the liveDelay when the user seeks. Then catchup mode is applied with the new live Delay as target value. At the same time we save the original live delay as calculated during start. By calling `player.seekToLive` the app can jump back to this original live delay.
As part of this PR the `latencyThreshold` parameter has been removed from the settings.

The same mechanism is applied when the user triggers play.