### PR TITLE
Fix styling of embedded WebVTT cues by adding support for sttg box

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dependencies": {
         "bcp-47-match": "^1.0.3",
         "bcp-47-normalize": "^1.1.1",
-        "codem-isoboxer": "0.3.8",
+        "codem-isoboxer": "0.3.9",
         "es6-promise": "^4.2.8",
         "fast-deep-equal": "2.0.1",
         "html-entities": "^1.2.1",

--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -188,7 +188,8 @@ function VTTParser() {
     }
 
     instance = {
-        parse: parse
+        parse: parse,
+        getCaptionStyles
     };
 
     setup();


### PR DESCRIPTION
Fix styling of embedded WebVTT cues by adding support for sttg box. Requires addition of the `sttg` box to Isoboxer, see https://github.com/Dash-Industry-Forum/codem-isoboxer/pull/54