### PR TITLE
Fix stalling when using buffer.fastSwitchEnabled setting

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -660,7 +660,7 @@ function StreamProcessor(config) {
     function _prepareForFastQualitySwitch(representationInfo) {
         // if we switch up in quality and need to replace existing parts in the buffer we need to adjust the buffer target
         const time = playbackController.getTime();
-        let safeBufferLevel = 1.5;
+        let safeBufferLevel = 1.5 * (!isNaN(representationInfo.fragmentDuration) ? representationInfo.fragmentDuration : 1);
         const request = fragmentModel.getRequests({
             state: FragmentModel.FRAGMENT_MODEL_EXECUTED,
             time: time + safeBufferLevel,


### PR DESCRIPTION
According to the docs in Settings, the value used by `StreamProcessor` was wrong.
The problem occurred on an environment with high latency and low bandwidth, where segments' length was 3s, which is significantly longer than previously hardcoded 1.5s.