### PR TITLE
Fix/4919

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -76,11 +76,6 @@ function FetchLoader() {
     function _handleFetchResponse(fetchResponse, commonMediaRequest, commonMediaResponse) {
         _updateCommonMediaResponseInstance(commonMediaResponse, fetchResponse);
 
-        if (!fetchResponse.ok) {
-            commonMediaRequest.customData.onloadend();
-            return;
-        }
-
         let totalBytesReceived = 0;
         let signaledFirstByte = false;
         let receivedData = new Uint8Array();

--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -78,6 +78,7 @@ function FetchLoader() {
 
         if (!fetchResponse.ok) {
             commonMediaRequest.customData.onloadend();
+            return;
         }
 
         let totalBytesReceived = 0;


### PR DESCRIPTION
This fixes #4919. Previously `onloadend` was triggered twice leading to CMAF fragments being requested multiple times.  Since `onloadend` is triggered in `_handleRequestComplete` even if a 404 occurs, no separate handling is required.