### PR TITLE
feat: update 608 library to support H.265/H.266 payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@svta/cml-608": "1.0.1",
+        "@svta/cml-608": "1.0.2",
         "@svta/cml-cmcd": "1.0.1",
         "@svta/cml-cmsd": "1.0.1",
         "@svta/cml-dash": "1.0.1",
@@ -2539,9 +2539,10 @@
       "dev": true
     },
     "node_modules/@svta/cml-608": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.1.tgz",
-      "integrity": "sha512-Y/Ier9VPUSOBnf0bJqdDyTlPrt4dDB+jk5mYHa1bnD2kcRl8qn7KkW3PRuj4w1aVN+BS2eHmsLxodt7P2hylUg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.2.tgz",
+      "integrity": "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "yargs": "^18.0.0"
   },
   "dependencies": {
-    "@svta/cml-608": "1.0.1",
+    "@svta/cml-608": "1.0.2",
     "@svta/cml-cmcd": "1.0.1",
     "@svta/cml-cmsd": "1.0.1",
     "@svta/cml-dash": "1.0.1",


### PR DESCRIPTION
Update CML's 608 library to version 1.0.2 to add support for H.265/H.266 SEI NALUs.

Resolves https://github.com/Dash-Industry-Forum/dash.js/issues/4953