### PR TITLE
make language matching more robust

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1515,7 +1515,7 @@ function MediaPlayer() {
     /**
      * This method allows to set media settings that will be used to pick the initial track. Format of the settings
      * is following: <br />
-     * {lang: langValue (can be either a string or a regex to match),
+     * {lang: langValue (can be either a string primitive, a string object, or a RegExp object to match),
      *  index: indexValue,
      *  viewpoint: viewpointValue,
      *  audioChannelConfiguration: audioChannelConfigurationValue,

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -35,9 +35,6 @@ import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
 import {bcp47Normalize} from 'bcp-47-normalize';
 import {extendedFilter} from 'bcp-47-match';
-// const bcp47Normalize = require('bcp-47-normalize').bcp47Normalize;
-// const extendedFilter = require('bcp-47-match').extendedFilter;
-
 
 function MediaController() {
 

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -33,6 +33,11 @@ import Events from '../../core/events/Events';
 import EventBus from '../../core/EventBus';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
+import {bcp47Normalize} from 'bcp-47-normalize';
+import {extendedFilter} from 'bcp-47-match';
+// const bcp47Normalize = require('bcp-47-normalize').bcp47Normalize;
+// const extendedFilter = require('bcp-47-match').extendedFilter;
+
 
 function MediaController() {
 
@@ -309,7 +314,7 @@ function MediaController() {
     }
 
     function matchSettings(settings, track, isTrackActive = false) {
-        const matchLang = !settings.lang || (track.lang.match(settings.lang));
+        const matchLang = !settings.lang || ( extendedFilter(track.lang, bcp47Normalize(settings.lang)).length>0 );
         const matchIndex = (settings.index === undefined) || (settings.index === null) || (track.index === settings.index);
         const matchViewPoint = !settings.viewpoint || (settings.viewpoint === track.viewpoint);
         const matchRole = !settings.role || !!track.roles.filter(function (item) {

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -33,7 +33,7 @@ import Events from '../../core/events/Events';
 import EventBus from '../../core/EventBus';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
-import {bcp47Normalize} from 'bcp-47-normalize';
+var bcp47Normalize = require('bcp-47-normalize')
 import {extendedFilter} from 'bcp-47-match';
 
 function MediaController() {
@@ -311,7 +311,9 @@ function MediaController() {
     }
 
     function matchSettings(settings, track, isTrackActive = false) {
-        const matchLang = !settings.lang || ( extendedFilter(track.lang, bcp47Normalize(settings.lang)).length>0 );
+        const matchLang = !settings.lang || (
+            (settings.lang instanceof RegExp)?(track.lang.match(settings.lang)):( extendedFilter(track.lang, bcp47Normalize(settings.lang) ).length>0 )
+        );
         const matchIndex = (settings.index === undefined) || (settings.index === null) || (track.index === settings.index);
         const matchViewPoint = !settings.viewpoint || (settings.viewpoint === track.viewpoint);
         const matchRole = !settings.role || !!track.roles.filter(function (item) {

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -334,99 +334,100 @@ describe('MediaController', function () {
     });
 
     describe('Initial Track Management', function () {
+        let streamInfo = {
+            id: 'id'
+        };
+        let frTrack = {
+            type: trackType,
+            streamInfo: streamInfo,
+            lang: 'fr',
+            viewpoint: 'viewpoint',
+            roles: 1,
+            accessibility: 1,
+            audioChannelConfiguration: 1
+        };
+        const qtzTrack = {
+            type: trackType,
+            streamInfo: streamInfo,
+            lang: 'qtz',
+            viewpoint: 'viewpoint',
+            roles: 1,
+            accessibility: 1,
+            audioChannelConfiguration: 1
+        };
 
         it('should check initial media settings to choose initial track', function () {
-            let streamInfo = {
-                id: 'id'
-            };
-            let track = {
-                type: trackType,
-                streamInfo: streamInfo,
-                lang: 'fr',
-                viewpoint: 'viewpoint',
-                roles: 1,
-                accessibility: 1,
-                audioChannelConfiguration: 1
-            };
-
-            mediaController.addTrack(track);
+            mediaController.addTrack(frTrack);
+            mediaController.addTrack(qtzTrack);
 
             let trackList = mediaController.getTracksFor(trackType, streamInfo.id);
-            expect(trackList).to.have.lengthOf(1);
-            expect(objectUtils.areEqual(trackList[0], track)).to.be.true; // jshint ignore:line
+            expect(trackList).to.have.lengthOf(2);
+            expect(objectUtils.areEqual(trackList[0], frTrack)).to.be.true; // jshint ignore:line
+            expect(objectUtils.areEqual(trackList[1], qtzTrack)).to.be.true; // jshint ignore:line
 
             let currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
-            expect(objectUtils.areEqual(currentTrack, track)).to.be.false; // jshint ignore:line
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.false; // jshint ignore:line
 
             // call to setInitialMediaSettingsForType
             mediaController.setInitialSettings(trackType, {
-                lang: 'fr',
+                lang: 'qtz',
                 viewpoint: 'viewpoint'
             });
             mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
 
             currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
-            expect(objectUtils.areEqual(currentTrack, track)).to.be.true; // jshint ignore:line
+            expect(objectUtils.areEqual(currentTrack, qtzTrack)).to.be.true; // jshint ignore:line
+
+        });
+
+        it('should check initial media settings to choose initial track with 639-2 3-letter code', function () {
+            mediaController.addTrack(qtzTrack);
+            mediaController.addTrack(frTrack);
+
+            let trackList = mediaController.getTracksFor(trackType, streamInfo.id);
+            expect(trackList).to.have.lengthOf(2);
+            expect(objectUtils.areEqual(trackList[0], qtzTrack)).to.be.true; // jshint ignore:line
+            expect(objectUtils.areEqual(trackList[1], frTrack)).to.be.true; // jshint ignore:line
+
+            let currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.false; // jshint ignore:line
+
+            // call to setInitialMediaSettingsForType
+            mediaController.setInitialSettings(trackType, {
+                lang: 'fre',
+                viewpoint: 'viewpoint'
+            });
+            mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
+
+            currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.true; // jshint ignore:line
 
         });
 
         it('should check initial media settings to choose initial track with a string/regex lang', function () {
-            const streamInfo = {
-                id: 'id'
-            };
-            const track = {
-                type: trackType,
-                streamInfo: streamInfo,
-                lang: 'fr',
-                viewpoint: 'viewpoint',
-                roles: 1,
-                accessibility: 1,
-                audioChannelConfiguration: 1
-            };
-
-            mediaController.addTrack(track);
+            mediaController.addTrack(frTrack);
+            mediaController.addTrack(qtzTrack);
 
             let trackList = mediaController.getTracksFor(trackType, streamInfo.id);
-            expect(trackList).to.have.lengthOf(1);
-            expect(objectUtils.areEqual(trackList[0], track)).to.be.true; // jshint ignore:line
+            expect(trackList).to.have.lengthOf(2);
+            expect(objectUtils.areEqual(trackList[0], frTrack)).to.be.true; // jshint ignore:line
+            expect(objectUtils.areEqual(trackList[1], qtzTrack)).to.be.true; // jshint ignore:line
 
             let currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
-            expect(objectUtils.areEqual(currentTrack, track)).to.be.false; // jshint ignore:line
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.false; // jshint ignore:line
 
             // call to setInitialMediaSettingsForType
             mediaController.setInitialSettings(trackType, {
-                lang: 'fr|en|qtz',
+                lang: /fr|en|qtz/,
                 viewpoint: 'viewpoint'
             });
             mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
 
             currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
-            expect(objectUtils.areEqual(currentTrack, track)).to.be.true; // jshint ignore:line
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.true; // jshint ignore:line
         });
 
         it('should check initial media settings to choose initial track with a regex lang', function () {
-            const streamInfo = {
-                id: 'id'
-            };
-            const frTrack = {
-                type: trackType,
-                streamInfo: streamInfo,
-                lang: 'fr',
-                viewpoint: 'viewpoint',
-                roles: 1,
-                accessibility: 1,
-                audioChannelConfiguration: 1
-            };
-            const qtzTrack = {
-                type: trackType,
-                streamInfo: streamInfo,
-                lang: 'qtz',
-                viewpoint: 'viewpoint',
-                roles: 1,
-                accessibility: 1,
-                audioChannelConfiguration: 1
-            };
-
             mediaController.addTrack(frTrack);
             mediaController.addTrack(qtzTrack);
 


### PR DESCRIPTION
* adding BCP-47 module
* use BCP-47 extended filter in settings matcher

- [] create unit test
- [] resolve test error (from 'npm test')