### PR TITLE
Add ./mss MSS bundles to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
       "browser": "./dist/modern/umd/dash.all.min.js",
       "script": "./dist/modern/umd/dash.all.min.js",
       "require": "./dist/modern/umd/dash.all.min.js"
+    },
+    "./mss": {
+      "types": "./index.d.ts",
+      "import": "./dist/modern/esm/dash.mss.min.js",
+      "default": "./dist/modern/esm/dash.mss.min.js",
+      "browser": "./dist/modern/umd/dash.mss.min.js",
+      "script": "./dist/modern/umd/dash.mss.min.js",
+      "require": "./dist/modern/umd/dash.mss.min.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
Based on https://github.com/Dash-Industry-Forum/dash.js/issues/4664#issuecomment-2621554195 this PR exports the MSS bundles from the `package.json`