### PR TITLE
TypeScript fix for DashAdapter and StreamProcessor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1116,7 +1116,7 @@ declare namespace dashjs {
 
         getUTCTimingSources(): any[];
 
-        getVoRepresentation(mediaInfo: MediaInfo): Representation[];
+        getVoRepresentations(mediaInfo: MediaInfo): Representation[];
 
         isPatchValid(manifest: object, patch: object): boolean;
 
@@ -5849,8 +5849,6 @@ declare namespace dashjs {
         getStreamInfo(): StreamInfo;
 
         getType(): string;
-
-        getVoRepresentation(quality: number): Representation;
 
         handleNewMediaInfo(mediaInfo: MediaInfo): void;
 

--- a/test/unit/mocks/RulesContextMock.js
+++ b/test/unit/mocks/RulesContextMock.js
@@ -26,8 +26,6 @@ function RulesContextMock() {
 
         return fragRequest;
     };
-    this.getVoRepresentation = function () {
-    };
     this.getAbrController = function () {
         return {
             getPossibleVoRepresentationsFilteredBySettings: function () {
@@ -37,11 +35,6 @@ function RulesContextMock() {
     };
     this.getSwitchRequestHistory = function () {
         return new SwitchRequestHistoryMock();
-    };
-    this.getVoRepresentation = function () {
-        return {
-            fragmentDuration: NaN
-        };
     };
 
     this.getScheduleController = function () {


### PR DESCRIPTION
* DashAdapter: Rename getVoRepresentation to getVoRepresentations
* StreamProcessor: Remove getVoRepresentation
* RulesContextMock: Remove getVoRepresentation which doesn't exist in RulesContext

Code references:

* [DashAdapter](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/dash/DashAdapter.js#L1261)
* [StreamProcessor](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/StreamProcessor.js#L1513-L1546)
* [RulesContext](https://github.com/Dash-Industry-Forum/dash.js/blob/development/src/streaming/rules/RulesContext.js#L93-L105)