### PR TITLE
Remove PlaybackErrorEvent duplicate in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1943,11 +1943,6 @@ declare namespace dashjs {
         adaptationSet: object;
     }
 
-    export interface PlaybackErrorEvent extends Event {
-        type: MediaPlayerEvents['PLAYBACK_ERROR'];
-        error: string;
-    }
-
     export interface MediaSettings {
         lang?: string;
         viewpoint?: any;


### PR DESCRIPTION
`PlaybackErrorEvent` interface definition is duplicated in `index.d.ts`. This commit removes the duplicate.