### PR TITLE
fix: VTT line styling failing, invalid snapToLines value

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -589,6 +589,9 @@ function TextTracks(config) {
                 if (currentItem.styles.line !== undefined && 'line' in cue) {
                     cue.line = currentItem.styles.line;
                 }
+                if (currentItem.styles.snapToLines !== undefined && 'snapToLines' in cue) {
+                    cue.snapToLines = currentItem.styles.snapToLines;
+                }
                 if (currentItem.styles.position !== undefined && 'position' in cue) {
                     cue.position = currentItem.styles.position;
                 }

--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -128,14 +128,19 @@ function VTTParser() {
         arr.forEach(function (element) {
             if (element.split(/:/).length > 1) {
                 let val = element.split(/:/)[1];
+                let isPercentage = false;
                 if (val && val.search(/%/) != -1) {
+                    isPercentage = true;
                     val = parseInt(val.replace(/%/, ''), 10);
                 }
                 if (element.match(/align/) || element.match(/A/)) {
                     styleObject.align = val;
                 }
                 if (element.match(/line/) || element.match(/L/) ) {
-                    styleObject.line = val;
+                    styleObject.line = val === 'auto' ? val : parseInt(val, 10);
+                    if (isPercentage) {
+                        styleObject.snapToLines = false;
+                    }
                 }
                 if (element.match(/position/) || element.match(/P/) ) {
                     styleObject.position = val;


### PR DESCRIPTION
Fixes two issues with the new VTT styling:

**Line**
https://developer.mozilla.org/en-US/docs/Web/API/VTTCue/line it's either a number or "auto". Setting it to a string number throws errors.

**snapToLines**
https://www.w3.org/TR/webvtt1/

> If the last character in linepos is a U+0025 PERCENT SIGN character (%), then let cue’s [WebVTT cue snap-to-lines flag](https://www.w3.org/TR/webvtt1/#webvtt-cue-snap-to-lines-flag) be false. Otherwise, let it be true.

It's true by default.