### PR TITLE
TypeScript - externalManifest is optional for several methods.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -714,13 +714,13 @@ declare namespace dashjs {
 
         getSuggestedPresentationDelay(): string;
 
-        getAvailabilityStartTime(externalManifest: object): number;
+        getAvailabilityStartTime(externalManifest?: object): number;
 
-        getIsDynamic(externalManifest: object): boolean;
+        getIsDynamic(externalManifest?: object): boolean;
 
-        getDuration(externalManifest: object): number;
+        getDuration(externalManifest?: object): number;
 
-        getRegularPeriods(externalManifest: object): any[];
+        getRegularPeriods(externalManifest?: object): any[];
 
         getMpd(externalManifest?: object): Mpd;
 


### PR DESCRIPTION
Found a few TS overrides in my code, they're better off being fixed upstream.

```javascript
// Types that are missing or wrong in dashjs, should push this upstream too.
declare module "dashjs" {
  class DashAdapter {
    getAvailabilityStartTime(externalManifest?: object): number;
    getIsDynamic(externalManifest?: object): boolean;
    getDuration(externalManifest?: object): number;
  }
}
```