### PR TITLE
[v5] Fix CommonMediaResponse resourceTiming.encodedBodySize

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -495,7 +495,7 @@ function HTTPLoader(cfg) {
         // Use Resource Timing info when available for CommonMediaResponse
         if (resource) {
             httpResponse.resourceTiming.startTime = resource.startTime;
-            httpResponse.resourceTiming.encodedBodySize = resource.startTime;
+            httpResponse.resourceTiming.encodedBodySize = resource.encodedBodySize;
             httpResponse.resourceTiming.responseStart = resource.startTime;
             httpResponse.resourceTiming.responseEnd = resource.responseEnd;
             httpResponse.resourceTiming.duration = resource.duration;


### PR DESCRIPTION
due to abusive copy/paste error