### PR TITLE
allow setting startTime on preload and attachView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1185,13 +1185,13 @@ declare namespace dashjs {
 
         extend(parentNameString: string, childInstance: object, override: boolean): void;
 
-        attachView(element: HTMLElement): void;
+        attachView(element: HTMLElement, startTime?: number | string): void;
 
         attachSource(urlOrManifest: string | object, startTime?: number | string): void;
 
         isReady(): boolean;
 
-        preload(): void;
+        preload(startTime?: number | string): void;
 
         play(): void;
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -541,18 +541,23 @@ function MediaPlayer() {
      * method in preparation for playing. It specifically does not require a view to be attached with {@link module:MediaPlayer#attachSource attachView()} to begin preloading.
      * When a view is attached after preloading, the buffered data is transferred to the attached mediaSource buffers.
      *
+     * @param {number|string} startTime - For VoD content the start time is relative to the start time of the first period.
+     * For live content
+     * If the parameter starts from prefix posix: it signifies the absolute time range defined in seconds of Coordinated Universal Time (ITU-R TF.460-6). This is the number of seconds since 01-01-1970 00:00:00 UTC. Fractions of seconds may be optionally specified down to the millisecond level.
+     * If no posix prefix is used the starttime is relative to MPD@availabilityStartTime
+     *
      * @see {@link module:MediaPlayer#attachSource attachSource()}
      * @see {@link module:MediaPlayer#attachView attachView()}
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~SOURCE_NOT_ATTACHED_ERROR SOURCE_NOT_ATTACHED_ERROR} if called before attachSource function
      * @instance
      */
-    function preload() {
+    function preload(startTime = NaN) {
         if (videoModel.getElement() || streamingInitialized) {
             return;
         }
         if (source) {
-            _initializePlayback();
+            _initializePlayback(startTime);
         } else {
             throw SOURCE_NOT_ATTACHED_ERROR;
         }
@@ -1410,11 +1415,16 @@ function MediaPlayer() {
      * Use this method to attach an HTML5 VideoElement for dash.js to operate upon.
      *
      * @param {Object} element - An HTMLMediaElement that has already been defined in the DOM (or equivalent stub).
+     * @param {number|string} startTime - For VoD content the start time is relative to the start time of the first period.
+     * For live content
+     * If the parameter starts from prefix posix: it signifies the absolute time range defined in seconds of Coordinated Universal Time (ITU-R TF.460-6). This is the number of seconds since 01-01-1970 00:00:00 UTC. Fractions of seconds may be optionally specified down to the millisecond level.
+     * If no posix prefix is used the starttime is relative to MPD@availabilityStartTime
+     *
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~MEDIA_PLAYER_NOT_INITIALIZED_ERROR MEDIA_PLAYER_NOT_INITIALIZED_ERROR} if called before initialize function
      * @instance
      */
-    function attachView(element) {
+    function attachView(element, startTime = NaN) {
         if (!mediaPlayerInitialized) {
             throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
         }
@@ -1435,7 +1445,7 @@ function MediaPlayer() {
             _resetPlaybackControllers();
         }
 
-        _initializePlayback();
+        _initializePlayback(startTime);
     }
 
     /**


### PR DESCRIPTION
right now `attachView` and `preload` would ignore `startTime` set on `initialize` and `attachSource`.

example:

```ts
player = dashjs.MediaPlayer().create();
player.initialize(null, url, true, 60);
player.preload();
// or
player.attachView();
```

this both would start playback and preload at the very beginning as if no `startTime` was set.

I would like to know if this PR has a chance of being merged if I add tests for it. Or if you have a better suggestion to solve the problem of preloading with offset, or autoplay after `attachView`