### PR TITLE
Feature/mss module sample

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2703,6 +2703,7 @@ declare namespace dashjs {
         mediaType: MediaType;
         newRepresentation: Representation;
         oldRepresentation: Representation;
+        streamId: string;
         type: MediaPlayerEvents['QUALITY_CHANGE_RENDERED'];
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -351,7 +351,7 @@ declare namespace dashjs {
 
         getRepresentationForQuality(quality: number): object | null;
 
-        prepareQualityChange(newQuality: number): void;
+        prepareQualityChange(newRep: Representation): void;
 
         reset(): void;
     }
@@ -2701,20 +2701,21 @@ declare namespace dashjs {
 
     export interface QualityChangeRenderedEvent extends MediaPlayerEvent {
         mediaType: MediaType;
-        newQuality: number;
-        oldQuality: number;
+        newRepresentation: Representation;
+        oldRepresentation: Representation;
         type: MediaPlayerEvents['QUALITY_CHANGE_RENDERED'];
     }
 
     export interface QualityChangeRequestedEvent extends MediaPlayerEvent {
         mediaType: MediaType;
-        newQuality: number;
-        oldQuality: number;
+        newRepresentation: Representation;
+        oldRepresentation: Representation;
         reason: {
             name?: string;
             droppedFrames?: number;
         } | null;
         streamInfo: StreamInfo | null;
+        isAdaptationSetSwitch: boolean;
         type: MediaPlayerEvents['QUALITY_CHANGE_REQUESTED'];
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2154,7 +2154,7 @@ declare namespace dashjs {
 
         refreshManifest(callback: (manifest: object | null, error: unknown) => void): void;
 
-        registerCustomCapabilitiesFilter(filter: CapabilitiesFilter): void;
+        registerCustomCapabilitiesFilter(filter: CapabilitiesFilterFunction): void;
 
         registerLicenseRequestFilter(filter: RequestFilter): void;
 
@@ -2222,7 +2222,7 @@ declare namespace dashjs {
 
         triggerSteeringRequest(): Promise<any>;
 
-        unregisterCustomCapabilitiesFilter(filter: CapabilitiesFilter): void;
+        unregisterCustomCapabilitiesFilter(filter: CapabilitiesFilterFunction): void;
 
         unregisterLicenseRequestFilter(filter: RequestFilter): void;
 
@@ -3744,7 +3744,7 @@ declare namespace dashjs {
 
         getAbrCustomRules(): Array<object>;
 
-        getCustomCapabilitiesFilters(): Array<Function>;
+        getCustomCapabilitiesFilters(): Array<CapabilitiesFilterFunction>;
 
         getCustomInitialTrackSelectionFunction(): Function;
 
@@ -3760,7 +3760,7 @@ declare namespace dashjs {
 
         getXHRWithCredentialsForType(type: string): any;
 
-        registerCustomCapabilitiesFilter(filter: Function): void;
+        registerCustomCapabilitiesFilter(filter: CapabilitiesFilterFunction): void;
 
         registerLicenseRequestFilter(filter: Function): void;
 
@@ -3787,7 +3787,7 @@ declare namespace dashjs {
 
         setXHRWithCredentialsForType(type: string, value: string): void;
 
-        unregisterCustomCapabilitiesFilter(filter: Function): void;
+        unregisterCustomCapabilitiesFilter(filter: CapabilitiesFilterFunction): void;
 
         unregisterLicenseRequestFilter(filter: Function): void;
 
@@ -5115,6 +5115,8 @@ declare namespace dashjs {
 
         supportsMediaSource(): boolean;
     }
+
+    export type CapabilitiesFilterFunction = (representation: Representation) => boolean;
 
     export interface CapabilitiesFilter {
         filterUnsupportedFeatures(manifest: object): Promise<any>;

--- a/samples/modules/typescript-smooth/index.html
+++ b/samples/modules/typescript-smooth/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Dash.js Rocks</title>
+
+        <style>
+            video {
+                width: 640px;
+                height: 360px;
+            }
+        </style>
+    </head>
+    <body>
+        <div>
+            <video id="myMainVideoPlayer" controls></video>
+            <div id="version-output"></div>
+        </div>
+    </body>
+</html>

--- a/samples/modules/typescript-smooth/package.json
+++ b/samples/modules/typescript-smooth/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dashjs-typescript-sample",
+  "version": "1.0.0",
+  "description": "Test using dash.js in a Typescript based project",
+  "dependencies": {
+    "dashjs": "file:../../.."
+  },
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  },
+  "author": "Daniel Silhavy",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "html-webpack-plugin": "^5.6.0",
+    "ts-loader": "^9.5.1",
+    "typescript": "^4.0.0",
+    "webpack": "^5.95.0"
+  }
+}

--- a/samples/modules/typescript-smooth/src/index.ts
+++ b/samples/modules/typescript-smooth/src/index.ts
@@ -1,0 +1,10 @@
+import * as dashjs from 'dashjs';
+import '../node_modules/dashjs/dist/modern/esm/dash.mss.min.js';
+
+
+let url = "https://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest";
+let player = dashjs.MediaPlayer().create();
+// @ts-ignore
+player.initialize(document.querySelector('#myMainVideoPlayer'), url, true);
+let version = player.getVersion();
+document.getElementById('version-output').innerText = `Version ${version}`;

--- a/samples/modules/typescript-smooth/tsconfig.json
+++ b/samples/modules/typescript-smooth/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "noImplicitAny": true,
+    "module": "ESNext",
+    "target": "es5",
+    "jsx": "react",
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/samples/modules/typescript-smooth/webpack.config.js
+++ b/samples/modules/typescript-smooth/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    entry: './src/index.ts',
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+    resolve: {
+        extensions: ['.tsx', '.ts', '.js'],
+    },
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+    },
+    plugins: [new HtmlWebpackPlugin({
+        inject: true,
+        filename: 'index.html',
+        template: 'index.html'
+    })],
+};


### PR DESCRIPTION
This PR addresses #4664 

* Adds an example how to include the`dash.mss.min.js` bundle in a Typescript application for playback of Smooth Streaming content
* Fixes Typescript definitions 

