### PR TITLE
fix naming inconsistency, remove unused functions

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1040,7 +1040,7 @@ function DashAdapter() {
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
         mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
-        mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptation(realAdaptation);
+        mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;
         mediaInfo.adaptationSetSwitchingCompatibleIds = _getAdaptationSetSwitchingCompatibleIds(mediaInfo);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -388,32 +388,6 @@ function DashAdapter() {
     }
 
     /**
-     * Return all EssentialProperties of an AdaptationSet
-     * @param {object} adaptationSet
-     * @return {array}
-     */
-    function getEssentialPropertiesForAdaptationSet(adaptationSet) {
-        try {
-            return dashManifestModel.getEssentialPropertiesForRepresentation(adaptationSet);
-        } catch (e) {
-            return [];
-        }
-    }
-
-    /**
-     * Return all EssentialProperties of a Representation
-     * @param {object} representation
-     * @return {array}
-     */
-    function getEssentialPropertiesForRepresentation(representation) {
-        try {
-            return dashManifestModel.getEssentialPropertiesForRepresentation(representation);
-        } catch (e) {
-            return [];
-        }
-    }
-
-    /**
      * Return supplementalCodecs of a Representation
      * @param {object} representation
      * @returns {array}
@@ -1221,8 +1195,6 @@ function DashAdapter() {
         getCodec,
         getContentSteering,
         getDuration,
-        getEssentialPropertiesForAdaptationSet,
-        getEssentialPropertiesForRepresentation,
         getEvent,
         getEventsFor,
         getIndexForRepresentation,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -1430,7 +1430,7 @@ function DashManifestModel() {
         return serviceDescriptions;
     }
 
-    function getSupplementalPropertiesForAdaptation(adaptation) {
+    function getSupplementalPropertiesForAdaptationSet(adaptation) {
         if (!adaptation || !adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) || !adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
             return [];
         }
@@ -1517,7 +1517,7 @@ function DashManifestModel() {
         getServiceDescriptions,
         getSubSegmentAlignment,
         getSuggestedPresentationDelay,
-        getSupplementalPropertiesForAdaptation,
+        getSupplementalPropertiesForAdaptationSet,
         getSupplementalPropertiesForRepresentation,
         getUTCTimingSources,
         getViewpointForAdaptation,

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -186,22 +186,22 @@ describe('DashManifestModel', function () {
             expect(essPropArray[0].value).equals('testVal');
         });
 
-        it('should return an empty array when getSupplementalPropertiesForAdaptation', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation();
+        it('should return an empty array when getSupplementalPropertiesForAdaptationSet', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet();
 
             expect(suppPropArray).to.be.instanceOf(Object);
             expect(suppPropArray).to.be.empty;
         });
 
-        it('should return an empty array when getSupplementalPropertiesForAdaptation', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation();
+        it('should return an empty array when getSupplementalPropertiesForAdaptationSet', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet();
 
             expect(suppPropArray).to.be.instanceOf(Array);
             expect(suppPropArray).to.be.empty;
         });
 
-        it('should return correct array of DescriptorType when getSupplementalPropertiesForAdaptation is called', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation({
+        it('should return correct array of DescriptorType when getSupplementalPropertiesForAdaptationSet is called', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet({
                 SupplementalProperty: [{ schemeIdUri: 'test.scheme', value: 'testVal' }, {
                     schemeIdUri: 'test.scheme',
                     value: 'test2Val'


### PR DESCRIPTION
Additional information:

I checked API documentation ; the removed functions are not documented for DashAdapter module, so I assume they are not needed as public-facing API methods.