### PR TITLE
Fix throughput on abort

### DIFF
--- a/src/streaming/rules/abr/lolp/LoLpRule.js
+++ b/src/streaming/rules/abr/lolp/LoLpRule.js
@@ -145,7 +145,7 @@ function LoLPRule(config) {
             scheduleController.setTimeToLoadDelay(0);
 
             if (switchRequest.quality !== currentQuality) {
-                console.log('[TgcLearningRule][' + mediaType + '] requesting switch to index: ', switchRequest.quality, 'Average throughput', Math.round(throughput), 'kbps');
+                logger.debug('[TgcLearningRule][' + mediaType + '] requesting switch to index: ', switchRequest.quality, 'Average throughput', Math.round(throughput), 'kbps');
             }
 
             return switchRequest;


### PR DESCRIPTION
This PR is fixing throughput history by taking into account metrics of aborted requests.
In case of bandwidth dropping leading to aborted requests, this fix enables throughput rule to consider measured throughput (or returned by CMSD response header) on the aborted requests.