### PR TITLE
Fixing essentialProperties in ObjectIron

### DIFF
--- a/src/dash/parser/maps/RepresentationBaseValuesMap.js
+++ b/src/dash/parser/maps/RepresentationBaseValuesMap.js
@@ -37,7 +37,7 @@ import DashConstants from '../../constants/DashConstants';
 class RepresentationBaseValuesMap extends MapNode {
     constructor() {
         const commonProperties = [
-            DashConstants.PROFILES, DashConstants.WIDTH, DashConstants.HEIGHT, DashConstants.SAR, DashConstants.FRAMERATE, DashConstants.AUDIO_SAMPLING_RATE, DashConstants.MIME_TYPE, DashConstants.SEGMENT_PROFILES, DashConstants.CODECS, DashConstants.MAXIMUM_SAP_PERIOD, DashConstants.START_WITH_SAP, DashConstants.MAX_PLAYOUT_RATE, DashConstants.CODING_DEPENDENCY, DashConstants.SCAN_TYPE, DashConstants.FRAME_PACKING, DashConstants.AUDIO_CHANNEL_CONFIGURATION, DashConstants.CONTENT_PROTECTION, DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY, DashConstants.INBAND_EVENT_STREAM
+            DashConstants.PROFILES, DashConstants.WIDTH, DashConstants.HEIGHT, DashConstants.SAR, DashConstants.FRAMERATE, DashConstants.AUDIO_SAMPLING_RATE, DashConstants.MIME_TYPE, DashConstants.SEGMENT_PROFILES, DashConstants.CODECS, DashConstants.MAXIMUM_SAP_PERIOD, DashConstants.START_WITH_SAP, DashConstants.MAX_PLAYOUT_RATE, DashConstants.CODING_DEPENDENCY, DashConstants.SCAN_TYPE, DashConstants.FRAME_PACKING, DashConstants.AUDIO_CHANNEL_CONFIGURATION, DashConstants.CONTENT_PROTECTION, DashConstants.ESSENTIAL_PROPERTY, DashConstants.ESSENTIAL_PROPERTY+'_asArray', DashConstants.SUPPLEMENTAL_PROPERTY, DashConstants.INBAND_EVENT_STREAM
         ];
 
         super(DashConstants.ADAPTATION_SET, commonProperties, [


### PR DESCRIPTION
This addresses: https://github.com/Dash-Industry-Forum/dash.js/issues/4125

This is just a quick hack to get ObjectIron to process `EssentialProperty_asArray` in addition to `EssentialProperty`.

This is required since `DashManifestModel.js/getEssentialPropertiesForRepresentation() only processes `EssentialProperty_asArray`, but not `EssentialProperty`.

I have not checked whether any other entry in `commonProperties` suffers from the same issue.

@dsilhavy : Please comment on how to proceed with this issue - IMHO it would be good to get this fixed for V4.7.0.

(Note: I've not seen any unit test on ObjectIron at all.)
