### PR TITLE
Corrected fallback responseHeaders value to be `null`

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -121,7 +121,7 @@ function HTTPLoader(cfg) {
                 const responseUrl = httpRequest.response ? httpRequest.response.responseURL : null;
                 const responseStatus = httpRequest.response ? httpRequest.response.status : null;
                 const responseHeaders = httpRequest.response && httpRequest.response.getAllResponseHeaders ? httpRequest.response.getAllResponseHeaders() :
-                    httpRequest.response ? httpRequest.response.responseHeaders : [];
+                    httpRequest.response ? httpRequest.response.responseHeaders : null;
 
                 dashMetrics.addHttpRequest(request, responseUrl, responseStatus, responseHeaders, success ? traces : null);
 


### PR DESCRIPTION
- The return value should match that of the function [`XMLHttpRequest.getAllResponseHeaders()`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders) which returns a string of valid headers, or `null` if no response headers have been received, or empty string on a network error.
- The existing fallback return value (`[]`) would lead to an error when passed to `Utils.parseHttpHeaders()`