### PR TITLE
Add support for scte214:supplementalCodecs

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -401,6 +401,19 @@ function DashAdapter() {
     }
 
     /**
+     * Return supplementalCodec of a Representation
+     * @param {object} representation
+     * @returns {null|String}
+     */
+    function getSupplementalCodec(representation) {
+        const supplementalCodecs = representation[DashConstants.SUPPLEMENTAL_CODECS]
+        if (!supplementalCodecs) {
+            return null;
+        }
+        return representation.mimeType + ';codecs="' + supplementalCodecs + '"';
+    }
+
+    /**
      * Returns the period as defined in the DashManifestModel for a given index
      * @param {number} index
      * @return {object}
@@ -1252,6 +1265,7 @@ function DashAdapter() {
         getRepresentationSortFunction,
         getStreamsInfo,
         getSuggestedPresentationDelay,
+        getSupplementalCodec,
         getUTCTimingSources,
         getVoRepresentations,
         isPatchValid,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -401,16 +401,16 @@ function DashAdapter() {
     }
 
     /**
-     * Return supplementalCodec of a Representation
+     * Return supplementalCodecs of a Representation
      * @param {object} representation
-     * @returns {null|String}
+     * @returns {array}
      */
-    function getSupplementalCodec(representation) {
-        const supplementalCodecs = representation[DashConstants.SUPPLEMENTAL_CODECS]
+    function getSupplementalCodecs(representation) {
+        const supplementalCodecs = representation[DashConstants.SUPPLEMENTAL_CODECS];
         if (!supplementalCodecs) {
-            return null;
+            return [];
         }
-        return representation.mimeType + ';codecs="' + supplementalCodecs + '"';
+        return supplementalCodecs.split(' ').map((codec) => representation.mimeType + ';codecs="' + codec + '"');
     }
 
     /**
@@ -1265,7 +1265,7 @@ function DashAdapter() {
         getRepresentationSortFunction,
         getStreamsInfo,
         getSuggestedPresentationDelay,
-        getSupplementalCodec,
+        getSupplementalCodecs,
         getUTCTimingSources,
         getVoRepresentations,
         isPatchValid,

--- a/src/dash/constants/DashConstants.js
+++ b/src/dash/constants/DashConstants.js
@@ -178,6 +178,7 @@ export default {
     SUB_SEGMENT_ALIGNMENT: 'subsegmentAlignment',
     SUGGESTED_PRESENTATION_DELAY: 'suggestedPresentationDelay',
     SUPPLEMENTAL_PROPERTY: 'SupplementalProperty',
+    SUPPLEMENTAL_CODECS: 'scte214:supplementalCodecs',
     TIMESCALE: 'timescale',
     TIMESHIFT_BUFFER_DEPTH: 'timeShiftBufferDepth',
     TTL: 'ttl',

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -136,6 +136,22 @@ function CapabilitiesFilter() {
             }
             return supported
         });
+
+        // handle scte214:supplementalCodecs
+        as.Representation = as.Representation.map((rep) => {
+            const supplementalCodecs = rep['scte214:supplementalCodecs']
+            if (!supplementalCodecs) {
+                return rep
+            }
+            const codec = rep.mimeType + ';codecs="' + supplementalCodecs + '"';
+            const config = _createConfiguration(type, rep, codec);
+            const supported = capabilities.isCodecSupportedBasedOnTestedConfigurations(config, type);
+            if (supported) {
+                logger.debug(`[CapabilitiesFilter] Codec ${codec} supported. Upgrading Representation with ID ${rep.id}`);
+                rep.codecs = supplementalCodecs;
+            }
+            return rep;
+        })
     }
 
     function _getConfigurationsToCheck(manifest, type) {

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -131,9 +131,13 @@ function CapabilitiesFilter() {
             configurations.push(config);
             const isCodecSupported = capabilities.isCodecSupportedBasedOnTestedConfigurations(config, type);
 
-            const supplementalCodec = adapter.getSupplementalCodec(rep);
             let isSupplementalCodecSupported = false;
-            if (supplementalCodec) {
+            const supplementalCodecs = adapter.getSupplementalCodecs(rep);
+            if (supplementalCodecs.length > 0) {
+                if (supplementalCodecs.length > 1) {
+                    logger.warn(`[CapabilitiesFilter] Multiple supplemental codecs not supported; using first in list`);
+                }
+                const supplementalCodec = supplementalCodecs[0];
                 const supplementalCodecConfig = _createConfiguration(type, rep, supplementalCodec);
                 configurations.push(supplementalCodecConfig);
                 isSupplementalCodecSupported = capabilities.isCodecSupportedBasedOnTestedConfigurations(supplementalCodecConfig, type);
@@ -173,9 +177,9 @@ function CapabilitiesFilter() {
                             configurations.push(config);
                         }
 
-                        const supplementalCodec = adapter.getSupplementalCodec(rep)
-                        if (supplementalCodec) {
-                            const config = _createConfiguration(type, rep, supplementalCodec);
+                        const supplementalCodecs = adapter.getSupplementalCodecs(rep)
+                        if (supplementalCodecs.length > 0) {
+                            const config = _createConfiguration(type, rep, supplementalCodecs[0]);
                             const configString = JSON.stringify(config);
                             if (!configurationsSet.has(configString)) {
                                 configurationsSet.add(configString);

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -146,7 +146,7 @@ function CapabilitiesFilter() {
             const config = _createConfiguration(type, rep, supplementalCodec);
             const supported = capabilities.isCodecSupportedBasedOnTestedConfigurations(config, type);
             if (supported) {
-                logger.debug(`[CapabilitiesFilter] Codec ${codec} supported. Upgrading Representation with ID ${rep.id}`);
+                logger.debug(`[CapabilitiesFilter] Codec ${supplementalCodec} supported. Upgrading Representation with ID ${rep.id}`);
                 rep.codecs = supplementalCodec;
             }
             return rep;
@@ -172,6 +172,16 @@ function CapabilitiesFilter() {
                         if (!configurationsSet.has(configString)) {
                             configurationsSet.add(configString);
                             configurations.push(config);
+                        }
+
+                        const supplementalCodec = adapter.getSupplementalCodec(rep)
+                        if (supplementalCodec) {
+                            const config = _createConfiguration(type, rep, supplementalCodec);
+                            const configString = JSON.stringify(config);
+                            if (!configurationsSet.has(configString)) {
+                                configurationsSet.add(configString);
+                                configurations.push(config);
+                            }
                         }
                     });
                 }

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -139,16 +139,15 @@ function CapabilitiesFilter() {
 
         // handle scte214:supplementalCodecs
         as.Representation = as.Representation.map((rep) => {
-            const supplementalCodecs = rep['scte214:supplementalCodecs']
-            if (!supplementalCodecs) {
-                return rep
+            const supplementalCodec = adapter.getSupplementalCodec(rep);
+            if (!supplementalCodec) {
+                return rep;
             }
-            const codec = rep.mimeType + ';codecs="' + supplementalCodecs + '"';
-            const config = _createConfiguration(type, rep, codec);
+            const config = _createConfiguration(type, rep, supplementalCodec);
             const supported = capabilities.isCodecSupportedBasedOnTestedConfigurations(config, type);
             if (supported) {
                 logger.debug(`[CapabilitiesFilter] Codec ${codec} supported. Upgrading Representation with ID ${rep.id}`);
-                rep.codecs = supplementalCodecs;
+                rep.codecs = supplementalCodec;
             }
             return rep;
         })

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -161,6 +161,10 @@ function AdapterMock() {
         return codec;
     };
 
+    this.getSupplementalCodecs = function () {
+        return [];
+    }
+
     this.getEssentialPropertiesForRepresentation = function (realRepresentation) {
         if (!realRepresentation || !realRepresentation.EssentialProperty || !realRepresentation.EssentialProperty.length) {
             return null;


### PR DESCRIPTION
Let me know if you need a copy of the spec.  With this change, DolbyVision Profile 8 now works.

For example, on Windows11 with DolbyVision:

* manifest: https://ott.dolby.com/browser_test_kit/cbcs/p81/24/dash.mpd
* playready license url: https://playready.ezdrm.com/cency/preauth.aspx?pX=DCB4DB
* robustness: 3000
