### PR TITLE
Remove outdated CMCD parameters from MPD request

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -98,6 +98,29 @@ class Utils {
         }
     }
 
+    static removeQueryParameterFromUrl(url, queryParameter) {
+        if (!url || !queryParameter) {
+            return url;
+        }
+        // Parse the URL
+        const parsedUrl = new URL(url);
+
+        // Get the search parameters
+        const params = new URLSearchParams(parsedUrl.search);
+
+        if (!params || params.size === 0) {
+            return url;
+        }
+
+        // Remove the CMCD parameter
+        params.delete(queryParameter);
+
+        // Reconstruct the URL without the CMCD parameter
+        parsedUrl.search = params.toString();
+
+        return parsedUrl.toString();
+    }
+
     static parseHttpHeaders(headerStr) {
         let headers = {};
         if (!headerStr) {

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -37,6 +37,7 @@ import Errors from '../core/errors/Errors.js';
 import DashConstants from '../dash/constants/DashConstants.js';
 import URLUtils from './utils/URLUtils.js';
 import LocationSelector from './utils/LocationSelector.js';
+import Utils from '../core/Utils.js';
 
 function ManifestUpdater() {
 
@@ -153,6 +154,11 @@ function ManifestUpdater() {
 
         // default to the original url in the manifest
         let url = manifest.url;
+
+        // Remove previous CMCD parameters from URL
+        if (url) {
+            url = Utils.removeQueryParameterFromUrl(url, 'CMCD');
+        }
 
         // Check for PatchLocation and Location alternatives
         let serviceLocation = null;

--- a/test/unit/test/core/core.Utils.js
+++ b/test/unit/test/core/core.Utils.js
@@ -168,4 +168,31 @@ describe('Utils', () => {
             expect(Utils.getCodecFamily('vp09.00.10.08.00.02.02.02.00')).to.be.equal('vp09');
         })
     })
+
+    describe('removeQueryParameterFromUrl', () => {
+
+        it('Should remove query parameter from URL', () => {
+            const url = 'http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd?CMCD=ot%3Dm%2Cpr%3D0.9900013331200346%2Csf%3Dd%2Csid%3D%22f3a875e8-da06-4261-b9fb-124ea694c524%22%2Cst%3Dl';
+            const modifiedUrl = Utils.removeQueryParameterFromUrl(url, 'CMCD');
+            expect(modifiedUrl).to.be.equal('http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd');
+        })
+
+        it('Should return original URL as query parameter to be removed is not included', () => {
+            const url = 'http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd?CMCD=ot%3Dm%2Cpr%3D0.9900013331200346%2Csf%3Dd%2Csid%3D%22f3a875e8-da06-4261-b9fb-124ea694c524%22%2Cst%3Dl';
+            const modifiedUrl = Utils.removeQueryParameterFromUrl(url, 'C');
+            expect(modifiedUrl).to.be.equal('http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd?CMCD=ot%3Dm%2Cpr%3D0.9900013331200346%2Csf%3Dd%2Csid%3D%22f3a875e8-da06-4261-b9fb-124ea694c524%22%2Cst%3Dl');
+        })
+
+        it('Should return original URL if no parameter to be removed is specified', () => {
+            const url = 'http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd?CMCD=ot%3Dm%2Cpr%3D0.9900013331200346%2Csf%3Dd%2Csid%3D%22f3a875e8-da06-4261-b9fb-124ea694c524%22%2Cst%3Dl';
+            const modifiedUrl = Utils.removeQueryParameterFromUrl(url,);
+            expect(modifiedUrl).to.be.equal('http://13.38.43.87:8080/packeng/dash_ll.toml/ateme.mpd?CMCD=ot%3Dm%2Cpr%3D0.9900013331200346%2Csf%3Dd%2Csid%3D%22f3a875e8-da06-4261-b9fb-124ea694c524%22%2Cst%3Dl');
+        })
+
+        it('Do not modify a string without query parameters', () => {
+            const url = 'http://example.com';
+            const modifiedUrl = Utils.removeQueryParameterFromUrl(url, 'CMCD');
+            expect(modifiedUrl).to.be.equal(url);
+        })
+    })
 })

--- a/test/unit/test/streaming/streaming.ManifestUpdater.js
+++ b/test/unit/test/streaming/streaming.ManifestUpdater.js
@@ -44,11 +44,11 @@ describe('ManifestUpdater', function () {
             error: { code: Errors.MANIFEST_LOADER_LOADING_FAILURE_ERROR_CODE, message: manifestErrorMockText }
         });
 
-        expect(spy).to.have.not.been.called(); // jshint ignore:line
+        expect(spy).to.have.not.been.called();
 
         eventBus.off(Events.MANIFEST_UPDATED, spy);
 
-        expect(errHandlerMock.errorCode).to.equal(undefined); // jshint ignore:line
+        expect(errHandlerMock.errorCode).to.equal(undefined);
     });
 
     it('should not call MANIFEST_UPDATED if a parsing error occurs, errorHandler should send an error', function () {
@@ -59,11 +59,11 @@ describe('ManifestUpdater', function () {
             error: { code: Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE, message: manifestErrorMockText }
         });
 
-        expect(spy).to.have.not.been.called(); // jshint ignore:line
+        expect(spy).to.have.not.been.called();
 
         eventBus.off(Events.MANIFEST_UPDATED, spy);
 
-        expect(errHandlerMock.errorCode).to.equal(Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE); // jshint ignore:line
+        expect(errHandlerMock.errorCode).to.equal(Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE);
     });
 
     it('should call MANIFEST_UPDATED with existing manifest if update provided 204', function () {
@@ -81,7 +81,7 @@ describe('ManifestUpdater', function () {
 
         expect(manifestModelMock.getValue()).to.equal(inMemoryManifest);
         expect(inMemoryManifest.loadedTime).to.not.equal(originalTime);
-        expect(spy.calledOnce).to.be.true; // jshint ignore:line
+        expect(spy.calledOnce).to.be.true;
         expect(spy.firstCall.args[0].manifest).to.equal(inMemoryManifest);
 
         manifestModelMock.setValue(null);
@@ -110,10 +110,10 @@ describe('ManifestUpdater', function () {
 
         expect(manifestModelMock.getValue()).to.equal(inMemoryManifest);
         expect(inMemoryManifest.loadedTime).to.not.equal(originalTime);
-        expect(patchCheckStub.called).to.be.true; // jshint ignore:line
-        expect(isPatchValidStub.called).to.be.true; // jshint ignore:line
-        expect(applyPatchStub.calledWith(inMemoryManifest, patch)).to.be.true; // jshint ignore:line
-        expect(spy.calledOnce).to.be.true; // jshint ignore:line
+        expect(patchCheckStub.called).to.be.true;
+        expect(isPatchValidStub.called).to.be.true;
+        expect(applyPatchStub.calledWith(inMemoryManifest, patch)).to.be.true;
+        expect(spy.calledOnce).to.be.true;
         expect(spy.firstCall.args[0].manifest).to.equal(inMemoryManifest);
 
         manifestModelMock.setValue(null);
@@ -143,10 +143,10 @@ describe('ManifestUpdater', function () {
         eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: patch });
 
         expect(manifestModelMock.getValue()).to.equal(inMemoryManifest);
-        expect(patchCheckStub.called).to.be.true; // jshint ignore:line
-        expect(isPatchValidStub.called).to.be.true; // jshint ignore:line
-        expect(applyPatchStub.called).to.be.false; // jshint ignore:line
-        expect(loaderStub.called).to.be.true; // jshint ignore:line
+        expect(patchCheckStub.called).to.be.true;
+        expect(isPatchValidStub.called).to.be.true;
+        expect(applyPatchStub.called).to.be.false;
+        expect(loaderStub.called).to.be.true;
 
         manifestModelMock.setValue(null);
         patchCheckStub.restore();
@@ -173,10 +173,10 @@ describe('ManifestUpdater', function () {
         eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: patch });
 
         expect(manifestModelMock.getValue()).to.equal(inMemoryManifest);
-        expect(patchCheckStub.called).to.be.true; // jshint ignore:line
-        expect(isPatchValidStub.called).to.be.true; // jshint ignore:line
-        expect(applyPatchStub.called).to.be.true; // jshint ignore:line
-        expect(loaderStub.called).to.be.true; // jshint ignore:line
+        expect(patchCheckStub.called).to.be.true;
+        expect(isPatchValidStub.called).to.be.true;
+        expect(applyPatchStub.called).to.be.true;
+        expect(loaderStub.called).to.be.true;
 
         manifestModelMock.setValue(null);
         patchCheckStub.restore();
@@ -219,7 +219,7 @@ describe('ManifestUpdater', function () {
 
             manifestUpdater.refreshManifest();
 
-            expect(loadStub.calledWith(patchLocation[0].url)).to.be.true; // jshint ignore:line
+            expect(loadStub.calledWith(patchLocation[0].url)).to.be.true;
         });
 
         it('should utilize location for update if provided one and no patch location', function () {
@@ -228,7 +228,7 @@ describe('ManifestUpdater', function () {
 
             manifestUpdater.refreshManifest();
 
-            expect(loadStub.calledWith(location[0].url)).to.be.true; // jshint ignore:line
+            expect(loadStub.calledWith(location[0].url)).to.be.true;
         });
 
         it('should utilize original mpd location if no other signal provided', function () {
@@ -237,7 +237,7 @@ describe('ManifestUpdater', function () {
 
             manifestUpdater.refreshManifest();
 
-            expect(loadStub.calledWith(manifest.url)).to.be.true; // jshint ignore:line
+            expect(loadStub.calledWith(manifest.url)).to.be.true;
         });
 
         it('should make relative locations absolute relative to the manifest', function () {
@@ -246,7 +246,7 @@ describe('ManifestUpdater', function () {
 
             manifestUpdater.refreshManifest();
 
-            expect(loadStub.calledWith(location[0].url)).to.be.true; // jshint ignore:line
+            expect(loadStub.calledWith(location[0].url)).to.be.true;
         });
     });
 });


### PR DESCRIPTION
This fixes an issue reported on Slack causing the CMCD string to be appended multiple times to the MPD requests