### PR TITLE
Add a limitBitrateByPortalMinimum setting to prevent limiting too much

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1839,6 +1839,7 @@ export class MediaPlayerSettingClass {
         abr?: {
             limitBitrateByPortal?: boolean;
             usePixelRatioInLimitBitrateByPortal?: boolean;
+            limitBitrateByPortalMinimum?: number,
             enableSupplementalPropertyAdaptationSetSwitching?: boolean,
             rules?: {
                 throughputRule?: {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -746,6 +746,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * If true, the size of the video portal will limit the max chosen video resolution.
  * @property {boolean} [usePixelRatioInLimitBitrateByPortal=false]
  * Sets whether to take into account the device's pixel ratio when defining the portal dimensions.
+ * @property {number} [limitBitrateByPortalMinimum=0]
+ * Sets a minimum bitrate in kbps for limitBitrateByPortal. Representations at this bitrate or below it will not be limited by the portal size. Useful if the player can be resized.
  *
  * Useful on, for example, retina displays.
  * @property {module:Settings~AbrRules} [rules]
@@ -1324,6 +1326,7 @@ function Settings() {
             abr: {
                 limitBitrateByPortal: false,
                 usePixelRatioInLimitBitrateByPortal: false,
+                limitBitrateByPortalMinimum: 0,
                 enableSupplementalPropertyAdaptationSetSwitching: true,
                 rules: {
                     throughputRule: {

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -400,12 +400,13 @@ function AbrController() {
             if (!settings.get().streaming.abr.limitBitrateByPortal) {
                 return voRepresentations;
             }
+            const minimum = (settings.get().streaming.abr.limitBitrateByPortalMinimum * 1000) || 0;
 
             const { elementWidth } = videoModel.getVideoElementSize();
 
             const filteredArray = voRepresentations.filter((voRepresentation) => {
-                return voRepresentation.mediaInfo.type !== Constants.VIDEO || voRepresentation.width <= elementWidth;
-            })
+                return voRepresentation.mediaInfo.type !== Constants.VIDEO || voRepresentation.width <= elementWidth || voRepresentation.bandwidth <= minimum;
+            });
 
             if (filteredArray.length > 0) {
                 return filteredArray

--- a/test/unit/test/streaming/streaming.controllers.AbrController.js
+++ b/test/unit/test/streaming/streaming.controllers.AbrController.js
@@ -936,5 +936,61 @@ describe('AbrController', function () {
             let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
             expect(possibleVoRepresentations.length).to.be.equal(2);
         });
-    })
+
+        it('should allow representations with a bandwidth below limitBitrateByPortalMinimum', function () {
+            videoModelMock.getVideoElementSize = () => {
+                return { elementWidth: 200 }
+            };
+            const s = {
+                streaming: {
+                    abr: {
+                        limitBitrateByPortal: true,
+                        limitBitrateByPortalMinimum: 2100
+                    }
+                }
+            };
+            settings.update(s);
+
+            const mediaInfo = streamProcessor.getMediaInfo();
+            const bitrateList = mediaInfo.bitrateList;
+
+            adapterMock.getVoRepresentations = () => {
+                return [
+                    {
+                        bitrateInKbit: bitrateList[0].bandwidth / 1000,
+                        bandwidth: 1000000,
+                        mediaInfo,
+                        id: 1,
+                        width: 640
+                    },
+                    {
+                        bitrateInKbit: bitrateList[1].bandwidth / 1000,
+                        bandwidth: 2000000,
+                        mediaInfo,
+                        id: 2,
+                        width: 720
+                    },
+                    {
+                        bitrateInKbit: bitrateList[2].bandwidth / 1000,
+                        bandwidth: 3000000,
+                        mediaInfo,
+                        id: 3,
+                        width: 1920
+                    }
+                ]
+            }
+
+            adapterMock.areMediaInfosEqual = () => {
+                return true
+            }
+
+            mediaInfo.streamInfo = streamProcessor.getStreamInfo();
+            mediaInfo.type = Constants.VIDEO;
+
+            let possibleVoRepresentations = abrCtrl.getPossibleVoRepresentationsFilteredBySettings(mediaInfo);
+            expect(possibleVoRepresentations.length).to.be.equal(2);
+            expect(possibleVoRepresentations[0].id).to.be.equal(1);
+            expect(possibleVoRepresentations[1].id).to.be.equal(2);
+        });
+    });
 });


### PR DESCRIPTION
We use the setting `limitBitrateByPortal` to prevent the player streaming a representation with a resolution that would be too big for the size of the video element. But we have a player that can be resized from quite small to full screen, and we'd like to have some minimum on this setting so we don't fill up the buffer with the very worst resolution in our ABR ladder before maximising.

So, `limitBitrateByPortalMinimum` takes a value in kbps and prevents `limitBitrateByPortal` from excluding any representations below this bitrate. The default is 0kbps so all representations can be limited.

```javascript
            player.updateSettings({
                streaming:{
                    abr: {
                        limitBitrateByPortal: true,
                        limitBitrateByPortalMinimum: 1700
                    }
                }
            });
``` 