### PR TITLE
Change StreamProcessor bandwidth check for scalable LCEVC

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -945,8 +945,16 @@ function StreamProcessor(config) {
             const bufferLevel = bufferController.getBufferLevel();
             const abandonmentState = abrController.getAbandonmentStateFor(streamInfo.id, type);
 
+            // In scalable dual-track mode, `newRepresentation.bandwidth` reflects the
+            // combined bandwidth of the base and enhancement layers. However, in the
+            // base layer stream processor (type VIDEO), `request.bandwidth` refers only
+            // to the base layer. Therefore, the comparison should use the base layer
+            // bandwidth (`dependentRepresentation`) only.
+            const newBandwidth = (type === Constants.VIDEO) && newRepresentation.dependentRepresentation ? 
+                newRepresentation.dependentRepresentation.bandwidth : newRepresentation.bandwidth;
+
             // The new quality is higher than the one we originally requested
-            if (request.bandwidth < newRepresentation.bandwidth && bufferLevel >= safeBufferLevel && abandonmentState === MetricsConstants.ALLOW_LOAD) {
+            if (request.bandwidth < newBandwidth && bufferLevel >= safeBufferLevel && abandonmentState === MetricsConstants.ALLOW_LOAD) {
                 bufferController.prepareForFastQualitySwitch(newRepresentation, oldRepresentation)
                     .then(() => {
                         _fastQualitySwitchPreparationDone(time, safeBufferLevel);


### PR DESCRIPTION
Change StreamProcessor bandwidth check for scalable LCEVC

**Description**

In scalable dual-track mode, `newRepresentation.bandwidth` contains the combined bandwidth of the base and enhancement layers. However, in the base layer stream processor (stream processor with type = `Constants.VIDEO`), `request.bandwidth` refers only to the bandwidth of the base layer. Therefore, the comparison should use the base layer bandwidth only, i.e. the bandwidth of the `dependentRepresentation`.