### PR TITLE
Fix/scheduling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.2",
+    "version": "4.7.3",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -735,8 +735,7 @@ function StreamProcessor(config) {
                 _prepareForDefaultQualitySwitch(representationInfo);
             }
         } else {
-            scheduleController.startScheduleTimer();
-            qualityChangeInProgress = false;
+            _prepareForDefaultQualitySwitch(representationInfo);
         }
     }
 

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -686,6 +686,7 @@ function StreamProcessor(config) {
         }, { mediaType: type, streamId: streamInfo.id });
 
         // Abort appending segments to the buffer. Also adjust the appendWindow as we might have been in the progress of prebuffering stuff.
+        scheduleController.setCheckPlaybackQuality(false);
         bufferController.prepareForForceReplacementQualitySwitch(representationInfo)
             .then(() => {
                 _bufferClearedForReplacement();
@@ -751,6 +752,7 @@ function StreamProcessor(config) {
 
         bufferController.updateBufferTimestampOffset(representationInfo)
             .then(() => {
+                scheduleController.setCheckPlaybackQuality(false);
                 if (mediaInfo.segmentAlignment || mediaInfo.subSegmentAlignment) {
                     scheduleController.startScheduleTimer();
                 } else {


### PR DESCRIPTION
Fix two scheduling errors

* In case we can not perform a fast quality switch we fallback to default quality switch
* Do not check the playback quality again in case we are already performing a quality switch. Otherwise we might get stuck in an infinite loop