### PR TITLE
add setting to change mediasource duration from infinity to math.pow(2, 32)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -987,6 +987,7 @@ declare namespace dashjs {
                 setStallState?: boolean
                 avoidCurrentTimeRangePruning?: boolean
                 useChangeTypeForTrackSwitch?: boolean
+                mediaSourceDurationInfinity?: boolean
             },
             gaps?: {
                 jumpGaps?: boolean,

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -302,6 +302,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.scheduleWhilePausedSelected = true;
     $scope.calcSegmentAvailabilityRangeFromTimelineSelected = false;
     $scope.reuseExistingSourceBuffersSelected = true;
+    $scope.mediaSourceDurationInfinitySelected = true;
     $scope.saveLastMediaSettingsSelected = true;
     $scope.localStorageSelected = true;
     $scope.jumpGapsSelected = true;
@@ -669,6 +670,17 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             }
         });
     };
+
+    $scope.toggleMediaSourceDurationInfinity = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    mediaSourceDurationInfinity: $scope.mediaSourceDurationInfinitySelected
+                }
+            }
+        });
+    };
+
 
     $scope.toggleSaveLastMediaSettings = function () {
         $scope.player.updateSettings({
@@ -2134,6 +2146,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.scheduleWhilePausedSelected = currentConfig.streaming.scheduling.scheduleWhilePaused;
         $scope.calcSegmentAvailabilityRangeFromTimelineSelected = currentConfig.streaming.timeShiftBuffer.calcFromSegmentTimeline;
         $scope.reuseExistingSourceBuffersSelected = currentConfig.streaming.buffer.reuseExistingSourceBuffers;
+        $scope.mediaSourceDurationInfinitySelected = currentConfig.streaming.buffer.mediaSourceDurationInfinity;
         $scope.saveLastMediaSettingsSelected = currentConfig.streaming.saveLastMediaSettingsForCurrentStreamingSession;
         $scope.localStorageSelected = currentConfig.streaming.lastBitrateCachingInfo.enabled;
         $scope.jumpGapsSelected = currentConfig.streaming.gaps.jumpGaps;

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -189,6 +189,13 @@
                     Reuse SourceBuffers
                 </label>
                 <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
+                       title="Allows duration to be set to Infinity on the MediaSource">
+                    <input type="checkbox" ng-model="mediaSourceDurationInfinitySelected"
+                           ng-change="toggleMediaSourceDurationInfinity()"
+                           ng-checked="mediaSourceDurationInfinitySelected">
+                    MediaSource duration Infinity
+                </label>
+                <label class="topcoat-checkbox" data-toggle="tooltip" data-placement="right"
                        title="Enable media settings from last selected track to be used for incoming track selection.">
                     <input type="checkbox" ng-model="saveLastMediaSettingsSelected"
                            ng-change="toggleSaveLastMediaSettings()" ng-checked="saveLastMediaSettingsSelected">

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -107,7 +107,8 @@ import Events from './events/Events';
  *                useAppendWindow: true,
  *                setStallState: true,
  *                avoidCurrentTimeRangePruning: false,
- *                useChangeTypeForTrackSwitch: true
+ *                useChangeTypeForTrackSwitch: true,
+ *                mediaSourceDurationInfinity: true
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -329,6 +330,9 @@ import Events from './events/Events';
  * @property {boolean} [useChangeTypeForTrackSwitch=true]
  * If this flag is set to true then dash.js will use the MSE v.2 API call "changeType()" before switching to a different track.
  * Note that some platforms might not implement the changeType functio. dash.js is checking for the availability before trying to call it.
+ * @property {boolean} [mediaSourceDurationInfinity=true]
+ * If this flag is set to true then dash.js will allow `Infinity` to be set as the MediaSource duration otherwise the duration will be set to `Math.pow(2,32)` instead of `Infinity` to allow appending segments indefinitely. 
+ * Some platforms such as WebOS 4.x have issues with seeking when duration is set to `Infinity`, setting this flag to false resolve this.
  */
 
 /**
@@ -875,7 +879,8 @@ function Settings() {
                 useAppendWindow: true,
                 setStallState: true,
                 avoidCurrentTimeRangePruning: false,
-                useChangeTypeForTrackSwitch: true
+                useChangeTypeForTrackSwitch: true,
+                mediaSourceDurationInfinity: true
             },
             gaps: {
                 jumpGaps: true,

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -35,6 +35,7 @@ function MediaSourceController() {
 
     let instance,
         mediaSource,
+        settings,
         logger;
 
     const context = this.context;
@@ -74,6 +75,10 @@ function MediaSourceController() {
         if (!mediaSource || mediaSource.readyState !== 'open') return;
         if (value === null && isNaN(value)) return;
         if (mediaSource.duration === value) return;
+
+        if (value === Infinity && !settings.get().streaming.buffer.mediaSourceDurationInfinity) {
+            value = Math.pow(2, 32);
+        }
 
         if (!isBufferUpdating(mediaSource)) {
             logger.info('Set MediaSource duration:' + value);
@@ -120,13 +125,27 @@ function MediaSourceController() {
         return false;
     }
 
+    /**
+     * Set the config of the MediaSourceController
+     * @param {object} config
+     */
+    function setConfig(config) {
+        if (!config) {
+            return;
+        }
+        if (config.settings) {
+            settings = config.settings;
+        }
+    }
+
     instance = {
         createMediaSource,
         attachMediaSource,
         detachMediaSource,
         setDuration,
         setSeekable,
-        signalEndOfStream
+        signalEndOfStream,
+        setConfig
     };
 
     setup();

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -105,6 +105,8 @@ function StreamController() {
         });
         timeSyncController.initialize();
 
+        mediaSourceController.setConfig({ settings });
+
         if (protectionController) {
             eventBus.trigger(Events.PROTECTION_CREATED, {
                 controller: protectionController


### PR DESCRIPTION
As discussed on slack https://dashif.slack.com/archives/C11R69M96/p1693394978870319

On WebOS 4.x ( Chrome 53 ) seeking in live content is currently broken because when duration is Infinity seeking back in time causes the seekable end time to move to the seek point so once you’ve seeked back in time you can never go to live again.
The solution is to set the duration of the MediaSource to something high so that you’re not blocked from appending segments eg. Math.pow(2, 32); eg. like shaka https://github.com/shaka-project/shaka-player/blob/main/lib/media/streaming_engine.js#L922