### PR TITLE
Add feature support for Common Media Server Data

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -283,6 +283,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     // Starting Options
     $scope.autoPlaySelected = true;
     $scope.cmcdEnabled = false;
+    $scope.cmsdEnabled = false;
     $scope.loopSelected = true;
     $scope.scheduleWhilePausedSelected = true;
     $scope.calcSegmentAvailabilityRangeFromTimelineSelected = false;
@@ -878,6 +879,16 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             'streaming': {
                 'cmcd': {
                     'enabled': $scope.cmcdEnabled
+                }
+            }
+        });
+    };
+
+    $scope.toggleCmsdEnabled = function () {
+        $scope.player.updateSettings({
+            'streaming': {
+                'cmsd': {
+                    'enabled': $scope.cmsdEnabled
                 }
             }
         });

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -835,6 +835,17 @@
                        ng-change="updateCmcdEnabledKeys()">
             </div>
         </div>
+        <div class="options-item">
+            <div class="options-item-title">CMSD</div>
+            <div class="options-item-body">
+                <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                       title="Enables parsing of CMSD response header parameters">
+                    <input type="checkbox" ng-model="cmsdEnabled" ng-change="toggleCmsdEnabled()"
+                           ng-checked="cmsdEnabled">
+                    Enable CMSD Parsing
+                </label>
+            </div>
+        </div>
 
     </div>
 

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -213,6 +213,9 @@ import Events from './events/Events';
  *                rtpSafetyFactor: 5,
  *                mode: Constants.CMCD_MODE_QUERY,
  *                enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v']
+ *            },
+ *            cmsd: {
+ *                enabled: false
  *            }
  *          },
  *          errors: {
@@ -655,6 +658,12 @@ import Events from './events/Events';
  */
 
 /**
+ * @typedef {Object} module:Settings~CmsdSettings
+ * @property {boolean} [enabled=false]
+ * Enable or disable the CMSD parsing.
+ */
+
+/**
  * @typedef {Object} Metrics
  * @property {number} [metricsMaxListDepth=100]
  * Maximum number of metrics that are persisted per type.
@@ -752,6 +761,8 @@ import Events from './events/Events';
  * Adaptive Bitrate algorithm related settings.
  * @property {module:Settings~CmcdSettings} cmcd
  * Settings related to Common Media Client Data reporting.
+ * @property {module:Settings~CmsdSettings} cmsd
+ * Settings related to Common Media Server Data parsing.
  */
 
 
@@ -966,6 +977,9 @@ function Settings() {
                 rtpSafetyFactor: 5,
                 mode: Constants.CMCD_MODE_QUERY,
                 enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v']
+            },
+            cmsd: {
+                enabled: false
             }
         },
         errors: {

--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -46,6 +46,7 @@ class CoreEvents extends EventsBase {
         this.BYTES_APPENDED_END_FRAGMENT = 'bytesAppendedEndFragment';
         this.BUFFER_REPLACEMENT_STARTED = 'bufferReplacementStarted';
         this.CHECK_FOR_EXISTENCE_COMPLETED = 'checkForExistenceCompleted';
+        this.CMSD_STATIC_HEADER = 'cmsdStaticHeader';
         this.CURRENT_TRACK_CHANGED = 'currentTrackChanged';
         this.DATA_UPDATE_COMPLETED = 'dataUpdateCompleted';
         this.INBAND_EVENTS = 'inbandEvents';

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -52,6 +52,7 @@ import AbrController from './controllers/AbrController';
 import SchemeLoaderFactory from './net/SchemeLoaderFactory';
 import VideoModel from './models/VideoModel';
 import CmcdModel from './models/CmcdModel';
+import CmsdModel from './models/CmsdModel';
 import DOMStorage from './utils/DOMStorage';
 import Debug from './../core/Debug';
 import Errors from './../core/errors/Errors';
@@ -159,6 +160,7 @@ function MediaPlayer() {
         dashMetrics,
         manifestModel,
         cmcdModel,
+        cmsdModel,
         videoModel,
         uriFragmentModel,
         domStorage,
@@ -337,6 +339,8 @@ function MediaPlayer() {
             manifestModel = ManifestModel(context).getInstance();
 
             cmcdModel = CmcdModel(context).getInstance();
+
+            cmsdModel = CmsdModel(context).getInstance();
 
             dashMetrics = DashMetrics(context).getInstance({
                 settings: settings
@@ -2053,6 +2057,7 @@ function MediaPlayer() {
         }
         textController.reset();
         cmcdModel.reset();
+        cmsdModel.reset();
     }
 
     function _createPlaybackControllers() {
@@ -2140,6 +2145,7 @@ function MediaPlayer() {
             domStorage,
             mediaPlayerModel,
             customParametersModel,
+            cmsdModel,
             dashMetrics,
             adapter,
             videoModel,
@@ -2151,6 +2157,8 @@ function MediaPlayer() {
             dashMetrics,
             playbackController
         });
+
+        cmsdModel.setConfig({});
 
         contentSteeringController.setConfig({
             adapter,
@@ -2170,6 +2178,7 @@ function MediaPlayer() {
         gapController.initialize();
         catchupController.initialize();
         cmcdModel.initialize();
+        cmsdModel.initialize();
         contentSteeringController.initialize();
         segmentBaseController.initialize();
     }

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -73,6 +73,7 @@ function AbrController() {
         videoModel,
         mediaPlayerModel,
         customParametersModel,
+        cmsdModel,
         domStorage,
         playbackIndex,
         switchHistoryDict,
@@ -243,6 +244,9 @@ function AbrController() {
         if (config.customParametersModel) {
             customParametersModel = config.customParametersModel;
         }
+        if (config.cmsdModel) {
+            cmsdModel = config.cmsdModel
+        }
         if (config.dashMetrics) {
             dashMetrics = config.dashMetrics;
         }
@@ -366,6 +370,7 @@ function AbrController() {
             }
 
             idx = _checkMaxBitrate(type, streamId);
+            idx = _checkCmsdMaxBitrate(idx, type, streamId);
             idx = _checkMaxRepresentationRatio(idx, type, streamId);
             idx = _checkPortalSize(idx, type, streamId);
             return idx;
@@ -459,6 +464,22 @@ function AbrController() {
         }
 
         return newIdx;
+    }
+
+    /**
+     * Returns the maximum possible index from CMSD model
+     * @param type
+     * @param streamId
+     * @return {number|*}
+     */
+    function _checkCmsdMaxBitrate(idx, type, streamId) {
+        const maxCmsdBitrate = cmsdModel.getMaxBitrate(type);
+        if (maxCmsdBitrate < 0) {
+            return idx;
+        }
+        logger.info('Stream ID: ' + streamId + ' [' + type + '] Apply max bit rate from CMSD: ' + maxCmsdBitrate);
+        const maxIdx = getQualityForBitrate(streamProcessorDict[streamId][type].getMediaInfo(), maxCmsdBitrate, streamId);
+        return Math.min(idx, maxIdx);
     }
 
     /**

--- a/src/streaming/models/CmsdModel.js
+++ b/src/streaming/models/CmsdModel.js
@@ -1,0 +1,218 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2022, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker';
+import EventBus from '../../core/EventBus';
+import Events from '../../core/events/Events';
+import Debug from '../../core/Debug';
+
+// Note: in modern browsers, the header names are returned in all lower case
+const CMSD_STATIC = 'static';
+const CMSD_DYNAMIC = 'dynamic';
+const CMSD_RESPONSE_FIELD_BASENAME = 'cmsd-';
+const CMSD_STATIC_RESPONSE_FIELD_NAME = CMSD_RESPONSE_FIELD_BASENAME + CMSD_STATIC;
+const CMSD_DYNAMIC_RESPONSE_FIELD_NAME = CMSD_RESPONSE_FIELD_BASENAME + CMSD_DYNAMIC;
+const OBJECT_TYPES = {
+    MANIFEST: 'm',
+    AUDIO: 'a',
+    VIDEO: 'v',
+    INIT: 'i',
+    CAPTION: 'c',
+    ISOBMFF_TEXT_TRACK: 'tt',
+    ENCRYPTION_KEY: 'k',
+    OTHER: 'o'
+};
+// const STREAMING_FORMATS = {
+//     DASH: 'd',
+//     HLS: 'h',
+//     MSS: 's',
+//     OTHER: 'o'
+// };
+// const STREAM_TYPES = {
+//     VOD: 'v',
+//     LIVE: 'l'
+// };
+
+const MEDIATYPE_TO_OBJECTTYPE = {
+    'video': OBJECT_TYPES.VIDEO,
+    'audio': OBJECT_TYPES.AUDIO,
+    'text': OBJECT_TYPES.ISOBMFF_TEXT_TRACK
+}
+
+const integerRegex = /^[-0-9]/
+
+function CmsdModel() {
+
+    const context = this.context;
+    const eventBus = EventBus(context).getInstance();
+
+    let instance,
+        logger,
+        _staticParamsDict,
+        _dynamicParamsDict;
+
+    function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
+        _resetInitialSettings();
+    }
+
+    function initialize() {}
+
+    function setConfig(/*config*/) {}
+
+    function _resetInitialSettings() {
+        _staticParamsDict = {};
+        _dynamicParamsDict = {};
+    }
+
+    function _parseParameterValue(value) {
+        // If the value type is BOOLEAN and the value is TRUE, then the equals sign and the value are omitted
+        if (!value) {
+            return true;
+        }
+        // Check if boolean 'false'
+        if (value.toLowerCase() === 'false') {
+            return false;
+        }
+        // Check if a number
+        if (integerRegex.test(value)) {
+            return parseInt(value, 10);
+        }
+        // Value is a string, remove double quotes from string value
+        return value.replace(/["]+/g, '');   
+    }
+
+    function _parseCMSDStatic(value) {
+        try {
+            const params = {};
+            const items = value.split(',');
+            for (let i = 0; i < items.length; i++) {
+                // <key>=<value>
+                const substrs = items[i].split('=');
+                const key = substrs[0];
+                const v = _parseParameterValue(substrs[1]);
+                params[key] = v;
+            }
+            return params;
+        } catch (e) {
+            logger.error('Failed to parse CMSD-Static response header value:', e);
+        }
+    }
+
+    function _parseCMSDDynamic(value) {
+        try {
+            const params = {};
+            const entries = value.split(',');
+            // Consider only last CMSD-Dynamic entry
+            const entry = entries[entries.length - 1];
+            const items = entry.split(';');
+            // Server identifier as 1st item
+            for (let i = 1; i < items.length; i++) {
+                // <key>=<value>
+                const substrs = items[i].split('=');
+                const key = substrs[0];
+                const v = _parseParameterValue(substrs[1]);
+                params[key] = v;
+            }
+            return params;
+        } catch (e) {
+            logger.error('Failed to parse CMSD-Dynamic response header value:', e);
+            return [];
+        }
+    }
+
+    function _mediaTypetoObjectType(mediaType) {
+        return MEDIATYPE_TO_OBJECTTYPE[mediaType] || OBJECT_TYPES.OTHER;
+    }
+
+    function _getParamValueForObjectType(paramsType, ot, key) {
+        const params = paramsType === CMSD_STATIC ? _staticParamsDict : _dynamicParamsDict;
+        const paramsForOT = params[ot] || params[OBJECT_TYPES.OTHER];
+        const value = paramsForOT[key] || params[OBJECT_TYPES.OTHER][key];
+        return value;
+    }
+
+    function parseResponseHeaders(responseHeaders) {
+        let staticParams = {};
+        let dynamicParams = {};
+        const headerArray = responseHeaders.split('\r\n');
+        for (let header of headerArray) {
+            let m = header.match(/^(?<key>[^:]*):\s*(?<value>.*)$/);
+            if (m && m.groups) {
+                // Note: in modern browsers, the header names are returned in all lower case
+                let key = m.groups.key.toLowerCase(),
+                    value = m.groups.value;
+                switch (key) {
+                    case CMSD_STATIC_RESPONSE_FIELD_NAME:
+                        staticParams = _parseCMSDStatic(value);
+                        eventBus.trigger(Events.CMSD_STATIC_HEADER, staticParams);
+                        break;
+                    case CMSD_DYNAMIC_RESPONSE_FIELD_NAME:
+                        dynamicParams = _parseCMSDDynamic(value);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // Get object type
+        const ot = staticParams['ot'] || OBJECT_TYPES.OTHER;
+
+        // Merge params with previously received params 
+        _staticParamsDict[ot] = Object.assign(_staticParamsDict[ot] || {}, staticParams);
+        _dynamicParamsDict[ot] = Object.assign(_dynamicParamsDict[ot] || {}, dynamicParams);
+    }
+
+    function getMaxBitrate(type) {
+        let ot = _mediaTypetoObjectType(type);
+        let mb = _getParamValueForObjectType(CMSD_DYNAMIC, ot, 'mb');
+        return mb ? mb : -1
+    }
+
+    function reset() {
+        _resetInitialSettings();
+    }
+
+    instance = {
+        setConfig,
+        initialize,
+        reset,
+        parseResponseHeaders,
+        getMaxBitrate
+    };
+
+    setup();
+
+    return instance;
+}
+
+CmsdModel.__dashjs_factory_name = 'CmsdModel';
+export default FactoryMaker.getSingletonFactory(CmsdModel);

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -34,6 +34,7 @@ import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 import FactoryMaker from '../../core/FactoryMaker';
 import DashJSError from '../vo/DashJSError';
 import CmcdModel from '../models/CmcdModel';
+import CmsdModel from '../models/CmsdModel';
 import Utils from '../../core/Utils';
 import Debug from '../../core/Debug';
 import EventBus from '../../core/EventBus';
@@ -70,6 +71,7 @@ function HTTPLoader(cfg) {
         retryRequests,
         downloadErrorToRequestTypeMap,
         cmcdModel,
+        cmsdModel,
         customParametersModel,
         lowLatencyThroughputModel,
         logger;
@@ -80,6 +82,7 @@ function HTTPLoader(cfg) {
         delayedRequests = [];
         retryRequests = [];
         cmcdModel = CmcdModel(context).getInstance();
+        cmsdModel = CmsdModel(context).getInstance();
         lowLatencyThroughputModel = LowLatencyThroughputModel(context).getInstance();
         customParametersModel = CustomParametersModel(context).getInstance();
 
@@ -122,6 +125,10 @@ function HTTPLoader(cfg) {
                 const responseStatus = httpRequest.response ? httpRequest.response.status : null;
                 const responseHeaders = httpRequest.response && httpRequest.response.getAllResponseHeaders ? httpRequest.response.getAllResponseHeaders() :
                     httpRequest.response ? httpRequest.response.responseHeaders : [];
+
+                if (settings.get().streaming.cmsd && settings.get().streaming.cmsd.enabled) {
+                    cmsdModel.parseResponseHeaders(responseHeaders);
+                }
 
                 dashMetrics.addHttpRequest(request, responseUrl, responseStatus, responseHeaders, success ? traces : null);
 


### PR DESCRIPTION
This PR adds support for CMSD (Common Media Server Data) parsing from response headers.
See #4071 

At this stage, what has been implemented:

-  CMSD response headers parsing
- If the "mb" Max-suggested-bitrate is present, then that value is used as an upper-bound for the ABR algorithm
- Add option in reference sample to enable/disable CMSD parsing

Waiting for a test stream and CMSD aware server, it is possible de test by using some browser plugin to manually add response headers.
As an example, the chrome plugin ModHeader (https://chrome.google.com/webstore/detail/modheader-modify-http-hea/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=fr) can be used, in which we can add specific response headers, including the header "Access-Control-Expose-Headers: CMSD-Static, CMSD-Dynamic" to get around CORS issues:

![image](https://user-images.githubusercontent.com/5312520/205265560-9483e411-973f-4632-93e2-f0050b7ee225.png)

