### PR TITLE
Avoid modifying element preload attribute as canplay event is baseline in Firefox

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -185,10 +185,6 @@ function VideoModel() {
         //add check of value type
         if (value === null || value === undefined || (value && (/^(VIDEO|AUDIO)$/i).test(value.nodeName))) {
             element = value;
-            // Workaround to force Firefox to fire the canplay event.
-            if (element) {
-                element.preload = 'auto';
-            }
         } else {
             throw VIDEO_MODEL_WRONG_ELEMENT_TYPE;
         }
@@ -284,7 +280,7 @@ function VideoModel() {
                     element.dispatchEvent(event);
                 }
             }
-            
+
             if (settings.get().streaming.buffer.syntheticStallEvents.ignoreReadyState) {
                 resume();
             } else {


### PR DESCRIPTION
This workaround should no longer be needed.

[Example](https://cdpn.io/cpe/boomboom/index.html?editors=1011&key=index.html-a4f8b9b5-68e0-2c5c-d0b6-7399f093b82d) of a `preload="metadata"` video element firing `canplay`