### PR TITLE
Fix jumping gaps at the beginning of a period when seamless switch is impossible

### DIFF
--- a/src/streaming/controllers/GapController.js
+++ b/src/streaming/controllers/GapController.js
@@ -348,11 +348,8 @@ function GapController() {
             const timeUntilGapEnd = seekToPosition - currentTime;
 
             if (jumpToStreamEnd) {
-                const nextStream = streamController.getStreamForTime(seekToPosition);
-                const internalSeek = nextStream && !!nextStream.getPreloaded();
-
                 logger.warn(`Jumping to end of stream because of gap from ${currentTime} to ${seekToPosition}. Gap duration: ${timeUntilGapEnd}`);
-                playbackController.seek(seekToPosition, true, internalSeek);
+                playbackController.seek(seekToPosition, true, false);
             } else {
                 const isDynamic = playbackController.getIsDynamic();
                 const start = nextRangeIndex > 0 ? ranges.end(nextRangeIndex - 1) : currentTime;


### PR DESCRIPTION
This addresses #4010. I am not sure if there are no side effects in some special cases, but this solves the problem in my streams. I haven't seen any problems with seeking after this change yet. The idea here is to disable `internalSeek` to keep the GapController running.