### PR TITLE
Feature/pathway cloning base

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -133,6 +133,8 @@ function StreamController() {
         eventBus.on(MediaPlayerEvents.MANIFEST_VALIDITY_CHANGED, _onManifestValidityChanged, instance);
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_UPDATED, _onBufferLevelUpdated, instance);
         eventBus.on(MediaPlayerEvents.QUALITY_CHANGE_REQUESTED, _onQualityChanged, instance);
+        eventBus.on(MediaPlayerEvents.CONTENT_STEERING_REQUEST_COMPLETED, _onSteeringManifestUpdated, instance);
+
 
         if (Events.KEY_SESSION_UPDATED) {
             eventBus.on(Events.KEY_SESSION_UPDATED, _onKeySessionUpdated, instance);
@@ -159,6 +161,7 @@ function StreamController() {
         eventBus.off(MediaPlayerEvents.MANIFEST_VALIDITY_CHANGED, _onManifestValidityChanged, instance);
         eventBus.off(MediaPlayerEvents.BUFFER_LEVEL_UPDATED, _onBufferLevelUpdated, instance);
         eventBus.off(MediaPlayerEvents.QUALITY_CHANGE_REQUESTED, _onQualityChanged, instance);
+        eventBus.off(MediaPlayerEvents.CONTENT_STEERING_REQUEST_COMPLETED, _onSteeringManifestUpdated, instance);
 
         if (Events.KEY_SESSION_UPDATED) {
             eventBus.off(Events.KEY_SESSION_UPDATED, _onKeySessionUpdated, instance);
@@ -1262,6 +1265,16 @@ function StreamController() {
         } catch (e) {
             return NaN;
         }
+    }
+
+    /**
+     * Callback handler after the steering manifest was updated
+     * @param {object} e
+     * @private
+     */
+    function _onSteeringManifestUpdated() {
+        const manifest = manifestModel.getValue();
+        baseURLController.initialize(manifest);
     }
 
     /**

--- a/src/streaming/models/BaseURLTreeModel.js
+++ b/src/streaming/models/BaseURLTreeModel.js
@@ -125,7 +125,18 @@ function BaseURLTreeModel() {
         const synthesizedBaseUrls = contentSteeringController.getSynthesizedBaseUrlElements(targetBaseUrls);
 
         if (synthesizedBaseUrls && synthesizedBaseUrls.length > 0) {
-            targetBaseUrls = targetBaseUrls.concat(synthesizedBaseUrls)
+            synthesizedBaseUrls.forEach((synthesizedBaseUrl) => {
+                // If we already have a BaseURL with the same serviceLocation, we overwrite it with the synthesized one
+                const foundIndex = targetBaseUrls.findIndex((elem) => {
+                    return elem.serviceLocation === synthesizedBaseUrl.serviceLocation
+                })
+
+                if (foundIndex !== -1) {
+                    targetBaseUrls[foundIndex] = synthesizedBaseUrl;
+                } else {
+                    targetBaseUrls.push(synthesizedBaseUrl)
+                }
+            })
         }
 
         return targetBaseUrls;

--- a/src/streaming/models/ManifestModel.js
+++ b/src/streaming/models/ManifestModel.js
@@ -52,8 +52,8 @@ function ManifestModel() {
     }
 
     instance = {
-        getValue: getValue,
-        setValue: setValue
+        getValue,
+        setValue
     };
 
     return instance;


### PR DESCRIPTION
This is a PoC fix for #4703 .

* Update available BaseURLs after each content steering manifest update
* Overwrite existing BaseURLs if they have the same `serviceLocation` as the synthesized ones

This is pretty much untested at this point, I need to spend more time on checking this. Also need to agree if overwriting existing `BaseURL` elements based on `serviceLocation` is a valid approach. We can also argue that a new element shall be synthesized and prioritized over the existing options in 'PATHWAY-PRIORITY' instead of replacing the old ones