### PR TITLE
Fix switching representations across different tracks

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -717,14 +717,12 @@ function StreamProcessor(config) {
         // Stop scheduling until we are done with preparing the quality switch
         scheduleController.clearScheduleTimer();
 
-        // Informing ScheduleController about AS switch
-        scheduleController.setSwitchTrack(true);
-
         const newMediaInfo = newRepresentation.mediaInfo;
         currentMediaInfo = newMediaInfo;
 
         selectMediaInfo(newMediaInfo, newRepresentation)
             .then(() => {
+                prepareTrackSwitch();
                 _handleDifferentSwitchTypes(e, newRepresentation);
             })
     }


### PR DESCRIPTION
prepareTrackSwitch() must be called after selectMediaInfo(). Otherwise, the mediaSource buffers will fail.