### PR TITLE
Remove `babel-preset-env`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.1",
+    "version": "4.7.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.1",
+            "version": "4.7.2",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",
@@ -27,7 +27,6 @@
                 "babel": "^5.3.1",
                 "babel-eslint": "^10.1.0",
                 "babel-loader": "^8.2.2",
-                "babel-preset-env": "^1.7.0",
                 "chai": "^3.4.1",
                 "chai-spies": "^1.0.0",
                 "eslint": "^7.23.0",
@@ -4969,23 +4968,6 @@
                 "babel-plugin": "bin/babel-plugin.js"
             }
         },
-        "node_modules/babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-            "dev": true
-        },
         "node_modules/babel-core": {
             "version": "5.8.38",
             "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
@@ -5080,133 +5062,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-define-map": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-regex": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
             }
         },
         "node_modules/babel-loader": {
@@ -5369,24 +5224,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/babel-messages": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
         "node_modules/babel-plugin-constant-folding": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
@@ -5531,299 +5368,6 @@
             "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
             "dev": true
         },
-        "node_modules/babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "node_modules/babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
-        "node_modules/babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "node_modules/babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "dependencies": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-            "dev": true,
-            "dependencies": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "dependencies": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "dependencies": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-            "dev": true,
-            "dependencies": {
-                "regenerator-transform": "^0.10.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-strict-mode": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
         "node_modules/babel-plugin-undeclared-variables-check": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
@@ -5838,130 +5382,6 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
             "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
             "dev": true
-        },
-        "node_modules/babel-preset-env": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-            "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-            "dev": true,
-            "dependencies": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-                "babel-plugin-transform-es2015-classes": "^6.23.0",
-                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-                "babel-plugin-transform-es2015-for-of": "^6.23.0",
-                "babel-plugin-transform-es2015-function-name": "^6.22.0",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-                "babel-plugin-transform-es2015-object-super": "^6.22.0",
-                "babel-plugin-transform-es2015-parameters": "^6.23.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-                "babel-plugin-transform-regenerator": "^6.22.0",
-                "browserslist": "^3.2.6",
-                "invariant": "^2.2.2",
-                "semver": "^5.3.0"
-            }
-        },
-        "node_modules/babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
-            "dependencies": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            }
-        },
-        "node_modules/babel-runtime/node_modules/core-js": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-            "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-            "dev": true
-        },
-        "node_modules/babel-template": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-template/node_modules/babylon": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-            "dev": true,
-            "bin": {
-                "babylon": "bin/babylon.js"
-            }
-        },
-        "node_modules/babel-traverse": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-            "dev": true,
-            "dependencies": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-traverse/node_modules/babylon": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-            "dev": true,
-            "bin": {
-                "babylon": "bin/babylon.js"
-            }
-        },
-        "node_modules/babel-traverse/node_modules/globals": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-types": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            }
         },
         "node_modules/babel/node_modules/lodash": {
             "version": "3.10.1",
@@ -6319,19 +5739,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "node_modules/browserslist": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-            "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-            "dev": true,
-            "dependencies": {
-                "caniuse-lite": "^1.0.30000844",
-                "electron-to-chromium": "^1.3.47"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            }
         },
         "node_modules/buffer": {
             "version": "5.7.1",
@@ -9885,15 +9292,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "dependencies": {
-                "loose-envify": "^1.0.0"
-            }
-        },
         "node_modules/invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -11700,24 +11098,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
-        },
-        "node_modules/loose-envify/node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
         },
         "node_modules/make-dir": {
             "version": "1.3.0",
@@ -13956,23 +13336,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-            "dev": true
-        },
-        "node_modules/regenerator-transform": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-            "dev": true,
-            "dependencies": {
-                "babel-runtime": "^6.18.0",
-                "babel-types": "^6.19.0",
-                "private": "^0.1.6"
-            }
-        },
         "node_modules/regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -14024,17 +13387,6 @@
             },
             "bin": {
                 "regexpu": "bin/regexpu"
-            }
-        },
-        "node_modules/regexpu-core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-            "dev": true,
-            "dependencies": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
             }
         },
         "node_modules/regexpu/node_modules/esprima": {
@@ -22123,25 +21475,6 @@
                 }
             }
         },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            },
-            "dependencies": {
-                "js-tokens": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-                    "dev": true
-                }
-            }
-        },
         "babel-core": {
             "version": "5.8.38",
             "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
@@ -22230,133 +21563,6 @@
                     "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
                     "dev": true
                 }
-            }
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-define-map": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "requires": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-regex": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "requires": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
             }
         },
         "babel-loader": {
@@ -22466,24 +21672,6 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
-            }
-        },
-        "babel-messages": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-constant-folding": {
@@ -22622,299 +21810,6 @@
             "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
             "dev": true
         },
-        "babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "requires": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "requires": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
-            }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "^0.10.0"
-            }
-        },
-        "babel-plugin-transform-strict-mode": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
         "babel-plugin-undeclared-variables-check": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
@@ -22929,126 +21824,6 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
             "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
             "dev": true
-        },
-        "babel-preset-env": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-            "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-                "babel-plugin-transform-es2015-classes": "^6.23.0",
-                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-                "babel-plugin-transform-es2015-for-of": "^6.23.0",
-                "babel-plugin-transform-es2015-function-name": "^6.22.0",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-                "babel-plugin-transform-es2015-object-super": "^6.22.0",
-                "babel-plugin-transform-es2015-parameters": "^6.23.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-                "babel-plugin-transform-regenerator": "^6.22.0",
-                "browserslist": "^3.2.6",
-                "invariant": "^2.2.2",
-                "semver": "^5.3.0"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            },
-            "dependencies": {
-                "core-js": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-                    "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
-                    "dev": true
-                }
-            }
-        },
-        "babel-template": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                }
-            }
-        },
-        "babel-traverse": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                },
-                "globals": {
-                    "version": "9.18.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-                    "dev": true
-                }
-            }
-        },
-        "babel-types": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            }
         },
         "babylon": {
             "version": "5.8.38",
@@ -23343,16 +22118,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "browserslist": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-            "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-            "dev": true,
-            "requires": {
-                "caniuse-lite": "^1.0.30000844",
-                "electron-to-chromium": "^1.3.47"
-            }
         },
         "buffer": {
             "version": "5.7.1",
@@ -26126,15 +24891,6 @@
             "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true
         },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
-        },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -27519,23 +26275,6 @@
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
             "dev": true
-        },
-        "loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "dependencies": {
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                }
-            }
         },
         "make-dir": {
             "version": "1.3.0",
@@ -29265,23 +28004,6 @@
                 "through": "~2.3.8"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-            "dev": true
-        },
-        "regenerator-transform": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.18.0",
-                "babel-types": "^6.19.0",
-                "private": "^0.1.6"
-            }
-        },
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -29326,17 +28048,6 @@
                     "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
                     "dev": true
                 }
-            }
-        },
-        "regexpu-core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-            "dev": true,
-            "requires": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
             }
         },
         "regjsgen": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "babel": "^5.3.1",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.2.2",
-        "babel-preset-env": "^1.7.0",
         "chai": "^3.4.1",
         "chai-spies": "^1.0.0",
         "eslint": "^7.23.0",


### PR DESCRIPTION
This is a 5 year old, unmaintained version of the already used `@babel/preset-env` dependency. 

## Checks Performed
- [x] New Javascript Features such as Arrow Functions are still being transpiled in the resultant build files. 
- [x] All Unit Tests Pass