### PR TITLE
Fix handling of MPDs containing SegmentList with SegmentTimeline

### DIFF
--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -313,8 +313,9 @@ function TimelineConverter() {
     function _calcRangeForTimeline(voRepresentation) {
         const adaptation = voRepresentation.adaptation.period.mpd.manifest.Period_asArray[voRepresentation.adaptation.period.index].AdaptationSet_asArray[voRepresentation.adaptation.index];
         const representation = dashManifestModel.getRepresentationFor(voRepresentation.index, adaptation);
-        const timeline = representation.SegmentTemplate.SegmentTimeline;
-        const timescale = representation.SegmentTemplate.timescale;
+        const base = representation.SegmentTemplate || representation.SegmentList;
+        const timeline = base.SegmentTimeline;
+        const timescale = base.timescale;
         const segments = timeline.S_asArray;
         const range = { start: 0, end: 0 };
         const segmentTime = segments[0].t;


### PR DESCRIPTION
The current code assumes that SegmentTimeline implies SegmentTemplate. SegmentList+SegmentTimeline combination, while rarely used, is still a valid MPD and should be supported. Thankfully, the fix is trivial.