### PR TITLE
Fix/filter update

### DIFF
--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -429,8 +429,11 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         var bitrate = Math.round(e.currentRepresentation.bandwidth / 1000);
         var availableRepresentations = $scope.player.getRepresentationsByType(e.mediaType)
         var maxIndex = availableRepresentations ? availableRepresentations.length : 0;
+        var pendingIndex = availableRepresentations.findIndex(function (element) {
+            return element.id === e.currentRepresentation.id
+        });
 
-        $scope[e.mediaType + 'PendingIndex'] = e.currentRepresentation.absoluteIndex + 1;
+        $scope[e.mediaType + 'PendingIndex'] = pendingIndex + 1;
         $scope[e.mediaType + 'PendingMaxIndex'] = maxIndex;
         $scope[e.mediaType + 'Bitrate'] = bitrate;
         $scope.plotPoint('pendingIndex', e.mediaType, e.newQuality + 1, getTimeForPlot());
@@ -443,7 +446,11 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     }, $scope);
 
     $scope.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, function (e) {
-        $scope[e.mediaType + 'Index'] = e.newRepresentation.absoluteIndex + 1;
+        var availableRepresentations = $scope.player.getRepresentationsByType(e.mediaType)
+        var index = availableRepresentations.findIndex(function (element) {
+            return element.id === e.newRepresentation.id
+        });
+        $scope[e.mediaType + 'Index'] = index + 1;
         $scope.plotPoint('index', e.mediaType, e.newQuality + 1, getTimeForPlot());
         $scope.safeApply();
     }, $scope);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1477,7 +1477,7 @@ function MediaPlayer() {
      * This value will be overwritten by the ABR rules unless autoSwitchBitrate is set to false.
      *
      * @param {MediaType} type - 'video', 'audio' or 'image'
-     * @param {number} value - the quality index, 0 corresponding to the lowest absolute index
+     * @param {number} value - the quality index, 0 corresponding to the lowest possible index
      * @param {boolean} forceReplace - true if segments have to be replaced by segments of the new quality
      * @memberof module:MediaPlayer
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
@@ -2398,7 +2398,7 @@ function MediaPlayer() {
             return null
         }
         // do not require Protection as dependencies as this is optional and intended to be loaded separately
-        let detectedProtection = dashjs.Protection; 
+        let detectedProtection = dashjs.Protection;
         if (typeof detectedProtection === 'function') { //TODO need a better way to register/detect plugin components
             let protection = detectedProtection(context).create();
             Events.extend(detectedProtection.events);
@@ -2434,7 +2434,7 @@ function MediaPlayer() {
             return;
         }
         // do not require MetricsReporting as dependencies as this is optional and intended to be loaded separately
-        let detectedMetricsReporting = dashjs.MetricsReporting; 
+        let detectedMetricsReporting = dashjs.MetricsReporting;
         if (typeof detectedMetricsReporting === 'function') { //TODO need a better way to register/detect plugin components
             let metricsReporting = detectedMetricsReporting(context).create();
 
@@ -2458,7 +2458,7 @@ function MediaPlayer() {
         }
 
         // do not require MssHandler as dependencies as this is optional and intended to be loaded separately
-        let detectedMssHandler = dashjs.MssHandler; 
+        let detectedMssHandler = dashjs.MssHandler;
         if (typeof detectedMssHandler === 'function') { //TODO need a better way to register/detect plugin components
             Errors.extend(detectedMssHandler.errors);
             mssHandler = detectedMssHandler(context).create({
@@ -2496,7 +2496,7 @@ function MediaPlayer() {
         }
 
         // do not require Offline as dependencies as this is optional and intended to be loaded separately
-        let detectedOfflineController = dashjs.OfflineController; 
+        let detectedOfflineController = dashjs.OfflineController;
 
         if (typeof detectedOfflineController === 'function') { //TODO need a better way to register/detect plugin components
             Events.extend(detectedOfflineController.events);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1475,6 +1475,8 @@ function MediaPlayer() {
     /**
      * Sets the current quality for media type instead of letting the ABR Heuristics automatically selecting it.
      * This value will be overwritten by the ABR rules unless autoSwitchBitrate is set to false.
+     * Note that you need to specify a relative index based on the position of the target entry in the return value of getRepresentationsByType().
+     * Do NOT use representation.absoluteIndex here as this index was assigned prior to applying any filter function. If you want to select a specific representation then use setRepresentationForTypeById() instead.
      *
      * @param {MediaType} type - 'video', 'audio' or 'image'
      * @param {number} value - the quality index, 0 corresponding to the lowest possible index

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -679,7 +679,7 @@ function Stream(config) {
             return thumbnailController.getPossibleVoRepresentations();
         }
         const mediaInfo = getMediaInfo(type);
-        return abrController.getPossibleVoRepresentations(mediaInfo, true);
+        return abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
     }
 
     /**
@@ -698,7 +698,7 @@ function Stream(config) {
             possibleVoRepresentations = thumbnailController.getPossibleVoRepresentations();
         } else {
             const mediaInfo = getMediaInfo(type);
-            possibleVoRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+            possibleVoRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
         }
 
         if (!possibleVoRepresentations || possibleVoRepresentations.length === 0) {
@@ -727,7 +727,7 @@ function Stream(config) {
             possibleVoRepresentations = thumbnailController.getPossibleVoRepresentations();
         } else {
             const mediaInfo = getMediaInfo(type);
-            possibleVoRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+            possibleVoRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
         }
 
         index = Math.max(Math.min(index, possibleVoRepresentations.length - 1), 0)

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -654,7 +654,7 @@ function StreamProcessor(config) {
                     targetRepresentation = representationController.getCurrentRepresentation()
                 }
 
-                // Update Representation Controller with the new data
+                // Update Representation Controller with the new data. Note we do not filter any Representations here as the filter values might change over time.
                 const voRepresentations = abrController.getPossibleVoRepresentations(currentMediaInfo, false);
                 const representationId = targetRepresentation.id;
                 return representationController.updateData(voRepresentations, currentMediaInfo.isFragmented, representationId)

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -216,7 +216,7 @@ function AbrController() {
     }
 
     function getOptimalRepresentationForBitrate(mediaInfo, bitrate, includeCompatibleMediaInfos = true) {
-        const possibleVoRepresentations = getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos);
+        const possibleVoRepresentations = getPossibleVoRepresentationsFilteredBySettings(mediaInfo, includeCompatibleMediaInfos);
 
         if (!possibleVoRepresentations || possibleVoRepresentations.length === 0) {
             return null;
@@ -246,7 +246,7 @@ function AbrController() {
             return null;
         }
 
-        const possibleVoRepresentations = getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos);
+        const possibleVoRepresentations = getPossibleVoRepresentationsFilteredBySettings(mediaInfo, includeCompatibleMediaInfos);
 
         return possibleVoRepresentations.find((rep) => {
             return rep.absoluteIndex === absoluteIndex
@@ -254,6 +254,19 @@ function AbrController() {
     }
 
     function getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos = true) {
+        return _getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos)
+    }
+
+    function getPossibleVoRepresentationsFilteredBySettings(mediaInfo, includeCompatibleMediaInfos = true) {
+        let voRepresentations = _getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos);
+
+        // Filter the list of options based on the provided settings
+        voRepresentations = _filterByAllowedSettings(voRepresentations)
+
+        return voRepresentations;
+    }
+
+    function _getPossibleVoRepresentations(mediaInfo, includeCompatibleMediaInfos) {
         let voRepresentations = [];
         if (!mediaInfo) {
             return voRepresentations;
@@ -271,10 +284,7 @@ function AbrController() {
         // Now sort by quality (usually simply by bitrate)
         voRepresentations = _sortByCalculatedQualityRank(voRepresentations);
 
-        // Filter the list of options based on the provided settings
-        voRepresentations = _filterByAllowedSettings(voRepresentations)
-
-        // Add an absolute index after filtering
+        // Add an absolute index
         voRepresentations.forEach((rep, index) => {
             rep.absoluteIndex = index
         })
@@ -287,7 +297,7 @@ function AbrController() {
             })
         }
 
-        return voRepresentations;
+        return voRepresentations
     }
 
     function _getPossibleMediaInfos(mediaInfo) {
@@ -746,7 +756,7 @@ function AbrController() {
      * @returns {boolean}
      */
     function isPlayingAtLowestQuality(representation) {
-        const voRepresentations = getPossibleVoRepresentations(representation.mediaInfo, true);
+        const voRepresentations = getPossibleVoRepresentationsFilteredBySettings(representation.mediaInfo, true);
 
         return voRepresentations[0].id === representation.id
     }
@@ -760,7 +770,7 @@ function AbrController() {
         if (!representation) {
             return true;
         }
-        const voRepresentations = getPossibleVoRepresentations(representation.mediaInfo, true);
+        const voRepresentations = getPossibleVoRepresentationsFilteredBySettings(representation.mediaInfo, true);
 
         return voRepresentations[voRepresentations.length - 1].id === representation.id;
     }
@@ -791,6 +801,7 @@ function AbrController() {
         getInitialBitrateFor,
         getOptimalRepresentationForBitrate,
         getPossibleVoRepresentations,
+        getPossibleVoRepresentationsFilteredBySettings,
         getRepresentationByAbsoluteIndex,
         initialize,
         isPlayingAtLowestQuality,

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -241,12 +241,12 @@ function CmcdModel() {
         invalidRequests.map((k) => {
             logger.warn(`request type ${k} is not supported.`);
         });
-        
+
         return true;
     }
 
     function _checkAvailableKeys(cmcdParametersFromManifest){
-        const defaultAvailableKeys = Constants.CMCD_AVAILABLE_KEYS; 
+        const defaultAvailableKeys = Constants.CMCD_AVAILABLE_KEYS;
         const enabledCMCDKeys = cmcdParametersFromManifest.version ? cmcdParametersFromManifest.keys : settings.get().streaming.cmcd.enabledKeys;
         const invalidKeys = enabledCMCDKeys.filter(k => !defaultAvailableKeys.includes(k));
 
@@ -267,7 +267,7 @@ function CmcdModel() {
             const serviceDescription = serviceDescriptionController.getServiceDescriptionSettings();
             if (
                 settings.get().streaming.cmcd.applyParametersFromMpd &&
-                serviceDescription.clientDataReporting && 
+                serviceDescription.clientDataReporting &&
                 serviceDescription.clientDataReporting.cmcdParameters
             ) {
                 cmcdParametersFromManifest = serviceDescription.clientDataReporting.cmcdParameters;
@@ -299,7 +299,7 @@ function CmcdModel() {
     function getCmcdData(request) {
         try {
             let cmcdData = null;
-            
+
             _updateLastMediaTypeRequest(request.type, request.mediaType);
 
             if (_isIncludedInRequestFilter(request.type)) {
@@ -334,7 +334,7 @@ function CmcdModel() {
 
     function _getCmcdDataForSteering(request) {
         const data = !_lastMediaTypeRequest ? _getGenericCmcdData(request) : _getCmcdDataForMediaSegment(request, _lastMediaTypeRequest);
-        
+
         data.ot = CmcdObjectType.OTHER;
 
         return data;
@@ -481,9 +481,9 @@ function CmcdModel() {
 
         let cid = settings.get().streaming.cmcd.cid ? settings.get().streaming.cmcd.cid : internalData.cid;
         cid = cmcdParametersFromManifest.contentID ? cmcdParametersFromManifest.contentID : cid;
-        
+
         data.v = CMCD_VERSION;
-        
+
         data.sid = settings.get().streaming.cmcd.sid ? settings.get().streaming.cmcd.sid : internalData.sid;
         data.sid = cmcdParametersFromManifest.sessionID ? cmcdParametersFromManifest.sessionID : data.sid;
 
@@ -518,7 +518,7 @@ function CmcdModel() {
 
     function _getTopBitrateByType(mediaInfo) {
         try {
-            const bitrates = abrController.getPossibleVoRepresentations(mediaInfo).map((rep) => {
+            const bitrates = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo).map((rep) => {
                 return rep.bitrateInKbit
             });
             return Math.max(...bitrates)

--- a/src/streaming/rules/abr/BolaRule.js
+++ b/src/streaming/rules/abr/BolaRule.js
@@ -157,7 +157,7 @@ function BolaRule(config) {
     function _getInitialBolaState(rulesContext) {
         const initialState = {};
         const mediaInfo = rulesContext.getMediaInfo();
-        const representations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+        const representations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
         const bitrates = representations.map(r => r.bandwidth);
         let utilities = bitrates.map(b => Math.log(b));
         utilities = utilities.map(u => u - utilities[0] + 1); // normalize

--- a/src/streaming/rules/abr/DroppedFramesRule.js
+++ b/src/streaming/rules/abr/DroppedFramesRule.js
@@ -31,7 +31,7 @@ function DroppedFramesRule() {
 
         let droppedFrames = 0;
         let totalFrames = 0;
-        const representations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+        const representations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
         let newRepresentation = null;
 
         //No point in measuring dropped frames for the first index.

--- a/src/streaming/rules/abr/L2ARule.js
+++ b/src/streaming/rules/abr/L2ARule.js
@@ -301,7 +301,7 @@ function L2ARule(config) {
         const representation = abrController.getOptimalRepresentationForBitrate(mediaInfo, safeThroughput, true);//During strat-up phase abr.controller is responsible for bitrate decisions.
         const bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType, true);
         const l2AParameter = l2AParameterDict[mediaType];
-        const possibleRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+        const possibleRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
 
         switchRequest.representation = representation;
         switchRequest.reason.throughput = safeThroughput;
@@ -350,7 +350,7 @@ function L2ARule(config) {
             //Main adaptation logic of L2A-LL
             const abrController = rulesContext.getAbrController();
             const mediaInfo = rulesContext.getMediaInfo();
-            const possibleRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+            const possibleRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
             const videoModel = rulesContext.getVideoModel();
             let currentPlaybackRate = videoModel.getPlaybackRate();
             const alpha = Math.max(Math.pow(HORIZON, 1), VL * Math.sqrt(HORIZON));// Step size, used for gradient descent exploration granularity

--- a/src/streaming/rules/abr/SwitchHistoryRule.js
+++ b/src/streaming/rules/abr/SwitchHistoryRule.js
@@ -22,7 +22,7 @@ function SwitchHistoryRule() {
         const switchRequests = switchRequestHistory ? switchRequestHistory.getSwitchRequests(streamId, mediaType) : {};
         const abrController = rulesContext.getAbrController();
         const mediaInfo = rulesContext.getMediaInfo();
-        const representations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+        const representations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
         let drops = 0;
         let noDrops = 0;
 

--- a/src/streaming/rules/abr/lolp/LearningAbrController.js
+++ b/src/streaming/rules/abr/lolp/LearningAbrController.js
@@ -385,7 +385,7 @@ function LearningAbrController() {
     function _setSomBitrateNeurons(mediaInfo, abrController) {
         if (!somBitrateNeurons) {
             somBitrateNeurons = [];
-            const possibleRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+            const possibleRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
             const bitrateList = possibleRepresentations.map((r) => r.bandwidth);
             minBitrate = Math.min(...bitrateList);
             bitrateNormalizationFactor = _getMagnitude(bitrateList);

--- a/src/streaming/rules/abr/lolp/LoLpRule.js
+++ b/src/streaming/rules/abr/lolp/LoLpRule.js
@@ -103,7 +103,7 @@ function LoLPRule(config) {
             }
 
             // QoE parameters
-            const possibleRepresentations = abrController.getPossibleVoRepresentations(mediaInfo, true);
+            const possibleRepresentations = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
             let bandwidths = possibleRepresentations.map(r => r.bandwidth);
             let segmentDuration = rulesContext.getRepresentation().fragmentDuration;
             let minBitrateKbps = Math.min(...bandwidths) / 1000.0; // min bitrate level

--- a/test/unit/mocks/AbrControllerMock.js
+++ b/test/unit/mocks/AbrControllerMock.js
@@ -110,6 +110,10 @@ function AbrControllerMock () {
     this.getPossibleVoRepresentations = function () {
         return []
     }
+
+    this.getPossibleVoRepresentationsFilteredBySettings = function () {
+        return []
+    }
 }
 
 export default AbrControllerMock;

--- a/test/unit/mocks/RulesContextMock.js
+++ b/test/unit/mocks/RulesContextMock.js
@@ -30,7 +30,7 @@ function RulesContextMock() {
     };
     this.getAbrController = function () {
         return {
-            getPossibleVoRepresentations: function () {
+            getPossibleVoRepresentationsFilteredBySettings: function () {
                 return [{ id: 1 }]
             }
         };

--- a/test/unit/test/streaming/streaming.controllers.AbrController.js
+++ b/test/unit/test/streaming/streaming.controllers.AbrController.js
@@ -153,43 +153,43 @@ describe('AbrController', function () {
         const s = { streaming: { abr: { maxBitrate: {} } } };
         s.streaming.abr.maxBitrate[Constants.VIDEO] = bitrateList[0].bandwidth / 1000;
         settings.update(s);
-        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo, false);
+        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, false);
         expect(possibleVoRepresentations.length).to.be.equal(1);
         expect(possibleVoRepresentations[0].id).to.be.equal(1);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = bitrateList[1].bandwidth / 1000;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(2);
         expect(possibleVoRepresentations[1].id).to.be.equal(2);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = bitrateList[2].bandwidth / 1000;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
         expect(possibleVoRepresentations[2].id).to.be.equal(3);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = (bitrateList[0].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(1);
         expect(possibleVoRepresentations[0].id).to.be.equal(1);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = (bitrateList[1].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(2);
         expect(possibleVoRepresentations[1].id).to.be.equal(2);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = (bitrateList[2].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
         expect(possibleVoRepresentations[2].id).to.be.equal(3);
 
         s.streaming.abr.maxBitrate[Constants.VIDEO] = (bitrateList[0].bandwidth / 1000) - 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
         expect(possibleVoRepresentations[2].id).to.be.equal(3);
     });
@@ -229,37 +229,37 @@ describe('AbrController', function () {
         const s = { streaming: { abr: { minBitrate: {} } } };
         s.streaming.abr.minBitrate[Constants.VIDEO] = bitrateList[0].bandwidth / 1000;
         settings.update(s);
-        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = bitrateList[1].bandwidth / 1000;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(2);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = bitrateList[2].bandwidth / 1000;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(1);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = (bitrateList[0].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(2);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = (bitrateList[1].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(1);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = (bitrateList[2].bandwidth / 1000) + 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
 
         s.streaming.abr.minBitrate[Constants.VIDEO] = (bitrateList[0].bandwidth / 1000) - 1;
         settings.update(s);
-        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(3);
     });
 
@@ -318,7 +318,7 @@ describe('AbrController', function () {
         mediaInfo.streamInfo = streamProcessor.getStreamInfo();
         mediaInfo.type = Constants.VIDEO;
 
-        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentations(mediaInfo);
+        let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
         expect(possibleVoRepresentations.length).to.be.equal(2);
     });
 

--- a/test/unit/test/streaming/streaming.models.CmcdModel.js
+++ b/test/unit/test/streaming/streaming.models.CmcdModel.js
@@ -136,7 +136,7 @@ describe('CmcdModel', function () {
                 const NEXT_OBJECT_URL = 'next_object';
                 const NEXT_OBJECT_RANGE = '100-500';
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: TOP_BITRATE / 1000
@@ -788,7 +788,7 @@ describe('CmcdModel', function () {
                 const NEXT_OBJECT_URL = 'next_object';
                 const NEXT_OBJECT_RANGE = '100-500';
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: 20
@@ -882,7 +882,7 @@ describe('CmcdModel', function () {
                 const DURATION = 987.213;
                 const CHANGED_PLAYBACK_RATE = 2.4;
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: BITRATE / 1000
@@ -917,7 +917,7 @@ describe('CmcdModel', function () {
                 const BITRATE = 10000;
                 const DURATION = 987.213;
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: BITRATE / 1000
@@ -953,7 +953,7 @@ describe('CmcdModel', function () {
                 const BITRATE = 10000;
                 const DURATION = 987.213;
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: BITRATE / 1000
@@ -992,7 +992,7 @@ describe('CmcdModel', function () {
                 const BITRATE = 10000;
                 const DURATION = 987.213;
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {
                             bitrateInKbit: BITRATE / 1000
@@ -1052,7 +1052,7 @@ describe('CmcdModel', function () {
                 const REQUEST_TYPE = HTTPRequest.MEDIA_SEGMENT_TYPE;
                 const MEDIA_TYPE = 'video';
 
-                abrControllerMock.getPossibleVoRepresentations = () => {
+                abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
                     return [
                         {}
                     ]


### PR DESCRIPTION
Provide all (no filter is applied) Representations to the `RepresentationController` in case the filters like min/max bitrate change over time. Otherwise, we run into an issue when trying to change the quality causing an infinite loop as the representation models in `RepresentationController` are only updated after an MPD update.