### PR TITLE
chore: Update IMSC.js version to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "es6-promise": "^4.2.8",
                 "fast-deep-equal": "2.0.1",
                 "html-entities": "^1.2.1",
-                "imsc": "^1.0.2",
+                "imsc": "^1.1.3",
                 "localforage": "^1.7.1",
                 "path-browserify": "^1.0.1",
                 "ua-parser-js": "^1.0.2"
@@ -9654,9 +9654,9 @@
             }
         },
         "node_modules/imsc": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.0.2.tgz",
-            "integrity": "sha512-oxQWr4g2bAzjz5TIXA4K+9xQ4nnktsDI12/nijLQ42lT5c76JO7A8i9pbVkC8MUNQl3sd+bdwshnxB1Wn8lZlQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.3.tgz",
+            "integrity": "sha512-IY0hMkVTNoqoYwKEp5UvNNKp/A5jeJUOrIO7judgOyhHT+xC6PA4VBOMAOhdtAYbMRHx9DTgI8p6Z6jhYQPFDA==",
             "dependencies": {
                 "sax": "1.2.1"
             }
@@ -25924,9 +25924,9 @@
             }
         },
         "imsc": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.0.2.tgz",
-            "integrity": "sha512-oxQWr4g2bAzjz5TIXA4K+9xQ4nnktsDI12/nijLQ42lT5c76JO7A8i9pbVkC8MUNQl3sd+bdwshnxB1Wn8lZlQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.3.tgz",
+            "integrity": "sha512-IY0hMkVTNoqoYwKEp5UvNNKp/A5jeJUOrIO7judgOyhHT+xC6PA4VBOMAOhdtAYbMRHx9DTgI8p6Z6jhYQPFDA==",
             "requires": {
                 "sax": "1.2.1"
             }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "es6-promise": "^4.2.8",
         "fast-deep-equal": "2.0.1",
         "html-entities": "^1.2.1",
-        "imsc": "^1.0.2",
+        "imsc": "^1.1.3",
         "localforage": "^1.7.1",
         "path-browserify": "^1.0.1",
         "ua-parser-js": "^1.0.2"


### PR DESCRIPTION
Resolves #3371.

I have tested that dash.js build and tests pass successfully with version 1.1.3 of imsc.js.
I have locally packaged a new version of dash.js and tested that subtitles still work on a couple of our test streams that include EBU-TT-D subtitles.