### PR TITLE
Representation bandwidth based cache Response detection timeout

### DIFF
--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -197,6 +197,7 @@ function MetricsModel(config) {
         vo._fileLoaderType = request.fileLoaderType;
         vo._resourceTimingValues = request.resourceTimingValues;
         vo._streamId = request && request.representation && request.representation.mediaInfo && request.representation.mediaInfo.streamInfo ? request.representation.mediaInfo.streamInfo.id : null;
+        vo._bandwidth_ratio = request && request.bandwidth && request.representation && request.representation.mediaInfo ? request.representation.mediaInfo.bitrateList[request.representation.mediaInfo.bitrateList.length - 1].bandwidth / request.bandwidth : 1;
 
         if (traces) {
             traces.forEach(trace => {

--- a/src/streaming/models/MetricsModel.js
+++ b/src/streaming/models/MetricsModel.js
@@ -197,7 +197,7 @@ function MetricsModel(config) {
         vo._fileLoaderType = request.fileLoaderType;
         vo._resourceTimingValues = request.resourceTimingValues;
         vo._streamId = request && request.representation && request.representation.mediaInfo && request.representation.mediaInfo.streamInfo ? request.representation.mediaInfo.streamInfo.id : null;
-        vo._bandwidth_ratio = request && request.bandwidth && request.representation && request.representation.mediaInfo ? request.representation.mediaInfo.bitrateList[request.representation.mediaInfo.bitrateList.length - 1].bandwidth / request.bandwidth : 1;
+        vo._bandwidthRatio = request && request.bandwidth && request.representation && request.representation.mediaInfo ? request.representation.mediaInfo.bitrateList[request.representation.mediaInfo.bitrateList.length - 1].bandwidth / request.bandwidth : 1;
 
         if (traces) {
             traces.forEach(trace => {

--- a/src/streaming/models/ThroughputModel.js
+++ b/src/streaming/models/ThroughputModel.js
@@ -106,7 +106,7 @@ function ThroughputModel(config) {
                 }
             }
 
-            const cacheReferenceTime = (httpRequest._tfinish.getTime() - httpRequest.trequest.getTime());
+            const cacheReferenceTime = (httpRequest._tfinish.getTime() - httpRequest.trequest.getTime()) * httpRequest._bandwidth_ratio;
 
             if (_isCachedResponse(mediaType, cacheReferenceTime, httpRequest)) {
                 logger.debug(`${mediaType} Assuming segment ${httpRequest.url} came from cache, ignoring it for throughput calculation`);

--- a/src/streaming/models/ThroughputModel.js
+++ b/src/streaming/models/ThroughputModel.js
@@ -106,7 +106,7 @@ function ThroughputModel(config) {
                 }
             }
 
-            const cacheReferenceTime = (httpRequest._tfinish.getTime() - httpRequest.trequest.getTime()) * httpRequest._bandwidth_ratio;
+            const cacheReferenceTime = (httpRequest._tfinish.getTime() - httpRequest.trequest.getTime()) * httpRequest._bandwidthRatio;
 
             if (_isCachedResponse(mediaType, cacheReferenceTime, httpRequest)) {
                 logger.debug(`${mediaType} Assuming segment ${httpRequest.url} came from cache, ignoring it for throughput calculation`);

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -141,6 +141,10 @@ class HTTPRequest {
          * The values derived from the ResourceTimingAPI.
          */
         this._resourceTimingValues = null;
+        /**
+         * The ratio of the current representation bandwidth to the top representation bandwidth - used for adjusting cachedetection to bitrate ladder.
+         */
+        this._bandwidth_ratio = 1;
     }
 }
 

--- a/src/streaming/vo/metrics/HTTPRequest.js
+++ b/src/streaming/vo/metrics/HTTPRequest.js
@@ -144,7 +144,7 @@ class HTTPRequest {
         /**
          * The ratio of the current representation bandwidth to the top representation bandwidth - used for adjusting cachedetection to bitrate ladder.
          */
-        this._bandwidth_ratio = 1;
+        this._bandwidthRatio = 1;
     }
 }
 

--- a/test/unit/test/streaming/streaming.models.ThroughputModel.js
+++ b/test/unit/test/streaming/streaming.models.ThroughputModel.js
@@ -148,6 +148,7 @@ describe('ThroughputModel', () => {
                 }
             })
             dummyHttpRequest._tfinish = dummyHttpRequest.trequest;
+            dummyHttpRequest._bandwidthRatio = 1;
             throughputModel.addEntry('video', dummyHttpRequest);
             const values = throughputModel.getThroughputDict('video');
 


### PR DESCRIPTION
This update changes the cached Response detection algorithm in the ThroughputModel so that it adjusts the cacheLoadThresholds according to the ratio of the bandwidth of the representation that has been downloaded to the top representation, as opposed to just using one threshold for all reps which can lead to incorrect cached  response detection. This is on the assumption that the cacheLoadThresholds represent the time for a top representation bandwidth segment to be delivered.

- Added new `bandwidth_ratio` metric which is a ratio of the current representation's bandwidth to the top representation
- This `bandwidth_ratio` is used to adjust the timeout used in the cache detection algorithm so it doesn't incorrectly trigger for lower representations.