### PR TITLE
refactor: replace global dashjs.FactoryMaker with ES6 imports

### DIFF
--- a/src/mss/MssHandler.js
+++ b/src/mss/MssHandler.js
@@ -37,6 +37,7 @@ import MssParser from './parser/MssParser.js';
 import MssErrors from './errors/MssErrors.js';
 import DashJSError from '../streaming/vo/DashJSError.js';
 import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest.js';
+import FactoryMaker from '../core/FactoryMaker.js';
 
 function MssHandler(config) {
 
@@ -206,10 +207,10 @@ function MssHandler(config) {
     }
 
     function registerEvents() {
-        eventBus.on(events.INIT_FRAGMENT_NEEDED, onInitFragmentNeeded, instance, { priority: dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
-        eventBus.on(events.PLAYBACK_PAUSED, onPlaybackPaused, instance, { priority: dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
-        eventBus.on(events.PLAYBACK_SEEKING, onPlaybackSeeking, instance, { priority: dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
-        eventBus.on(events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, { priority: dashjs.FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
+        eventBus.on(events.INIT_FRAGMENT_NEEDED, onInitFragmentNeeded, instance, { priority: FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
+        eventBus.on(events.PLAYBACK_PAUSED, onPlaybackPaused, instance, { priority: FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
+        eventBus.on(events.PLAYBACK_SEEKING, onPlaybackSeeking, instance, { priority: FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
+        eventBus.on(events.FRAGMENT_LOADING_COMPLETED, onSegmentMediaLoaded, instance, { priority: FactoryMaker.getSingletonFactoryByName(eventBus.getClassName()).EVENT_PRIORITY_HIGH });
         eventBus.on(events.TTML_TO_PARSE, onTTMLPreProcess, instance);
     }
 
@@ -247,7 +248,7 @@ function MssHandler(config) {
 }
 
 MssHandler.__dashjs_factory_name = 'MssHandler';
-const factory = dashjs.FactoryMaker.getClassFactory(MssHandler);
+const factory = FactoryMaker.getClassFactory(MssHandler);
 factory.errors = MssErrors;
-dashjs.FactoryMaker.updateClassFactory(MssHandler.__dashjs_factory_name, factory);
+FactoryMaker.updateClassFactory(MssHandler.__dashjs_factory_name, factory);
 export default factory;

--- a/src/offline/OfflineStreamProcessor.js
+++ b/src/offline/OfflineStreamProcessor.js
@@ -34,6 +34,7 @@ import FragmentModel from '../streaming/models/FragmentModel.js';
 import FragmentLoader from '../streaming/FragmentLoader.js';
 import URLUtils from '../streaming/utils/URLUtils.js';
 import SegmentsController from '../dash/controllers/SegmentsController.js';
+import FactoryMaker from '../core/FactoryMaker.js';
 
 function OfflineStreamProcessor(config) {
 
@@ -379,5 +380,5 @@ function OfflineStreamProcessor(config) {
 }
 
 OfflineStreamProcessor.__dashjs_factory_name = 'OfflineStreamProcessor';
-const factory = dashjs.FactoryMaker.getClassFactory(OfflineStreamProcessor); 
+const factory = FactoryMaker.getClassFactory(OfflineStreamProcessor);
 export default factory;

--- a/src/offline/controllers/OfflineController.js
+++ b/src/offline/controllers/OfflineController.js
@@ -37,6 +37,7 @@ import OfflineUrlUtils from '../utils/OfflineUrlUtils.js';
 import OfflineEvents from '../events/OfflineEvents.js';
 import OfflineErrors from '../errors/OfflineErrors.js';
 import OfflineRecord from '../vo/OfflineDownloadVo.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
 
 /**
  * @module OfflineController
@@ -383,8 +384,8 @@ function OfflineController(config) {
 }
 
 OfflineController.__dashjs_factory_name = 'OfflineController';
-const factory = dashjs.FactoryMaker.getClassFactory(OfflineController); 
+const factory = FactoryMaker.getClassFactory(OfflineController);
 factory.events = OfflineEvents;
 factory.errors = OfflineErrors;
-dashjs.FactoryMaker.updateClassFactory(OfflineController.__dashjs_factory_name, factory); 
+FactoryMaker.updateClassFactory(OfflineController.__dashjs_factory_name, factory);
 export default factory;

--- a/src/offline/net/IndexDBOfflineLoader.js
+++ b/src/offline/net/IndexDBOfflineLoader.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import IndexDBStore from '../storage/IndexDBStore.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
 
 function IndexDBOfflineLoader(config) {
     config = config || {};
@@ -100,5 +101,5 @@ function IndexDBOfflineLoader(config) {
 }
 
 IndexDBOfflineLoader.__dashjs_factory_name = 'IndexDBOfflineLoader';
-const factory = dashjs.FactoryMaker.getClassFactory(IndexDBOfflineLoader); 
+const factory = FactoryMaker.getClassFactory(IndexDBOfflineLoader);
 export default factory;

--- a/src/streaming/metrics/MetricsReporting.js
+++ b/src/streaming/metrics/MetricsReporting.js
@@ -34,6 +34,7 @@ import MetricsReportingEvents from './MetricsReportingEvents.js';
 import MetricsCollectionController from './controllers/MetricsCollectionController.js';
 import MetricsHandlerFactory from './metrics/MetricsHandlerFactory.js';
 import ReportingFactory from './reporting/ReportingFactory.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
 
 function MetricsReporting() {
 
@@ -83,7 +84,7 @@ function MetricsReporting() {
 }
 
 MetricsReporting.__dashjs_factory_name = 'MetricsReporting';
-const factory = dashjs.FactoryMaker.getClassFactory(MetricsReporting); 
+const factory = FactoryMaker.getClassFactory(MetricsReporting);
 factory.events = MetricsReportingEvents;
-dashjs.FactoryMaker.updateClassFactory(MetricsReporting.__dashjs_factory_name, factory); 
+FactoryMaker.updateClassFactory(MetricsReporting.__dashjs_factory_name, factory);
 export default factory;

--- a/src/streaming/protection/Protection.js
+++ b/src/streaming/protection/Protection.js
@@ -35,6 +35,7 @@ import ProtectionErrors from './errors/ProtectionErrors.js';
 import DefaultProtectionModel from './models/DefaultProtectionModel.js';
 import ProtectionModel_3Feb2014 from './models/ProtectionModel_3Feb2014.js';
 import ProtectionModel_01b from './models/ProtectionModel_01b.js';
+import FactoryMaker from '../../core/FactoryMaker.js';
 
 const APIS_ProtectionModel_01b = [
     // Un-prefixed as per spec
@@ -200,8 +201,8 @@ function Protection() {
 }
 
 Protection.__dashjs_factory_name = 'Protection';
-const factory = dashjs.FactoryMaker.getClassFactory(Protection);
+const factory = FactoryMaker.getClassFactory(Protection);
 factory.events = ProtectionEvents;
 factory.errors = ProtectionErrors;
-dashjs.FactoryMaker.updateClassFactory(Protection.__dashjs_factory_name, factory);
+FactoryMaker.updateClassFactory(Protection.__dashjs_factory_name, factory);
 export default factory;


### PR DESCRIPTION
Replace all usages of the global `dashjs.FactoryMaker` with proper ES6 module imports across 6 core files. This harmonizes the import pattern with the rest of the codebase and improves module compatibility when dash.js is used as an ES6 module in modern build tools.

This prevents issues when:

- Importing modules directly without the main entry point
- Using tree-shaking in modern bundlers
- Integrating dash.js in codebases with strict ES6 module requirements