### PR TITLE
Fix: changeType() is Not Fully Implemented on Sony PS5

### DIFF
--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -83,7 +83,10 @@ function SourceBufferSink(config) {
 
         promises.push(_abortBeforeAppend());
         promises.push(updateAppendWindow(mediaInfo.streamInfo));
-        promises.push(changeType(codec));
+
+        if (settings.get().streaming.buffer.useChangeTypeForTrackSwitch) {
+            promises.push(changeType(codec));
+        }
 
         if (selectedRepresentation && selectedRepresentation.MSETimeOffset !== undefined) {
             promises.push(updateTimestampOffset(selectedRepresentation.MSETimeOffset));

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -482,7 +482,7 @@ function StreamController() {
                 // check if change type is supported by the browser
                 if (sinks) {
                     const keys = Object.keys(sinks);
-                    if (keys.length > 0 && sinks[keys[0]].getBuffer().changeType && settings.get().streaming.buffer.useChangeTypeForTrackSwitch) {
+                    if (keys.length > 0 && sinks[keys[0]].getBuffer().changeType) {
                         supportsChangeType = true;
                     }
                     bufferSinks = sinks;
@@ -622,7 +622,7 @@ function StreamController() {
             // Seamless period switch allowed only if:
             // - none of the periods uses contentProtection.
             // - AND changeType method implemented by browser or periods use the same codec.
-            return (settings.get().streaming.buffer.reuseExistingSourceBuffers && (previousStream.isProtectionCompatible(nextStream) || firstLicenseIsFetched) && (supportsChangeType || previousStream.isMediaCodecCompatible(nextStream, previousStream)));
+            return (settings.get().streaming.buffer.reuseExistingSourceBuffers && (previousStream.isProtectionCompatible(nextStream) || firstLicenseIsFetched) && (supportsChangeType && settings.get().streaming.buffer.useChangeTypeForTrackSwitch || previousStream.isMediaCodecCompatible(nextStream, previousStream)));
         } catch (e) {
             return false;
         }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -482,7 +482,7 @@ function StreamController() {
                 // check if change type is supported by the browser
                 if (sinks) {
                     const keys = Object.keys(sinks);
-                    if (keys.length > 0 && sinks[keys[0]].getBuffer().changeType) {
+                    if (keys.length > 0 && sinks[keys[0]].getBuffer().changeType && settings.get().streaming.buffer.useChangeTypeForTrackSwitch) {
                         supportsChangeType = true;
                     }
                     bufferSinks = sinks;


### PR DESCRIPTION
Fixes [issue/4148](https://github.com/Dash-Industry-Forum/dash.js/issues/4148) by offering client an option to use `useChangeTypeForTrackSwitch` flag to avoid errors involving changeType() not being supported on certain platforms.  