### PR TITLE
Add MediaPlayer capability to refresh manifest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1243,6 +1243,8 @@ declare namespace dashjs {
 
         attachSource(urlOrManifest: string | object, startTime?: number | string): void;
 
+        refreshManifest(callback: (manifest: object | null, error: unknown) => void): void;
+
         isReady(): boolean;
 
         preload(): void;
@@ -2607,8 +2609,6 @@ declare namespace dashjs {
         getXHRWithCredentialsForType(type: string): object;
 
         getDefaultUtcTimingSource(): UTCTiming;
-
-        refreshManifest(callback: (manifest: object | null, error: any) => void): void;
 
         reset(): void;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2608,6 +2608,8 @@ declare namespace dashjs {
 
         getDefaultUtcTimingSource(): UTCTiming;
 
+        refreshManifest(callback: (manifest: object | null, error: any) => void): void;
+
         reset(): void;
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1908,6 +1908,44 @@ function MediaPlayer() {
     }
 
     /**
+     *  Reload the manifest that the player is currently using.
+     *
+     *  @memberof module:MediaPlayer
+     *  @param {function} callback - A Callback function provided when retrieving manifests
+     *  @instance
+     */
+    function refreshManifest(callback) {
+        if (!mediaPlayerInitialized) {
+            throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
+        }
+
+        if(!isReady()) {
+            callback(null, {
+                error: SOURCE_NOT_ATTACHED_ERROR
+            });
+
+            return;
+        }
+
+        let self = this;
+
+        if (typeof callback === 'function') {
+            const handler = function (e) {
+                if (!e.error) {
+                    callback(e.manifest);
+                } else {
+                    callback(null, e.error);
+                }
+                eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+            };
+
+            eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+        }
+
+        streamController.refreshManifest();
+    }
+
+    /**
      * Get the current settings object being used on the player.
      * @returns {PlayerSettings} The settings object being used.
      *
@@ -2449,6 +2487,7 @@ function MediaPlayer() {
         extend,
         attachView,
         attachSource,
+        refreshManifest,
         isReady,
         preload,
         play,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1920,23 +1920,20 @@ function MediaPlayer() {
         }
 
         if(!isReady()) {
-            callback(null, {
-                error: SOURCE_NOT_ATTACHED_ERROR
-            });
-
-            return;
+            return callback(null, SOURCE_NOT_ATTACHED_ERROR);
         }
 
         let self = this;
 
         if (typeof callback === 'function') {
             const handler = function (e) {
-                if (!e.error) {
-                    callback(e.manifest);
-                } else {
-                    callback(null, e.error);
-                }
                 eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+
+                if (e.error) {
+                    return callback(null, e.error);
+                }
+
+                callback(e.manifest);
             };
 
             eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1930,7 +1930,8 @@ function MediaPlayer() {
                 eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
 
                 if (e.error) {
-                    return callback(null, e.error);
+                    callback(null, e.error);
+                    return;
                 }
 
                 callback(e.manifest);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1919,7 +1919,7 @@ function MediaPlayer() {
             throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
         }
 
-        if(!isReady()) {
+        if (!isReady()) {
             return callback(null, SOURCE_NOT_ATTACHED_ERROR);
         }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1598,6 +1598,10 @@ function StreamController() {
         }
     }
 
+    function refreshManifest() {
+        manifestUpdater.refreshManifest();
+    }
+
     function getStreams() {
         return streams;
     }
@@ -1623,6 +1627,7 @@ function StreamController() {
         getActiveStream,
         getInitialPlayback,
         getAutoPlay,
+        refreshManifest,
         reset
     };
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1522,6 +1522,9 @@ function StreamController() {
         if (config.segmentBaseController) {
             segmentBaseController = config.segmentBaseController;
         }
+        if (config.manifestUpdater) {
+            manifestUpdater = config.manifestUpdater;
+        }
     }
 
     function setProtectionData(protData) {
@@ -1608,7 +1611,9 @@ function StreamController() {
     }
 
     function refreshManifest() {
-        manifestUpdater.refreshManifest();
+        if (!manifestUpdater.getIsUpdating()) {
+            manifestUpdater.refreshManifest();
+        }
     }
 
     function getStreams() {

--- a/test/unit/mocks/ManifestUpdaterMock.js
+++ b/test/unit/mocks/ManifestUpdaterMock.js
@@ -9,6 +9,10 @@ class ManifestUpdaterMock {
     getManifestLoader() {
         return this.manifestLoader;
     }
+
+    refreshManifest() {}
+
+    getIsUpdating() {}
 }
 
 export default ManifestUpdaterMock;

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -14,6 +14,8 @@ class StreamControllerMock {
         this.streams = streams;
     }
 
+    refreshManifest() {}
+
     getStreams() {
         return this.streams;
     }

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -16,6 +16,7 @@ import Settings from '../../src/core/Settings';
 import ABRRulesCollection from '../../src/streaming/rules/abr/ABRRulesCollection';
 import CustomParametersModel from '../../src/streaming/models/CustomParametersModel';
 
+const sinon = require('sinon');
 const expect = require('chai').expect;
 const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
 const SOURCE_NOT_ATTACHED_ERROR = 'You must first call attachSource() with a valid source before calling this method';
@@ -1160,7 +1161,7 @@ describe('MediaPlayer with context injected', () => {
         const customParametersModel = CustomParametersModel(context).getInstance();
         eventBus = EventBus(context).getInstance();
         settings = Settings(context).getInstance();
-        
+
         player = MediaPlayer(context).create();
 
         // to avoid unwanted log
@@ -1199,7 +1200,7 @@ describe('MediaPlayer with context injected', () => {
                 player.refreshManifest(stub);
 
                 expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
-                
+
                 eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: { __mocked: true } });
 
                 expect(stub.calledOnce).to.be.true;

--- a/test/unit/streaming.controllers.StreamController.js
+++ b/test/unit/streaming.controllers.StreamController.js
@@ -19,6 +19,7 @@ import URIFragmentModelMock from './mocks/URIFragmentModelMock';
 import CapabilitiesFilterMock from './mocks/CapabilitiesFilterMock';
 import ContentSteeringControllerMock from './mocks/ContentSteeringControllerMock';
 import TextControllerMock from './mocks/TextControllerMock';
+import ManifestUpdaterMock from './mocks/ManifestUpdaterMock';
 import ServiceDescriptionController from '../../src/dash/controllers/ServiceDescriptionController';
 
 const chai = require('chai');
@@ -48,6 +49,7 @@ const uriFragmentModelMock = new URIFragmentModelMock();
 const capabilitiesFilterMock = new CapabilitiesFilterMock();
 const textControllerMock = new TextControllerMock();
 const contentSteeringControllerMock = new ContentSteeringControllerMock();
+const manifestUpdaterMock = new ManifestUpdaterMock();
 
 Events.extend(ProtectionEvents);
 
@@ -478,5 +480,36 @@ describe('StreamController', function () {
                 });
             });
         });
+    });
+
+    describe('refreshManifest', function () {
+        beforeEach(function () {
+            streamController.setConfig({
+                manifestUpdater: manifestUpdaterMock
+            });
+            sinon.spy(manifestUpdaterMock, 'refreshManifest');
+            sinon.stub(manifestUpdaterMock, 'getIsUpdating');
+        });
+
+
+        afterEach(function () {
+            manifestUpdaterMock.refreshManifest.restore();
+            manifestUpdaterMock.getIsUpdating.restore();
+        });
+
+
+        it('calls refreshManifest on ManifestUpdater', function () {
+            streamController.refreshManifest();
+
+            expect(manifestUpdaterMock.refreshManifest.calledOnce).to.be.true;
+        });
+
+        it('does not call refreshManifest on ManifrstUpdater if it is already updating', function () {
+            manifestUpdaterMock.getIsUpdating.returns(true)
+
+            streamController.refreshManifest();
+
+            expect(manifestUpdaterMock.refreshManifest.notCalled).to.be.true;
+        })
     });
 });


### PR DESCRIPTION
## What?

Add capability to refresh the manifest through the MediaPlayer API. 

## Why?

We call this before seeking in a dynamic stream if we expect the steam could become static, to ensure users can't seek past the end.