### PR TITLE
Fix#4651

### DIFF
--- a/samples/dash-if-reference-player/app/sources.json
+++ b/samples/dash-if-reference-player/app/sources.json
@@ -1101,6 +1101,16 @@
                     }
                 },
                 {
+                    "name": "Livesim 2 DRM EZDRM-2-keys-cbcs",
+                    "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-2-keys-cbcs/testpic_2s/Manifest.mpd",
+                    "provider": "dashif"
+                },
+                {
+                    "name": "Livesim 2 DRM EZDRM-1-key-cbcs",
+                    "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-1-key-cbcs/testpic_2s/Manifest.mpd",
+                    "provider": "dashif"
+                },
+                {
                     "name": "Livesim 2 ECCP with CBCS encryption and dashif:Laurl",
                     "url": "https://livesim2.dashif.org/livesim2/eccp_cbcs/testpic_2s/Manifest.mpd",
                     "provider": "dashif"

--- a/samples/drm/clearkey.html
+++ b/samples/drm/clearkey.html
@@ -67,8 +67,8 @@
                 <div class="h-100 p-5 bg-light border rounded-3">
                     <h3>Clearkey DRM instantiation example</h3>
                     <p>This example shows how to use dash.js to play streams with Clearkey DRM protection. </p><p>For a detailed explanation on DRM playback in dash.js checkout the
-                    <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                       target="_blank">Wiki</a>.</p>
+                    <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                       target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/keepProtectionKeys.html
+++ b/samples/drm/keepProtectionKeys.html
@@ -100,8 +100,8 @@
                         the first playback attempt license requests will be visible. For any subsequent playback attempt
                         the existing MediaKeySession is reused and no additional license requests are performed.</p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/license-wrapping.html
+++ b/samples/drm/license-wrapping.html
@@ -88,8 +88,8 @@
                     <p>This example shows how to use dash.js to modify the license request and the license
                         repsonse. </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/playready.html
+++ b/samples/drm/playready.html
@@ -68,8 +68,8 @@
                 <div class="h-100 p-5 bg-light border rounded-3">
                     <h3>PlayReady DRM instantiation example</h3>
                     <p>This example shows how to use dash.js to play streams with PlayReady DRM protection. </p><p>For a detailed explanation on DRM playback in dash.js checkout the
-                    <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                       target="_blank">Wiki</a>.</p>
+                    <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                       target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/robustness-level.html
+++ b/samples/drm/robustness-level.html
@@ -74,8 +74,8 @@
                     <p>This example shows how to define a robustness level to be used by dash.js in the <i>requestMediaKeySystemAccess</i>
                         call. </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/system-priority.html
+++ b/samples/drm/system-priority.html
@@ -79,8 +79,8 @@
                         multiple DRM systems. In this example, dash.js checks for the support of Widevine before
                         Playready. </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/system-string-priority.html
+++ b/samples/drm/system-string-priority.html
@@ -88,8 +88,8 @@
                         with the system strings "com.microsoft.playready.recommendation" and
                         "com.microsoft.playready". </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/drm/widevine.html
+++ b/samples/drm/widevine.html
@@ -71,8 +71,8 @@
                     <h3>Widevine DRM instantiation example</h3>
                     <p>This example shows how to use dash.js to play streams with Widevine DRM protection. </p>
                     <p>For a detailed explanation on DRM playback in dash.js checkout the
-                        <a href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Digital-Rights-Management-(DRM)-and-license-acquisition"
-                           target="_blank">Wiki</a>.</p>
+                        <a href="https://dashif.org/dash.js/pages/usage/drm.html"
+                           target="_blank">documentation</a>.</p>
                 </div>
             </div>
             <div class="col-md-8">

--- a/samples/low-latency/testplayer/testplayer.html
+++ b/samples/low-latency/testplayer/testplayer.html
@@ -32,7 +32,7 @@
                     <h3><i class="bi bi-info-square"></i> Live low-latency playback</h3>
                     Example showing how to use dash.js to play low latency streams. The low-latency related parameters
                     can be adjusted in the settings section. For more information checkout the <a
-                    href="https://github.com/Dash-Industry-Forum/dash.js/wiki/Low-Latency-streaming" target="_blank">Wiki</a>.
+                    href="https://dashif.org/dash.js/pages/usage/low-latency.html" target="_blank">documentation</a>.
 
                     <div class="alert alert-warning mt-4" role="alert">
                         <ul>

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1389,7 +1389,8 @@ function StreamController() {
         })
 
         if (!supportedMediaInfos || supportedMediaInfos.length === 0) {
-            errHandler.error(new DashJSError(Errors.NO_SUPPORTED_KEY_IDS, Errors.NO_SUPPORTED_KEY_IDS_MESSAGE));
+            const type = streamProcessor.getType();
+            errHandler.error(new DashJSError(Errors.NO_SUPPORTED_KEY_IDS, `Type: ${type}: ${Errors.NO_SUPPORTED_KEY_IDS_MESSAGE}`));
             return
         }
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -717,7 +717,7 @@ function ProtectionController(config) {
      * @param {object} error
      * @private
      */
-    function _sendLicenseRequestCompleteEvent(data, error) {
+    function _sendLicenseRequestCompleteEvent(data, error = null) {
         eventBus.trigger(events.LICENSE_REQUEST_COMPLETE, { data: data, error: error });
     }
 
@@ -1127,6 +1127,7 @@ function ProtectionController(config) {
                 return
             }
 
+            e.sessionToken.hasTriggeredKeyStatusMapUpdate = true;
             const parsedKeyStatuses = e.parsedKeyStatuses;
             const ua = Utils.parseUserAgent();
             const isEdgeBrowser = ua && ua.browser && ua.browser.name && ua.browser.name.toLowerCase() === 'edge';
@@ -1161,7 +1162,7 @@ function ProtectionController(config) {
 
     function areKeyIdsUsable(normalizedKeyIds) {
         try {
-            if (!normalizedKeyIds || normalizedKeyIds.size === 0 || !keyStatusMap || keyStatusMap.size === 0 || settings.get().streaming.protection.ignoreKeyStatuses) {
+            if (!_shouldCheckKeyStatusMap(normalizedKeyIds)) {
                 return true;
             }
 
@@ -1177,22 +1178,35 @@ function ProtectionController(config) {
 
     function areKeyIdsExpired(normalizedKeyIds) {
         try {
-            if (!normalizedKeyIds || normalizedKeyIds.size === 0) {
+            if (!_shouldCheckKeyStatusMap(normalizedKeyIds)) {
                 return false;
             }
 
-            let expired = false
-
-            normalizedKeyIds.forEach((normalizedKeyId) => {
-                const keyStatus = keyStatusMap.get(normalizedKeyId)
-                expired = keyStatus && keyStatus === ProtectionConstants.MEDIA_KEY_STATUSES.EXPIRED
+            return [...normalizedKeyIds].every((normalizedKeyId) => {
+                const keyStatus = keyStatusMap.get(normalizedKeyId);
+                return keyStatus === ProtectionConstants.MEDIA_KEY_STATUSES.EXPIRED;
             })
-
-            return expired
         } catch (error) {
             logger.error(error);
-            return true
+            return false
         }
+    }
+
+    function _shouldCheckKeyStatusMap(normalizedKeyIds) {
+        const sessionTokens = protectionModel.getSessionTokens();
+
+        if (sessionTokens && sessionTokens.length > 0) {
+            const targetSessionTokens = sessionTokens.filter((sessionToken) => {
+                return [...normalizedKeyIds].includes(sessionToken.normalizedKeyId);
+            })
+            const hasNotTriggeredKeyStatusMapUpdate = targetSessionTokens.some((sessionToken) => {
+                return !sessionToken.hasTriggeredKeyStatusMapUpdate;
+            })
+            if (hasNotTriggeredKeyStatusMapUpdate) {
+                return false;
+            }
+        }
+        return !settings.get().streaming.protection.ignoreKeyStatuses && normalizedKeyIds && normalizedKeyIds.size > 0 && keyStatusMap && keyStatusMap.size > 0
     }
 
     instance = {

--- a/src/streaming/protection/models/DefaultProtectionModel.js
+++ b/src/streaming/protection/models/DefaultProtectionModel.js
@@ -359,6 +359,7 @@ function DefaultProtectionModel(config) {
 
         const session = mediaKeys.createSession(keySystemMetadata.sessionType);
         const sessionToken = _createSessionToken(session, keySystemMetadata);
+        sessionToken.hasTriggeredKeyStatusMapUpdate = true;
 
         // Load persisted session data into our newly created session object
         session.load(sessionId).then(function (success) {
@@ -455,9 +456,11 @@ function DefaultProtectionModel(config) {
         const token = { // Implements SessionToken
             session: session,
             keyId: keySystemMetadata.keyId,
+            normalizedKeyId: keySystemMetadata.keyId.replace(/-/g, '').toLowerCase(),
             initData: keySystemMetadata.initData,
             sessionId: keySystemMetadata.sessionId,
             sessionType: keySystemMetadata.sessionType,
+            hasTriggeredKeyStatusMapUpdate: false,
 
             // This is our main event handler for all desired MediaKeySession events
             // These events are translated into our API-independent versions of the

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -222,7 +222,9 @@ function ProtectionModel_01b(config) {
             const newSession = { // Implements SessionToken
                 sessionId: null,
                 keyId: ksInfo.keyId,
+                normalizedKeyId: ksInfo.keyId.replace(/-/g, '').toLowerCase(),
                 initData: ksInfo.initData,
+                hasTriggeredKeyStatusMapUpdate: false,
 
                 getKeyId: function () {
                     return this.keyId;

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -336,7 +336,9 @@ function ProtectionModel_3Feb2014(config) {
             // Implements SessionToken
             session: keySession,
             keyId: ksInfo.keyId,
+            normalizedKeyId: ksInfo.keyId.replace(/-/g, '').toLowerCase(),
             initData: ksInfo.initData,
+            hasTriggeredKeyStatusMapUpdate: false,
 
             getKeyId: function () {
                 return this.keyId;

--- a/test/functional/config/test-configurations/streams/drm.json
+++ b/test/functional/config/test-configurations/streams/drm.json
@@ -157,6 +157,32 @@
       "excludedTestfiles": [
         "playback-advanced/preload"
       ]
+    },
+    {
+      "name": "LiveSim2 - DRM EZDRM-2-keys-cbcs",
+      "type": "live",
+      "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-2-keys-cbcs/testpic_2s/Manifest.mpd",
+      "includedTestfiles": [
+        "playback/*"
+      ],
+      "excludedPlatforms": [
+        {
+          "browser": "safari"
+        }
+      ]
+    },
+    {
+      "name": "LiveSim2 - DRM EZDRM-1-key-cbcs",
+      "type": "live",
+      "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-1-key-cbcs/testpic_2s/Manifest.mpd",
+      "includedTestfiles": [
+        "playback/*"
+      ],
+      "excludedPlatforms": [
+        {
+          "browser": "safari"
+        }
+      ]
     }
   ]
 }

--- a/test/functional/config/test-configurations/streams/drm.json
+++ b/test/functional/config/test-configurations/streams/drm.json
@@ -163,7 +163,8 @@
       "type": "live",
       "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-2-keys-cbcs/testpic_2s/Manifest.mpd",
       "includedTestfiles": [
-        "playback/*"
+        "playback/*",
+        "drm/keep-media-key-sessions"
       ],
       "excludedPlatforms": [
         {
@@ -176,7 +177,8 @@
       "type": "live",
       "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-1-key-cbcs/testpic_2s/Manifest.mpd",
       "includedTestfiles": [
-        "playback/*"
+        "playback/*",
+        "drm/keep-media-key-sessions"
       ],
       "excludedPlatforms": [
         {

--- a/test/functional/config/test-configurations/streams/smoke.json
+++ b/test/functional/config/test-configurations/streams/smoke.json
@@ -93,7 +93,8 @@
       "includedTestfiles": [
         "playback/*",
         "audio/initial-audio",
-        "text/*"
+        "text/*",
+        "drm/keep-media-key-sessions"
       ],
       "excludedPlatforms": [
         {
@@ -106,7 +107,8 @@
       "type": "live",
       "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-2-keys-cbcs/testpic_2s/Manifest.mpd",
       "includedTestfiles": [
-        "playback/*"
+        "playback/*",
+        "drm/keep-media-key-sessions"
       ],
       "excludedPlatforms": [
         {
@@ -119,7 +121,8 @@
       "type": "live",
       "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-1-key-cbcs/testpic_2s/Manifest.mpd",
       "includedTestfiles": [
-        "playback/*"
+        "playback/*",
+        "drm/keep-media-key-sessions"
       ],
       "excludedPlatforms": [
         {

--- a/test/functional/config/test-configurations/streams/smoke.json
+++ b/test/functional/config/test-configurations/streams/smoke.json
@@ -102,6 +102,32 @@
       ]
     },
     {
+      "name": "LiveSim2 - DRM EZDRM-2-keys-cbcs",
+      "type": "live",
+      "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-2-keys-cbcs/testpic_2s/Manifest.mpd",
+      "includedTestfiles": [
+        "playback/*"
+      ],
+      "excludedPlatforms": [
+        {
+          "browser": "safari"
+        }
+      ]
+    },
+    {
+      "name": "LiveSim2 - DRM EZDRM-1-key-cbcs",
+      "type": "live",
+      "url": "https://livesim2.dashif.org/livesim2/drm_EZDRM-1-key-cbcs/testpic_2s/Manifest.mpd",
+      "includedTestfiles": [
+        "playback/*"
+      ],
+      "excludedPlatforms": [
+        {
+          "browser": "safari"
+        }
+      ]
+    },
+    {
       "name": "1080p with W3C Clear Key, single key",
       "type": "vod",
       "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd",

--- a/test/functional/src/Constants.js
+++ b/test/functional/src/Constants.js
@@ -3,6 +3,7 @@ const TESTCASES = {
         ADVANCED: 'advanced/',
         AUDIO: 'audio/',
         BUFFER: 'buffer/',
+        DRM: 'drm/',
         FEATURE_SUPPORT: 'feature-support/',
         LIVE: 'live/',
         PLAYBACK: 'playback/',
@@ -14,6 +15,7 @@ const TESTCASES = {
     ADVANCED: {},
     AUDIO: {},
     BUFFER: {},
+    DRM: {},
     FEATURE_SUPPORT: {},
     LIVE: {},
     PLAYBACK: {},
@@ -150,6 +152,8 @@ TESTCASES.BUFFER.CLEANUP = TESTCASES.CATEGORIES.BUFFER + 'buffer-cleanup';
 TESTCASES.BUFFER.INITIAL_TARGET = TESTCASES.CATEGORIES.BUFFER + 'initial-buffer-target';
 TESTCASES.BUFFER.TARGET = TESTCASES.CATEGORIES.BUFFER + 'buffer-target';
 TESTCASES.BUFFER.TO_KEEP_SEEK = TESTCASES.CATEGORIES.BUFFER + 'buffer-to-keep-seek';
+
+TESTCASES.DRM.KEEP_MEDIA_KEY_SESSIONS = TESTCASES.CATEGORIES.DRM + 'keep-media-key-sessions';
 
 TESTCASES.FEATURE_SUPPORT.EMSG_TRIGGERED = TESTCASES.CATEGORIES.FEATURE_SUPPORT + 'emsg-triggered';
 TESTCASES.FEATURE_SUPPORT.MPD_PATCHING = TESTCASES.CATEGORIES.FEATURE_SUPPORT + 'mpd-patching';

--- a/test/functional/test/drm/keep-media-key-sessions.js
+++ b/test/functional/test/drm/keep-media-key-sessions.js
@@ -1,0 +1,59 @@
+import Constants from '../../src/Constants.js';
+import Utils from '../../src/Utils.js';
+import ProtectionEvents from '../../../../src/streaming/protection/ProtectionEvents.js';
+import {expect} from 'chai'
+import {checkIsPlaying, checkIsProgressing, checkNoCriticalErrors, initializeDashJsAdapter} from '../common/common.js';
+
+const TESTCASE = Constants.TESTCASES.DRM.KEEP_MEDIA_KEY_SESSIONS;
+
+Utils.getTestvectorsForTestcase(TESTCASE).forEach((item) => {
+    const mpd = item.url;
+
+    describe(`${TESTCASE} - ${item.name} - ${mpd}`, function () {
+
+        let playerAdapter;
+        const completedLicenseRequests = []
+
+        before(function () {
+            if (item.type === Constants.CONTENT_TYPES.VOD || !item.testdata || !item.testdata.drm || !item.testdata.drm.keepMediaKeySessions) {
+                this.skip();
+            }
+            const settings = {
+                streaming: {
+                    protection: {
+                        keepProtectionMediaKeys: true
+                    }
+                }
+            }
+            playerAdapter = initializeDashJsAdapter(item, mpd, settings);
+        })
+
+        after(() => {
+            if (playerAdapter) {
+                playerAdapter.destroy();
+            }
+        })
+
+        it(`Checking playing state`, async () => {
+            await checkIsPlaying(playerAdapter, true);
+        })
+
+        it(`Checking progressing state`, async () => {
+            await checkIsProgressing(playerAdapter);
+        });
+
+        it(`Should not trigger any new license requests and is progressing`, async () => {
+            playerAdapter.registerEvent(ProtectionEvents.LICENSE_REQUEST_COMPLETE, (e) => {
+                completedLicenseRequests.push(e.data);
+            });
+            playerAdapter.attachSource(mpd);
+            await checkIsProgressing(playerAdapter);
+            expect(completedLicenseRequests).to.be.empty
+        });
+
+        it(`Expect no critical errors to be thrown`, () => {
+            checkNoCriticalErrors(playerAdapter);
+        })
+
+    })
+})

--- a/test/functional/test/playback-advanced/switch-quality.js
+++ b/test/functional/test/playback-advanced/switch-quality.js
@@ -28,7 +28,6 @@ Utils.getTestvectorsForTestcase(TESTCASE).forEach((item) => {
             await checkIsProgressing(playerAdapter)
         });
 
-
         it(`Switch video qualities`, async () => {
             await _executeSwitchesForMediaType(Constants.DASH_JS.MEDIA_TYPES.VIDEO);
         });


### PR DESCRIPTION
This PR fixes #4651:

* For each media key session, check if it has updated the key status map. For details refer to #4651
* Adds a new functional test to check if `keepProtectionMediaKeys` is working and no additional license requests are made
* Adds LiveSim2 DRM teststreams to the list of reference vectors and list of smoke vectors
* Fix links to DRM documentation in the samples
