### PR TITLE
Fix TS typings for KeyErrorEvent and KeySessionCreatedEvent error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1896,16 +1896,9 @@ declare namespace dashjs {
         data: object
     }
 
-    export class KeyError {
-        constructor(sessionToken: SessionToken, errorString: string);
-
-        sessionToken: SessionToken;
-        error: string;
-    }
-
     export interface KeyErrorEvent extends Event {
         type: MediaPlayerEvents['KEY_ERROR'];
-        data: KeyError;
+        error: DashJSError;
     }
 
     export class KeyMessage {
@@ -1943,7 +1936,7 @@ declare namespace dashjs {
     export interface KeySystemSelectedEvent extends Event {
         type: MediaPlayerEvents['KEY_SYSTEM_SELECTED'];
         data: object | null;
-        error?: string;
+        error?: DashJSError;
     }
 
     export interface LicenseRequestCompleteEvent extends Event {


### PR DESCRIPTION
`KeyErrorEvent` is triggered with `error` (`DashJSError`) instead of `data`.

`KeySystemSelectedEvent` has incorrect `error` type:  it's `DashJSError` as well instead of `string`.

As a result, `KeyError` type becomes redundant and can be removed.

## Context

`KeyErrorEvent` is triggered here:
https://github.com/search?q=repo%3ADash-Industry-Forum%2Fdash.js+path%3A%2Fsrc%2Fstreaming%2Fprotection%2Fmodels%2F*+KEY_ERROR&type=code

`KeySystemSelectedEvent` is triggered here:
https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/protection/controllers/ProtectionController.js#L249