### PR TITLE
Check K value when determining whether to enable low latency mode

### DIFF
--- a/src/dash/constants/DashConstants.js
+++ b/src/dash/constants/DashConstants.js
@@ -100,6 +100,7 @@ export default {
     INDEX_RANGE: 'indexRange',
     INITIALIZATION: 'Initialization',
     INITIALIZATION_MINUS: 'initialization',
+    K: 'k',
     LA_URL: 'Laurl',
     LA_URL_LOWER_CASE: 'laurl',
     LABEL: 'Label',

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -936,7 +936,7 @@ function DashManifestModel() {
             voRepresentation.media = segmentInfo.media;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.K)) {
-            voRepresentation.k = segmentInfo.k || NaN;
+            voRepresentation.k = segmentInfo.k || 1;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.START_NUMBER)) {
             voRepresentation.startNumber = parseInt(segmentInfo.startNumber);
@@ -984,10 +984,10 @@ function DashManifestModel() {
 
     function _getKValue(segmentTimeline) {
         if (!segmentTimeline || !segmentTimeline.S) {
-            return NaN;
+            return 1;
         }
         const s0 = segmentTimeline.S[0];
-        return s0.hasOwnProperty(DashConstants.K) ? s0.k : NaN;
+        return s0.hasOwnProperty(DashConstants.K) ? s0.k : 1;
     }
 
     function _calcMseTimeOffset(representation) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -752,7 +752,7 @@ function DashManifestModel() {
 
     function getRepresentationFor(index, adaptation) {
         return adaptation && adaptation.Representation && adaptation.Representation.length > 0 &&
-        isInteger(index) ? adaptation.Representation[index] : null;
+            isInteger(index) ? adaptation.Representation[index] : null;
     }
 
     function getRealAdaptationFor(voAdaptation) {
@@ -933,6 +933,9 @@ function DashManifestModel() {
         }
         if (segmentInfo.hasOwnProperty(DashConstants.MEDIA)) {
             voRepresentation.media = segmentInfo.media;
+        }
+        if (segmentInfo.hasOwnProperty(DashConstants.K)) {
+            voRepresentation.k = segmentInfo.k || 1;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.START_NUMBER)) {
             voRepresentation.startNumber = parseInt(segmentInfo.startNumber);

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -930,6 +930,7 @@ function DashManifestModel() {
             voRepresentation.segmentDuration = segmentInfo.duration / voRepresentation.timescale;
         } else if (segmentInfoType === DashConstants.SEGMENT_TIMELINE) {
             voRepresentation.segmentDuration = calcSegmentDuration(segmentInfo.SegmentTimeline) / voRepresentation.timescale;
+            voRepresentation.k = _getKValue(segmentInfo.SegmentTimeline)
         }
         if (segmentInfo.hasOwnProperty(DashConstants.MEDIA)) {
             voRepresentation.media = segmentInfo.media;
@@ -979,6 +980,14 @@ function DashManifestModel() {
         let s0 = segmentTimeline.S[0];
         let s1 = segmentTimeline.S[1];
         return s0.hasOwnProperty('d') ? s0.d : (s1.t - s0.t);
+    }
+
+    function _getKValue(segmentTimeline) {
+        if (!segmentTimeline || !segmentTimeline.S) {
+            return NaN;
+        }
+        const s0 = segmentTimeline.S[0];
+        return s0.hasOwnProperty('k') ? s0.k : undefined;
     }
 
     function _calcMseTimeOffset(representation) {

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -936,7 +936,7 @@ function DashManifestModel() {
             voRepresentation.media = segmentInfo.media;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.K)) {
-            voRepresentation.k = segmentInfo.k || 1;
+            voRepresentation.k = segmentInfo.k;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.START_NUMBER)) {
             voRepresentation.startNumber = parseInt(segmentInfo.startNumber);

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -936,7 +936,7 @@ function DashManifestModel() {
             voRepresentation.media = segmentInfo.media;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.K)) {
-            voRepresentation.k = segmentInfo.k;
+            voRepresentation.k = segmentInfo.k || NaN;
         }
         if (segmentInfo.hasOwnProperty(DashConstants.START_NUMBER)) {
             voRepresentation.startNumber = parseInt(segmentInfo.startNumber);
@@ -987,7 +987,7 @@ function DashManifestModel() {
             return NaN;
         }
         const s0 = segmentTimeline.S[0];
-        return s0.hasOwnProperty('k') ? s0.k : undefined;
+        return s0.hasOwnProperty(DashConstants.K) ? s0.k : NaN;
     }
 
     function _calcMseTimeOffset(representation) {

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -58,6 +58,7 @@ class Representation {
         this.id = null;
         this.indexRange = null;
         this.initialization = null;
+        this.k = 1;
         this.maxPlayoutRate = NaN;
         this.mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN };
         this.mediaInfo = null;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -58,7 +58,7 @@ class Representation {
         this.id = null;
         this.indexRange = null;
         this.initialization = null;
-        this.k = 1;
+        this.k = NaN;
         this.maxPlayoutRate = NaN;
         this.mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN };
         this.mediaInfo = null;

--- a/src/dash/vo/Representation.js
+++ b/src/dash/vo/Representation.js
@@ -58,7 +58,7 @@ class Representation {
         this.id = null;
         this.indexRange = null;
         this.initialization = null;
-        this.k = NaN;
+        this.k = 1;
         this.maxPlayoutRate = NaN;
         this.mediaFinishedInformation = { numberOfSegments: 0, mediaTimeOfLastSignaledSegment: NaN };
         this.mediaInfo = null;

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -177,7 +177,7 @@ function PlaybackController() {
     /**
      * Triggers play() on the video element
      */
-    function play(adjustLiveDelay = false) {''
+    function play(adjustLiveDelay = false) {
         if (streamInfo && videoModel && videoModel.getElement()) {
             if (adjustLiveDelay && isDynamic) {
                 _adjustLiveDelayAfterUserInteraction(getTime());
@@ -829,7 +829,7 @@ function PlaybackController() {
     }
 
     /**
-     * We enable low latency playback if for the current representation availabilityTimeComplete is set to false
+     * We enable low latency playback if for the current representation availabilityTimeComplete is set to false or there is a k value larger than 1 in the segment template
      * @param e
      * @private
      */
@@ -839,7 +839,7 @@ function PlaybackController() {
             return;
         }
 
-        lowLatencyModeEnabled = e.currentRepresentation.availabilityTimeComplete === false;
+        lowLatencyModeEnabled = e.currentRepresentation.availabilityTimeComplete === false || e.currentRepresentation.k > 1;
 
         // If we enable low latency mode for the first time we also enable the catchup mechanism. This can be deactivated again for instance if the user seeks within the DVR window. We leave deactivation up to the application but also do not activate automatically again.
         if (lowLatencyModeEnabled && !initialCatchupModeActivated) {


### PR DESCRIPTION
Fixes #4914

Adds `k` value to the representation model and then checks `k > 1` on `_onRepresentationSwitch` to catch edge case where when using individually addressed chunks with `availabilityTimeComplete` unset or set to `true`.

- [x] Tests passing
- [x] MPD can be provided privately for testings as required