### PR TITLE
fix(types): TextRequest url property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4067,7 +4067,7 @@ declare namespace dashjs {
         startTime: number;
         timescale: number;
         type: 'InitializationSegment' | 'MediaSegment' | null;
-        url: string;
+        url: string | null;
         wallStartTime: number | null;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "sinon": "^7.3.2",
                 "stream-browserify": "^3.0.0",
                 "string-replace-loader": "^3.0.1",
-                "typescript": "^4.1.5",
+                "typescript": "^5.1.3",
                 "webpack": "^5.75.0",
                 "webpack-cli": "^5.0.1",
                 "webpack-dev-server": "^4.11.1",
@@ -16278,16 +16278,16 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-            "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/ua-parser-js": {
@@ -31088,9 +31088,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-            "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
             "dev": true
         },
         "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "sinon": "^7.3.2",
         "stream-browserify": "^3.0.0",
         "string-replace-loader": "^3.0.1",
-        "typescript": "^4.1.5",
+        "typescript": "^5.1.3",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "index.d.ts"
   ],
   "compilerOptions": {
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "skipLibCheck": false
   }
+  
 }


### PR DESCRIPTION
the `type` property was fixed in https://github.com/Dash-Industry-Forum/dash.js/pull/4191
this is a follow up fix for the `url` property, and to ensure it never silently fails again.

closes #4210 