### PR TITLE
Fix init value for storeLastSettings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1042,6 +1042,7 @@ declare namespace dashjs {
                 enabled?: boolean;
                 ttl?: number;
             };
+            saveLastMediaSettingsForCurrentStreamingSession?: boolean;
             cacheLoadThresholds?: {
                 video?: number;
                 audio?: number;
@@ -1344,7 +1345,7 @@ declare namespace dashjs {
 
         getInitialMediaSettingsFor(type: MediaType): MediaSettings;
 
-        setCurrentTrack(track: MediaInfo): void;
+        setCurrentTrack(track: MediaInfo, noSettingsSave?: boolean): void;
 
         addABRCustomRule(type: string, rulename: string, rule: object): void;
 

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -302,6 +302,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.scheduleWhilePausedSelected = true;
     $scope.calcSegmentAvailabilityRangeFromTimelineSelected = false;
     $scope.reuseExistingSourceBuffersSelected = true;
+    $scope.saveLastMediaSettingsSelected = true;
     $scope.localStorageSelected = true;
     $scope.jumpGapsSelected = true;
     $scope.fastSwitchSelected = true;
@@ -665,6 +666,14 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                 buffer: {
                     reuseExistingSourceBuffers: $scope.reuseExistingSourceBuffersSelected
                 }
+            }
+        });
+    };
+
+    $scope.toggleSaveLastMediaSettings = function () {
+        $scope.player.updateSettings({
+            'streaming': {
+                'saveLastMediaSettingsForCurrentStreamingSession': $scope.saveLastMediaSettingsSelected
             }
         });
     };
@@ -2125,6 +2134,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.scheduleWhilePausedSelected = currentConfig.streaming.scheduling.scheduleWhilePaused;
         $scope.calcSegmentAvailabilityRangeFromTimelineSelected = currentConfig.streaming.timeShiftBuffer.calcFromSegmentTimeline;
         $scope.reuseExistingSourceBuffersSelected = currentConfig.streaming.buffer.reuseExistingSourceBuffers;
+        $scope.saveLastMediaSettingsSelected = currentConfig.streaming.saveLastMediaSettingsForCurrentStreamingSession;
         $scope.localStorageSelected = currentConfig.streaming.lastBitrateCachingInfo.enabled;
         $scope.jumpGapsSelected = currentConfig.streaming.gaps.jumpGaps;
     }

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -189,6 +189,12 @@
                     Reuse SourceBuffers
                 </label>
                 <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                       title="Enable media settings from last selected track to be used for incoming track selection.">
+                    <input type="checkbox" ng-model="saveLastMediaSettingsSelected"
+                           ng-change="toggleSaveLastMediaSettings()" ng-checked="saveLastMediaSettingsSelected">
+                    Save last media settings
+                </label>
+                <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
                        title="Enables local storage of player state (last bitrate, a/v or text track etc). This is then used when the next time media is played.">
                     <input type="checkbox" id="localStorageCB" ng-model="localStorageSelected"
                            ng-change="toggleLocalStorage()" ng-checked="localStorageSelected">

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -154,6 +154,7 @@ import Events from './events/Events';
  *            },
  *            lastBitrateCachingInfo: { enabled: true, ttl: 360000 },
  *            lastMediaSettingsCachingInfo: { enabled: true, ttl: 360000 },
+ *            saveLastMediaSettingsForCurrentStreamingSession: true,
  *            cacheLoadThresholds: { video: 50, audio: 5 },
  *            trackSwitchMode: {
  *                audio: Constants.TRACK_SWITCH_MODE_ALWAYS_REPLACE,
@@ -924,6 +925,7 @@ function Settings() {
                 enabled: true,
                 ttl: 360000
             },
+            saveLastMediaSettingsForCurrentStreamingSession: true,
             cacheLoadThresholds: {
                 video: 50,
                 audio: 5

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -733,6 +733,12 @@ import Events from './events/Events';
  * The default expiration is one hour, defined in milliseconds.
  *
  * If expired, the default initial bit rate (closest to 1000 kbps) will be used for that session and a new bit rate will be stored during that session.
+ * @property {module:Settings~CachingInfoSettings} [lastMediaSettingsCachingInfo={enabled: true, ttl: 360000}]
+ * Set to false if you would like to disable the last media settings from being stored to localStorage during playback and used to set the initial track for subsequent playback within the expiration window.
+ *
+ * The default expiration is one hour, defined in milliseconds.
+ * @property {boolean} [saveLastMediaSettingsForCurrentStreamingSession=true]
+ * Set to true if dash.js should save media settings from last selected track for incoming track selection during current streaming session.
  * @property {module:Settings~AudioVideoSettings} [cacheLoadThresholds={video: 50, audio: 5}]
  * For a given media type, the threshold which defines if the response to a fragment request is coming from browser cache or not.
  * @property {module:Settings~AudioVideoSettings} [trackSwitchMode={video: "neverReplace", audio: "alwaysReplace"}]

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1614,15 +1614,16 @@ function MediaPlayer() {
 
     /**
      * @param {MediaInfo} track - instance of {@link MediaInfo}
+     * @param {boolean} [noSettingsSave] - specify if settings from the track must not be saved for incoming track selection
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
      * @instance
      */
-    function setCurrentTrack(track) {
+    function setCurrentTrack(track, noSettingsSave = false) {
         if (!streamingInitialized) {
             throw STREAMING_NOT_INITIALIZED_ERROR;
         }
-        mediaController.setTrack(track);
+        mediaController.setTrack(track, noSettingsSave);
     }
 
     /*

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -601,7 +601,7 @@ function MediaController() {
 
 
     function createTrackInfo() {
-        const storeLastSettings = settings.get().streaming.lastMediaSettingsCachingInfo.enabled;
+        const storeLastSettings = settings.get().streaming.saveLastMediaSettingsForCurrentStreamingSession;
 
         return {
             audio: {

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -89,7 +89,7 @@ function MediaController() {
             setTrack(selectInitialTrack(type, tracksForType), true);
         } else {
             if (tracks.length > 1) {
-                setTrack(selectInitialTrack(type, tracks, !!lastSelectedTracks[type]));
+                setTrack(selectInitialTrack(type, tracks));
             } else {
                 setTrack(tracks[0]);
             }

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -601,25 +601,27 @@ function MediaController() {
 
 
     function createTrackInfo() {
+        const storeLastSettings = settings.get().streaming.lastMediaSettingsCachingInfo.enabled;
+
         return {
             audio: {
                 list: [],
-                storeLastSettings: true,
+                storeLastSettings,
                 current: null
             },
             video: {
                 list: [],
-                storeLastSettings: true,
+                storeLastSettings,
                 current: null
             },
             text: {
                 list: [],
-                storeLastSettings: true,
+                storeLastSettings,
                 current: null
             },
             image: {
                 list: [],
-                storeLastSettings: true,
+                storeLastSettings,
                 current: null
             }
         };

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -639,6 +639,69 @@ describe('MediaController', function () {
             expect(objectUtils.areEqual(currentTrack, esTrack)).to.be.true;
         });
 
+        it('should not check initial media settings to choose initial track when it has already selected a track', function () {
+            mediaController.addTrack(frTrack);
+            mediaController.addTrack(qtzTrack);
+
+            let trackList = mediaController.getTracksFor(trackType, streamInfo.id);
+            expect(trackList).to.have.lengthOf(2);
+            expect(objectUtils.areEqual(trackList[0], frTrack)).to.be.true;
+            expect(objectUtils.areEqual(trackList[1], qtzTrack)).to.be.true;
+
+            let currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.false;
+            expect(objectUtils.areEqual(currentTrack, qtzTrack)).to.be.false;
+
+            mediaController.setInitialSettings(trackType, {
+                lang: 'fr'
+            });
+            mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
+
+            currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.true;
+
+            // pretend we're switching period, which will call setInitialMediaSettingsForType again
+            mediaController.setInitialSettings(trackType, {
+                lang: 'qtz'
+            });
+            mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
+
+            currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.true;
+        });
+
+        it('should always check initial media settings to choose initial track when saveLastMediaSettingsForCurrentStreamingSession is disabled', function () {
+            settings.update({ streaming: { saveLastMediaSettingsForCurrentStreamingSession: false } });
+
+            mediaController.addTrack(frTrack);
+            mediaController.addTrack(qtzTrack);
+
+            let trackList = mediaController.getTracksFor(trackType, streamInfo.id);
+            expect(trackList).to.have.lengthOf(2);
+            expect(objectUtils.areEqual(trackList[0], frTrack)).to.be.true;
+            expect(objectUtils.areEqual(trackList[1], qtzTrack)).to.be.true;
+
+            let currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.false;
+            expect(objectUtils.areEqual(currentTrack, qtzTrack)).to.be.false;
+
+            mediaController.setInitialSettings(trackType, {
+                lang: 'fr'
+            });
+            mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
+
+            currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, frTrack)).to.be.true;
+
+            // pretend we're switching period, which will call setInitialMediaSettingsForType again
+            mediaController.setInitialSettings(trackType, {
+                lang: 'qtz'
+            });
+            mediaController.setInitialMediaSettingsForType(trackType, streamInfo);
+
+            currentTrack = mediaController.getCurrentTrackFor(trackType, streamInfo.id);
+            expect(objectUtils.areEqual(currentTrack, qtzTrack)).to.be.true;
+        });
     });
 
     describe('Initial Track Selection', function () {


### PR DESCRIPTION
Hi here,
If `streaming.lastMediaSettingsCachingInfo.enabled` is disabled, from my understanding, dash.js should not take last selected track into account.
But from current implementation, if a a track set by `MediaPlayer.setCurrentTrack()`, it will be treated as `lastSelectedTrack`, see L209
https://github.com/Dash-Industry-Forum/dash.js/blob/2ed723974b0d7fabb76b70572dfef271d5d1e342/src/streaming/controllers/MediaController.js#L209
then it will affect which track will be selected, see L64
https://github.com/Dash-Industry-Forum/dash.js/blob/2ed723974b0d7fabb76b70572dfef271d5d1e342/src/streaming/controllers/MediaController.js#L63-L65
So need to get a way to avoid to set  `lastSelectedTrack` when `streaming.lastMediaSettingsCachingInfo` is disabled. `storeLastSettings` seems to be a proper flag, see L194, but `storeLastSettings` of a track is hardcoded to `true` and never changed. This PR is to respect `streaming.lastMediaSettingsCachingInfo.enabled` and give a reasonable initial value.
https://github.com/Dash-Industry-Forum/dash.js/blob/2ed723974b0d7fabb76b70572dfef271d5d1e342/src/streaming/controllers/MediaController.js#L190-L194