### PR TITLE
docs: fix contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
 # How to contribute #
+
+> **Note:** For the most up-to-date contribution guidelines, please refer to our official documentation at [https://dashif.org/dash.js/pages/developers/how-to-contribute.html](https://dashif.org/dash.js/pages/developers/how-to-contribute.html)
+
 As an open source project, operating under a [meritocratic governance model](https://github.com/Dash-Industry-Forum/dash.js/wiki/governance-model), we welcome contributions of any kind. Naturally this includes software contributions, but we also welcome help on documentation, testing, project coordination, marketing, [release preparation](https://github.com/Dash-Industry-Forum/dash.js/wiki/Release-Management) and more.
 
 For any kind of contribution your first port of call should be to join our [mailing list]( https://groups.google.com/d/forum/dashjs). We welcome all contributions to the mailing list (including asking questions which demonstrate our documentation needs to be improved).
@@ -38,12 +41,12 @@ If you find a low priority issues is affecting your use case then the only way t
 ## Process for contributing code
 
 1. Before starting work on a new feature, enhancement or fix, ask the group if anyone else is already working on the same task. This will avoid duplication of effort.
-1. Read and understand the wiki sections on [Developer Getting Started Guide](https://github.com/Dash-Industry-Forum/dash.js/wiki/Developer-Getting-Started-Guide) and [JSLint compliance](https://github.com/Dash-Industry-Forum/dash.js/wiki/JSLint-Compliance).
+1. Read and understand the developer documentation at [https://dashif.org/dash.js/pages/developers/](https://dashif.org/dash.js/pages/developers/), including information about code quality and ESLint compliance.
 1. Read and understand the project's [Branching Strategy](http://nvie.com/posts/a-successful-git-branching-model/).
 1. Fork the repository and setup a new branch to work in.
 1. In each of your files, include the required BSD-3 header available [here](https://dashif.org/docs/dash.js.license-header.May2013.txt). Be sure to replace the placeholder text "YOUR_COMPANY_NAME_HERE" with the name of your company before adding it to the header.
 1. Add or modify unit tests for any new or modified functionality in your patch.
-1. Run `grunt` before you commit so that you may catch test failures, lint issues, or syntax errors. Pull requests that do not compile or pass linter checks or pass all unit tests will not be accepted.
+1. Run `npm run build` before you commit so that you may catch test failures, lint issues, or syntax errors. Pull requests that do not compile or pass linter checks or pass all unit tests will not be accepted.
 1. If you are submitting code as an individual or on behalf of a company who is _not a member_ of the DASH [Industry Forum](http://dashif.org/members), then download, sign, scan and email back to the email list the [Feedback Agreement](https://dashif.org/docs/DASH-IF-Feedback-Agreement-3-7-2014.pdf). Your code will not be reviewed and accepted by the Admins until this has been received. DASH IF members do not need to take this step, as the Forum's By-Laws already cover your submission to this open source project.
 1. Issue a Pull Request.
 1. The Admins will review your code and may optionally request conformance, functional or other changes. Work with them to resolve any issues.


### PR DESCRIPTION
- Fix broken links
- Move from grunt to npm build, from JSlint to ESlint
- Point to web version of documentation guide