### PR TITLE
Optimize MediaCapabilitiesAPI checks by saving the results and only r…

### DIFF
--- a/src/streaming/utils/ObjectUtils.js
+++ b/src/streaming/utils/ObjectUtils.js
@@ -54,7 +54,7 @@ function ObjectUtils() {
     }
 
     instance = {
-        areEqual: areEqual
+        areEqual
     };
 
     return instance;


### PR DESCRIPTION
…unning new checks when the configuration has not been tested before. This avoids calling the MediaCapabilitiesAPI after each MPD update to filter unsupported tracks and qualities. Calling the MediaCapabilitiesAPI for large manifest files can lead to performance problems. 