### PR TITLE
Addresses performance issues for event dispatching

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1656,7 +1656,7 @@ declare namespace dashjs {
             },
             events?: {
                 eventControllerRefreshDelay?: number,
-                deleteEventMessageDataAfterEventStarted?: boolean
+                deleteEventMessageDataTimeout?: number
             }
             timeShiftBuffer?: {
                 calcFromSegmentTimeline?: boolean

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -87,7 +87,7 @@ import Events from './events/Events.js';
  *            },
  *            events: {
  *              eventControllerRefreshDelay: 100,
- *              deleteEventMessageDataAfterEventStarted: true
+ *              deleteEventMessageDataTimeout: 10000
  *            }
  *            timeShiftBuffer: {
  *                calcFromSegmentTimeline: false,
@@ -352,10 +352,12 @@ import Events from './events/Events.js';
  * @typedef {Object} EventSettings
  * @property {number} [eventControllerRefreshDelay=100]
  * Interval timer used by the EventController to check if events need to be triggered or removed.
- * @property {boolean} [deleteEventMessageDataAfterEventStarted=true]
- * If this flag is enabled the EventController will delete the message data of events after they have been started. This is to save memory in case events have a long duration and need to be persisted in the EventController.
- * Note: Applications will receive a copy of the original event data when they subscribe to an event. This copy contains the original message data and is not affected by this setting.
- * Only if an event is dispatched for the second time (e.g. when the user seeks back) the message data will not be included in the dispatched event.
+ * @property {number} [deleteEventMessageDataTimeout=10000]
+ * If this value is larger than -1 the EventController will delete the message data attributes of events after they have been started and dispatched to the application.
+ * This is to save memory in case events have a long duration and need to be persisted in the EventController.
+ * This parameter defines the time in milliseconds between the start of an event and when the message data is deleted.
+ * If an event is dispatched for the second time (e.g. when the user seeks back) the message data will not be included in the dispatched event if it has been deleted already.
+ * Set this value to -1 to not delete any message data.
  */
 
 /**
@@ -1118,7 +1120,7 @@ function Settings() {
             },
             events: {
                 eventControllerRefreshDelay: 100,
-                deleteEventMessageDataAfterEventStarted: true
+                deleteEventMessageDataTimeout: 10000
             },
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -477,7 +477,7 @@ function EventController() {
             if (mode === MediaPlayerEvents.EVENT_MODE_ON_RECEIVE && !event.triggeredReceivedEvent) {
                 logger.debug(`Received event ${eventId}`);
                 event.triggeredReceivedEvent = true;
-                eventBus.trigger(event.eventStream.schemeIdUri, { event: JSON.parse(JSON.stringify(event)) }, { mode });
+                eventBus.trigger(event.eventStream.schemeIdUri, { event }, { mode });
                 return;
             }
 
@@ -494,10 +494,12 @@ function EventController() {
                     _sendCallbackRequest(url);
                 } else {
                     logger.debug(`Starting event ${eventId} from period ${event.eventStream.period.id} at ${currentVideoTime}`);
-                    eventBus.trigger(event.eventStream.schemeIdUri, { event: JSON.parse(JSON.stringify(event)) }, { mode });
-                    if (settings.get().streaming.events.deleteEventMessageDataAfterEventStarted) {
-                        delete event.messageData;
-                        delete event.parsedMessageData;
+                    eventBus.trigger(event.eventStream.schemeIdUri, { event }, { mode });
+                    if (settings.get().streaming.events.deleteEventMessageDataTimeout > -1) {
+                        setTimeout(() => {
+                            delete event.messageData;
+                            delete event.parsedMessageData;
+                        }, settings.get().streaming.events.deleteEventMessageDataTimeout);
                     }
                 }
                 event.triggeredStartEvent = true;


### PR DESCRIPTION
This fixes #4740.

The idea is to allow applications to define a timeout, after which the message data of an event is deleted. This timeout value is relative to the start time of an event.

The PR also removes the logic to clone events to avoid the performance issues described in #4740. The previously described timeout should provide applications with enough time to create a copy of an event if required.

If people have suggestions for a more elegant solution, I am open to changing this behavior. 