### PR TITLE
fix skip flow when actualurl is an empty string

### DIFF
--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -144,7 +144,7 @@ function MetricsModel(config) {
         // The redirect-to URL or alternative url (where multiple have been
         // provided in the MPD) will appear as the actualurl of the next
         // entry with the same url value.
-        if (actualurl && (actualurl !== url)) {
+        if (actualurl !== null && actualurl !== undefined && (actualurl !== url)) {
 
             // given the above, add an entry for the original request
             addHttpRequest(
@@ -154,7 +154,7 @@ function MetricsModel(config) {
                 url,
                 quality,
                 null,
-                null,
+                serviceLocation,
                 range,
                 trequest,
                 null, // unknown
@@ -168,6 +168,7 @@ function MetricsModel(config) {
             );
 
             vo.actualurl = actualurl;
+            return;
         }
 
         vo.tcpid = tcpid;


### PR DESCRIPTION
![image](https://github.com/Dash-Industry-Forum/dash.js/assets/144431865/2535b104-895e-4d0a-87d4-cbdf556a6d02)

This Test case is from hbbtv.org, which is the HBBTV official site. This case is expect to report a C01 error to the hbbtv test server, but gets none. 

**First tips**

I found out the reason is that atucalurl is an empty string.
If using the old expresseion: `if (actualurl && (actualurl !== url))`, it will return false and skip the statements in the curly brace. It needs to change to the new expression: `if (actualurl !== null && actualurl !== undefined && (actualurl !== url))`.

**Second tips**

The testcase supposes to get the report with serviceLocation, so I append it.

Please have a look, check & verify this Pull Request. Thank you!