### PR TITLE
Improve the AbandonRequestsRule.js by using traces from progress event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1176,15 +1176,31 @@ declare namespace dashjs {
             abr?: {
                 limitBitrateByPortal?: boolean;
                 usePixelRatioInLimitBitrateByPortal?: boolean;
-                activeRules?: {
-                    throughputRule?: boolean,
-                    bolaRule?: boolean,
-                    insufficientBufferRule?: boolean,
-                    switchHistoryRule?: boolean,
-                    droppedFramesRule?: boolean,
-                    abandonRequestsRule?: boolean
-                    l2ARule?: boolean
-                    loLPRule?: boolean
+                rules?: {
+                    throughputRule?: {
+                        active?: boolean
+                    },
+                    bolaRule?: {
+                        active?: boolean
+                    },
+                    insufficientBufferRule?: {
+                        active?: boolean
+                    },
+                    switchHistoryRule?: {
+                        active?: boolean
+                    },
+                    droppedFramesRule?: {
+                        active?: boolean
+                    },
+                    abandonRequestsRule?: {
+                        active?: boolean
+                    }
+                    l2ARule?: {
+                        active?: boolean
+                    }
+                    loLPRule?: {
+                        active?: boolean
+                    }
                 },
                 throughput?: {
                     averageCalculationMode?: ThroughputCalculationModes,

--- a/samples/abr/abr.html
+++ b/samples/abr/abr.html
@@ -29,13 +29,25 @@
             player.updateSettings({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: true,
-                            bolaRule: false,
-                            insufficientBufferRule: true,
-                            switchHistoryRule: false,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            } ,
+                            bolaRule: {
+                                active: false
+                            },
+                            insufficientBufferRule: {
+                                active: true
+                            },
+                            switchHistoryRule: {
+                                active: false
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: false
+                            }
                         }
                     }
                 }

--- a/samples/abr/custom-abr-rules.html
+++ b/samples/abr/custom-abr-rules.html
@@ -32,12 +32,24 @@
             player.updateSettings({
                 abr: {
                     activeRules: {
-                        throughputRule: false,
-                        bolaRule: false,
-                        insufficientBufferRule: false,
-                        switchHistoryRule: false,
-                        droppedFramesRule: false,
-                        abandonRequestsRule: false
+                        throughputRule: {
+                            active: false
+                        },
+                        bolaRule: {
+                            active: false
+                        },
+                        insufficientBufferRule: {
+                            active: false
+                        },
+                        switchHistoryRule: {
+                            active: false
+                        },
+                        droppedFramesRule: {
+                            active: false
+                        },
+                        abandonRequestsRule: {
+                            active: false
+                        }
                     }
                 }
             });

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -574,15 +574,31 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.player.updateSettings({
             streaming: {
                 abr: {
-                    activeRules: {
-                        throughputRule: $scope.activeAbrRules.throughputRule,
-                        bolaRule: $scope.activeAbrRules.bolaRule,
-                        insufficientBufferRule: $scope.activeAbrRules.insufficientBufferRule,
-                        switchHistoryRule: $scope.activeAbrRules.switchHistoryRule,
-                        droppedFramesRule: $scope.activeAbrRules.droppedFramesRule,
-                        abandonRequestsRule: $scope.activeAbrRules.abandonRequestsRule,
-                        l2ARule: $scope.activeAbrRules.l2ARule,
-                        loLPRule: $scope.activeAbrRules.loLPRule,
+                    rules: {
+                        throughputRule: {
+                            active: $scope.activeAbrRules.throughputRule
+                        },
+                        bolaRule: {
+                            active: $scope.activeAbrRules.bolaRule
+                        },
+                        insufficientBufferRule: {
+                            active: $scope.activeAbrRules.insufficientBufferRule,
+                        },
+                        switchHistoryRule: {
+                            active: $scope.activeAbrRules.switchHistoryRule
+                        },
+                        droppedFramesRule: {
+                            active: $scope.activeAbrRules.droppedFramesRule
+                        },
+                        abandonRequestsRule: {
+                            active: $scope.activeAbrRules.abandonRequestsRule
+                        },
+                        l2ARule: {
+                            active: $scope.activeAbrRules.l2ARule
+                        },
+                        loLPRule: {
+                            active: $scope.activeAbrRules.loLPRule
+                        }
                     }
                 }
             }
@@ -2071,14 +2087,14 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
 
     function setAbrRules() {
         var currentConfig = $scope.player.getSettings();
-        $scope.activeAbrRules.throughputRule = currentConfig.streaming.abr.activeRules.throughputRule;
-        $scope.activeAbrRules.bolaRule = currentConfig.streaming.abr.activeRules.bolaRule;
-        $scope.activeAbrRules.insufficientBufferRule = currentConfig.streaming.abr.activeRules.insufficientBufferRule;
-        $scope.activeAbrRules.switchHistoryRule = currentConfig.streaming.abr.activeRules.switchHistoryRule;
-        $scope.activeAbrRules.droppedFramesRule = currentConfig.streaming.abr.activeRules.droppedFramesRule;
-        $scope.activeAbrRules.abandonRequestsRule = currentConfig.streaming.abr.activeRules.abandonRequestsRule;
-        $scope.activeAbrRules.loLPRule = currentConfig.streaming.abr.activeRules.loLPRule;
-        $scope.activeAbrRules.l2ARule = currentConfig.streaming.abr.activeRules.l2ARule;
+        $scope.activeAbrRules.throughputRule = currentConfig.streaming.abr.rules.throughputRule.active;
+        $scope.activeAbrRules.bolaRule = currentConfig.streaming.abr.rules.bolaRule.active;
+        $scope.activeAbrRules.insufficientBufferRule = currentConfig.streaming.abr.rules.insufficientBufferRule.active;
+        $scope.activeAbrRules.switchHistoryRule = currentConfig.streaming.abr.rules.switchHistoryRule.active;
+        $scope.activeAbrRules.droppedFramesRule = currentConfig.streaming.abr.rules.droppedFramesRule.active;
+        $scope.activeAbrRules.abandonRequestsRule = currentConfig.streaming.abr.rules.abandonRequestsRule.active;
+        $scope.activeAbrRules.loLPRule = currentConfig.streaming.abr.rules.loLPRule.active;
+        $scope.activeAbrRules.l2ARule = currentConfig.streaming.abr.rules.l2ARule.active;
     }
 
     function setAdditionalPlaybackOptions() {

--- a/samples/low-latency/testplayer/main.js
+++ b/samples/low-latency/testplayer/main.js
@@ -104,15 +104,31 @@ App.prototype._applyParameters = function () {
                 mode: settings.catchupMechanism
             },
             abr: {
-                activeRules: {
-                    throughputRule: settings.abrThroughputRule,
-                    bolaRule: settings.abrBolaRule,
-                    insufficientBufferRule: settings.abrInsufficientBufferRule,
-                    switchHistoryRule: settings.abrSwitchHistoryRule,
-                    droppedFramesRule: settings.abrDroppedFramesRule,
-                    abandonRequestsRule: settings.abrAbandonRequestRule,
-                    l2ARule: settings.abrL2ARule,
-                    loLPRule: settings.abrLoLPRule,
+                rules: {
+                    throughputRule: {
+                        active: settings.abrThroughputRule
+                    },
+                    bolaRule: {
+                        active: settings.abrBolaRule
+                    },
+                    insufficientBufferRule: {
+                        active: settings.abrInsufficientBufferRule
+                    },
+                    switchHistoryRule: {
+                        active: settings.abrSwitchHistoryRule
+                    },
+                    droppedFramesRule: {
+                        active: settings.abrDroppedFramesRule
+                    },
+                    abandonRequestsRule: {
+                        active: settings.abrAbandonRequestRule
+                    },
+                    l2ARule: {
+                        active: settings.abrL2ARule
+                    },
+                    loLPRule: {
+                        active: settings.abrLoLPRule
+                    },
                 },
                 throughput: {
                     averageCalculationMode: settings.throughputEstimation,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -191,15 +191,32 @@ import Events from './events/Events.js';
  *             abr: {
  *                 limitBitrateByPortal: false,
  *                 usePixelRatioInLimitBitrateByPortal: false,
- *                 activeRules: {
- *                     throughputRule: true,
- *                     bolaRule: true,
- *                     insufficientBufferRule: true,
- *                     switchHistoryRule: true,
- *                     droppedFramesRule: true,
- *                     abandonRequestsRule: true,
- *                     l2ARule: false,
- *                     loLPRule: false
+ *                 rules: {
+ *                     throughputRule: {
+ *                        active: true
+ *                    },
+ *                    bolaRule: {
+ *                        active: true
+ *                    },
+ *                     insufficientBufferRule: {
+ *                        active: true
+ *                    },
+ *                    switchHistoryRule: {
+ *                        active: true
+ *                    },
+ *                    droppedFramesRule: {
+ *                        active: true
+ *                    },
+ *                    abandonRequestsRule: {
+ *                        active: true
+ *                    },
+ *                   l2ARule: {
+ *                        active: false
+ *                    },
+ *                   loLPRule: {
+ *                        active: false
+ *                    }
+ *
  *                 },
  *                 throughput: {
  *                     averageCalculationMode: Constants.THROUGHPUT_CALCULATION_MODES.EWMA,
@@ -607,7 +624,7 @@ import Events from './events/Events.js';
  * Sets whether to take into account the device's pixel ratio when defining the portal dimensions.
  *
  * Useful on, for example, retina displays.
- * @property {object} [activeRules={throughputRule: true, bolaRule: true, insufficientBufferRule: true,switchHistoryRule: true,droppedFramesRule: true,abandonRequestsRule: true, l2ARule: false, loLPRule: false}]
+ * @property {object} [activeRules={throughputRule: {active: true}, bolaRule: {active: true}, insufficientBufferRule: {active: true},switchHistoryRule: {active: true},droppedFramesRule: {active: true},abandonRequestsRule: {active: true}, l2ARule: {active: false}, loLPRule: {active: false}}]
  * Enable/Disable individual ABR rules. Note that if the throughputRule and the bolaRule are activated at the same time we switch to a dynamic mode.
  * In the dynamic mode either ThroughputRule or BolaRule are active but not both at the same time.
  *
@@ -851,14 +868,14 @@ function Settings() {
         'streaming.liveCatchup.enabled': Events.SETTING_UPDATED_CATCHUP_ENABLED,
         'streaming.liveCatchup.playbackRate.min': Events.SETTING_UPDATED_PLAYBACK_RATE_MIN,
         'streaming.liveCatchup.playbackRate.max': Events.SETTING_UPDATED_PLAYBACK_RATE_MAX,
-        'streaming.abr.activeRules.throughputRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.bolaRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.insufficientBufferRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.switchHistoryRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.droppedFramesRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.abandonRequestsRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.l2ARule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
-        'streaming.abr.activeRules.loLPRule': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.throughputRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.bolaRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.insufficientBufferRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.switchHistoryRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.droppedFramesRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.abandonRequestsRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.l2ARule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
+        'streaming.abr.rules.loLPRule.active': Events.SETTING_UPDATED_ABR_ACTIVE_RULES,
     };
 
     /**
@@ -1016,15 +1033,36 @@ function Settings() {
                 limitBitrateByPortal: false,
                 usePixelRatioInLimitBitrateByPortal: false,
                 enableSupplementalPropertyAdaptationSetSwitching: true,
-                activeRules: {
-                    throughputRule: true,
-                    bolaRule: true,
-                    insufficientBufferRule: true,
-                    switchHistoryRule: true,
-                    droppedFramesRule: true,
-                    abandonRequestsRule: true,
-                    l2ARule: false,
-                    loLPRule: false
+                rules: {
+                    throughputRule: {
+                        active: true
+                    },
+                    bolaRule: {
+                        active: true
+                    },
+                    insufficientBufferRule: {
+                        active: true
+                    },
+                    switchHistoryRule: {
+                        active: true
+                    },
+                    droppedFramesRule: {
+                        active: true
+                    },
+                    abandonRequestsRule: {
+                        active: true,
+                        parameters: {
+                            abandonDurationMultiplier: 1.8,
+                            minSegmentDownloadTimeThresholdInMs: 500,
+                            minThroughputSamplesThreshold: 6
+                        }
+                    },
+                    l2ARule: {
+                        active: false
+                    },
+                    loLPRule: {
+                        active: false
+                    }
                 },
                 throughput: {
                     averageCalculationMode: Constants.THROUGHPUT_CALCULATION_MODES.EWMA,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -127,7 +127,7 @@ function AbrController() {
         // Do not change current value if it has been set before
         const currentState = abrRulesCollection.getBolaState(type)
         if (currentState === undefined) {
-            abrRulesCollection.setBolaState(type, settings.get().streaming.abr.activeRules.bolaRule && !_shouldApplyDynamicAbrStrategy());
+            abrRulesCollection.setBolaState(type, settings.get().streaming.abr.rules.bolaRule.active && !_shouldApplyDynamicAbrStrategy());
         }
 
     }
@@ -720,7 +720,7 @@ function AbrController() {
      * @private
      */
     function _shouldApplyDynamicAbrStrategy() {
-        return settings.get().streaming.abr.activeRules.bolaRule && settings.get().streaming.abr.activeRules.throughputRule
+        return settings.get().streaming.abr.rules.bolaRule.active && settings.get().streaming.abr.rules.throughputRule.active
     }
 
     /**

--- a/src/streaming/controllers/ThroughputController.js
+++ b/src/streaming/controllers/ThroughputController.js
@@ -93,7 +93,7 @@ function ThroughputController() {
     }
 
     /**
-     * Push new values to the throughput model once a HTTP request completed
+     * Push new values to the throughput model once an HTTP request completed
      * @param {object} e
      * @private
      */

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -171,6 +171,7 @@ function HTTPLoader(cfg) {
                     t: event.throughput
                 });
 
+                requestObject.traces = traces;
                 lastTraceTime = currentTime;
                 lastTraceReceivedCount = event.loaded;
             }
@@ -234,7 +235,7 @@ function HTTPLoader(cfg) {
                 } else {
                     _onerror();
                 }
-            });    
+            });
         };
 
         /**
@@ -294,14 +295,14 @@ function HTTPLoader(cfg) {
             return new Promise((resolve) => {
                 _applyRequestInterceptors(httpRequest).then((_httpRequest) => {
                     httpRequest = _httpRequest;
-    
+
                     httpRequest.customData.onload = _onload;
                     httpRequest.customData.onloadend = _onloadend;
                     httpRequest.customData.onerror = _onloadend;
                     httpRequest.customData.onprogress = _onprogress;
                     httpRequest.customData.onabort = _onabort;
                     httpRequest.customData.ontimeout = _ontimeout;
-            
+
                     httpResponse.resourceTiming.startTime = Date.now();
                     loader.load(httpRequest, httpResponse);
                     resolve();
@@ -353,10 +354,11 @@ function HTTPLoader(cfg) {
 
         let httpRequest; // CommonMediaLibrary.request.CommonMediaRequest
         let httpResponse; // CommonMediaLibrary.request.CommonMediaResponse
-    
+
         requestObject.bytesLoaded = NaN;
         requestObject.bytesTotal = NaN;
         requestObject.firstByteDate = null;
+        requestObject.traces = [];
         firstProgress = true;
         requestStartTime = new Date();
         lastTraceTime = requestStartTime;

--- a/src/streaming/rules/abr/ABRRulesCollection.js
+++ b/src/streaming/rules/abr/ABRRulesCollection.js
@@ -115,13 +115,13 @@ function ABRRulesCollection(config) {
     function _handleRuleUpdate(ruleName, rulesCollection) {
         // we use camel case in the settings while the rules start with a capital latter. Not ideal but convert between these formats
         const attribute = ruleName.charAt(0).toLowerCase() + ruleName.slice(1);
-        if (settings.get().streaming.abr.activeRules[attribute] && !_arrayContainsRule(rulesCollection, ruleName)) {
+        if (settings.get().streaming.abr.rules[attribute].active && !_arrayContainsRule(rulesCollection, ruleName)) {
             rulesCollection.push(
                 _createRuleInstance(ruleName)
             );
 
             return rulesCollection
-        } else if (!settings.get().streaming.abr.activeRules[attribute]) {
+        } else if (!settings.get().streaming.abr.rules[attribute].active) {
             return _removeRuleFromArray(rulesCollection, ruleName)
         }
 

--- a/test/unit/streaming.rules.abr.ABRRulesCollection.js
+++ b/test/unit/streaming.rules.abr.ABRRulesCollection.js
@@ -25,15 +25,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: true,
-                            bolaRule: true,
-                            insufficientBufferRule: true,
-                            switchHistoryRule: true,
-                            droppedFramesRule: true,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            },
+                            bolaRule: {
+                                active: true
+                            },
+                            insufficientBufferRule: {
+                                active: true
+                            },
+                            switchHistoryRule: {
+                                active: true
+                            },
+                            droppedFramesRule: {
+                                active: true
+                            },
+                            abandonRequestsRule: {
+                                active: true
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -65,15 +81,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: true,
-                            bolaRule: true,
-                            insufficientBufferRule: true,
-                            switchHistoryRule: true,
-                            droppedFramesRule: true,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            },
+                            bolaRule: {
+                                active: true
+                            },
+                            insufficientBufferRule: {
+                                active: true
+                            },
+                            switchHistoryRule: {
+                                active: true
+                            },
+                            droppedFramesRule: {
+                                active: true
+                            },
+                            abandonRequestsRule: {
+                                active: true
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -102,15 +134,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: false,
-                            bolaRule: false,
-                            insufficientBufferRule: false,
-                            switchHistoryRule: false,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: false
+                            },
+                            bolaRule: {
+                                active: false
+                            },
+                            insufficientBufferRule: {
+                                active: false
+                            },
+                            switchHistoryRule: {
+                                active: false
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: true
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -140,15 +188,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: false,
-                            bolaRule: false,
-                            insufficientBufferRule: true,
-                            switchHistoryRule: true,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: false
+                            },
+                            bolaRule: {
+                                active: false
+                            },
+                            insufficientBufferRule: {
+                                active: true
+                            },
+                            switchHistoryRule: {
+                                active: true
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: true
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -174,15 +238,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: true,
-                            bolaRule: true,
-                            insufficientBufferRule: false,
-                            switchHistoryRule: false,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            },
+                            bolaRule: {
+                                active: true
+                            },
+                            insufficientBufferRule: {
+                                active: false
+                            },
+                            switchHistoryRule: {
+                                active: false
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: false
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -205,15 +285,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: false,
-                            bolaRule: false,
-                            insufficientBufferRule: true,
-                            switchHistoryRule: true,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: false,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            },
+                            bolaRule: {
+                                active: true
+                            },
+                            insufficientBufferRule: {
+                                active: false
+                            },
+                            switchHistoryRule: {
+                                active: false
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: false
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }
@@ -233,15 +329,31 @@ describe('ABRRulesCollection', function () {
             settings.update({
                 streaming: {
                     abr: {
-                        activeRules: {
-                            throughputRule: true,
-                            bolaRule: true,
-                            insufficientBufferRule: false,
-                            switchHistoryRule: false,
-                            droppedFramesRule: false,
-                            abandonRequestsRule: true,
-                            l2ARule: false,
-                            loLPRule: false
+                        rules: {
+                            throughputRule: {
+                                active: true
+                            },
+                            bolaRule: {
+                                active: true
+                            },
+                            insufficientBufferRule: {
+                                active: false
+                            },
+                            switchHistoryRule: {
+                                active: false
+                            },
+                            droppedFramesRule: {
+                                active: false
+                            },
+                            abandonRequestsRule: {
+                                active: true
+                            },
+                            l2ARule: {
+                                active: false
+                            },
+                            loLPRule: {
+                                active: false
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR addresses #3840 

* The `AbandonRequestRule` now uses the traces that are populated in the `_onprogress` event of `HTTPLoader`. The current throughput is calculated based on these traces aalso removing the first sample from the calculation as it includes latency.
* Removed `fragmentDict` and `throughputArray` from `AbandonRequestRule` as they are not needed and blow up the code.
* Allow configuration of the relevant parameters for the `AbandonRequestRule` via `Settings.js`. 
* Refactor the code in `AbandonRequestRule` for better structuring and easier understanding.