### PR TITLE
Fix flickering/blinking IMSC Subtitles

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -455,9 +455,7 @@ function TextTracks(config) {
             return false;
         }
 
-        // Compare cues content
         if (!_cuesContentAreEqual(prevCue, cue, CUE_PROPS_TO_COMPARE)) {
-            // Extend the previous cue if they are identical
             return false;
         } 
 
@@ -529,9 +527,13 @@ function TextTracks(config) {
 
                             if (_areCuesAdjacent(cue, prevCue)) {
                                 if (!_extendLastCue(cue, prevCue)) {
-                                    // If cues are adjacent but not identical (extended), let the render function of the next cue 
-                                    // clear up the captionsContainer so removal and appending are instantaneous
-                                    prevCue.onexit = function () { };
+                                    /* If cues are adjacent but not identical (extended), let the render function of the next cue 
+                                     * clear up the captionsContainer so removal and appending are instantaneous.
+                                     * Only do this for imsc subs (where isd is present).
+                                     */
+                                    if (prevCue.isd) {
+                                        prevCue.onexit = function () { };
+                                    }
                                     track.addCue(cue);
                                 }
                             } else {
@@ -603,6 +605,7 @@ function TextTracks(config) {
             }
         };
 
+        // For imsc subs, this could be reassigned to not do anything if there is a cue that immediately follows this one
         cue.onexit = function () {
             if (captionContainer) {
                 const divs = captionContainer.childNodes;

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -411,10 +411,7 @@ function TextTracks(config) {
 
     function _renderCaption(cue) {
         if (captionContainer) {
-
-            while (captionContainer.firstChild) {
-                captionContainer.removeChild(captionContainer.firstChild);
-            }
+            clearCaptionContainer.call(this);
             
             const finalCue = document.createElement('div');
             captionContainer.appendChild(finalCue);
@@ -442,11 +439,7 @@ function TextTracks(config) {
         }
         // Check previous cue endTime with current cue startTime
         // (should we consider an epsilon margin? for example to get around rounding issues)
-        if (prevCue.endTime < cue.startTime) {
-            return false;
-        }
-
-        return true;
+        return prevCue.endTime >= cue.startTime;
     }
 
     // Check if cue content is identical. If it is, extend the previous cue.


### PR DESCRIPTION
This is detailed further in issue #4358.

This is a proposed fix to prevent subtitle flickering, where the time between removal and appending of divs representing subtitle cues can have gaps in between. Using the stream in the reference player titled “[BBC] On-demand Elephant's Dream - with EBU-TT-D 'Snaking' Subtitle Track (random text) - lines grow over time simulating live subtitles”, it’s clear to see the effect before and after this code is applied.

These changes preserve the work done by @bbert in #4103 & #4155. Extending identical cues is still preserved and I have checked [the test stream mentioned in the PR](https://broadpeak-tv.github.io/test-content/dash/imsc-image/imsc1_img.mpd) still operates as expected. Additionally, this PR doesn’t affect the operation of WebVTT subtitles or CEA608 captions. The intent is to just target imsc subtitles where this flickering effect has been witnessed.

The following changes have been made:

- Clear up the `captionsContainer` immediately before adding new elements in `_renderCaption()`.
- Use requestAnimationFrame (where available) for performance benefits and to ensure drawing as a cause of `_renderCaption()` happens in the same frame (it should if not available anyway now).
- If cues are adjacent, and not identical, make sure they are cleaned up within `_renderCaption()` and not at a different time by the `onexit` event. Ensure this only happens for imsc subs.
- Refactor around `_extendLastCue()` for clarity.
- Separate out arguments for the imscJS `renderHTML` function, for readability. I have not changed the arguments, just the formatting.