### PR TITLE
perf: make GapController interval configurable and reduce hot-path allocations

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -561,6 +561,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * Value to be used in case enableStallFix is set to true
  * @property {number} [seekOffset=0]
  * An additional offset in seconds that is applied when performing a seek to jump a gap.
+ * @property {number} [checkInterval=250]
+ * The interval in milliseconds at which the gap handler checks for gaps in the buffer. Lower values detect gaps faster but increase CPU usage. Default is 250ms.
  */
 
 /**
@@ -1226,7 +1228,8 @@ function Settings() {
                 enableSeekFix: true,
                 enableStallFix: false,
                 stallSeek: 0.1,
-                seekOffset: 0
+                seekOffset: 0,
+                checkInterval: 250
             },
             utcSynchronization: {
                 enabled: true,

--- a/src/streaming/controllers/GapController.js
+++ b/src/streaming/controllers/GapController.js
@@ -34,7 +34,6 @@ import Events from '../../core/events/Events.js';
 import EventBus from '../../core/EventBus.js';
 import Constants from '../constants/Constants.js';
 
-const GAP_HANDLER_INTERVAL = 100;
 const THRESHOLD_TO_STALLS = 10;
 const GAP_JUMP_WAITING_TIME_OFFSET = 0.1;
 
@@ -199,9 +198,13 @@ function GapController() {
         if (!streamController.getActiveStream()) {
             return false;
         }
-        const trackSwitchInProgress = Object.keys(trackSwitchByMediaType).some((key) => {
-            return trackSwitchByMediaType[key];
-        });
+        let trackSwitchInProgress = false;
+        for (const key in trackSwitchByMediaType) {
+            if (trackSwitchByMediaType[key]) {
+                trackSwitchInProgress = true;
+                break;
+            }
+        }
         const shouldIgnoreSeekingState = checkSeekingState ? _shouldIgnoreSeekingState() : false;
 
         return !trackSwitchInProgress && settings.get().streaming.gaps.jumpGaps && streamController.getActiveStreamProcessors().length > 0 && (!playbackController.isSeeking() || shouldIgnoreSeekingState) && !playbackController.isPaused() && !streamController.getIsStreamSwitchInProgress() &&
@@ -281,7 +284,7 @@ function GapController() {
                     const currentTime = playbackController.getTime();
                     _jumpGap(currentTime);
 
-                }, GAP_HANDLER_INTERVAL);
+                }, settings.get().streaming.gaps.checkInterval);
             }
         } catch (e) {
         }
@@ -306,11 +309,12 @@ function GapController() {
      * @private
      */
     function _jumpGap(currentTime, playbackStalled = false) {
-        const enableStallFix = settings.get().streaming.gaps.enableStallFix;
-        const stallSeek = settings.get().streaming.gaps.stallSeek;
-        const smallGapLimit = settings.get().streaming.gaps.smallGapLimit;
-        const jumpLargeGaps = settings.get().streaming.gaps.jumpLargeGaps;
-        const seekOffset = settings.get().streaming.gaps.seekOffset;
+        const gapSettings = settings.get().streaming.gaps;
+        const enableStallFix = gapSettings.enableStallFix;
+        const stallSeek = gapSettings.stallSeek;
+        const smallGapLimit = gapSettings.smallGapLimit;
+        const jumpLargeGaps = gapSettings.jumpLargeGaps;
+        const seekOffset = gapSettings.seekOffset;
         const ranges = videoModel.getBufferRange();
         let nextRangeIndex;
         let seekToPosition = NaN;

--- a/test/unit/test/streaming/streaming.controllers.GapController.js
+++ b/test/unit/test/streaming/streaming.controllers.GapController.js
@@ -284,5 +284,22 @@ describe('GapController', function () {
             expect(currentSettings.streaming.gaps.smallGapLimit).to.equal(2.0);
             expect(currentSettings.streaming.gaps.threshold).to.equal(0.5);
         });
+
+        it('should use default checkInterval of 250ms', function () {
+            const currentSettings = settings.get();
+            expect(currentSettings.streaming.gaps.checkInterval).to.equal(250);
+        });
+
+        it('should allow overriding checkInterval via settings', function () {
+            settings.update({
+                streaming: {
+                    gaps: {
+                        checkInterval: 100
+                    }
+                }
+            });
+            const currentSettings = settings.get();
+            expect(currentSettings.streaming.gaps.checkInterval).to.equal(100);
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Replace hardcoded 100ms `GAP_HANDLER_INTERVAL` with configurable `streaming.gaps.checkInterval` (default 250ms), reducing timer wake-ups by 60% on resource-constrained devices
- Replace `Object.keys().some()` with `for..in` loop in `_shouldCheckForGaps()` to avoid array allocation per tick
- Cache `settings.get().streaming.gaps` in `_jumpGap()` to eliminate redundant property traversals

Closes #4942

## Test plan

- [x] All 3242 unit tests pass
- [x] New tests for `checkInterval` default value and override via settings
- [ ] Manual testing on constrained device (Smart TV / STB)