### PR TITLE
fix: can't switch to next period due to precision

### DIFF
--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -283,7 +283,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
     }
 
     function precisionRound(number) {
-        return parseFloat(number.toPrecision(15));
+        return parseFloat(number.toPrecision(16));
     }
 
     instance = {


### PR DESCRIPTION
Fellow-up of https://github.com/Dash-Industry-Forum/dash.js/pull/3928
This PR is fixing a bug when searching a segment in a SegmentTimeline of next period from a requested media time.
In some cases, due to lost precision, no segment of next period will be found, so playback stalled.

For example, with following timeline:

```
<SegmentTemplate timescale="1000000" presentationTimeOffset="1755760276636011" startNumber="292626713" media="media_$RepresentationID$-$Number$.m4s" initialization="init_$RepresentationID$.m4s">
    <SegmentTimeline>
        <S t="1755760276636011" d="6006000" r="3" />
    </SegmentTimeline>
</SegmentTemplate>
```
If you seek and request segment at time 1755760276.636011 the TimelineSegmentsGetter will fail to find a segment due to `precisionRound` returns 1755760276636010.
<img width="386" height="48" alt="image" src="https://github.com/user-attachments/assets/33439511-509d-4342-8517-b8d50470f6a5" />
