### PR TITLE
Add text.imsc settings for rollUp and displayForcedOnly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1024,6 +1024,10 @@ declare namespace dashjs {
             text?: {
                 defaultEnabled?: boolean,
                 extendSegmentedCues?: boolean,
+                imsc?: {
+                    displayForcedOnlyMode?: boolean,
+                    enableRollUp?: boolean
+                },
                 webvtt?: {
                     customRenderingEnabled?: number
                 }

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -234,7 +234,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.drmToday = false;
 
     $scope.imscEnableRollUp = true;
-    $scope.imscDisplayForcedOnly = false;
+    $scope.imscdisplayForcedOnlyMode = false;
 
     $scope.isDynamic = false;
 
@@ -248,7 +248,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         muted: false,
         drmToday: false,
         enableRollUp: true,
-        displayForcedOnly: false,
+        displayForcedOnlyMode: false,
         forceQualitySwitchSelected: false,
         drmPrioritiesEnabled: false,
         languageAudio: null,
@@ -830,8 +830,8 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.player.updateSettings({ streaming: { text: { imsc: { enableRollUp: $scope.imscEnableRollUp }}}});
     }
 
-    $scope.toggleImscDisplayForcedOnly = function() {
-        $scope.player.updateSettings({ streaming: { text: { imsc: { displayForcedOnlyMode: $scope.imscDisplayForcedOnly }}}});
+    $scope.toggleImscdisplayForcedOnlyMode = function() {
+        $scope.player.updateSettings({ streaming: { text: { imsc: { displayForcedOnlyMode: $scope.imscdisplayForcedOnlyMode }}}});
     }
 
     $scope.updateCmcdSessionId = function () {
@@ -1551,7 +1551,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             muted: $scope.muted,
             drmToday: $scope.drmToday,
             enableRollUp: $scope.imscEnableRollUp,
-            displayForcedOnly: $scope.imscDisplayForcedOnly,
+            displayForcedOnlyMode: $scope.imscdisplayForcedOnlyMode,
             forceQualitySwitchSelected: $scope.forceQualitySwitchSelected,
             drmPrioritiesEnabled: $scope.prioritiesEnabled,
             languageAudio: $scope.initialSettings.audio,
@@ -1833,8 +1833,8 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                 case 'enableRollUp':
                     $scope.imscEnableRollUp = this.parseBoolean(value);
                     break;
-                case 'displayForcedOnly':
-                    $scope.imscDisplayForcedOnly = this.parseBoolean(value);
+                case 'displayForcedOnlyMode':
+                    $scope.imscdisplayForcedOnlyMode = this.parseBoolean(value);
                     break;
                 case 'forceQualitySwitchSelected':
                     $scope.forceQualitySwitchSelected = this.parseBoolean(value);
@@ -2204,7 +2204,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     function setTextOptions() {
         var currentConfig = $scope.player.getSettings();
         $scope.imscEnableRollUp = currentConfig.streaming.text.imsc.enableRollUp;
-        $scope.imscDisplayForcedOnly = currentConfig.streaming.text.imsc.displayForcedOnlyMode;
+        $scope.imscdisplayForcedOnlyMode = currentConfig.streaming.text.imsc.displayForcedOnlyMode;
     }
 
     function setLiveDelayOptions() {

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -233,6 +233,9 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
 
     $scope.drmToday = false;
 
+    $scope.imscEnableRollUp = true;
+    $scope.imscDisplayForcedOnly = false;
+
     $scope.isDynamic = false;
 
     $scope.conformanceViolations = [];
@@ -244,6 +247,8 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         autoLoad: false,
         muted: false,
         drmToday: false,
+        enableRollUp: true,
+        displayForcedOnly: false,
         forceQualitySwitchSelected: false,
         drmPrioritiesEnabled: false,
         languageAudio: null,
@@ -819,6 +824,14 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
 
     $scope.toggleForcedTextStreaming = function () {
         $scope.player.enableForcedTextStreaming($scope.initialSettings.forceTextStreaming);
+    }
+
+    $scope.toggleImscEnableRollUp = function() {
+        $scope.player.updateSettings({ streaming: { text: { imsc: { enableRollUp: $scope.imscEnableRollUp }}}});
+    }
+
+    $scope.toggleImscDisplayForcedOnly = function() {
+        $scope.player.updateSettings({ streaming: { text: { imsc: { displayForcedOnlyMode: $scope.imscDisplayForcedOnly }}}});
     }
 
     $scope.updateCmcdSessionId = function () {
@@ -1537,6 +1550,8 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             autoLoad: $scope.autoLoadSelected,
             muted: $scope.muted,
             drmToday: $scope.drmToday,
+            enableRollUp: $scope.imscEnableRollUp,
+            displayForcedOnly: $scope.imscDisplayForcedOnly,
             forceQualitySwitchSelected: $scope.forceQualitySwitchSelected,
             drmPrioritiesEnabled: $scope.prioritiesEnabled,
             languageAudio: $scope.initialSettings.audio,
@@ -1814,6 +1829,12 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                     break;
                 case 'drmToday':
                     $scope.drmToday = this.parseBoolean(value);
+                    break;
+                case 'enableRollUp':
+                    $scope.imscEnableRollUp = this.parseBoolean(value);
+                    break;
+                case 'displayForcedOnly':
+                    $scope.imscDisplayForcedOnly = this.parseBoolean(value);
                     break;
                 case 'forceQualitySwitchSelected':
                     $scope.forceQualitySwitchSelected = this.parseBoolean(value);
@@ -2180,6 +2201,12 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.drmClearkey.priority = $scope.drmClearkey.priority.toString();
     }
 
+    function setTextOptions() {
+        var currentConfig = $scope.player.getSettings();
+        $scope.imscEnableRollUp = currentConfig.streaming.text.imsc.enableRollUp;
+        $scope.imscDisplayForcedOnly = currentConfig.streaming.text.imsc.displayForcedOnlyMode;
+    }
+
     function setLiveDelayOptions() {
         var currentConfig = $scope.player.getSettings();
         $scope.initialLiveDelay = currentConfig.streaming.delay.liveDelay;
@@ -2335,6 +2362,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             setAdditionalPlaybackOptions();
             setAdditionalAbrOptions();
             setDrmOptions();
+            setTextOptions();
             setLiveDelayOptions();
             setInitialSettings();
             setTrackSwitchModeSettings();

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -247,8 +247,6 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         autoLoad: false,
         muted: false,
         drmToday: false,
-        enableRollUp: true,
-        displayForcedOnlyMode: false,
         forceQualitySwitchSelected: false,
         drmPrioritiesEnabled: false,
         languageAudio: null,
@@ -1550,8 +1548,6 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             autoLoad: $scope.autoLoadSelected,
             muted: $scope.muted,
             drmToday: $scope.drmToday,
-            enableRollUp: $scope.imscEnableRollUp,
-            displayForcedOnlyMode: $scope.imscdisplayForcedOnlyMode,
             forceQualitySwitchSelected: $scope.forceQualitySwitchSelected,
             drmPrioritiesEnabled: $scope.prioritiesEnabled,
             languageAudio: $scope.initialSettings.audio,
@@ -1829,12 +1825,6 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                     break;
                 case 'drmToday':
                     $scope.drmToday = this.parseBoolean(value);
-                    break;
-                case 'enableRollUp':
-                    $scope.imscEnableRollUp = this.parseBoolean(value);
-                    break;
-                case 'displayForcedOnlyMode':
-                    $scope.imscdisplayForcedOnlyMode = this.parseBoolean(value);
                     break;
                 case 'forceQualitySwitchSelected':
                     $scope.forceQualitySwitchSelected = this.parseBoolean(value);

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -714,8 +714,8 @@
                     <div class="sub-options-item-body">
                         <label data-toggle="tooltip" data-placement="right"
                                title="Forced Only Mode">
-                            <input type="checkbox" id="imscDisplayForcedOnly" ng-model="imscDisplayForcedOnly" ng-checked="imscDisplayForcedOnly" autocomplete="off"
-                                   ng-change="toggleImscDisplayForcedOnly()" name="inputMode">
+                            <input type="checkbox" id="imscdisplayForcedOnlyMode" ng-model="imscdisplayForcedOnlyMode" ng-checked="imscdisplayForcedOnlyMode" autocomplete="off"
+                                   ng-change="toggleImscdisplayForcedOnlyMode()" name="inputMode">
                             Forced Only
                         </label>
                     </div>

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -699,6 +699,30 @@
             </div>
         </div>
         <div class="options-item">
+            <div class="options-item-title">Text</div>
+            <div class="options-item-body">
+                <div class="sub-options-item">
+                    <div class="sub-options-item-title">IMSC</div>
+                    <div class="sub-options-item-body">
+                        <label data-toggle="tooltip" data-placement="right"
+                               title="Enable Roll-up mode">
+                            <input type="checkbox" id="imscEnableRollUp" ng-model="imscEnableRollUp" autocomplete="off" ng-checked="imscEnableRollUp"
+                                   ng-change="toggleImscEnableRollUp()" name="inputMode">
+                            Enable Roll-up
+                        </label>
+                    </div>
+                    <div class="sub-options-item-body">
+                        <label data-toggle="tooltip" data-placement="right"
+                               title="Forced Only Mode">
+                            <input type="checkbox" id="imscDisplayForcedOnly" ng-model="imscDisplayForcedOnly" ng-checked="imscDisplayForcedOnly" autocomplete="off"
+                                   ng-change="toggleImscDisplayForcedOnly()" name="inputMode">
+                            Forced Only
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="options-item">
             <div class="options-item-title">Initial Settings</div>
             <div class="options-item-body">
                 <label class="options-label">Initial bitrate Video:</label>

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -143,6 +143,10 @@ import Events from './events/Events';
  *            text: {
  *                defaultEnabled: true,
  *                extendSegmentedCues: true,
+ *                imsc: {
+ *                    displayForcedOnlyMode: false,
+ *                    enableRollUp: true
+ *                },
  *                webvtt: {
  *                    customRenderingEnabled: false
  *                }
@@ -480,7 +484,12 @@ import Events from './events/Events';
  * Enable/disable subtitle rendering by default.
  * @property {boolean} [extendSegmentedCues=true]
  * Enable/disable patching of segmented cues in order to merge as a single cue by extending cue end time.
- * @property {object} [webvtt={customRenderingEnabled=false}]
+ * @property {boolean} [imsc.displayForcedOnlyMode=false]
+ * Enable/disable forced only mode in IMSC captions.
+ * When true, only those captions where itts:forcedDisplay="true" will be displayed.
+ * @property {boolean} [imsc.enableRollUp=true]
+ * Enable/disable rollUp style display of IMSC captions.
+ * @property {object} [webvtt.customRenderingEnabled=false]
  * Enables the custom rendering for WebVTT captions. For details refer to the "Subtitles and Captions" sample section of dash.js.
  * Custom WebVTT rendering requires the external library vtt.js that can be found in the contrib folder.
  */
@@ -943,6 +952,10 @@ function Settings() {
             text: {
                 defaultEnabled: true,
                 extendSegmentedCues: true,
+                imsc: {
+                    displayForcedOnlyMode: false,
+                    enableRollUp: true
+                },
                 webvtt: {
                     customRenderingEnabled: false
                 }

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -413,10 +413,10 @@ function TextTracks(config) {
             captionContainer.appendChild(finalCue);
             previousISDState = renderHTML(cue.isd, finalCue, function (src) {
                 return _resolveImageSrc(cue, src);
-            }, captionContainer.clientHeight, captionContainer.clientWidth, false/*displayForcedOnlyMode*/, function (err) {
+            }, captionContainer.clientHeight, captionContainer.clientWidth, settings.get().streaming.text.imsc.displayForcedOnlyMode, function (err) {
                 logger.info('renderCaption :', err);
                 //TODO add ErrorHandler management
-            }, previousISDState, true /*enableRollUp*/);
+            }, previousISDState, settings.get().streaming.text.imsc.enableRollUp);
             finalCue.id = cue.cueID;
             eventBus.trigger(MediaPlayerEvents.CAPTION_RENDERED, { captionDiv: finalCue, currentTrackIdx });
         }


### PR DESCRIPTION
Closes #4332 by allowing imscJS's `displayForcedOnlyMode` and `enableRollUp` parameters to be configured in `settings.streaming.text.imsc.displayForcedOnlyMode` and `settings.streaming.text.imsc.enableRollUp`. Adds configuration check-boxes to the reference player to allow them to be adjusted at playback time. 