### PR TITLE
fix: allow large ints to be passed in as time values for processUriTemplate

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,3 +53,4 @@
 * @santimintegui [Santiago Mintegui, Qualabs]
 * @N1Knight [Nicolás Caballero, Qualabs]
 * @v-nova-vinod [Vinod Balakrishnan, V-Nova]
+* @littlespex [Casey Occhialini, Paramount]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@svta/common-media-library": "^0.11.0",
+        "@svta/common-media-library": "^0.12.4",
         "bcp-47-match": "^2.0.3",
         "bcp-47-normalize": "^2.3.0",
         "codem-isoboxer": "0.3.10",
@@ -2542,9 +2542,9 @@
       "dev": true
     },
     "node_modules/@svta/common-media-library": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@svta/common-media-library/-/common-media-library-0.11.0.tgz",
-      "integrity": "sha512-O+j71s605qywuB55meW68/dxHaOdq1AMRDA3iqECru7uUsOijrn8m4xj9uRaY4as3Bjv6rS0J1fMKJo98R2Naw==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@svta/common-media-library/-/common-media-library-0.12.4.tgz",
+      "integrity": "sha512-9EuOoaNmz7JrfGwjsrD9SxF9otU5TNMnbLu1yU4BeLK0W5cDxVXXR58Z89q9u2AnHjIctscjMTYdlqQ1gojTuw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@svta/common-media-library": "^0.11.0",
+    "@svta/common-media-library": "^0.12.4",
     "bcp-47-match": "^2.0.3",
     "bcp-47-normalize": "^2.3.0",
     "codem-isoboxer": "0.3.10",


### PR DESCRIPTION
see: #4711 & https://github.com/streaming-video-technology-alliance/common-media-library/issues/190