### PR TITLE
Define target web and es5 for webpack to make build files ES5 compliant

### DIFF
--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -5,6 +5,7 @@ const out_dir = '../dist';
 
 const config = {
     devtool: 'source-map',
+    target: ['web', 'es5'],
     output: {
         path: path.resolve(__dirname, out_dir),
         publicPath: '/dist/',


### PR DESCRIPTION
Fixes #4216 