### PR TITLE
Fix timescale inconsistency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,7 @@ declare namespace dashjs {
             cacheInitSegments?: boolean,
             eventControllerRefreshDelay?: number,
             enableManifestDurationMismatchFix?: boolean,
+            enableManifestTimescaleMismatchFix?: boolean,
             capabilities?: {
                 filterUnsupportedEssentialProperties?: boolean,
                 useMediaCapabilitiesApi?: boolean

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -68,6 +68,7 @@ import Events from './events/Events';
  *            applyContentSteering: true,
  *            eventControllerRefreshDelay: 100,
  *            enableManifestDurationMismatchFix: true,
+ *            enableManifestTimescaleMismatchFix: false,
  *            capabilities: {
  *               filterUnsupportedEssentialProperties: true,
  *               useMediaCapabilitiesApi: false
@@ -681,6 +682,8 @@ import Events from './events/Events';
  * @property {number} [eventControllerRefreshDelay=100]
  * For multi-period streams, overwrite the manifest mediaPresentationDuration attribute with the sum of period durations if the manifest mediaPresentationDuration is greater than the sum of period durations
  * @property {boolean} [enableManifestDurationMismatchFix=true]
+ * Overwrite the manifest segments base information timescale attributes with the timescale set in initialization segments
+ * @property {boolean} [enableManifestTimescaleMismatchFix=false]
  * Defines the delay in milliseconds between two consecutive checks for events to be fired.
  * @property {module:Settings~Metrics} metrics Metric settings
  * @property {module:Settings~LiveDelay} delay Live Delay settings
@@ -791,6 +794,7 @@ function Settings() {
             applyContentSteering: true,
             eventControllerRefreshDelay: 100,
             enableManifestDurationMismatchFix: true,
+            enableManifestTimescaleMismatchFix: false,
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
                 useMediaCapabilitiesApi: false

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -96,6 +96,7 @@ function StreamProcessor(config) {
         eventBus.on(Events.DATA_UPDATE_COMPLETED, _onDataUpdateCompleted, instance, { priority: EventBus.EVENT_PRIORITY_HIGH }); // High priority to be notified before Stream
         eventBus.on(Events.INIT_FRAGMENT_NEEDED, _onInitFragmentNeeded, instance);
         eventBus.on(Events.MEDIA_FRAGMENT_NEEDED, _onMediaFragmentNeeded, instance);
+        eventBus.on(Events.INIT_FRAGMENT_LOADED, _onInitFragmentLoaded, instance);
         eventBus.on(Events.MEDIA_FRAGMENT_LOADED, _onMediaFragmentLoaded, instance);
         eventBus.on(Events.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.on(Events.BUFFER_CLEARED, _onBufferCleared, instance);
@@ -954,6 +955,18 @@ function StreamProcessor(config) {
         );
 
         return request;
+    }
+
+    function _onInitFragmentLoaded(e) {
+        const chunk = e.chunk;
+        const bytes = chunk.bytes;
+        const quality = chunk.quality;
+        const currentRepresentation = getRepresentationInfo(quality);
+        const voRepresentation = representationController && currentRepresentation ? representationController.getRepresentationForQuality(currentRepresentation.quality) : null;
+        if (currentRepresentation && voRepresentation) {
+            const timescale = boxParser.getMediaTimescaleFromMoov(bytes);
+            voRepresentation.timescale = timescale;
+        }
     }
 
     function _onMediaFragmentLoaded(e) {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -241,6 +241,7 @@ function StreamProcessor(config) {
         eventBus.off(Events.DATA_UPDATE_COMPLETED, _onDataUpdateCompleted, instance);
         eventBus.off(Events.INIT_FRAGMENT_NEEDED, _onInitFragmentNeeded, instance);
         eventBus.off(Events.MEDIA_FRAGMENT_NEEDED, _onMediaFragmentNeeded, instance);
+        eventBus.off(Events.INIT_FRAGMENT_LOADED, _onInitFragmentLoaded, instance);
         eventBus.off(Events.MEDIA_FRAGMENT_LOADED, _onMediaFragmentLoaded, instance);
         eventBus.off(Events.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.off(Events.BUFFER_CLEARED, _onBufferCleared, instance);
@@ -958,6 +959,9 @@ function StreamProcessor(config) {
     }
 
     function _onInitFragmentLoaded(e) {
+        if (!settings.get().streaming.enableManifestTimescaleMismatchFix) {
+            return;
+        }
         const chunk = e.chunk;
         const bytes = chunk.bytes;
         const quality = chunk.quality;

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -36,7 +36,6 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
-import BoxParser from '../utils/BoxParser';
 import InitCache from '../utils/InitCache';
 import DashJSError from '../vo/DashJSError';
 import Errors from '../../core/errors/Errors';
@@ -67,7 +66,6 @@ function BufferController(config) {
 
     let instance,
         logger,
-        boxParser,
         isBufferingCompleted,
         bufferLevel,
         criticalBufferLevel,
@@ -88,7 +86,6 @@ function BufferController(config) {
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
-        boxParser = BoxParser(context).getInstance();
         initCache = InitCache(context).getInstance();
 
         resetInitialSettings();
@@ -211,13 +208,6 @@ function BufferController(config) {
         }
         logger.debug('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality, ', data size:', e.chunk.bytes.byteLength);
         _appendToBuffer(e.chunk);
-
-        // Check timescale from init segment (in case different from manifest)
-        const timescale = boxParser.getMediaTimescaleFromMoov(e.chunk.bytes);
-        const representationInfo = representationController.getRepresentationForQuality(e.chunk.quality);
-        if (representationInfo) {
-            representationInfo.timescale = timescale;
-        }
     }
 
     /**

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -36,6 +36,7 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import FactoryMaker from '../../core/FactoryMaker';
 import Debug from '../../core/Debug';
+import BoxParser from '../utils/BoxParser';
 import InitCache from '../utils/InitCache';
 import DashJSError from '../vo/DashJSError';
 import Errors from '../../core/errors/Errors';
@@ -66,6 +67,7 @@ function BufferController(config) {
 
     let instance,
         logger,
+        boxParser,
         isBufferingCompleted,
         bufferLevel,
         criticalBufferLevel,
@@ -86,6 +88,7 @@ function BufferController(config) {
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
+        boxParser = BoxParser(context).getInstance();
         initCache = InitCache(context).getInstance();
 
         resetInitialSettings();
@@ -208,6 +211,13 @@ function BufferController(config) {
         }
         logger.debug('Append Init fragment', type, ' with representationId:', e.chunk.representationId, ' and quality:', e.chunk.quality, ', data size:', e.chunk.bytes.byteLength);
         _appendToBuffer(e.chunk);
+
+        // Check timescale from init segment (in case different from manifest)
+        const timescale = boxParser.getMediaTimescaleFromMoov(e.chunk.bytes);
+        const representationInfo = representationController.getRepresentationForQuality(e.chunk.quality);
+        if (representationInfo) {
+            representationInfo.timescale = timescale;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue when timescale in manifest differs from timescale in init segments.
This inconsistency can be reproduced using ffmpeg with SegmentTemplate mode: https://trac.ffmpeg.org/ticket/10134
Even though this inconsistency is not conformed to DASH spec, this PR adds robustness to get around this issue.

Test stream that encounters this issue: https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd
