### PR TITLE
Fix ProducerReferenceTime id attribute parsing

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -189,7 +189,7 @@ function DashManifestModel() {
             const entry = new ProducerReferenceTime();
 
             if (prt.hasOwnProperty(DashConstants.ID)) {
-                entry[DashConstants.ID] = prt[DashConstants.ID];
+                entry[DashConstants.ID] = parseInt(prt[DashConstants.ID]);
             } else {
                 // Ignore. Missing mandatory attribute
                 return;


### PR DESCRIPTION
ProducerReferenceTime's id attribute should be as `xs:unsignedInt`
