### PR TITLE
Add matchSettingsId to mediaController

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -140,6 +140,7 @@ function MediaController() {
             filteredTracks = Array.from(possibleTracks);
             logger.info('Filtering ' + filteredTracks.length + ' ' + type + ' tracks based on settings');
 
+            filteredTracks = filterTracksBySettings(filteredTracks, matchSettingsId, settings)
             filteredTracks = filterTracksBySettings(filteredTracks, matchSettingsLang, settings);
             filteredTracks = filterTracksBySettings(filteredTracks, matchSettingsIndex, settings);
             filteredTracks = filterTracksBySettings(filteredTracks, matchSettingsViewPoint, settings);
@@ -424,6 +425,10 @@ function MediaController() {
 
     function matchSettingsIndex(settings, track) {
         return (settings.index === undefined) || (settings.index === null) || (track.index === settings.index);
+    }
+
+    function matchSettingsId(settings, track) {
+        return (settings.id === undefined) || (settings.id === null) || (track.id === settings.id)
     }
 
     function matchSettingsViewPoint(settings, track) {


### PR DESCRIPTION
This PR adds the ability to set initial media settings using ID and filter tracks by their id.
This is necessary so that in the absence of other parameters (lang, index, viewPoint, role, accessibility, audioChannelConfig, codec) it was possible to uniquely initialize the track