### PR TITLE
Calculate correct framerate when using MediaCapabilitiesAPI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -437,6 +437,8 @@ declare namespace dashjs {
 
         getEventsForPeriod(period: Period): any[];
 
+        getFramerate(representation: object): number;
+
         getId(manifest: object): string;
 
         getIndexForAdaptation(realAdaptation: object, manifest: object, periodIndex: number): number;
@@ -1064,6 +1066,8 @@ declare namespace dashjs {
         getEvent(eventBox: object, eventStreams: object, mediaStartTime: number, voRepresentation: object): null | Event;
 
         getEventsFor(info: object, voRepresentation: object): Array<Event>;
+
+        getFramerate(representation: object): number;
 
         getIndexForRepresentation(representationId: string, periodIdx: number): number;
 

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -767,7 +767,7 @@ function DashAdapter() {
     /**
      * Returns the framerate of a Representation as number
      * @param representation
-     * @returns {*}
+     * @returns {number}
      */
     function getFramerate(representation) {
         return dashManifestModel.getFramerate(representation);

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -765,6 +765,15 @@ function DashAdapter() {
     }
 
     /**
+     * Returns the framerate of a Representation as number
+     * @param representation
+     * @returns {*}
+     */
+    function getFramerate(representation) {
+        return dashManifestModel.getFramerate(representation);
+    }
+
+    /**
      * Returns the bandwidth for a given representation id and the corresponding period index
      * @param {number} representationId
      * @param {number} periodIdx
@@ -1225,6 +1234,7 @@ function DashAdapter() {
         getEssentialPropertiesForRepresentation,
         getEvent,
         getEventsFor,
+        getFramerate,
         getIndexForRepresentation,
         getIsDVB,
         getIsDynamic,

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -542,6 +542,9 @@ function DashManifestModel() {
             return null
         }
         const frameRate = realRepresentation[DashConstants.FRAMERATE];
+        if (!frameRate) {
+            return null
+        }
 
         if (typeof frameRate === 'string' && frameRate.includes('/')) {
             const [numerator, denominator] = frameRate.split('/').map(value => parseInt(value, 10));

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -538,20 +538,20 @@ function DashManifestModel() {
     }
 
     function getFramerate(realRepresentation) {
-        const frameRate = realRepresentation[DashConstants.FRAMERATE];
-        if (isNaN(frameRate) && frameRate.includes('/')) {
-            const parts = frameRate.split('/');
-            if (parts.length === 2) {
-                const numerator = parseFloat(parts[0]);
-                const denominator = parseFloat(parts[1]);
-
-                if (!isNaN(numerator) && !isNaN(denominator) && denominator !== 0) {
-                    return numerator / denominator;
-                }
-            }
-        } else {
-            return frameRate
+        if (!realRepresentation) {
+            return null
         }
+        const frameRate = realRepresentation[DashConstants.FRAMERATE];
+
+        if (typeof frameRate === 'string' && frameRate.includes('/')) {
+            const [numerator, denominator] = frameRate.split('/').map(value => parseInt(value, 10));
+
+            if (!isNaN(numerator) && !isNaN(denominator) && denominator !== 0) {
+                return numerator / denominator;
+            }
+        }
+
+        return parseInt(frameRate);
     }
 
     function getManifestUpdatePeriod(manifest, latencyOfLastUpdate = 0) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -537,6 +537,23 @@ function DashManifestModel() {
         return representation && representation.bandwidth ? representation.bandwidth : NaN;
     }
 
+    function getFramerate(realRepresentation) {
+        const frameRate = realRepresentation[DashConstants.FRAMERATE];
+        if (isNaN(frameRate) && frameRate.includes('/')) {
+            const parts = frameRate.split('/');
+            if (parts.length === 2) {
+                const numerator = parseFloat(parts[0]);
+                const denominator = parseFloat(parts[1]);
+
+                if (!isNaN(numerator) && !isNaN(denominator) && denominator !== 0) {
+                    return numerator / denominator;
+                }
+            }
+        } else {
+            return frameRate
+        }
+    }
+
     function getManifestUpdatePeriod(manifest, latencyOfLastUpdate = 0) {
         let delay = NaN;
         if (manifest && manifest.hasOwnProperty(DashConstants.MINIMUM_UPDATE_PERIOD)) {
@@ -595,7 +612,7 @@ function DashManifestModel() {
         if (!repr || !repr.length) {
             return [];
         }
-        
+
         let propertiesOfFirstRepresentation = repr[0][propertyType] || [];
 
         if (propertiesOfFirstRepresentation.length === 0) {
@@ -605,12 +622,12 @@ function DashManifestModel() {
         if (repr.length === 1) {
             return propertiesOfFirstRepresentation;
         }
-        
+
         // now, only return properties present on all Representations
         // repr.legth is always >= 2
-        return propertiesOfFirstRepresentation.filter( prop => {
-            return repr.slice(1).every( currRep => {
-                return currRep.hasOwnProperty(propertyType) && currRep[propertyType].some( e => {
+        return propertiesOfFirstRepresentation.filter(prop => {
+            return repr.slice(1).every(currRep => {
+                return currRep.hasOwnProperty(propertyType) && currRep[propertyType].some(e => {
                     return e.schemeIdUri === prop.schemeIdUri && e.value === prop.value;
                 });
             });
@@ -638,7 +655,7 @@ function DashManifestModel() {
     function getEssentialPropertiesForAdaptationSet(adaptation) {
         return _getProperties(DashConstants.ESSENTIAL_PROPERTY, adaptation);
     }
-    
+
     function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {
         return _getCombinedPropertiesForAdaptationSet(DashConstants.ESSENTIAL_PROPERTY, adaptation);
     }
@@ -724,20 +741,7 @@ function DashManifestModel() {
                     voRepresentation.scanType = realRepresentation.scanType;
                 }
                 if (realRepresentation.hasOwnProperty(DashConstants.FRAMERATE)) {
-                    const frameRate = realRepresentation[DashConstants.FRAMERATE];
-                    if (isNaN(frameRate) && frameRate.includes('/')) {
-                        const parts = frameRate.split('/');
-                        if (parts.length === 2) {
-                            const numerator = parseFloat(parts[0]);
-                            const denominator = parseFloat(parts[1]);
-
-                            if (!isNaN(numerator) && !isNaN(denominator) && denominator !== 0) {
-                                voRepresentation.frameRate = numerator / denominator;
-                            }
-                        }
-                    } else {
-                        voRepresentation.frameRate = frameRate
-                    }
+                    voRepresentation.frameRate = getFramerate(realRepresentation);
                 }
                 if (realRepresentation.hasOwnProperty(DashConstants.QUALITY_RANKING)) {
                     voRepresentation.qualityRanking = realRepresentation[DashConstants.QUALITY_RANKING];
@@ -1527,6 +1531,7 @@ function DashManifestModel() {
         getEventStreamForAdaptationSet,
         getEventStreamForRepresentation,
         getEventsForPeriod,
+        getFramerate,
         getId,
         getIndexForAdaptation,
         getIsDynamic,

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -221,7 +221,7 @@ function CapabilitiesFilter() {
             codec: codec,
             width: rep.width || null,
             height: rep.height || null,
-            framerate: rep.frameRate || null,
+            framerate: adapter.getFramerate(rep) || null,
             bitrate: rep.bandwidth || null,
             isSupported: true
         }

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -17,6 +17,14 @@ function AdapterMock() {
         return null;
     };
 
+    this.getFramerate = function (rep) {
+        if (rep && rep.frameRate) {
+            return rep.frameRate
+        }
+
+        return null
+    }
+
     this.getEventsFor = function () {
         return [];
     };

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -1665,8 +1665,13 @@ describe('DashManifestModel', function () {
 
         describe('getFramerate()', () => {
 
-            it('Should be undefined when no Representation is provided', () => {
+            it('Should be null when no Representation is provided', () => {
                 const framerate = dashManifestModel.getFramerate();
+                expect(framerate).to.be.null;
+            })
+
+            it('Should be null when not defined', () => {
+                const framerate = dashManifestModel.getFramerate({});
                 expect(framerate).to.be.null;
             })
 

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -1513,8 +1513,8 @@ describe('DashManifestModel', function () {
 
             it('should return client data reporting from manifest', () => {
                 const manifestData = {
-                    ServiceDescription:[{
-                        'ClientDataReporting':{
+                    ServiceDescription: [{
+                        'ClientDataReporting': {
                             'CMCDParameters': { schemeIdUri: 'urn:mpeg:dash:cta-5004:2023' },
                             'serviceLocations': 'cdn-a cdn-b',
                             'adaptationSets': 'test1 test2'
@@ -1541,8 +1541,8 @@ describe('DashManifestModel', function () {
 
             it('should NOT return client data reporting if schemeIdUri is missed in manifest', () => {
                 const manifestData = {
-                    ServiceDescription:[{
-                        'ClientDataReporting':{
+                    ServiceDescription: [{
+                        'ClientDataReporting': {
                             'CMCDParameters': {},
                             'serviceLocations': 'cdn-a cdn-b',
                             'adaptationSets': 'test1 test2'
@@ -1567,8 +1567,8 @@ describe('DashManifestModel', function () {
 
             it('should NOT return client data reporting if schemeIdUri is invalid in manifest', () => {
                 const manifestData = {
-                    ServiceDescription:[{
-                        'ClientDataReporting':{
+                    ServiceDescription: [{
+                        'ClientDataReporting': {
                             'CMCDParameters': { schemeIdUri: 'urn:mpeg:daaash:ctaa-5003:2003' },
                             'serviceLocations': 'cdn-a cdn-b',
                             'adaptationSets': 'test1 test2'
@@ -1598,14 +1598,14 @@ describe('DashManifestModel', function () {
                 const mode = 'query';
                 const sessionID = 2;
                 const manifestData = {
-                    ServiceDescription:[{
-                        'ClientDataReporting':{
+                    ServiceDescription: [{
+                        'ClientDataReporting': {
                             'CMCDParameters': {
-                                'contentID':contentID,
-                                'includeInRequests':includeInRequests,
-                                'keys':keys,
-                                'mode':mode,
-                                'sessionID':sessionID,
+                                'contentID': contentID,
+                                'includeInRequests': includeInRequests,
+                                'keys': keys,
+                                'mode': mode,
+                                'sessionID': sessionID,
                                 'version': 1,
                                 'schemeIdUri': 'urn:mpeg:dash:cta-5004:2023'
                             },
@@ -1633,14 +1633,14 @@ describe('DashManifestModel', function () {
                 const serviceLocations = 'cdn-a cdn-b';
                 const adaptationSets = 'test1 test2';
                 const manifestData = {
-                    ServiceDescription:[{
-                        'ClientDataReporting':{
+                    ServiceDescription: [{
+                        'ClientDataReporting': {
                             'CMCDParameters': {
-                                'contentID':contentID,
-                                'includeInRequests':includeInRequests,
-                                'keys':keys,
-                                'mode':mode,
-                                'sessionID':sessionID,
+                                'contentID': contentID,
+                                'includeInRequests': includeInRequests,
+                                'keys': keys,
+                                'mode': mode,
+                                'sessionID': sessionID,
                                 'schemeIdUri': 'urn:mpeg:dash:cta-5004:2023'
                             },
                             'serviceLocations': serviceLocations,
@@ -1661,6 +1661,24 @@ describe('DashManifestModel', function () {
                 expect(cmcdParameters.sessionID).to.be.equal(sessionID);
             })
 
+        })
+
+        describe('getFramerate()', () => {
+
+            it('Should be undefined when no Representation is provided', () => {
+                const framerate = dashManifestModel.getFramerate();
+                expect(framerate).to.be.null;
+            })
+
+            it('Should parse single integer', () => {
+                const framerate = dashManifestModel.getFramerate({frameRate: '24'});
+                expect(framerate).to.be.equal(24);
+            })
+
+            it('Should parse two separated Integers', () => {
+                const framerate = dashManifestModel.getFramerate({frameRate: '48/2'});
+                expect(framerate).to.be.equal(24);
+            })
         })
     });
 });


### PR DESCRIPTION
This fixes a small bug that did not account for framerates defined in the format "x/y" when checking for support with the Media Capabilities API