### PR TITLE
bugfix/reset-race-conditions

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -1013,6 +1013,10 @@ function BufferController(config) {
     function _onRemoved(e) {
         logger.debug('onRemoved buffer from:', e.from, 'to', e.to);
 
+        if (!sourceBufferSink) {
+            return;
+        }
+
         const ranges = sourceBufferSink.getAllBufferRanges();
         _showBufferRanges(ranges);
 

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -51,7 +51,8 @@ function VideoModel() {
         _currentTime,
         TTMLRenderingDiv,
         vttRenderingDiv,
-        previousPlaybackRate;
+        previousPlaybackRate,
+        timeout;
 
     const VIDEO_MODEL_WRONG_ELEMENT_TYPE = 'element is not video or audio DOM type!';
 
@@ -69,6 +70,7 @@ function VideoModel() {
     }
 
     function reset() {
+        clearTimeout(timeout);
         eventBus.off(Events.PLAYBACK_PLAYING, onPlaying, this);
     }
 
@@ -94,6 +96,10 @@ function VideoModel() {
         if (element) {
             _currentTime = currentTime;
             waitForReadyState(Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA, () => {
+                if (!element) {
+                    return;
+                }
+
                 // We don't set the same currentTime because it can cause firing unexpected Pause event in IE11
                 // providing playbackRate property equals to zero.
                 if (element.currentTime === _currentTime) {
@@ -112,7 +118,7 @@ function VideoModel() {
                     _currentTime = NaN;
                 } catch (e) {
                     if (element.readyState === 0 && e.code === e.INVALID_STATE_ERR) {
-                        setTimeout(function () {
+                        timeout = setTimeout(function () {
                             element.currentTime = _currentTime;
                             _currentTime = NaN;
                         }, 400);


### PR DESCRIPTION
Fixes for edge case errors that have been captured by Sentry IO around referencing `null` objects after `reset` has been called.