### PR TITLE
Add Low Latency Stall Threshold

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1685,6 +1685,7 @@ declare namespace dashjs {
                 bufferTimeDefault?: number,
                 longFormContentDurationThreshold?: number,
                 stallThreshold?: number,
+                lowLatencyStallThreshold?: number,
                 useAppendWindow?: boolean,
                 setStallState?: boolean
                 avoidCurrentTimeRangePruning?: boolean

--- a/samples/dash-if-reference-player/app/main.js
+++ b/samples/dash-if-reference-player/app/main.js
@@ -332,6 +332,9 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
     $scope.cmcdMode = 'query';
     $scope.cmcdAllKeys = ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v']
 
+    $scope.stallThreshold = 0.3;
+    $scope.lowLatencyStallThreshold = 0.3;
+
     // Persistent license
     $scope.persistentSessionId = {};
     $scope.selectedKeySystem = null;
@@ -778,6 +781,26 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         });
     };
 
+    $scope.updateStallThreshold = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    stallThreshold: parseFloat($scope.stallThreshold)
+                }
+            }
+        });
+    }
+
+    $scope.updateLowLatencyStallThreshold = function () {
+        $scope.player.updateSettings({
+            streaming: {
+                buffer: {
+                    lowLatencyStallThreshold: parseFloat($scope.lowLatencyStallThreshold)
+                }
+            }
+        });
+    }
+
     $scope.updateInitialRoleVideo = function () {
         $scope.player.setInitialMediaSettingsFor('video', {
             role: $scope.initialSettings.video
@@ -813,7 +836,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
 
     $scope._backconvertRoleScheme = function (setting) {
         var scheme = 'off';
-        
+
         if (setting) {
             scheme = undefined;
             switch (setting.schemeIdUri) {
@@ -1134,6 +1157,16 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         const maxBitrate = parseInt($scope.maxVideoBitrate);
         if (!isNaN(maxBitrate)) {
             config.streaming.abr.maxBitrate = { 'video': maxBitrate };
+        }
+
+        const stallThreshold = parseFloat($scope.stallThreshold);
+        if (!isNaN(stallThreshold)) {
+            config.streaming.buffer.stallThreshold = stallThreshold;
+        }
+
+        const lowLatencyStallThreshold = parseFloat($scope.lowLatencyStallThreshold);
+        if (!isNaN(lowLatencyStallThreshold)) {
+            config.streaming.buffer.lowLatencyStallThreshold = lowLatencyStallThreshold;
         }
 
         config.streaming.cmcd.sid = $scope.cmcdSessionId ? $scope.cmcdSessionId : null;
@@ -1935,7 +1968,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
                     if (scheme === 'off') {
                         delete settings.accessibility;
                     } else {
-                        Object.assign(settings, {accessibility: $scope._genSettingsAudioAccessibility(scheme, $scope.initialSettings.audioAccessibility)} );
+                        Object.assign(settings, { accessibility: $scope._genSettingsAudioAccessibility(scheme, $scope.initialSettings.audioAccessibility) });
                     }
                     $scope.player.setInitialMediaSettingsFor('audio', settings);
                     break;
@@ -2308,6 +2341,12 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
         $scope.useSuggestedPresentationDelay = currentConfig.streaming.delay.useSuggestedPresentationDelay;
     }
 
+    function setStallThresholdOptions() {
+        var currentConfig = $scope.player.getSettings();
+        $scope.stallThreshold = currentConfig.streaming.buffer.stallThreshold;
+        $scope.lowLatencyStallThreshold = currentConfig.streaming.buffer.lowLatencyStallThreshold;
+    }
+
     function setInitialSettings() {
         var currentConfig = $scope.player.getSettings();
         if (currentConfig.streaming.abr.initialBitrate.video !== -1) {
@@ -2468,6 +2507,7 @@ app.controller('DashController', ['$scope', '$window', 'sources', 'contributors'
             setDrmOptions();
             setTextOptions();
             setLiveDelayOptions();
+            setStallThresholdOptions()
             setInitialSettings();
             setTrackSwitchModeSettings();
             setInitialLogLevel();

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -674,6 +674,19 @@
             </div>
         </div>
         <div class="options-item">
+            <div class="options-item-title">Buffer</div>
+            <div class="options-item-body">
+                <div class="sub-options-item-body">
+                    <label class="options-label">Stall Threshold:</label>
+                    <input type="text" class="form-control" placeholder="value in seconds" ng-model="stallThreshold"
+                        ng-change="updateStallThreshold()">
+                    <label class="options-label">Low Latency Stall Threshold:</label>
+                    <input type="text" class="form-control" placeholder="value in seconds" ng-model="lowLatencyStallThreshold"
+                        ng-change="updateLowLatencyStallThreshold()">
+                </div>
+            </div>
+        </div>
+        <div class="options-item">
             <div class="options-item-title">Initial Settings</div>
             <div class="options-item-body">
                 <div class="sub-options-item">

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -120,6 +120,7 @@ import Events from './events/Events.js';
  *                bufferTimeDefault: 18,
  *                longFormContentDurationThreshold: 600,
  *                stallThreshold: 0.3,
+ *                lowLatencyStallThreshold: 0.3,
  *                useAppendWindow: true,
  *                setStallState: true,
  *                avoidCurrentTimeRangePruning: false,
@@ -429,6 +430,8 @@ import Events from './events/Events.js';
  * Initial buffer level before playback starts
  * @property {number} [stallThreshold=0.3]
  * Stall threshold used in BufferController.js to determine whether a track should still be changed and which buffer range to prune.
+ * @property {number} [lowLatencyStallThreshold=0.3]
+ * Low Latency stall threshold used in BufferController.js to determine whether a track should still be changed and which buffer range to prune.
  * @property {boolean} [useAppendWindow=true]
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
@@ -1147,6 +1150,7 @@ function Settings() {
                 bufferTimeDefault: 18,
                 longFormContentDurationThreshold: 600,
                 stallThreshold: 0.3,
+                lowLatencyStallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
                 avoidCurrentTimeRangePruning: false,

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -894,26 +894,13 @@ function BufferController(config) {
             return;
         }
 
-        //If the player is in low latency mode, use the lowLatencyStallThreshold
-        if (playbackController.getLowLatencyModeEnabled()) {
-            if ((bufferLevel <= settings.get().streaming.buffer.lowLatencyStallThreshold) && !isBufferingCompleted) {
-                _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
-            } else {
-                if (isBufferingCompleted || bufferLevel > settings.get().streaming.buffer.lowLatencyStallThreshold) {
-                    _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
-                }
-            }
+        //Set stall threshold based on player mode
+        const stallThreshold = playbackController.getLowLatencyModeEnabled() ? settings.get().streaming.buffer.lowLatencyStallThreshold : settings.get().streaming.buffer.stallThreshold;
 
-        }
-        //If the player is not im low latency mode, use the stallThreshold
-        else {
-            if ((bufferLevel <= settings.get().streaming.buffer.stallThreshold) && !isBufferingCompleted) {
-                _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
-            } else {
-                if (isBufferingCompleted || bufferLevel > settings.get().streaming.buffer.stallThreshold) {
-                    _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
-                }
-            }
+        if ((bufferLevel <= stallThreshold) && !isBufferingCompleted) {
+            _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
+        } else if (isBufferingCompleted || bufferLevel > stallThreshold) {
+            _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -894,14 +894,25 @@ function BufferController(config) {
             return;
         }
 
-        // When the player is working in low latency mode, the buffer is often below STALL_THRESHOLD.
-        // So, when in low latency mode, change dash.js behavior so it notifies a stall just when
-        // buffer reach 0 seconds
-        if (((!playbackController.getLowLatencyModeEnabled() && bufferLevel < settings.get().streaming.buffer.stallThreshold) || bufferLevel === 0) && !isBufferingCompleted) {
-            _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
-        } else {
-            if (isBufferingCompleted || bufferLevel >= settings.get().streaming.buffer.stallThreshold || (playbackController.getLowLatencyModeEnabled() && bufferLevel > 0)) {
-                _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
+        //If the player is in low latency mode, use the lowLatencyStallThreshold
+        if (playbackController.getLowLatencyModeEnabled()) {
+            if ((bufferLevel <= settings.get().streaming.buffer.lowLatencyStallThreshold) && !isBufferingCompleted) {
+                _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
+            } else {
+                if (isBufferingCompleted || bufferLevel > settings.get().streaming.buffer.lowLatencyStallThreshold) {
+                    _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
+                }
+            }
+
+        }
+        //If the player is not im low latency mode, use the stallThreshold
+        else {
+            if ((bufferLevel <= settings.get().streaming.buffer.stallThreshold) && !isBufferingCompleted) {
+                _notifyBufferStateChanged(MetricsConstants.BUFFER_EMPTY);
+            } else {
+                if (isBufferingCompleted || bufferLevel > settings.get().streaming.buffer.stallThreshold) {
+                    _notifyBufferStateChanged(MetricsConstants.BUFFER_LOADED);
+                }
             }
         }
     }


### PR DESCRIPTION
In some cases when using Dash.js in Low Latency mode - seen in this caue with chunks of 0.96s in duration, `BUFFER_EMPTY` events are not raised when the player is observed to stall.

Current operation has a catch for low-latency mode in the `checkIfSufficientBuffer` within the `BufferController` which says if the player is in low latency mode only when the buffer reaches 0 is a `BUFFER_EMPTY` raised.

In some low latency use cases the player can stall in low-latency mode with a buffer level greater than 0. Particulary when chunk sizes are greater than just a handful of frames.

Outside of low-latency mode the BUFFER_EMPTY event is raised whenever the buffer is below the `stallThreshold` setting. Set by default to 0.3s.

This PR solves the above by adding a seperate `lowLatencyStallThreshold` alongside the exisiting `stallThreshold` to enable users to configure each indepedently to allow for cases when the player is to be used to play both low-latency and regular live DASH content.

Also included are extensions to the reference player samples to allow the configuration of both `stallThreshold` and `lowLatencyStallThreshold`