### PR TITLE
Consistent use of camelCase for DVB extension properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2498,8 +2498,8 @@ declare namespace dashjs {
 
         schemeIdUri: string;
         value: string;
-        dvb_reportingUrl: string;
-        dvb_probability: number;
+        dvbReportingUrl: string;
+        dvbProbability: number;
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -394,8 +394,8 @@ declare namespace dashjs {
     export interface BaseURL {
         url: string;
         serviceLocation: string;
-        dvb_priority: number;
-        dvb_weight: number;
+        dvbPriority: number;
+        dvbWeight: number;
         availabilityTimeOffset: number;
         availabilityTimeComplete: boolean;
         queryParams: object;

--- a/src/dash/controllers/ContentSteeringController.js
+++ b/src/dash/controllers/ContentSteeringController.js
@@ -426,8 +426,8 @@ function ContentSteeringController() {
             return synthesizedElements.map((element) => {
                 const synthesizedBaseUrl = new BaseURL(element.synthesizedUrl, element.serviceLocation)
                 synthesizedBaseUrl.queryParams = element.queryParams;
-                synthesizedBaseUrl.dvb_priority = element.reference.dvb_priority;
-                synthesizedBaseUrl.dvb_weight = element.reference.dvb_weight;
+                synthesizedBaseUrl.dvbPriority = element.reference.dvbPriority;
+                synthesizedBaseUrl.dvbWeight = element.reference.dvbWeight;
                 synthesizedBaseUrl.availabilityTimeOffset = element.reference.availabilityTimeOffset;
                 synthesizedBaseUrl.availabilityTimeComplete = element.reference.availabilityTimeComplete;
 

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -1130,11 +1130,11 @@ function DashManifestModel() {
                 }
 
                 if (entry.hasOwnProperty(DashConstants.DVB_PRIORITY)) {
-                    baseUrl.dvb_priority = entry[DashConstants.DVB_PRIORITY];
+                    baseUrl.dvbPriority = entry[DashConstants.DVB_PRIORITY];
                 }
 
                 if (entry.hasOwnProperty(DashConstants.DVB_WEIGHT)) {
-                    baseUrl.dvb_weight = entry[DashConstants.DVB_WEIGHT];
+                    baseUrl.dvbWeight = entry[DashConstants.DVB_WEIGHT];
                 }
 
                 if (entry.hasOwnProperty(DashConstants.AVAILABILITY_TIME_OFFSET)) {

--- a/src/dash/vo/BaseURL.js
+++ b/src/dash/vo/BaseURL.js
@@ -42,8 +42,8 @@ class BaseURL {
         this.serviceLocation = serviceLocation || url || '';
 
         // DVB extensions
-        this.dvb_priority = priority || DEFAULT_DVB_PRIORITY;
-        this.dvb_weight = weight || DEFAULT_DVB_WEIGHT;
+        this.dvbPriority = priority || DEFAULT_DVB_PRIORITY;
+        this.dvbWeight = weight || DEFAULT_DVB_WEIGHT;
 
         this.availabilityTimeOffset = 0;
         this.availabilityTimeComplete = true;

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -141,7 +141,7 @@ function DVBReporting(config) {
 
         rangeController = rc;
 
-        reportingUrl = entry.dvb_reportingUrl;
+        reportingUrl = entry.dvbReportingUrl;
 
         // If a required attribute is missing, the Reporting descriptor may
         // be ignored by the Player
@@ -155,7 +155,7 @@ function DVBReporting(config) {
         // static for the duration of the MPD, regardless of MPD updates.
         // (i.e. only calling reset (or failure) changes this state)
         if (!reportingPlayerStatusDecided) {
-            probability = entry.dvb_probability;
+            probability = entry.dvbProbability;
             // TS 103 285 Clause 10.12.3.4
             // If the @probability attribute is set to 1000, it shall be a reporting Player.
             // If the @probability attribute is absent it will take the default value of 1000.

--- a/src/streaming/metrics/utils/ManifestParsing.js
+++ b/src/streaming/metrics/utils/ManifestParsing.js
@@ -93,11 +93,11 @@ function ManifestParsing (config) {
                         }
 
                         if (reporting.hasOwnProperty(constants.DVB_REPORTING_URL)) {
-                            reportingEntry.dvb_reportingUrl = reporting[constants.DVB_REPORTING_URL];
+                            reportingEntry.dvbReportingUrl = reporting[constants.DVB_REPORTING_URL];
                         }
 
                         if (reporting.hasOwnProperty(constants.DVB_PROBABILITY)) {
-                            reportingEntry.dvb_probability = reporting[constants.DVB_PROBABILITY];
+                            reportingEntry.dvbProbability = reporting[constants.DVB_PROBABILITY];
                         }
 
                         metricEntry.Reporting.push(reportingEntry);

--- a/src/streaming/metrics/vo/Reporting.js
+++ b/src/streaming/metrics/vo/Reporting.js
@@ -43,8 +43,8 @@ class Reporting {
         this.value = '';
 
         // DVB Extensions
-        this.dvb_reportingUrl = '';
-        this.dvb_probability = DEFAULT_DVB_PROBABILITY;
+        this.dvbReportingUrl = '';
+        this.dvbProbability = DEFAULT_DVB_PROBABILITY;
     }
 }
 

--- a/src/streaming/utils/baseUrlResolution/DVBSelector.js
+++ b/src/streaming/utils/baseUrlResolution/DVBSelector.js
@@ -42,8 +42,8 @@ function DVBSelector(config) {
 
         const samePrioritiesFilter = function (el) {
             if (removedPriorities.length) {
-                if ((el.dvb_priority) &&
-                        (removedPriorities.indexOf(el.dvb_priority) !== -1)) {
+                if ((el.dvbPriority) &&
+                        (removedPriorities.indexOf(el.dvbPriority) !== -1)) {
                     return false;
                 }
             }
@@ -56,8 +56,8 @@ function DVBSelector(config) {
                 // whenever a BaseURL is removed from the available list of
                 // BaseURLs, any other BaseURL with the same @priority
                 // value as the BaseURL being removed shall also be removed
-                if (baseUrl.dvb_priority) {
-                    removedPriorities.push(baseUrl.dvb_priority);
+                if (baseUrl.dvbPriority) {
+                    removedPriorities.push(baseUrl.dvbPriority);
                 }
 
                 // all URLs in the list which have a @serviceLocation
@@ -74,14 +74,14 @@ function DVBSelector(config) {
 
     function selectByWeight(availableUrls) {
         const prioritySorter = function (a, b) {
-            let diff = a.dvb_priority - b.dvb_priority;
+            let diff = a.dvbPriority - b.dvbPriority;
             return isNaN(diff) ? 0 : diff;
         };
 
         const topPriorityFilter = function (baseUrl, idx, arr) {
             return !idx || (
-                (arr[0].dvb_priority && baseUrl.dvb_priority) &&
-                (arr[0].dvb_priority === baseUrl.dvb_priority)
+                (arr[0].dvbPriority && baseUrl.dvbPriority) &&
+                (arr[0].dvbPriority === baseUrl.dvbPriority)
             );
         };
 
@@ -106,7 +106,7 @@ function DVBSelector(config) {
 
                 // add all the weights together, storing the accumulated weight per entry
                 urls.forEach(baseUrl => {
-                    totalWeight += baseUrl.dvb_weight;
+                    totalWeight += baseUrl.dvbWeight;
                     cumulWeights.push(totalWeight);
                 });
 

--- a/test/unit/dash.models.DashManifestModel.js
+++ b/test/unit/dash.models.DashManifestModel.js
@@ -1081,8 +1081,8 @@ describe('DashManifestModel', function () {
 
                 expect(obj).to.be.instanceOf(Array);
                 expect(obj).to.have.lengthOf(1);
-                expect(obj[0].dvb_priority).to.equal(BaseURL.DEFAULT_DVB_PRIORITY);
-                expect(obj[0].dvb_weight).to.equal(BaseURL.DEFAULT_DVB_WEIGHT);
+                expect(obj[0].dvbPriority).to.equal(BaseURL.DEFAULT_DVB_PRIORITY);
+                expect(obj[0].dvbWeight).to.equal(BaseURL.DEFAULT_DVB_WEIGHT);
             });
 
             it('returns an Array of BaseURLs with BaseURL[0] having correct priority and weight for DVB extensions when specified', () => {
@@ -1100,8 +1100,8 @@ describe('DashManifestModel', function () {
 
                 expect(obj).to.be.instanceOf(Array);
                 expect(obj).to.have.lengthOf(1);
-                expect(obj[0].dvb_priority).to.equal(TEST_PRIORITY);
-                expect(obj[0].dvb_weight).to.equal(TEST_WEIGHT);
+                expect(obj[0].dvbPriority).to.equal(TEST_PRIORITY);
+                expect(obj[0].dvbWeight).to.equal(TEST_WEIGHT);
             });
 
             it('returns an Array of BaseURLs with BaseURL[0] resolved to the document base uri when the base uri is specified and the input url is relative', () => {

--- a/test/unit/streaming.utils.DVBSelector.js
+++ b/test/unit/streaming.utils.DVBSelector.js
@@ -106,13 +106,13 @@ describe('BaseURLResolution/DVBSelector', function () {
 
     it('should select baseUrls as defined in the example in DVB A168 10.8.2.4', () => {
         const baseUrls = [
-            { dvb_priority: 1, dvb_weight: 10, serviceLocation: 'A' },
-            { dvb_priority: 1, dvb_weight: 30, serviceLocation: 'B' },
-            { dvb_priority: 1, dvb_weight: 60, serviceLocation: 'C' },
-            { dvb_priority: 3, dvb_weight: 1, serviceLocation: 'C' },
-            { dvb_priority: 4, dvb_weight: 1, serviceLocation: 'B' },
-            { dvb_priority: 5, dvb_weight: 1, serviceLocation: 'D' },
-            { dvb_priority: 5, dvb_weight: 1, serviceLocation: 'E' }
+            { dvbPriority: 1, dvbWeight: 10, serviceLocation: 'A' },
+            { dvbPriority: 1, dvbWeight: 30, serviceLocation: 'B' },
+            { dvbPriority: 1, dvbWeight: 60, serviceLocation: 'C' },
+            { dvbPriority: 3, dvbWeight: 1, serviceLocation: 'C' },
+            { dvbPriority: 4, dvbWeight: 1, serviceLocation: 'B' },
+            { dvbPriority: 5, dvbWeight: 1, serviceLocation: 'D' },
+            { dvbPriority: 5, dvbWeight: 1, serviceLocation: 'E' }
         ];
 
         // we need Math.random to be completely unrandom
@@ -133,13 +133,13 @@ describe('BaseURLResolution/DVBSelector', function () {
         stub.returns(0.3);
 
         const firstSelection = dvbSelector.select(baseUrls);
-        expect(firstSelection.dvb_priority).to.equal(1);
+        expect(firstSelection.dvbPriority).to.equal(1);
         expect(firstSelection.serviceLocation).to.equal('B');
 
         blacklist.push(firstSelection.serviceLocation);
 
         const secondSelection = dvbSelector.select(baseUrls);
-        expect(secondSelection.dvb_priority).to.equal(3);
+        expect(secondSelection.dvbPriority).to.equal(3);
         expect(secondSelection.serviceLocation).to.equal('C');
 
         // Math.random (called in select()) will return 1
@@ -148,7 +148,7 @@ describe('BaseURLResolution/DVBSelector', function () {
         blacklist.push(secondSelection.serviceLocation);
 
         const thirdSelection = dvbSelector.select(baseUrls);
-        expect(thirdSelection.dvb_priority).to.equal(5);
+        expect(thirdSelection.dvbPriority).to.equal(5);
         expect(thirdSelection.serviceLocation).to.equal('E');
 
         blacklist.push(thirdSelection.serviceLocation);
@@ -159,8 +159,8 @@ describe('BaseURLResolution/DVBSelector', function () {
 
     it('should not select baseUrls with invalid priority when there is another option', () => {
         const baseUrls = [
-            { serviceLocation: 'A', dvb_priority: 1, dvb_weight: 1 },
-            { serviceLocation: 'B', dvb_priority: 'STRING', dvb_weight: 100000000 }
+            { serviceLocation: 'A', dvbPriority: 1, dvbWeight: 1 },
+            { serviceLocation: 'B', dvbPriority: 'STRING', dvbWeight: 100000000 }
         ];
 
         const dvbSelector = DVBSelector(context).create(defaultConfig);
@@ -171,7 +171,7 @@ describe('BaseURLResolution/DVBSelector', function () {
 
     it('should select baseUrls with invalid priority if there is no other option', () => {
         const baseUrls = [
-            { serviceLocation: 'B', dvb_priority: 'STRING', dvb_weight: 1 }
+            { serviceLocation: 'B', dvbPriority: 'STRING', dvbWeight: 1 }
         ];
 
         const dvbSelector = DVBSelector(context).create(defaultConfig);


### PR DESCRIPTION
As mentioned in #4338, it would be preferable if existing references to DVB extension properties consistently use camelCase. This should handle the following MPD elements@dvb extensions.

- BaseUrl@dvb:priority
- BaseUrl@dvb:weight
- Reporting@dvb:reportingUrl
- Reporting@dvb:probability