### PR TITLE
Reset MSE when switching codec if changeType is unstable or unavailable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -48,3 +48,4 @@
 * @epiclabsDASH [Jesus Oliva, Epic Labs]
 * @adripanico [Adrian Caballero, Epic Labs]
 * @ahfarmer [Andrew Farmer, Rhombus Systems]
+* @matvp91 [Matthias Van Parijs]

--- a/index.d.ts
+++ b/index.d.ts
@@ -984,9 +984,10 @@ declare namespace dashjs {
                 longFormContentDurationThreshold?: number,
                 stallThreshold?: number,
                 useAppendWindow?: boolean,
-                setStallState?: boolean
-                avoidCurrentTimeRangePruning?: boolean
-                useChangeTypeForTrackSwitch?: boolean
+                setStallState?: boolean,
+                avoidCurrentTimeRangePruning?: boolean,
+                useChangeTypeForTrackSwitch?: boolean,
+                resetSourceBuffersForTrackSwitch?: boolean
             },
             gaps?: {
                 jumpGaps?: boolean,

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -303,6 +303,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.calcSegmentAvailabilityRangeFromTimelineSelected = false;
     $scope.reuseExistingSourceBuffersSelected = true;
     $scope.mediaSourceDurationInfinitySelected = true;
+    $scope.resetSourceBuffersForTrackSwitch = false;
     $scope.saveLastMediaSettingsSelected = true;
     $scope.localStorageSelected = true;
     $scope.jumpGapsSelected = true;
@@ -681,6 +682,15 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         });
     };
 
+    $scope.toggleResetSourceBuffersForTrackSwitch = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    resetSourceBuffersForTrackSwitch: $scope.resetSourceBuffersForTrackSwitch
+                }
+            }
+        })
+    };
 
     $scope.toggleSaveLastMediaSettings = function () {
         $scope.player.updateSettings({
@@ -2147,6 +2157,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.calcSegmentAvailabilityRangeFromTimelineSelected = currentConfig.streaming.timeShiftBuffer.calcFromSegmentTimeline;
         $scope.reuseExistingSourceBuffersSelected = currentConfig.streaming.buffer.reuseExistingSourceBuffers;
         $scope.mediaSourceDurationInfinitySelected = currentConfig.streaming.buffer.mediaSourceDurationInfinity;
+        $scope.resetSourceBuffersForTrackSwitch = currentConfig.streaming.buffer.resetSourceBuffersForTrackSwitch;
         $scope.saveLastMediaSettingsSelected = currentConfig.streaming.saveLastMediaSettingsForCurrentStreamingSession;
         $scope.localStorageSelected = currentConfig.streaming.lastBitrateCachingInfo.enabled;
         $scope.jumpGapsSelected = currentConfig.streaming.gaps.jumpGaps;

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -196,6 +196,13 @@
                     MediaSource duration Infinity
                 </label>
                 <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                       title="Reset existing MediaSource Sourcebuffers when switching incompatible track.">
+                    <input type="checkbox" ng-model="resetSourceBuffersForTrackSwitch"
+                           ng-change="toggleResetSourceBuffersForTrackSwitch()"
+                           ng-checked="resetSourceBuffersForTrackSwitch">
+                    Reset SourceBuffers on incompatible track switch
+                </label>
+                <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
                        title="Enable media settings from last selected track to be used for incoming track selection.">
                     <input type="checkbox" ng-model="saveLastMediaSettingsSelected"
                            ng-change="toggleSaveLastMediaSettings()" ng-checked="saveLastMediaSettingsSelected">

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -334,6 +334,9 @@ import Events from './events/Events';
  * @property {boolean} [mediaSourceDurationInfinity=true]
  * If this flag is set to true then dash.js will allow `Infinity` to be set as the MediaSource duration otherwise the duration will be set to `Math.pow(2,32)` instead of `Infinity` to allow appending segments indefinitely. 
  * Some platforms such as WebOS 4.x have issues with seeking when duration is set to `Infinity`, setting this flag to false resolve this.
+ * @property {boolean} [resetSourceBuffersForTrackSwitch=false]
+ * When switching to a track that is not compatible with the currently active MSE SourceBuffers, MSE will be reset. This happens when we switch codecs on a system
+ * that does not properly implement "changeType()", such as webOS 4.0 and before.
  */
 
 /**

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -107,7 +107,8 @@ import Events from './events/Events';
  *                useAppendWindow: true,
  *                setStallState: true,
  *                avoidCurrentTimeRangePruning: false,
- *                useChangeTypeForTrackSwitch: true
+ *                useChangeTypeForTrackSwitch: true,
+ *                resetSourceBuffersForTrackSwitch: false
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -875,7 +876,8 @@ function Settings() {
                 useAppendWindow: true,
                 setStallState: true,
                 avoidCurrentTimeRangePruning: false,
-                useChangeTypeForTrackSwitch: true
+                useChangeTypeForTrackSwitch: true,
+                resetSourceBuffersForTrackSwitch: false,
             },
             gaps: {
                 jumpGaps: true,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -343,6 +343,9 @@ function BufferController(config) {
      * @private
      */
     function _appendToBuffer(chunk, request = null) {
+        if (!sourceBufferSink) {
+            return;
+        }
         sourceBufferSink.append(chunk, request)
             .then((e) => {
                 _onAppended(e);
@@ -761,6 +764,9 @@ function BufferController(config) {
     }
 
     function getRangeAt(time, tolerance) {
+        if (!sourceBufferSink) {
+            return null;
+        }
         const ranges = sourceBufferSink.getAllBufferRanges();
         let start = 0;
         let end = 0;

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -67,6 +67,11 @@ function MediaController() {
 
         if (!settings) {
             settings = domStorage.getSavedMediaSettings(type);
+            if (settings) {
+                // If the settings are defined locally, do not take codec into account or it'll be too strict.
+                // eg: An audio track should not be selected by codec but merely by lang.
+                delete settings.codec;
+            }
             setInitialSettings(type, settings);
         }
 
@@ -83,6 +88,7 @@ function MediaController() {
             }
             tracks = filterTracksBySettings(tracks, matchSettingsAccessibility, settings);
             tracks = filterTracksBySettings(tracks, matchSettingsAudioChannelConfig, settings);
+            tracks = filterTracksBySettings(tracks, matchSettingsCodec, settings);
         }
 
         if (tracks.length === 0) {
@@ -311,7 +317,8 @@ function MediaController() {
             viewpoint: mediaInfo.viewpoint,
             roles: mediaInfo.roles,
             accessibility: mediaInfo.accessibility,
-            audioChannelConfiguration: mediaInfo.audioChannelConfiguration
+            audioChannelConfiguration: mediaInfo.audioChannelConfiguration,
+            codec: mediaInfo.codec
         };
         let notEmpty = settings.lang || settings.viewpoint || (settings.role && settings.role.length > 0) ||
             (settings.accessibility && settings.accessibility.length > 0) || (settings.audioChannelConfiguration && settings.audioChannelConfiguration.length > 0);
@@ -376,6 +383,10 @@ function MediaController() {
         })[0];
 
         return matchAudioChannelConfiguration;
+    }
+
+    function matchSettingsCodec(settings, track) {
+        return !settings.codec || (settings.codec === track.codec);
     }
 
     function matchSettings(settings, track, isTrackActive = false) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -639,6 +639,13 @@ function StreamController() {
         // If the track was changed in the active stream we need to stop preloading and remove the already prebuffered stuff. Since we do not support preloading specific handling of specific AdaptationSets yet.
         _deactivateAllPreloadingStreams();
 
+        if (settings.get().streaming.buffer.resetSourceBuffersForTrackSwitch && e.oldMediaInfo && e.oldMediaInfo.codec !== e.newMediaInfo.codec) {
+            const time = playbackController.getTime();
+            activeStream.deactivate(false);
+            _openMediaSource(time, false, false);
+            return;
+        }
+
         activeStream.prepareTrackChange(e);
     }
 


### PR DESCRIPTION
Noticed on webOS 4, when switching audio track from one codec to another. A MEDIA_ERR_DECODE error is thrown and `_handleMediaErrorDecode` resets MSE. Waiting for decode error to occur is not favourable, thus introducing a new buffer setting `resetSourceBuffersForTrackSwitch` that resets MSE when we're switching to a new track with a different codec than the active track.