### PR TITLE
propagate Properties common to all Representations to MediaInfo

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1039,8 +1039,10 @@ function DashAdapter() {
         }
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
-        mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
-        mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptation(realAdaptation);
+        // mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
+        mediaInfo.essentialProperties = dashManifestModel.getAllEssentialPropertiesForAdaptationSet(realAdaptation);
+        // mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptation(realAdaptation);
+        mediaInfo.supplementalProperties = dashManifestModel.getAllSupplementalPropertiesForAdaptation(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;
         mediaInfo.adaptationSetSwitchingCompatibleIds = _getAdaptationSetSwitchingCompatibleIds(mediaInfo);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1039,9 +1039,7 @@ function DashAdapter() {
         }
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
-        // mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.essentialProperties = dashManifestModel.getCommonEssentialPropertiesForAdaptationSet(realAdaptation);
-        // mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.supplementalProperties = dashManifestModel.getCommonSupplementalPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1041,8 +1041,8 @@ function DashAdapter() {
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
         // mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.essentialProperties = dashManifestModel.getCommonEssentialPropertiesForAdaptationSet(realAdaptation);
-        // mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptation(realAdaptation);
-        mediaInfo.supplementalProperties = dashManifestModel.getCommonSupplementalPropertiesForAdaptation(realAdaptation);
+        // mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptationSet(realAdaptation);
+        mediaInfo.supplementalProperties = dashManifestModel.getCommonSupplementalPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;
         mediaInfo.adaptationSetSwitchingCompatibleIds = _getAdaptationSetSwitchingCompatibleIds(mediaInfo);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1039,8 +1039,8 @@ function DashAdapter() {
         }
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
-        mediaInfo.essentialProperties = dashManifestModel.getCommonEssentialPropertiesForAdaptationSet(realAdaptation);
-        mediaInfo.supplementalProperties = dashManifestModel.getCommonSupplementalPropertiesForAdaptationSet(realAdaptation);
+        mediaInfo.essentialProperties = dashManifestModel.getCombinedEssentialPropertiesForAdaptationSet(realAdaptation);
+        mediaInfo.supplementalProperties = dashManifestModel.getCombinedSupplementalPropertiesForAdaptationSet(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;
         mediaInfo.adaptationSetSwitchingCompatibleIds = _getAdaptationSetSwitchingCompatibleIds(mediaInfo);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1040,9 +1040,9 @@ function DashAdapter() {
 
         mediaInfo.isText = dashManifestModel.getIsText(realAdaptation);
         // mediaInfo.essentialProperties = dashManifestModel.getEssentialPropertiesForAdaptationSet(realAdaptation);
-        mediaInfo.essentialProperties = dashManifestModel.getAllEssentialPropertiesForAdaptationSet(realAdaptation);
+        mediaInfo.essentialProperties = dashManifestModel.getCommonEssentialPropertiesForAdaptationSet(realAdaptation);
         // mediaInfo.supplementalProperties = dashManifestModel.getSupplementalPropertiesForAdaptation(realAdaptation);
-        mediaInfo.supplementalProperties = dashManifestModel.getAllSupplementalPropertiesForAdaptation(realAdaptation);
+        mediaInfo.supplementalProperties = dashManifestModel.getCommonSupplementalPropertiesForAdaptation(realAdaptation);
         mediaInfo.isFragmented = dashManifestModel.getIsFragmented(realAdaptation);
         mediaInfo.isEmbedded = false;
         mediaInfo.adaptationSetSwitchingCompatibleIds = _getAdaptationSetSwitchingCompatibleIds(mediaInfo);

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -600,12 +600,12 @@ function DashManifestModel() {
             propFirstRepr = repr[0][propertyType];
         }
         
-        if (repr.length == 1 ) {
+        if (repr.length === 1 ) {
             return propFirstRepr;
         }
 
         // now, only return properties present on all Representations
-        // repr.legth is always >= 2
+        // repr.length is always >= 2
         return propFirstRepr.filter( prop => {
             return repr.slice(1).every( repr_n => {
                 return repr_n.hasOwnProperty(propertyType) && repr_n[propertyType].some( e => {
@@ -615,7 +615,7 @@ function DashManifestModel() {
         })
     }
 
-    function getCommonEssentialPropertiesForAdaptationSet(adaptation) {
+    function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {
         if (!adaptation) {
             return [];
         }
@@ -1485,7 +1485,7 @@ function DashManifestModel() {
         });
     }
 
-    function getCommonSupplementalPropertiesForAdaptationSet(adaptation) {
+    function getCombinedSupplementalPropertiesForAdaptationSet(adaptation) {
         if (!adaptation) {
             return [];
         }
@@ -1541,13 +1541,14 @@ function DashManifestModel() {
         getBaseURLsFromElement,
         getBitrateListForAdaptation,
         getCodec,
+        getCombinedEssentialPropertiesForAdaptationSet,
+        getCombinedSupplementalPropertiesForAdaptationSet,
         getContentProtectionByAdaptation,
         getContentProtectionByManifest,
         getContentProtectionByPeriod,
         getContentSteering,
         getDuration,
         getEssentialPropertiesForAdaptationSet,
-        getCommonEssentialPropertiesForAdaptationSet,
         getEssentialPropertiesForRepresentation,
         getEventStreamForAdaptationSet,
         getEventStreamForRepresentation,
@@ -1581,7 +1582,6 @@ function DashManifestModel() {
         getSubSegmentAlignment,
         getSuggestedPresentationDelay,
         getSupplementalPropertiesForAdaptationSet,
-        getCommonSupplementalPropertiesForAdaptationSet,
         getSupplementalPropertiesForRepresentation,
         getUTCTimingSources,
         getViewpointForAdaptation,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -584,9 +584,9 @@ function DashManifestModel() {
             return [];
         }
 
-        return element[propertyType].map((essentialProperty) => {
+        return element[propertyType].map((property) => {
             const s = new DescriptorType();
-            s.init(essentialProperty);
+            s.init(property);
             return s
         });
     }
@@ -609,20 +609,12 @@ function DashManifestModel() {
         // now, only return properties present on all Representations
         // repr.legth is always >= 2
         return propertiesOfFirstRepresentation.filter( prop => {
-            return repr.slice(1).every( repr_n => {
-                return repr_n.hasOwnProperty(propertyType) && repr_n[propertyType].some( e => {
+            return repr.slice(1).every( currRep => {
+                return currRep[propertyType].some( e => {
                     return e.schemeIdUri === prop.schemeIdUri && e.value === prop.value;
                 });
             });
         })
-        
-        // const propSet = new Set(repr.slice(1).flatMap(currRep =>
-        //     currRep[propertyType]?.map(e => `${e.schemeIdUri}-${e.value}`) || []
-        // ));
-
-        // return propertiesOfFirstRepresentation.filter(prop =>
-        //     propSet.has(`${prop.schemeIdUri}-${prop.value}`)
-        // );
     }
 
     function _getCombinedPropertiesForAdaptationSet(propertyType, adaptation) {
@@ -653,6 +645,18 @@ function DashManifestModel() {
 
     function getEssentialPropertiesForRepresentation(realRepresentation) {
         return _getProperties(DashConstants.ESSENTIAL_PROPERTY, realRepresentation);
+    }
+
+    function getSupplementalPropertiesForAdaptationSet(adaptation) {
+        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
+    }
+
+    function getCombinedSupplementalPropertiesForAdaptationSet(adaptation) {
+        return _getCombinedPropertiesForAdaptationSet(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
+    }
+
+    function getSupplementalPropertiesForRepresentation(representation) {
+        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, representation);
     }
 
     function getRepresentationFor(index, adaptation) {
@@ -1482,18 +1486,6 @@ function DashManifestModel() {
         }
 
         return serviceDescriptions;
-    }
-
-    function getSupplementalPropertiesForAdaptationSet(adaptation) {
-        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
-    }
-
-    function getCombinedSupplementalPropertiesForAdaptationSet(adaptation) {
-        return _getCombinedPropertiesForAdaptationSet(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
-    }
-
-    function getSupplementalPropertiesForRepresentation(representation) {
-        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, representation);
     }
 
     function setConfig(config) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -591,7 +591,7 @@ function DashManifestModel() {
         });
     }
 
-    function _getCommonPropertiesFromRepresentations(propertyType, repr) {
+    function _getPropertiesCommonToAllRepresentations(propertyType, repr) {
         if (!repr || !repr.length) {
             return [];
         }
@@ -620,7 +620,7 @@ function DashManifestModel() {
             return [];
         }
 
-        let allProperties = _getCommonPropertiesFromRepresentations(propertyType, adaptation[DashConstants.REPRESENTATION]);
+        let allProperties = _getPropertiesCommonToAllRepresentations(propertyType, adaptation[DashConstants.REPRESENTATION]);
         if (adaptation.hasOwnProperty(propertyType) && adaptation[propertyType].length) {
             allProperties.push(...adaptation[propertyType])
         }

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -1474,7 +1474,7 @@ function DashManifestModel() {
         return serviceDescriptions;
     }
 
-    function getSupplementalPropertiesForAdaptation(adaptation) {
+    function getSupplementalPropertiesForAdaptationSet(adaptation) {
         if (!adaptation || !adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) || !adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
             return [];
         }
@@ -1485,7 +1485,7 @@ function DashManifestModel() {
         });
     }
 
-    function getCommonSupplementalPropertiesForAdaptation(adaptation) {
+    function getCommonSupplementalPropertiesForAdaptationSet(adaptation) {
         if (!adaptation) {
             return [];
         }
@@ -1580,8 +1580,8 @@ function DashManifestModel() {
         getServiceDescriptions,
         getSubSegmentAlignment,
         getSuggestedPresentationDelay,
-        getSupplementalPropertiesForAdaptation,
-        getCommonSupplementalPropertiesForAdaptation,
+        getSupplementalPropertiesForAdaptationSet,
+        getCommonSupplementalPropertiesForAdaptationSet,
         getSupplementalPropertiesForRepresentation,
         getUTCTimingSources,
         getViewpointForAdaptation,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -578,18 +578,19 @@ function DashManifestModel() {
         }
     }
 
-    function getEssentialPropertiesForAdaptationSet(adaptation) {
-        if (!adaptation || !adaptation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) || !adaptation[DashConstants.ESSENTIAL_PROPERTY].length) {
+    // propertyType is one of { DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY }
+    function _getProperties(propertyType, element) {
+        if (!element || !element.hasOwnProperty(propertyType) || !element[propertyType].length) {
             return [];
         }
-        return adaptation[DashConstants.ESSENTIAL_PROPERTY].map(essentialProperty => {
+
+        return element[propertyType].map((essentialProperty) => {
             const s = new DescriptorType();
             s.init(essentialProperty);
             return s
         });
     }
 
-    // propertyType is one of { DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY }
     function _getCommonPropertiesFromRepresentations(propertyType, repr) {
         if (!repr || !repr.length) {
             return [];
@@ -614,14 +615,14 @@ function DashManifestModel() {
         );
     }
 
-    function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {
+    function _getCombinedPropertiesForAdaptationSet(propertyType, adaptation) {
         if (!adaptation) {
             return [];
         }
 
-        let allProperties = _getCommonPropertiesFromRepresentations(DashConstants.ESSENTIAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
-        if (adaptation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) && adaptation[DashConstants.ESSENTIAL_PROPERTY].length) {
-            allProperties.push(...adaptation[DashConstants.ESSENTIAL_PROPERTY])
+        let allProperties = _getCommonPropertiesFromRepresentations(propertyType, adaptation[DashConstants.REPRESENTATION]);
+        if (adaptation.hasOwnProperty(propertyType) && adaptation[propertyType].length) {
+            allProperties.push(...adaptation[propertyType])
         }
         // we don't check whether there are duplicates on AdaptationSets and Representations
 
@@ -632,16 +633,16 @@ function DashManifestModel() {
         });
     }
 
-    function getEssentialPropertiesForRepresentation(realRepresentation) {
-        if (!realRepresentation || !realRepresentation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) || !realRepresentation[DashConstants.ESSENTIAL_PROPERTY].length) {
-            return [];
-        }
+    function getEssentialPropertiesForAdaptationSet(adaptation) {
+        return _getProperties(DashConstants.ESSENTIAL_PROPERTY, adaptation);
+    }
+    
+    function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {
+        return _getCombinedPropertiesForAdaptationSet(DashConstants.ESSENTIAL_PROPERTY, adaptation);
+    }
 
-        return realRepresentation[DashConstants.ESSENTIAL_PROPERTY].map((essentialProperty) => {
-            const s = new DescriptorType();
-            s.init(essentialProperty);
-            return s
-        });
+    function getEssentialPropertiesForRepresentation(realRepresentation) {
+        return _getProperties(DashConstants.ESSENTIAL_PROPERTY, realRepresentation);
     }
 
     function getRepresentationFor(index, adaptation) {
@@ -1474,43 +1475,15 @@ function DashManifestModel() {
     }
 
     function getSupplementalPropertiesForAdaptationSet(adaptation) {
-        if (!adaptation || !adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) || !adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
-            return [];
-        }
-        return adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].map(supp => {
-            const s = new DescriptorType();
-            s.init(supp);
-            return s
-        });
+        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
     }
 
     function getCombinedSupplementalPropertiesForAdaptationSet(adaptation) {
-        if (!adaptation) {
-            return [];
-        }
-
-        let allProperties = _getCommonPropertiesFromRepresentations(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
-        if (adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) && adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
-            allProperties.push(...adaptation[DashConstants.SUPPLEMENTAL_PROPERTY])
-        }
-        // we don't check whether there are duplicates on AdaptationSets and Representations
-
-        return allProperties.map(essentialProperty => {
-            const s = new DescriptorType();
-            s.init(essentialProperty);
-            return s
-        });
+        return _getCombinedPropertiesForAdaptationSet(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation);
     }
 
     function getSupplementalPropertiesForRepresentation(representation) {
-        if (!representation || !representation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) || !representation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
-            return [];
-        }
-        return representation[DashConstants.SUPPLEMENTAL_PROPERTY].map(supp => {
-            const s = new DescriptorType();
-            s.init(supp);
-            return s
-        });
+        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, representation);
     }
 
     function setConfig(config) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -594,25 +594,24 @@ function DashManifestModel() {
         if (!repr || !repr.length) {
             return [];
         }
-        let propFirstRepr = [];
         
-        if (repr[0].hasOwnProperty(propertyType)) {
-            propFirstRepr = repr[0][propertyType];
-        }
-        
-        if (repr.length === 1 ) {
-            return propFirstRepr;
+        let propertiesOfFirstRepresentation = repr[0][propertyType] || [];
+
+        if (propertiesOfFirstRepresentation.length === 0) {
+            return [];
         }
 
-        // now, only return properties present on all Representations
-        // repr.length is always >= 2
-        return propFirstRepr.filter( prop => {
-            return repr.slice(1).every( repr_n => {
-                return repr_n.hasOwnProperty(propertyType) && repr_n[propertyType].some( e => {
-                    return e.schemeIdUri === prop.schemeIdUri && e.value === prop.value;
-                });
-            });
-        })
+        if (repr.length === 1) {
+            return propertiesOfFirstRepresentation;
+        }
+        
+        const propSet = new Set(repr.slice(1).flatMap(currRep =>
+            currRep[propertyType]?.map(e => `${e.schemeIdUri}-${e.value}`) || []
+        ));
+
+        return propertiesOfFirstRepresentation.filter(prop =>
+            propSet.has(`${prop.schemeIdUri}-${prop.value}`)
+        );
     }
 
     function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -590,7 +590,7 @@ function DashManifestModel() {
     }
 
     // propertyType is one of { DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY }
-    function _getCommonProperties(propertyType, repr) {
+    function _getCommonPropertiesFromRepresentations(propertyType, repr) {
         if (!repr || !repr.length) {
             return [];
         }
@@ -615,18 +615,16 @@ function DashManifestModel() {
         })
     }
 
-
-
-    function getAllEssentialPropertiesForAdaptationSet(adaptation) {
+    function getCommonEssentialPropertiesForAdaptationSet(adaptation) {
         if (!adaptation) {
             return [];
         }
 
-        let allProperties = _getCommonProperties(DashConstants.ESSENTIAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
+        let allProperties = _getCommonPropertiesFromRepresentations(DashConstants.ESSENTIAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
         if (adaptation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) && adaptation[DashConstants.ESSENTIAL_PROPERTY].length) {
             allProperties.push(...adaptation[DashConstants.ESSENTIAL_PROPERTY])
         }
-        // we assume there are no duplicates on AdaptationSets and Representations
+        // we don't check whether there are duplicates on AdaptationSets and Representations
 
         return allProperties.map(essentialProperty => {
             const s = new DescriptorType();
@@ -1487,16 +1485,16 @@ function DashManifestModel() {
         });
     }
 
-    function getAllSupplementalPropertiesForAdaptation(adaptation) {
+    function getCommonSupplementalPropertiesForAdaptation(adaptation) {
         if (!adaptation) {
             return [];
         }
 
-        let allProperties = _getCommonProperties(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
+        let allProperties = _getCommonPropertiesFromRepresentations(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
         if (adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) && adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
             allProperties.push(...adaptation[DashConstants.SUPPLEMENTAL_PROPERTY])
         }
-        // we assume there are no duplicates on AdaptationSets and Representations
+        // we don't check whether there are duplicates on AdaptationSets and Representations
 
         return allProperties.map(essentialProperty => {
             const s = new DescriptorType();
@@ -1549,7 +1547,7 @@ function DashManifestModel() {
         getContentSteering,
         getDuration,
         getEssentialPropertiesForAdaptationSet,
-        getAllEssentialPropertiesForAdaptationSet,
+        getCommonEssentialPropertiesForAdaptationSet,
         getEssentialPropertiesForRepresentation,
         getEventStreamForAdaptationSet,
         getEventStreamForRepresentation,
@@ -1583,7 +1581,7 @@ function DashManifestModel() {
         getSubSegmentAlignment,
         getSuggestedPresentationDelay,
         getSupplementalPropertiesForAdaptation,
-        getAllSupplementalPropertiesForAdaptation,
+        getCommonSupplementalPropertiesForAdaptation,
         getSupplementalPropertiesForRepresentation,
         getUTCTimingSources,
         getViewpointForAdaptation,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -606,13 +606,23 @@ function DashManifestModel() {
             return propertiesOfFirstRepresentation;
         }
         
-        const propSet = new Set(repr.slice(1).flatMap(currRep =>
-            currRep[propertyType]?.map(e => `${e.schemeIdUri}-${e.value}`) || []
-        ));
+        // now, only return properties present on all Representations
+        // repr.legth is always >= 2
+        return propertiesOfFirstRepresentation.filter( prop => {
+            return repr.slice(1).every( repr_n => {
+                return repr_n.hasOwnProperty(propertyType) && repr_n[propertyType].some( e => {
+                    return e.schemeIdUri === prop.schemeIdUri && e.value === prop.value;
+                });
+            });
+        })
+        
+        // const propSet = new Set(repr.slice(1).flatMap(currRep =>
+        //     currRep[propertyType]?.map(e => `${e.schemeIdUri}-${e.value}`) || []
+        // ));
 
-        return propertiesOfFirstRepresentation.filter(prop =>
-            propSet.has(`${prop.schemeIdUri}-${prop.value}`)
-        );
+        // return propertiesOfFirstRepresentation.filter(prop =>
+        //     propSet.has(`${prop.schemeIdUri}-${prop.value}`)
+        // );
     }
 
     function _getCombinedPropertiesForAdaptationSet(propertyType, adaptation) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -589,6 +589,52 @@ function DashManifestModel() {
         });
     }
 
+    // propertyType is one of { DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY }
+    function _getCommonProperties(propertyType, repr) {
+        if (!repr || !repr.length) {
+            return [];
+        }
+        let propFirstRepr = [];
+        
+        if (repr[0].hasOwnProperty(propertyType)) {
+            propFirstRepr = repr[0][propertyType];
+        }
+        
+        if (repr.length == 1 ) {
+            return propFirstRepr;
+        }
+
+        // now, only return properties present on all Representations
+        // repr.legth is always >= 2
+        return propFirstRepr.filter( prop => {
+            return repr.slice(1).every( repr_n => {
+                return repr_n.hasOwnProperty(propertyType) && repr_n[propertyType].some( e => {
+                    return e.schemeIdUri === prop.schemeIdUri && e.value === prop.value;
+                });
+            });
+        })
+    }
+
+
+
+    function getAllEssentialPropertiesForAdaptationSet(adaptation) {
+        if (!adaptation) {
+            return [];
+        }
+
+        let allProperties = _getCommonProperties(DashConstants.ESSENTIAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
+        if (adaptation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) && adaptation[DashConstants.ESSENTIAL_PROPERTY].length) {
+            allProperties.push(...adaptation[DashConstants.ESSENTIAL_PROPERTY])
+        }
+        // we assume there are no duplicates on AdaptationSets and Representations
+
+        return allProperties.map(essentialProperty => {
+            const s = new DescriptorType();
+            s.init(essentialProperty);
+            return s
+        });
+    }
+
     function getEssentialPropertiesForRepresentation(realRepresentation) {
         if (!realRepresentation || !realRepresentation.hasOwnProperty(DashConstants.ESSENTIAL_PROPERTY) || !realRepresentation[DashConstants.ESSENTIAL_PROPERTY].length) {
             return [];
@@ -1441,6 +1487,24 @@ function DashManifestModel() {
         });
     }
 
+    function getAllSupplementalPropertiesForAdaptation(adaptation) {
+        if (!adaptation) {
+            return [];
+        }
+
+        let allProperties = _getCommonProperties(DashConstants.SUPPLEMENTAL_PROPERTY, adaptation[DashConstants.REPRESENTATION]);
+        if (adaptation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) && adaptation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
+            allProperties.push(...adaptation[DashConstants.SUPPLEMENTAL_PROPERTY])
+        }
+        // we assume there are no duplicates on AdaptationSets and Representations
+
+        return allProperties.map(essentialProperty => {
+            const s = new DescriptorType();
+            s.init(essentialProperty);
+            return s
+        });
+    }
+
     function getSupplementalPropertiesForRepresentation(representation) {
         if (!representation || !representation.hasOwnProperty(DashConstants.SUPPLEMENTAL_PROPERTY) || !representation[DashConstants.SUPPLEMENTAL_PROPERTY].length) {
             return [];
@@ -1485,6 +1549,7 @@ function DashManifestModel() {
         getContentSteering,
         getDuration,
         getEssentialPropertiesForAdaptationSet,
+        getAllEssentialPropertiesForAdaptationSet,
         getEssentialPropertiesForRepresentation,
         getEventStreamForAdaptationSet,
         getEventStreamForRepresentation,
@@ -1518,6 +1583,7 @@ function DashManifestModel() {
         getSubSegmentAlignment,
         getSuggestedPresentationDelay,
         getSupplementalPropertiesForAdaptation,
+        getAllSupplementalPropertiesForAdaptation,
         getSupplementalPropertiesForRepresentation,
         getUTCTimingSources,
         getViewpointForAdaptation,

--- a/test/unit/test/dash/dash.DashAdapter.js
+++ b/test/unit/test/dash/dash.DashAdapter.js
@@ -90,6 +90,62 @@ const manifest_with_supplemental_properties = {
         }]
     }]
 };
+const manifest_with_essential_properties_on_repr = {
+    loadedTime: new Date(),
+    mediaPresentationDuration: 10,
+    Period: [{
+        AdaptationSet: [{
+            id: 0, mimeType: Constants.VIDEO,
+            // SupplementalProperty: [{schemeIdUri: 'test:scheme', value: 'value1'},{schemeIdUri: 'test:scheme', value: 'value2'},{schemeIdUri: 'test:scheme', value: 'value3'}],
+            [DashConstants.REPRESENTATION]: [
+                {
+                    id: 10, bandwidth: 128000,
+                    [DashConstants.ESSENTIAL_PROPERTY]: [
+                        { schemeIdUri: 'test:scheme', value: 'value0' },
+                        { schemeIdUri: 'test:scheme', value: 'value2' },
+                        { schemeIdUri: 'test:scheme', value: 'value3' }
+                    ]
+                },
+                {
+                    id: 11, bandwidth: 160000,
+                    [DashConstants.ESSENTIAL_PROPERTY]: [
+                        { schemeIdUri: 'test:scheme', value: 'value1' },
+                        { schemeIdUri: 'test:scheme', value: 'value2' },
+                        { schemeIdUri: 'test:scheme', value: 'value3' }
+                    ]
+                }
+            ]
+        }]
+    }]
+};
+const manifest_with_supplemental_properties_on_repr = {
+    loadedTime: new Date(),
+    mediaPresentationDuration: 10,
+    Period: [{
+        AdaptationSet: [{
+            id: 0, mimeType: Constants.VIDEO,
+            // SupplementalProperty: [{schemeIdUri: 'test:scheme', value: 'value1'},{schemeIdUri: 'test:scheme', value: 'value2'},{schemeIdUri: 'test:scheme', value: 'value3'}],
+            [DashConstants.REPRESENTATION]: [
+                {
+                    id: 10, bandwidth: 128000,
+                    [DashConstants.SUPPLEMENTAL_PROPERTY]: [
+                        { schemeIdUri: 'test:scheme', value: 'value1' },
+                        { schemeIdUri: 'test:scheme', value: 'value2' },
+                        { schemeIdUri: 'test:scheme', value: 'value3' }
+                    ]
+                },
+                {
+                    id: 11, bandwidth: 160000,
+                    [DashConstants.SUPPLEMENTAL_PROPERTY]: [
+                        { schemeIdUri: 'test:scheme', value: 'value1' },
+                        { schemeIdUri: 'test:scheme', value: 'value2' },
+                        { schemeIdUri: 'test:scheme', value: 'value4' }
+                    ]
+                }
+            ]
+        }]
+    }]
+};
 const manifest_with_essential_properties_on_only_one_repr = {
     loadedTime: new Date(),
     mediaPresentationDuration: 10,
@@ -597,6 +653,25 @@ describe('DashAdapter', function () {
                     expect(mediaInfoArray[0].essentialProperties.length).equals(2);
                 });
 
+                it('essential properties should be filled if set on all representations', function () {
+                    const mediaInfoArray = dashAdapter.getAllMediaInfoForType({
+                        id: 'defaultId_0',
+                        index: 0
+                    }, Constants.VIDEO, manifest_with_essential_properties_on_repr);
+
+                    expect(mediaInfoArray).to.be.instanceOf(Array);
+                    expect(mediaInfoArray.length).equals(1);
+
+                    expect(mediaInfoArray[0].representationCount).equals(2);
+                    expect(mediaInfoArray[0].codec).not.to.be.null;
+
+                    expect(mediaInfoArray[0].essentialProperties).to.be.instanceOf(Array);
+                    expect(mediaInfoArray[0].essentialProperties.length).equals(2);
+
+                    expect(mediaInfoArray[0].essentialProperties[1].schemeIdUri).equals('test:scheme');
+                    expect(mediaInfoArray[0].essentialProperties[1].value).equals('value3');
+                });
+
                 it('essential properties should not be filled if not set on all representations', function () {
                     const mediaInfoArray = dashAdapter.getAllMediaInfoForType({
                         id: 'defaultId_0',
@@ -638,6 +713,25 @@ describe('DashAdapter', function () {
 
                     expect(mediaInfoArray[0].supplementalProperties).to.be.instanceOf(Array);
                     expect(mediaInfoArray[0].supplementalProperties.length).equals(2);
+                });
+
+                it('supplemental properties should be filled if set on all representations', function () {
+                    const mediaInfoArray = dashAdapter.getAllMediaInfoForType({
+                        id: 'defaultId_0',
+                        index: 0
+                    }, Constants.VIDEO, manifest_with_supplemental_properties_on_repr);
+
+                    expect(mediaInfoArray).to.be.instanceOf(Array);
+                    expect(mediaInfoArray.length).equals(1);
+
+                    expect(mediaInfoArray[0].representationCount).equals(2);
+                    expect(mediaInfoArray[0].codec).not.to.be.null;
+
+                    expect(mediaInfoArray[0].supplementalProperties).to.be.instanceOf(Array);
+                    expect(mediaInfoArray[0].supplementalProperties.length).equals(2);
+
+                    expect(mediaInfoArray[0].supplementalProperties[1].schemeIdUri).equals('test:scheme');
+                    expect(mediaInfoArray[0].supplementalProperties[1].value).equals('value2');
                 });
 
                 it('supplemental properties should not be filled if not set on all representations', function () {

--- a/test/unit/test/dash/dash.DashAdapter.js
+++ b/test/unit/test/dash/dash.DashAdapter.js
@@ -96,12 +96,11 @@ const manifest_with_essential_properties_on_repr = {
     Period: [{
         AdaptationSet: [{
             id: 0, mimeType: Constants.VIDEO,
-            // SupplementalProperty: [{schemeIdUri: 'test:scheme', value: 'value1'},{schemeIdUri: 'test:scheme', value: 'value2'},{schemeIdUri: 'test:scheme', value: 'value3'}],
             [DashConstants.REPRESENTATION]: [
                 {
                     id: 10, bandwidth: 128000,
                     [DashConstants.ESSENTIAL_PROPERTY]: [
-                        { schemeIdUri: 'test:scheme', value: 'value0' },
+                        { schemeIdUri: 'test:scheme', value: 'value1' },
                         { schemeIdUri: 'test:scheme', value: 'value2' },
                         { schemeIdUri: 'test:scheme', value: 'value3' }
                     ]
@@ -109,9 +108,17 @@ const manifest_with_essential_properties_on_repr = {
                 {
                     id: 11, bandwidth: 160000,
                     [DashConstants.ESSENTIAL_PROPERTY]: [
-                        { schemeIdUri: 'test:scheme', value: 'value1' },
+                        { schemeIdUri: 'test:scheme', value: 'value4' },
+                        { schemeIdUri: 'test:scheme', value: 'value3' },
                         { schemeIdUri: 'test:scheme', value: 'value2' },
-                        { schemeIdUri: 'test:scheme', value: 'value3' }
+                        { schemeIdUri: 'test:scheme', value: 'value0' }
+                    ]
+                },
+                {
+                    id: 12, bandwidth: 192000,
+                    [DashConstants.ESSENTIAL_PROPERTY]: [
+                        { schemeIdUri: 'test:scheme', value: 'value3' },
+                        { schemeIdUri: 'test:scheme', value: 'value1' }
                     ]
                 }
             ]
@@ -124,7 +131,6 @@ const manifest_with_supplemental_properties_on_repr = {
     Period: [{
         AdaptationSet: [{
             id: 0, mimeType: Constants.VIDEO,
-            // SupplementalProperty: [{schemeIdUri: 'test:scheme', value: 'value1'},{schemeIdUri: 'test:scheme', value: 'value2'},{schemeIdUri: 'test:scheme', value: 'value3'}],
             [DashConstants.REPRESENTATION]: [
                 {
                     id: 10, bandwidth: 128000,
@@ -662,14 +668,14 @@ describe('DashAdapter', function () {
                     expect(mediaInfoArray).to.be.instanceOf(Array);
                     expect(mediaInfoArray.length).equals(1);
 
-                    expect(mediaInfoArray[0].representationCount).equals(2);
+                    expect(mediaInfoArray[0].representationCount).equals(3);
                     expect(mediaInfoArray[0].codec).not.to.be.null;
 
                     expect(mediaInfoArray[0].essentialProperties).to.be.instanceOf(Array);
-                    expect(mediaInfoArray[0].essentialProperties.length).equals(2);
+                    expect(mediaInfoArray[0].essentialProperties.length).equals(1);
 
-                    expect(mediaInfoArray[0].essentialProperties[1].schemeIdUri).equals('test:scheme');
-                    expect(mediaInfoArray[0].essentialProperties[1].value).equals('value3');
+                    expect(mediaInfoArray[0].essentialProperties[0].schemeIdUri).equals('test:scheme');
+                    expect(mediaInfoArray[0].essentialProperties[0].value).equals('value3');
                 });
 
                 it('essential properties should not be filled if not set on all representations', function () {

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -186,22 +186,22 @@ describe('DashManifestModel', function () {
             expect(essPropArray[0].value).equals('testVal');
         });
 
-        it('should return an empty array when getSupplementalPropertiesForAdaptation', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation();
+        it('should return an empty array when getSupplementalPropertiesForAdaptationSet', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet();
 
             expect(suppPropArray).to.be.instanceOf(Object);
             expect(suppPropArray).to.be.empty;
         });
 
-        it('should return an empty array when getSupplementalPropertiesForAdaptation', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation();
+        it('should return an empty array when getSupplementalPropertiesForAdaptationSet', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet();
 
             expect(suppPropArray).to.be.instanceOf(Array);
             expect(suppPropArray).to.be.empty;
         });
 
-        it('should return correct array of DescriptorType when getSupplementalPropertiesForAdaptation is called', () => {
-            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptation({
+        it('should return correct array of DescriptorType when getSupplementalPropertiesForAdaptationSet is called', () => {
+            const suppPropArray = dashManifestModel.getSupplementalPropertiesForAdaptationSet({
                 SupplementalProperty: [{ schemeIdUri: 'test.scheme', value: 'testVal' }, {
                     schemeIdUri: 'test.scheme',
                     value: 'test2Val'


### PR DESCRIPTION
This PR re-establishes the use case that Supplemental- and EssentialProperties can be assigned to either AdaptationSets or Representations.
