### PR TITLE
Fix TTML parsing error catching

### DIFF
--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -339,8 +339,8 @@ function TextSourceBuffer(config) {
 
             } catch (e) {
                 fragmentModel.removeExecutedRequestsBeforeTime();
-                this.remove();
-                logger.error('TTML parser error: ' + e.message);
+                remove();
+                logger.error('TTML parser error: ' + e);
             }
         }
     }


### PR DESCRIPTION
In case of TTML parsing error, dash.js raise a javascript error:

![image](https://github.com/user-attachments/assets/b8118360-c287-4b99-afc8-9fca6896ba07)

With this fix:

![image](https://github.com/user-attachments/assets/57aff426-b265-4009-bf57-142cdf58388d)
