### PR TITLE
Added liveUpdateTimeThreshold to control time syncing during live streams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -963,6 +963,7 @@ declare namespace dashjs {
             abandonLoadTimeout?: number,
             wallclockTimeUpdateInterval?: number,
             manifestUpdateRetryInterval?: number,
+            liveUpdateTimeThresholdInMilliseconds?: number,
             applyServiceDescription?: boolean,
             applyProducerReferenceTime?: boolean,
             applyContentSteering?: boolean,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -62,7 +62,7 @@ import Events from './events/Events';
  *            abandonLoadTimeout: 10000,
  *            wallclockTimeUpdateInterval: 100,
  *            manifestUpdateRetryInterval: 100,
- *            liveUpdateTimeThreshold: 0,
+ *            liveUpdateTimeThresholdInMilliseconds: NaN,
  *            cacheInitSegments: false,
  *            applyServiceDescription: true,
  *            applyProducerReferenceTime: true,
@@ -742,7 +742,7 @@ import Events from './events/Events';
  * How frequently the wallclockTimeUpdated internal event is triggered (in milliseconds).
  * @property {number} [manifestUpdateRetryInterval=100]
  * For live streams, set the interval-frequency in milliseconds at which dash.js will check if the current manifest is still processed before downloading the next manifest once the minimumUpdatePeriod time has.
- * @property {number} [liveUpdateTimeThreshold=0]
+ * @property {number} [liveUpdateTimeThresholdInMilliseconds=NaN]
  * For live streams, postpone syncing time updates until the threshold is passed. Increase if problems occurs during live streams on low end devices.
  * @property {boolean} [cacheInitSegments=false]
  * Enables the caching of init segments to avoid requesting the init segments before each representation switch.
@@ -874,7 +874,7 @@ function Settings() {
             abandonLoadTimeout: 10000,
             wallclockTimeUpdateInterval: 100,
             manifestUpdateRetryInterval: 100,
-            liveUpdateTimeThreshold: 0,
+            liveUpdateTimeThresholdInMilliseconds: NaN,
             cacheInitSegments: false,
             applyServiceDescription: true,
             applyProducerReferenceTime: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -62,6 +62,7 @@ import Events from './events/Events';
  *            abandonLoadTimeout: 10000,
  *            wallclockTimeUpdateInterval: 100,
  *            manifestUpdateRetryInterval: 100,
+ *            liveUpdateTimeThreshold: 0,
  *            cacheInitSegments: false,
  *            applyServiceDescription: true,
  *            applyProducerReferenceTime: true,
@@ -741,6 +742,8 @@ import Events from './events/Events';
  * How frequently the wallclockTimeUpdated internal event is triggered (in milliseconds).
  * @property {number} [manifestUpdateRetryInterval=100]
  * For live streams, set the interval-frequency in milliseconds at which dash.js will check if the current manifest is still processed before downloading the next manifest once the minimumUpdatePeriod time has.
+ * @property {number} [liveUpdateTimeThreshold=0]
+ * For live streams, postpone syncing time updates until the threshold is passed. Increase if problems occurs during live streams on low end devices.
  * @property {boolean} [cacheInitSegments=false]
  * Enables the caching of init segments to avoid requesting the init segments before each representation switch.
  * @property {boolean} [applyServiceDescription=true]
@@ -871,6 +874,7 @@ function Settings() {
             abandonLoadTimeout: 10000,
             wallclockTimeUpdateInterval: 100,
             manifestUpdateRetryInterval: 100,
+            liveUpdateTimeThreshold: 0,
             cacheInitSegments: false,
             applyServiceDescription: true,
             applyProducerReferenceTime: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -62,7 +62,7 @@ import Events from './events/Events';
  *            abandonLoadTimeout: 10000,
  *            wallclockTimeUpdateInterval: 100,
  *            manifestUpdateRetryInterval: 100,
- *            liveUpdateTimeThresholdInMilliseconds: NaN,
+ *            liveUpdateTimeThresholdInMilliseconds: 0,
  *            cacheInitSegments: false,
  *            applyServiceDescription: true,
  *            applyProducerReferenceTime: true,
@@ -742,7 +742,7 @@ import Events from './events/Events';
  * How frequently the wallclockTimeUpdated internal event is triggered (in milliseconds).
  * @property {number} [manifestUpdateRetryInterval=100]
  * For live streams, set the interval-frequency in milliseconds at which dash.js will check if the current manifest is still processed before downloading the next manifest once the minimumUpdatePeriod time has.
- * @property {number} [liveUpdateTimeThresholdInMilliseconds=NaN]
+ * @property {number} [liveUpdateTimeThresholdInMilliseconds=0]
  * For live streams, postpone syncing time updates until the threshold is passed. Increase if problems occurs during live streams on low end devices.
  * @property {boolean} [cacheInitSegments=false]
  * Enables the caching of init segments to avoid requesting the init segments before each representation switch.
@@ -874,7 +874,7 @@ function Settings() {
             abandonLoadTimeout: 10000,
             wallclockTimeUpdateInterval: 100,
             manifestUpdateRetryInterval: 100,
-            liveUpdateTimeThresholdInMilliseconds: NaN,
+            liveUpdateTimeThresholdInMilliseconds: 0,
             cacheInitSegments: false,
             applyServiceDescription: true,
             applyProducerReferenceTime: true,

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -58,6 +58,7 @@ function PlaybackController() {
         isDynamic,
         playOnceInitialized,
         lastLivePlaybackTime,
+        lastLiveUpdateTime,
         availabilityStartTime,
         availabilityTimeComplete,
         lowLatencyModeEnabled,
@@ -723,11 +724,15 @@ function PlaybackController() {
         // Updates playback time for paused dynamic streams
         // (video element doesn't call timeupdate when the playback is paused)
         if (getIsDynamic()) {
-            streamController.addDVRMetric();
-            if (isPaused()) {
-                _updateLivePlaybackTime();
-            } else {
-                updateCurrentTime();
+            const now = Date.now();
+            if (!lastLiveUpdateTime || now > lastLiveUpdateTime + settings.get().streaming.liveUpdateTimeThreshold) {
+                streamController.addDVRMetric();
+                if (isPaused()) {
+                    _updateLivePlaybackTime();
+                } else {
+                    updateCurrentTime();
+                }
+                lastLiveUpdateTime = now;
             }
         }
     }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -89,7 +89,7 @@ function PlaybackController() {
         lowLatencyModeEnabled = false;
         initialCatchupModeActivated = false;
         seekTarget = NaN;
-        liveUpdateTimeThresholdInMilliseconds = NaN;
+        lastLiveUpdateTime = NaN;
 
         if (videoModel) {
             eventBus.off(Events.DATA_UPDATE_COMPLETED, _onDataUpdateCompleted, instance);
@@ -726,8 +726,7 @@ function PlaybackController() {
         // (video element doesn't call timeupdate when the playback is paused)
         if (getIsDynamic()) {
             const now = Date.now();
-            // When liveUpdateTimeThresholdInMilliseconds is NaN, we do not throttle and update time each tick.
-            if (isNaN(settings.get().streaming.liveUpdateTimeThresholdInMilliseconds) || !lastLiveUpdateTime || now > lastLiveUpdateTime + settings.get().streaming.liveUpdateTimeThresholdInMilliseconds) {
+            if (isNaN(lastLiveUpdateTime) || now > lastLiveUpdateTime + settings.get().streaming.liveUpdateTimeThresholdInMilliseconds) {
                 streamController.addDVRMetric();
                 if (isPaused()) {
                     _updateLivePlaybackTime();

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -89,6 +89,7 @@ function PlaybackController() {
         lowLatencyModeEnabled = false;
         initialCatchupModeActivated = false;
         seekTarget = NaN;
+        liveUpdateTimeThresholdInMilliseconds = NaN;
 
         if (videoModel) {
             eventBus.off(Events.DATA_UPDATE_COMPLETED, _onDataUpdateCompleted, instance);
@@ -725,7 +726,8 @@ function PlaybackController() {
         // (video element doesn't call timeupdate when the playback is paused)
         if (getIsDynamic()) {
             const now = Date.now();
-            if (!lastLiveUpdateTime || now > lastLiveUpdateTime + settings.get().streaming.liveUpdateTimeThreshold) {
+            // When liveUpdateTimeThresholdInMilliseconds is NaN, we do not throttle and update time each tick.
+            if (isNaN(settings.get().streaming.liveUpdateTimeThresholdInMilliseconds) || !lastLiveUpdateTime || now > lastLiveUpdateTime + settings.get().streaming.liveUpdateTimeThresholdInMilliseconds) {
                 streamController.addDVRMetric();
                 if (isPaused()) {
                     _updateLivePlaybackTime();


### PR DESCRIPTION
On low end devices, we noticed an increasing burden on the CPU during live streams. This setting adds a threshold that must be passed in order for `PlaybackController` to push another time sync instruction during dynamic manifests.

This is very comparable to `wallclockTimeUpdateInterval` but it does not interfere with other logic based on wall clock such as gap jumping (which is a way less heavy instruction for low end CPU's to handle).