### PR TITLE
WPE fix: Avoid pruning buffered ranges already enqueued for playback

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -103,7 +103,8 @@ import Events from './events/Events';
  *                longFormContentDurationThreshold: 600,
  *                stallThreshold: 0.5,
  *                useAppendWindow: true,
- *                setStallState: true
+ *                setStallState: true,
+ *                avoidCurrentTimeRangePruning: false
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -304,6 +305,10 @@ import Events from './events/Events';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
  * Specifies if we fire manual waiting events once the stall threshold is reached
+ * @property {boolean} [avoidCurrentTimeRangePruning=false]
+ * Avoids pruning of the buffered range that contains the current playback time.
+ *
+ * That buffered range is likely to have been enqueued for playback. Pruning it causes a flush and reenqueue in WPE and WebKitGTK based browsers. This stresses the video decoder and can cause stuttering on embedded platforms.
  */
 
 /**
@@ -801,7 +806,8 @@ function Settings() {
                 longFormContentDurationThreshold: 600,
                 stallThreshold: 0.3,
                 useAppendWindow: true,
-                setStallState: true
+                setStallState: true,
+                avoidCurrentTimeRangePruning: false
             },
             gaps: {
                 jumpGaps: true,


### PR DESCRIPTION
In WPE WebKit (a WebKit-based embedded browser used in many commercial set-top-boxes), the buffered range of the currentTime has high chances to have been internally enqueued for playback (an action that can't be undone, there's no way to unenqueue other than flushing the whole playback pipeline). If that range is pruned, an internal flush is triggered, but in order to keep playing from the currentTime onwards, the needed samples must be enqueued again at least since the previous sync sample. This can cause a lot of stress to the video decoder and generate stuttering.

This patch solves the problem by avoiding pruning (deleting) ranges belonging to the same buffered range where the currentTime (or seek target) is. This only applies to WebKit based browsers.

See also: https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/871