### PR TITLE
fix(mss): prevent crash when all DVR segments are removed

### DIFF
--- a/src/mss/MssFragmentMoofProcessor.js
+++ b/src/mss/MssFragmentMoofProcessor.js
@@ -165,25 +165,30 @@ function MssFragmentMoofProcessor(config) {
                 // Remove segments prior to availability start time
                 segment = segments[0];
                 endTime = (segment.t + segment.d) / timescale;
-                while (endTime < availabilityStartTime) {
+                while (segments.length > 0 && endTime < availabilityStartTime) {
                     // Check if not currently playing the segment to be removed
                     if (!playbackController.isPaused() && playbackController.getTime() < endTime) {
                         break;
                     }
                     // logger.debug('Remove segment  - t = ' + (segment.t / timescale));
                     segments.splice(0, 1);
+                    if (segments.length === 0) {
+                        break;
+                    }
                     segment = segments[0];
                     endTime = (segment.t + segment.d) / timescale;
                 }
             }
 
             // Update DVR window range => set range end to end time of current segment
-            range = {
-                start: segments[0].t / timescale,
-                end: (tfdt.baseMediaDecodeTime / timescale) + request.duration
-            };
+            if (segments.length > 0) {
+                range = {
+                    start: segments[0].t / timescale,
+                    end: (tfdt.baseMediaDecodeTime / timescale) + request.duration
+                };
 
-            updateDVR(type, range, streamProcessor.getStreamInfo().manifestInfo);
+                updateDVR(type, range, streamProcessor.getStreamInfo().manifestInfo);
+            }
         }
 
     }


### PR DESCRIPTION
## Summary

Fixes #4945

- Add `segments.length > 0` guard to the DVR segment cleanup loop condition in `MssFragmentMoofProcessor`
- Add early `break` after `splice()` when the segments array becomes empty
- Guard the DVR range update after the loop with a length check on `segments`

Without this fix, a `TypeError: Cannot read properties of undefined (reading 't')` crash occurs when all segments fall before `availabilityStartTime` in live MSS streams with `timeShiftBufferDepth`.

## Test plan

- [ ] Play a live MSS stream with short `timeShiftBufferDepth` and verify no crash on segment cleanup
- [ ] Pause playback longer than `timeShiftBufferDepth`, resume, and verify graceful handling
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)