### PR TITLE
fix: Allow enhancement codecs to be re-tested in Capabilities.js if Settings change

### DIFF
--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -138,8 +138,11 @@ function Capabilities() {
             return Promise.resolve();
         }
 
-        const enhancementCodecs = settings.get().streaming.enhancement.codecs;
-        if (settings.get().streaming.enhancement.enabled && enhancementCodecs.some(cdc => basicConfiguration.codec.includes(cdc))) {
+        if (settings.get().streaming.enhancement.enabled && _isEnhancementCodec(basicConfiguration.codec)) {
+            // Remove enhancement codecs from tested configurations so that they can be re-tested if the enhancement settings change
+            testedCodecConfigurations = testedCodecConfigurations.filter((configuration) => {
+                return !_isEnhancementCodec(configuration.mediaSourceCodecString);
+            });
             return Promise.resolve(true);
         }
 
@@ -353,6 +356,18 @@ function Capabilities() {
                     resolve();
                 })
         })
+    }
+
+    /**
+     * Check if codec is an enhancement layer codec, e.g. LCEVC
+     * Enhancement layer codecs can be configured via settings.
+     * @param {string} codec
+     * @return {boolean} true if enhancement codec
+     * @private
+     */
+    function _isEnhancementCodec(codec) {
+        const enhancementCodecs = settings.get().streaming.enhancement.codecs;
+        return enhancementCodecs.some((c) => codec.includes(c));
     }
 
     function _isConfigSupported(testedConfigurations) {


### PR DESCRIPTION
This PR aims to fix a minor issue that we are seeing in the Reference Player: if a stream is loaded, and afterwards the Enhancement Layer is enabled, enhancement codecs would still be filtered out due to them being in the testedCodecConfigurations on next stream load. This PR removes them from testedCodecConfigurations so they can be re-tested on next stream load if the enhancement settings change.