### PR TITLE
respect configuerd startTime in initialize and attachSource on preload and attachView

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -132,6 +132,7 @@ function MediaPlayer() {
         streamingInitialized,
         playbackInitialized,
         autoPlay,
+        providedStartTime,
         abrController,
         schemeLoaderFactory,
         timelineConverter,
@@ -552,7 +553,7 @@ function MediaPlayer() {
             return;
         }
         if (source) {
-            _initializePlayback();
+            _initializePlayback(providedStartTime);
         } else {
             throw SOURCE_NOT_ATTACHED_ERROR;
         }
@@ -1435,7 +1436,7 @@ function MediaPlayer() {
             _resetPlaybackControllers();
         }
 
-        _initializePlayback();
+        _initializePlayback(providedStartTime);
     }
 
     /**
@@ -1893,6 +1894,7 @@ function MediaPlayer() {
             startTime = Math.max(0, startTime);
         }
 
+        providedStartTime = startTime
         source = urlOrManifest;
 
         if (streamingInitialized || playbackInitialized) {
@@ -1900,7 +1902,7 @@ function MediaPlayer() {
         }
 
         if (isReady()) {
-            _initializePlayback(startTime);
+            _initializePlayback(providedStartTime);
         }
     }
 
@@ -2380,7 +2382,7 @@ function MediaPlayer() {
      *
      * @private
      */
-    function _initializePlayback(startTime = NaN) {
+    function _initializePlayback(startTime) {
 
         if (offlineController) {
             offlineController.resetRecords();


### PR DESCRIPTION
this is an alternate solution for #4159

right now `attachView` and `preload` would ignore `startTime` set on `initialize` and `attachSource`.

example:

```ts
player = dashjs.MediaPlayer().create();
player.initialize(null, url, true, 60);
player.preload();
// or
player.attachView();
```

this both would start playback and preload at the very beginning as if no `startTime` was set.

I would like to know if this PR has a chance of being merged if I add tests for it. Or if you have a better suggestion to solve the problem of preloading with offset, or autoplay after `attachView`