### PR TITLE
Fix PlaybackErrorEvent error TS typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1846,7 +1846,7 @@ declare namespace dashjs {
 
     export interface PlaybackErrorEvent extends Event {
         type: MediaPlayerEvents['PLAYBACK_ERROR'];
-        error: string;
+        error: MediaError;
     }
 
     export interface PlaybackPausedEvent extends Event {
@@ -4461,5 +4461,4 @@ declare namespace dashjs {
     export type RequestFilter = (request: LicenseRequest) => Promise<any>;
     export type ResponseFilter = (response: LicenseResponse) => Promise<any>;
 }
-
 

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -402,12 +402,12 @@ describe('PlaybackController', function () {
                 let onError = function (e) {
                     eventBus.off(Events.PLAYBACK_ERROR, onError);
 
-                    expect(e.error).to.equal('error');
+                    expect(e.error.message).to.equal('error');
                     done();
                 };
 
                 eventBus.on(Events.PLAYBACK_ERROR, onError, this);
-                videoModelMock.fireEvent('error', [{ target: { error: 'error' } }]);
+                videoModelMock.fireEvent('error', [{ target: { error: { code: 3, message: 'error' } } }]);
             });
 
             it('should handle stalled event', function (done) {


### PR DESCRIPTION
`PlaybackErrorEvent` when triggered in `PlaybackController`, attaches the original `MediaError` as `error` property.  This commit corrects the TS typing to reflect that.

## Context

See here for reference: https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/controllers/PlaybackController.js#L714

We've encountered this as we pass errors using `MessageBus` and we failed to serialise this one as it carries an `object` property (thus becomes an `object` itself) which was not correctly reflected in `PlaybackErrorEvent` TS type.

Also see here: https://html.spec.whatwg.org/multipage/media.html#dom-media-error