### PR TITLE
Fix regression when setting size of VTT cue

### DIFF
--- a/src/streaming/utils/VTTParser.js
+++ b/src/streaming/utils/VTTParser.js
@@ -157,7 +157,7 @@ function VTTParser() {
                         break;
                     case 'size':
                     case 'S':
-                        styleObject.size = settingValue;
+                        styleObject.size = parseInt(settingValue, 10);
                         break;
                 }
             }


### PR DESCRIPTION
Fixes a regression introduced in #4773 