### PR TITLE
Transpile to plain ES5

### DIFF
--- a/build/webpack.base.cjs
+++ b/build/webpack.base.cjs
@@ -19,9 +19,6 @@ const commonConfig = {
                     {
                         loader: 'babel-loader',
                         options: {
-                            targets: {
-                                'chrome': '51'
-                            },
                             presets: ['@babel/preset-env']
                         },
                     },


### PR DESCRIPTION
Address #4619 and transform to plain ES5 code. This is done to enable easy testing on all platforms. The configuration will be revisited before the release of v5.