### PR TITLE
fix(steering): fix incorrect splice/indexOf arguments in blacklist timer cleanup

### DIFF
--- a/src/streaming/utils/baseUrlResolution/ContentSteeringSelector.js
+++ b/src/streaming/utils/baseUrlResolution/ContentSteeringSelector.js
@@ -108,7 +108,7 @@ function ContentSteeringSelector() {
         const entry = e.entry
         const timer = setTimeout(() => {
             blacklistController.remove(entry);
-            blacklistResetTimeout.splice(blacklistResetTimeout.indexOf(timer, 1))
+            blacklistResetTimeout.splice(blacklistResetTimeout.indexOf(timer), 1)
         }, currentSteeringResponseData.ttl * 1000);
         blacklistResetTimeout.push(timer)
     }


### PR DESCRIPTION
## Summary

Fixes #4944

- Fix misplaced parenthesis in `ContentSteeringSelector._onAddBlackList()` where `1` was passed as `fromIndex` to `indexOf()` instead of as `deleteCount` to `splice()`
- Before: `blacklistResetTimeout.splice(blacklistResetTimeout.indexOf(timer, 1))` — skips index 0 and removes all elements from found index
- After: `blacklistResetTimeout.splice(blacklistResetTimeout.indexOf(timer), 1)` — correctly finds timer at any position and removes only that one entry

## Test plan

- [ ] Verify content steering blacklist timers are correctly removed after TTL expiry
- [ ] Verify `blacklistResetTimeout` array does not grow unboundedly during long sessions
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)