### PR TITLE
Override the minPlaybackRateChange check when newRate=1.0

### DIFF
--- a/src/streaming/controllers/CatchupController.js
+++ b/src/streaming/controllers/CatchupController.js
@@ -234,7 +234,7 @@ function CatchupController() {
                 const minPlaybackRateChange = isSafari ? 0.25 : 0.02 / (0.5 / liveCatchupPlaybackRates.max);
 
                 // Obtain newRate and apply to video model.  Don't change playbackrate for small variations (don't overload element with playbackrate changes)
-                if (newRate && Math.abs(currentPlaybackRate - newRate) >= minPlaybackRateChange) { // non-null
+                if (newRate && Math.abs(currentPlaybackRate - newRate) >= minPlaybackRateChange || newRate == 1.0) { // non-null
                     logger.debug(`[CatchupController]: Setting playback rate to ${newRate}`);
                     videoModel.setPlaybackRate(newRate);
                 }


### PR DESCRIPTION
- This avoids the situation where the playbackrate can get stuck at a non 1.0 rate, if the rate change is less than minPlaybackRateChange. If even a small non 1.0 playbackrate persists it leads to playback buffer and latency decrease (or increase) over time.