### PR TITLE
Segment Sequences with @k

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -242,7 +242,12 @@ function DashHandler(config) {
         if (segment) {
             if (representation.k > 1) {
                 if (lastSubNumber === undefined) {
-                    lastSubNumber = 0; // Initialize subNumber if not set
+                    // TODO: calculate lastSubNumber based on segment and current time
+                    // can start downloading the segment with subNumber > 0
+                    // lastSubNumber = representation.k - Math.ceil((time - segment.mediaStartTime) /
+                    //                                         (segment.representation.segmentDuration / representation.k));
+                    // Currently, we just set it to k - 1 because the next segment will be requested afterwards.
+                    lastSubNumber = representation.k - 1;
                 }
                 segment.subNumber = lastSubNumber;
                 request = _getRequestForSegment(mediaInfo, segment);

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -255,7 +255,7 @@ function DashManifestModel() {
             if ( role.schemeIdUri === Constants.DASH_ROLE_SCHEME_ID && role.value === 'Main') {
                 role.value = DashConstants.MAIN;
             }
-            
+
             const r = new DescriptorType();
             r.init(role);
             return r
@@ -823,6 +823,9 @@ function DashManifestModel() {
 
                         if (segmentInfo.hasOwnProperty(DashConstants.SEGMENT_TIMELINE)) {
                             voRepresentation.segmentDuration = calcSegmentDuration(segmentInfo.SegmentTimeline) / voRepresentation.timescale;
+                            if (segmentInfo.SegmentTimeline.S[0].hasOwnProperty('k')) {
+                                voRepresentation.k = segmentInfo.SegmentTimeline.S[0].k || 1;
+                            }
                         }
                     }
                     if (segmentInfo.hasOwnProperty(DashConstants.MEDIA)) {

--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -142,7 +142,7 @@ export function getTimeBasedSegment(timelineConverter, isDynamic, representation
         url,
         undefined,
         seg.replacementNumber,
-        undefined,
+        seg.subNumber,
         undefined,
         seg.replacementTime,
     );

--- a/src/dash/utils/TemplateSegmentsGetter.js
+++ b/src/dash/utils/TemplateSegmentsGetter.js
@@ -85,7 +85,7 @@ function TemplateSegmentsGetter(config, isDynamic) {
                 template.media,
                 undefined,
                 seg.replacementNumber,
-                undefined,
+                seg.subNumber,
                 undefined,
                 seg.replacementTime,
             );

--- a/src/dash/vo/Segment.js
+++ b/src/dash/vo/Segment.js
@@ -56,6 +56,8 @@ class Segment {
         this.representation = null;
         // For dynamic mpd's, this is the wall clock time that the video
         this.wallStartTime = NaN;
+        // this is the subnumber that should be inserted into the media url if S@k is defined
+        this.subNumber = undefined;
     }
 }
 


### PR DESCRIPTION
## Task

Implement support for segment sequences. As a first step, this implementation does not include SegmentTimeline.S@ssp but the @k attribute: If @k is present and greater than 1, then the value of the attribute specifies the nominal number of Partial Segments NPS included in this time interval.

## Specification

For more details check section 5.3.9.7 of ISO/IEC 23009-1 6th edition

## Related issue: https://github.com/Dash-Industry-Forum/dash.js/issues/4796