### PR TITLE
Fix for Issue #4318: Indefinite stalling on rapid seeking

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -667,6 +667,7 @@ function PlaybackController() {
     function _onPlaybackSeeking() {
         // Check if internal seeking to be ignored
         if (internalSeek) {
+            internalSeek = false;
             return;
         }
 


### PR DESCRIPTION
The internalSeek flag is now reset when skipping the next _onPlaybackSeeking, ensuring it always only skips the next instance.This prevents the player ending in a state where internalSeek is always active and, as a result, stalling indefinitely.

This is to fix the issue reported here: https://github.com/Dash-Industry-Forum/dash.js/issues/4318