### PR TITLE
Adjust disconnect values for functional Karma tests

### DIFF
--- a/test/functional/config/karma.functional.conf.cjs
+++ b/test/functional/config/karma.functional.conf.cjs
@@ -125,6 +125,8 @@ module.exports = function (config) {
         autoWatch: false,
 
         browserNoActivityTimeout: 180000,
+        browserDisconnectTimeout: 10000,
+        browserDisconnectTolerance: 3,
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher


### PR DESCRIPTION
Overcome the following error:

15 04 2024 12:43:51.521:WARN [Chrome 123.0.0.0 (Windows 10)]: Disconnected (3 times) reconnect failed before timeout of 2000ms (transport close)