### PR TITLE
Allow preload to work even when the setting cacheInitSegments is false

### DIFF
--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -152,6 +152,7 @@ function PreBufferSink(onAppendedCallback) {
 
         if (outstandingInit) {
             result.push(outstandingInit);
+            outstandingInit = null;
         }
 
         chunks = [];

--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -134,13 +134,8 @@ function PreBufferSink(onAppendedCallback) {
         return this;
     }
 
-    /**
-     * Return the all chunks in the buffer the lie between times start and end.
-     * Because a chunk cannot be split, this returns the full chunk if any part of its time lies in the requested range.
-     * Chunks are removed from the buffer when they are discharged.
-     * @function PreBufferSink#discharge
-     * @returns {Array} The set of chunks from the buffer within the time ranges.
-     */
+    //Return an array of all chunks along with init segments in the order to append to the SourceBuffer.
+    //Chunks are removed from PreBuffer when they are discharged.
     function discharge() {
         const result = chunks;
         let lastInit = null;

--- a/src/streaming/PreBufferSink.js
+++ b/src/streaming/PreBufferSink.js
@@ -45,6 +45,8 @@ function PreBufferSink(onAppendedCallback) {
     let instance,
         logger,
         outstandingInit;
+
+    let initSegments = [];
     let chunks = [];
     let onAppended = onAppendedCallback;
 
@@ -54,18 +56,23 @@ function PreBufferSink(onAppendedCallback) {
 
     function reset() {
         chunks = [];
+        initSegments = [];
         outstandingInit = null;
         onAppended = null;
     }
 
     function append(chunk) {
-        if (chunk.segmentType !== 'InitializationSegment') { //Init segments are stored in the initCache.
+        if (chunk.segmentType !== 'InitializationSegment') {
             chunks.push(chunk);
             chunks.sort(function (a, b) {
                 return a.start - b.start;
             });
             outstandingInit = null;
-        } else {//We need to hold an init chunk for when a corresponding media segment is being downloaded when the discharge happens.
+        } else {
+            if (!initSegments.includes(chunk)) {
+                initSegments.push(chunk);
+            }
+            //We might be in the process of downloading a media segment, this would be its init pair.
             outstandingInit = chunk;
         }
 
@@ -79,7 +86,7 @@ function PreBufferSink(onAppendedCallback) {
     }
 
     function remove(start, end) {
-        chunks = chunks.filter(a => !((isNaN(end) || a.start < end) && (isNaN(start) || a.end > start))); //The opposite of the getChunks predicate.
+        chunks = chunks.filter(a => !((isNaN(end) || a.start < end) && (isNaN(start) || a.end > start)));
         return Promise.resolve();
     }
 
@@ -132,24 +139,30 @@ function PreBufferSink(onAppendedCallback) {
      * Because a chunk cannot be split, this returns the full chunk if any part of its time lies in the requested range.
      * Chunks are removed from the buffer when they are discharged.
      * @function PreBufferSink#discharge
-     * @param {?Number} start The start time from which to discharge from the buffer. If NaN, it is regarded as unbounded.
-     * @param {?Number} end The end time from which to discharge from the buffer. If NaN, it is regarded as unbounded.
      * @returns {Array} The set of chunks from the buffer within the time ranges.
      */
-    function discharge(start, end) {
-        const result = getChunksAt(start, end);
-        if (outstandingInit) {
-            result.push(outstandingInit);
-            outstandingInit = null;
+    function discharge() {
+        const result = chunks;
+        let lastInit = null;
+
+        for (let i = 0; i < result.length; i++) {
+            if (!lastInit || result[i].representation.id != lastInit.representation.id) {
+                lastInit = initSegments.find(init => init.representation.id === result[i].representation.id);
+                if (lastInit) {
+                    result.splice(i, 0, lastInit);
+                    i++;
+                }
+            }
         }
 
-        remove(start, end);
+        if (outstandingInit) {
+            result.push(outstandingInit);
+        }
+
+        chunks = [];
+        initSegments = [];
 
         return result;
-    }
-
-    function getChunksAt(start, end) {
-        return chunks.filter(a => ((isNaN(end) || a.start < end) && (isNaN(start) || a.end > start)));
     }
 
     function waitForUpdateEnd(callback) {

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -277,19 +277,8 @@ function BufferController(config) {
             //A list of fragments to supress bytesAppended events for. This makes transferring from a prebuffer to a sourcebuffer silent.
             dischargeFragments = [];
             let chunks = dischargeBuffer.discharge();
-            let lastInit = null;
             for (let j = 0; j < chunks.length; j++) {
                 const chunk = chunks[j];
-                if (chunk.segmentType !== HTTPRequest.INIT_SEGMENT_TYPE) {
-                    const initChunk = initCache.extract(chunk.streamId, chunk.representation.id);
-                    if (initChunk) {
-                        if (lastInit !== initChunk) {
-                            dischargeFragments.push(initChunk);
-                            sourceBufferSink.append(initChunk);
-                            lastInit = initChunk;
-                        }
-                    }
-                }
                 dischargeFragments.push(chunk);
                 sourceBufferSink.append(chunk);
             }

--- a/test/unit/test/streaming/streaming.controllers.PreBufferSink.js
+++ b/test/unit/test/streaming/streaming.controllers.PreBufferSink.js
@@ -4,12 +4,23 @@ import {expect} from 'chai';
 const context = {};
 
 describe('PreBufferSink', function () {
-    function makeChunk(start, end, data) {
+    function makeInit(representation) {
+        const init = {
+            data: 'init segment',
+            segmentType: 'InitializationSegment',
+            representation: representation || { id: 'representation1' }
+        };
+
+        return init;
+    }
+
+    function makeChunk(start, end, representation) {
         const chunk = {
             start: start || 0,
             end: end || 4,
-            data: data || 'chickens',
-            segmentType: 'data'
+            data: 'chickens',
+            segmentType: 'data',
+            representation: representation || { id: 'representation1' }
         };
 
         return chunk;
@@ -34,15 +45,19 @@ describe('PreBufferSink', function () {
             expect(chunk.data).to.equal('chickens');
         });
 
-        it('should take a series of chunks and return them in chronological order on discharge', function () {
+        it('should take a series of chunks and corresponding inits and return them in chronological order on discharge', function () {
+            const representation2 = { id: 'representation2' };
+            sink.append(makeInit());
             sink.append(makeChunk(4, 8));
-            sink.append(makeChunk(12, 16));
-            sink.append(makeChunk(16, 20));
+            sink.append(makeInit(representation2));
+            sink.append(makeChunk(12, 16, representation2));
+            sink.append(makeChunk(16, 20, representation2));
+            sink.append(makeInit());
             sink.append(makeChunk(0, 4));
             sink.append(makeChunk(8, 12));
 
             const chunkList = sink.discharge();
-            expect(chunkList).to.have.length(5);
+            expect(chunkList).to.have.length(7);
 
             let lastStart, lastEnd;
             for (let i = 0; i < chunkList.length; i++) {
@@ -54,65 +69,52 @@ describe('PreBufferSink', function () {
                 lastStart = chunk.start;
                 lastEnd = chunk.end;
             }
+
+            expect(chunkList[0].segmentType).to.equal('InitializationSegment');
+            expect(chunkList[0].representation.id).to.equal('representation1');
+
+            expect(chunkList[4].segmentType).to.equal('InitializationSegment');
+            expect(chunkList[4].representation.id).to.equal('representation2');
         });
 
         it('should return an init segment if it is the last segment that is passed in', function () {
-            const chunk = makeChunk();
-            chunk.segmentType = 'InitializationSegment';
-
-            sink.append(chunk);
-
-            const chunkList = sink.discharge();
-            expect(chunkList).to.have.length(1);
-        });
-
-        it('should not return an init segment if other media segments are passed in afterwards', function () {
-            const chunk = makeChunk();
-            chunk.segmentType = 'InitializationSegment';
-
-            sink.append(chunk);
-            sink.append(makeChunk(0, 4));
+            sink.append(makeInit());
+            sink.append(makeChunk());
+            sink.append(makeInit({ id: 'representation2' }));
 
             const chunkList = sink.discharge();
-            expect(chunkList).to.have.length(1);
-            expect(chunkList[0].segmentType).to.equal('data');
-        });
-
-        it('should discharge only over a specified timerange', function () {
-            sink.append(makeChunk(0, 4));
-            sink.append(makeChunk(4, 8));
-            sink.append(makeChunk(8, 12));
-            sink.append(makeChunk(12, 16));
-            sink.append(makeChunk(16, 20));
-
-            const chunkList = sink.discharge(0, 12);
             expect(chunkList).to.have.length(3);
+        });
 
-            expect(chunkList[0].start).to.equal(0);
-            expect(chunkList[1].start).to.equal(4);
-            expect(chunkList[2].start).to.equal(8);
+        it('should not return an init segment last if other media segments are passed in afterwards', function () {
+            const init = makeInit();
+
+            sink.append(init);
+            sink.append(makeChunk(0, 4));
+
+            const chunkList = sink.discharge();
+            expect(chunkList).to.have.length(2);
+            expect(chunkList[0].segmentType).to.equal('InitializationSegment');
+            expect(chunkList[1].segmentType).to.equal('data');
         });
 
         it('should remove chunks after they have been discharged', function () {
+            sink.append(makeInit());
             sink.append(makeChunk(0, 4));
             sink.append(makeChunk(4, 8));
             sink.append(makeChunk(8, 12));
             sink.append(makeChunk(12, 16));
             sink.append(makeChunk(16, 20));
 
-            const chunkList = sink.discharge(0, 12);
-            expect(chunkList).to.have.length(3);
-
-            const emptyChunkList = sink.discharge(0, 12);
-            expect(emptyChunkList).to.have.length(0);
-
-            const remainingChunkList = sink.discharge(12, 20);
-            expect(remainingChunkList).to.have.length(2);
+            const chunkList = sink.discharge();
+            expect(chunkList).to.have.length(6);
+            expect(sink.getAllBufferRanges().length).to.equal(0);
         });
     });
 
     describe('getAllBufferRanges', function () {
         it('should report the buffer ranges of the chunks that have been added', function () {
+            sink.append(makeInit());
             sink.append(makeChunk(0, 4));
             sink.append(makeChunk(4, 8));
             sink.append(makeChunk(12, 16));
@@ -131,6 +133,7 @@ describe('PreBufferSink', function () {
 
     describe('Reset', function () {
         it('should have no segments left after it has reset', function () {
+            sink.append(makeInit());
             sink.append(makeChunk(0, 4));
             sink.append(makeChunk(4, 8));
             sink.append(makeChunk(8, 12));


### PR DESCRIPTION
_preload()_ took advantage of the InitCache to store and retrieve init segments so it only needed to worry about the media segments. Since v4 this setting has been turned off by default. This change modfies PreBufferSink to handle init segments as well media so it will still work with either setting of cacheInitSegments.