### PR TITLE
Output ESM via webpack build script

### DIFF
--- a/build/webpack.base.cjs
+++ b/build/webpack.base.cjs
@@ -1,18 +1,9 @@
 const path = require('path');
 const pkg = require('../package.json');
 
-const out_dir = '../dist';
-
-const config = {
+const commonConfig = {
     devtool: 'source-map',
     target: ['web', 'es5'],
-    output: {
-        path: path.resolve(__dirname, out_dir),
-        publicPath: '/dist/',
-        library: 'dashjs',
-        libraryTarget: 'umd',
-        libraryExport: 'default'
-    },
     module: {
         rules: [
             {
@@ -29,7 +20,7 @@ const config = {
                 use: [
                     {
                         loader: `babel-loader`,
-                        options: {presets: ['@babel/env']}
+                        options: { presets: ['@babel/env'] }
                     }
                 ]
             }
@@ -43,4 +34,30 @@ const config = {
     },
 }
 
-module.exports = {config};
+const umdConfig = {
+    ...commonConfig,
+    output: {
+        path: path.resolve(__dirname, '../dist'),
+        publicPath: '/dist/',
+        library: 'dashjs',
+        libraryTarget: 'umd',
+        libraryExport: 'default'
+    },
+};
+
+const esmConfig = {
+    ...commonConfig,
+    experiments: {
+        outputModule: true
+    },
+    output: {
+        path: path.resolve(__dirname, '../dist/esm'),
+        publicPath: '/dist/esm/',
+        library: {
+            type: 'module',
+        },
+        libraryExport: 'default',
+    },
+};
+
+module.exports = { umdConfig, esmConfig };

--- a/build/webpack.dev.cjs
+++ b/build/webpack.dev.cjs
@@ -23,16 +23,5 @@ const umdDevConfig = merge(umdConfig, {
     }
 });
 
-const esmDevConfig = merge(esmConfig, {
-    mode: 'development',
-    entry: {
-        'dash.all': './index.js',
-        'dash.mss': './src/mss/index.js',
-        'dash.offline': './src/offline/index.js'
-    },
-    output: {
-        filename: '[name].debug.esm.js',
-    },
-});
 
-module.exports = [umdDevConfig, esmDevConfig];
+module.exports = [umdDevConfig];

--- a/build/webpack.dev.cjs
+++ b/build/webpack.dev.cjs
@@ -1,8 +1,8 @@
 const { merge } = require('webpack-merge');
-const common = require('./webpack.base.cjs').config;
+const { umdConfig, esmConfig } = require('./webpack.base.cjs');
 const path = require('path');
 
-const config = merge(common, {
+const umdDevConfig = merge(umdConfig, {
     mode: 'development',
     entry: {
         'dash.all': './index.js',
@@ -23,4 +23,16 @@ const config = merge(common, {
     }
 });
 
-module.exports = config;
+const esmDevConfig = merge(esmConfig, {
+    mode: 'development',
+    entry: {
+        'dash.all': './index.js',
+        'dash.mss': './src/mss/index.js',
+        'dash.offline': './src/offline/index.js'
+    },
+    output: {
+        filename: '[name].debug.esm.js',
+    },
+});
+
+module.exports = [umdDevConfig, esmDevConfig];

--- a/build/webpack.dev.cjs
+++ b/build/webpack.dev.cjs
@@ -1,5 +1,5 @@
 const { merge } = require('webpack-merge');
-const { umdConfig, esmConfig } = require('./webpack.base.cjs');
+const { umdConfig } = require('./webpack.base.cjs');
 const path = require('path');
 
 const umdDevConfig = merge(umdConfig, {

--- a/build/webpack.prod.cjs
+++ b/build/webpack.prod.cjs
@@ -1,6 +1,6 @@
 const { merge } = require('webpack-merge');
 const ESLintPlugin = require('eslint-webpack-plugin');
-const common = require('./webpack.base.cjs').config;
+const { umdConfig, esmConfig } = require('./webpack.base.cjs');
 
 const entries = {
     'dash.all': './index.js',
@@ -11,7 +11,7 @@ const entries = {
     'dash.offline': './src/offline/index.js'
 }
 
-const configDev = merge(common, {
+const configDevUmd = merge(umdConfig, {
     mode: 'development',
     entry: entries,
     output: {
@@ -19,7 +19,7 @@ const configDev = merge(common, {
     }
 });
 
-const configProd = merge(common, {
+const configProdUmd = merge(umdConfig, {
     mode: 'production',
     entry: entries,
     output: {
@@ -37,4 +37,30 @@ const configProd = merge(common, {
     ]
 });
 
-module.exports = [configDev, configProd];
+const configDevEsm = merge(esmConfig, {
+    mode: 'development',
+    entry: entries,
+    output: {
+        filename: '[name].debug.esm.js'
+    }
+});
+
+const configProdEsm = merge(esmConfig, {
+    mode: 'production',
+    entry: entries,
+    output: {
+        filename: '[name].min.esm.js'
+    },
+    performance: { hints: false },
+    plugins: [
+        new ESLintPlugin({
+            files: [
+                'src/**/*.js',
+                'test/unit/mocks/*.js',
+                'test/unit/test/**/*.js'
+            ]
+        })
+    ]
+});
+
+module.exports = [configDevUmd, configProdUmd, configDevEsm, configProdEsm];


### PR DESCRIPTION
This PR adds support for ECMAScript Modules (ESM). It adjusts the webpack build script to provide an ESM bundle in the `dist/esm` folder.

I would like to collect feedback on this PR to understand if this is what is required by dash.js users and if this is the preferred way to implement it. 

This addresses #4190 