### PR TITLE
[v5] Fix CommonMediaResponse.resourceTiming info

### DIFF
--- a/src/streaming/models/ThroughputModel.js
+++ b/src/streaming/models/ThroughputModel.js
@@ -190,7 +190,7 @@ function ThroughputModel(config) {
         let deriveThroughputViaResourceTimingApi = false;
 
         // Calculate the throughput using the ResourceTimingAPI if available
-        if (httpRequest._resourceTimingValues) {
+        if (settings.get().streaming.abr.throughput.useResourceTimingApi && httpRequest._resourceTimingValues) {
             downloadedBytes = httpRequest._resourceTimingValues.transferSize;
             downloadTimeInMs = httpRequest._resourceTimingValues.responseEnd - httpRequest._resourceTimingValues.responseStart;
             deriveThroughputViaResourceTimingApi = true;
@@ -249,7 +249,7 @@ function ThroughputModel(config) {
      */
     function _isCachedResponse(mediaType, cacheReferenceTime, httpRequest) {
 
-        if (httpRequest._resourceTimingValues) {
+        if (settings.get().streaming.abr.throughput.useResourceTimingApi && httpRequest._resourceTimingValues) {
             return httpRequest._resourceTimingValues.transferSize === 0 && httpRequest._resourceTimingValues.decodedBodySize > 0
         }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -490,16 +490,34 @@ function HTTPLoader(cfg) {
             i += 1;
         }
 
+        // Check if PerformanceResourceTiming values are usable
+        // Note: to allow seeing cross-origin timing information, the Timing-Allow-Origin HTTP response header needs to be set
+        // See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming#cross-origin_timing_information
+        if (!_areResourceTimingValuesUsable(resource)) {
+            return;
+        }
+
         httpRequest.customData.request.resourceTimingValues = resource;
 
-        // Use Resource Timing info when available for CommonMediaResponse
-        if (resource) {
-            httpResponse.resourceTiming.startTime = resource.startTime;
-            httpResponse.resourceTiming.encodedBodySize = resource.encodedBodySize;
-            httpResponse.resourceTiming.responseStart = resource.startTime;
-            httpResponse.resourceTiming.responseEnd = resource.responseEnd;
-            httpResponse.resourceTiming.duration = resource.duration;
-        }
+        // Update CommonMediaResponse Resouce Timing info
+        httpResponse.resourceTiming.startTime = resource.startTime;
+        httpResponse.resourceTiming.encodedBodySize = resource.encodedBodySize;
+        httpResponse.resourceTiming.responseStart = resource.startTime;
+        httpResponse.resourceTiming.responseEnd = resource.responseEnd;
+        httpResponse.resourceTiming.duration = resource.duration;
+    }
+
+    /**
+     * Checks if we got usable ResourceTimingAPI values
+     * @param httpRequest
+     * @returns {boolean}
+     * @private
+     */
+    function _areResourceTimingValuesUsable(resource) {
+        return resource &&
+            !isNaN(resource.responseStart) && resource.responseStart > 0 &&
+            !isNaN(resource.responseEnd) && resource.responseEnd > 0 &&
+            !isNaN(resource.transferSize) && resource.transferSize > 0
     }
 
     /**

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -499,7 +499,7 @@ function HTTPLoader(cfg) {
 
         httpRequest.customData.request.resourceTimingValues = resource;
 
-        // Update CommonMediaResponse Resouce Timing info
+        // Update CommonMediaResponse Resource Timing info
         httpResponse.resourceTiming.startTime = resource.startTime;
         httpResponse.resourceTiming.encodedBodySize = resource.encodedBodySize;
         httpResponse.resourceTiming.responseStart = resource.startTime;


### PR DESCRIPTION
in case PerformanceResourceTiming is not usable (due to cross-origin restrictions)
