### PR TITLE
Add a try/catch around matchSettingsLang in case bcp47Normalize fails…

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -340,10 +340,14 @@ function MediaController() {
     }
 
     function matchSettingsLang(settings, track) {
-        return !settings.lang ||
-        (settings.lang instanceof RegExp) ?
-            (track.lang.match(settings.lang)) : track.lang !== '' ?
-                (extendedFilter(track.lang, bcp47Normalize(settings.lang)).length > 0) : false;
+        try {
+            return !settings.lang ||
+            (settings.lang instanceof RegExp) ?
+                (track.lang.match(settings.lang)) : track.lang !== '' ?
+                    (extendedFilter(track.lang, bcp47Normalize(settings.lang)).length > 0) : false;
+        } catch (e) {
+            return false
+        }
     }
 
     function matchSettingsIndex(settings, track) {


### PR DESCRIPTION
… with an error