### PR TITLE
Added getTargetLiveDelay method to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1287,6 +1287,8 @@ declare namespace dashjs {
 
         getDVRSeekOffset(value: number): number;
 
+        getTargetLiveDelay(): number;
+
         convertToTimeCode(value: number): string;
 
         formatUTC(time: number, locales: string, hour12: boolean, withDate?: boolean): string;


### PR DESCRIPTION
We use this method in our codebase but noticed it was missing in the type definitions.