### PR TITLE
TypeScript fix for MediaPlayerClass

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2219,7 +2219,7 @@ declare namespace dashjs {
 
         setProtectionData(value: ProtectionDataSet): void;
 
-        setRepresentationForTypeById(type: MediaType, id: number, forceReplace?: boolean): void;
+        setRepresentationForTypeById(type: MediaType, id: string, forceReplace?: boolean): void;
 
         setRepresentationForTypeByIndex(type: MediaType, index: number, forceReplace?: boolean): void;
 


### PR DESCRIPTION
This changes the `id` parameter of `setRepresentationForTypeById` from `number` to `string` to match `Representation['id']`.

Fixes https://github.com/Dash-Industry-Forum/dash.js/issues/4820