### PR TITLE
Initial, fixed FragmentRequest 'type' typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4066,7 +4066,7 @@ declare namespace dashjs {
         serviceLocation: string;
         startTime: number;
         timescale: number;
-        type: 'InitializationSegment' | 'MediaSegment';
+        type: 'InitializationSegment' | 'MediaSegment' | null;
         url: string;
         wallStartTime: number | null;
     }


### PR DESCRIPTION
Fixed discrepancy of the "type" variable between the classes FragmentRequest and TextRequest in index.d.ts.