### PR TITLE
Feature/filter message

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -84,8 +84,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *                   ...Constants.THUMBNAILS_SCHEME_ID_URIS.map(ep => { return { 'schemeIdUri': ep }; })
  *               ],
  *               useMediaCapabilitiesApi: true,
- *               filterVideoColorimetryEssentialProperties: false,
- *               filterHDRMetadataFormatEssentialProperties: false,
+ *               filterVideoColorimetryEssentialProperties: true,
+ *               filterHDRMetadataFormatEssentialProperties: true,
  *               filterAudioChannelConfiguration: false
  *            },
  *            events: {
@@ -734,10 +734,10 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * List of supported \<EssentialProperty\> elements
  * @property {boolean} [useMediaCapabilitiesApi=true]
  * Enable to use the MediaCapabilities API to check whether codecs are supported. If disabled MSE.isTypeSupported will be used instead.
- * @property {boolean} [filterVideoColorimetryEssentialProperties=false]
+ * @property {boolean} [filterVideoColorimetryEssentialProperties=true]
  * Enable dash.js to query MediaCapabilities API for signalled Colorimetry EssentialProperties (per schemeIdUris: 'urn:mpeg:mpegB:cicp:ColourPrimaries', 'urn:mpeg:mpegB:cicp:TransferCharacteristics').
  * If disabled, registered properties per supportedEssentialProperties will be allowed without any further checking (including 'urn:mpeg:mpegB:cicp:MatrixCoefficients').
- * @property {boolean} [filterHDRMetadataFormatEssentialProperties=false]
+ * @property {boolean} [filterHDRMetadataFormatEssentialProperties=true]
  * Enable dash.js to query MediaCapabilities API for signalled HDR-MetadataFormat EssentialProperty (per schemeIdUri:'urn:dvb:dash:hdr-dmi').
  * @property {boolean} [filterAudioChannelConfiguration=false]
  * Enable dash.js to query MediaCapabilities API for signalled AudioChannelConfiguration.
@@ -1163,10 +1163,10 @@ function Settings() {
                 filterUnsupportedEssentialProperties: true,
                 supportedEssentialProperties: [
                     { schemeIdUri: Constants.FONT_DOWNLOAD_DVB_SCHEME },
-                    { schemeIdUri: Constants.COLOUR_PRIMARIES_SCHEME_ID_URI, value: /1|5|6|7|9/ },
+                    { schemeIdUri: Constants.COLOUR_PRIMARIES_SCHEME_ID_URI, value: /1|5|6|7/ },
                     { schemeIdUri: Constants.URL_QUERY_INFO_SCHEME },
                     { schemeIdUri: Constants.EXT_URL_QUERY_INFO_SCHEME },
-                    { schemeIdUri: Constants.MATRIX_COEFFICIENTS_SCHEME_ID_URI, value: /0|1|5|6|9/ },
+                    { schemeIdUri: Constants.MATRIX_COEFFICIENTS_SCHEME_ID_URI, value: /0|1|5|6/ },
                     { schemeIdUri: Constants.TRANSFER_CHARACTERISTICS_SCHEME_ID_URI, value: /1|6|13|14|15/ },
                     { schemeIdUri: Constants.SEGMENT_SEQUENCE_REPRESENTATION_SCHEME_ID_URI},
                     ...Constants.THUMBNAILS_SCHEME_ID_URIS.map(ep => {
@@ -1174,8 +1174,8 @@ function Settings() {
                     })
                 ],
                 useMediaCapabilitiesApi: true,
-                filterVideoColorimetryEssentialProperties: false,
-                filterHDRMetadataFormatEssentialProperties: false,
+                filterVideoColorimetryEssentialProperties: true,
+                filterHDRMetadataFormatEssentialProperties: true,
                 filterAudioChannelConfiguration: false
             },
             events: {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1163,10 +1163,10 @@ function Settings() {
                 filterUnsupportedEssentialProperties: true,
                 supportedEssentialProperties: [
                     { schemeIdUri: Constants.FONT_DOWNLOAD_DVB_SCHEME },
-                    { schemeIdUri: Constants.COLOUR_PRIMARIES_SCHEME_ID_URI, value: /1|5|6|7/ },
+                    { schemeIdUri: Constants.COLOUR_PRIMARIES_SCHEME_ID_URI, value: /1|5|6|7|9/ },
                     { schemeIdUri: Constants.URL_QUERY_INFO_SCHEME },
                     { schemeIdUri: Constants.EXT_URL_QUERY_INFO_SCHEME },
-                    { schemeIdUri: Constants.MATRIX_COEFFICIENTS_SCHEME_ID_URI, value: /0|1|5|6/ },
+                    { schemeIdUri: Constants.MATRIX_COEFFICIENTS_SCHEME_ID_URI, value: /0|1|5|6|9/ },
                     { schemeIdUri: Constants.TRANSFER_CHARACTERISTICS_SCHEME_ID_URI, value: /1|6|13|14|15/ },
                     { schemeIdUri: Constants.SEGMENT_SEQUENCE_REPRESENTATION_SCHEME_ID_URI},
                     ...Constants.THUMBNAILS_SCHEME_ID_URIS.map(ep => {

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -79,7 +79,7 @@ function CapabilitiesFilter() {
 
                     _removeMultiRepresentationPreselections(manifest);
                     _removePreselectionWithNoAdaptationSet(manifest);
-                    
+
                     return _applyCustomFilters(manifest);
                 })
                 .then(() => {
@@ -245,6 +245,7 @@ function CapabilitiesFilter() {
     }
 
     /* Build the configuration object for capability requests based on primary element (Representation or Preselection) */
+
     /* In case Preselection elements are present, attributes of this element override their counterparts from the Representation element */
     function _createConfiguration(type, primaryElement, codec, prslCommonRepresentation) {
         let config = null;
@@ -305,12 +306,12 @@ function CapabilitiesFilter() {
 
             if (primaryElement.tagName === DashConstants.PRESELECTION && prslCommonRep) {
                 let prslCommonRepresentationHDRColorimetryConfig = _convertHDRColorimetryToConfig(prslCommonRep);
-                
+
                 // if either the properties of the Preselection or the CommonRepresentation is not supported, we can't mark the config as supported.
                 let isCommonRepCfgSupported = prslCommonRepresentationHDRColorimetryConfig.isSupported;
                 delete prslCommonRepresentationHDRColorimetryConfig.isSupported;
                 config.isSupported = config.isSupported && isCommonRepCfgSupported;
-                
+
                 // asign only those attributes that are not present in config
                 _assignMissing(config, prslCommonRepresentationHDRColorimetryConfig);
             }
@@ -322,7 +323,7 @@ function CapabilitiesFilter() {
 
             if (primaryElement.tagName === DashConstants.PRESELECTION && prslCommonRep) {
                 let prslCommonRepresentationHDRMetadataFormatConfig = _convertHDRMetadataFormatToConfig(prslCommonRep);
-                
+
                 // if either the properties of the Preselection or the CommonRepresentation is not supported, we can't mark the config as supported.
                 let isCommonRepCfgSupported = prslCommonRepresentationHDRMetadataFormatConfig.isSupported;
                 delete prslCommonRepresentationHDRMetadataFormatConfig.isSupported;
@@ -473,6 +474,7 @@ function CapabilitiesFilter() {
                 const doesSupportEssentialProperties = _doesSupportEssentialProperties(adaptationSetEssentialProperties);
 
                 if (!doesSupportEssentialProperties) {
+                    logger.warn(`[CapabilitiesFilter] removed AdaptationSet (id: ${as.id}) with unsupported EssentialProperty`);
                     return false;
                 }
 
@@ -481,7 +483,11 @@ function CapabilitiesFilter() {
                     return _doesSupportEssentialProperties(essentialProperties);
                 });
 
-                return as.Representation && as.Representation.length > 0;
+                const isSupported = as.Representation && as.Representation.length > 0;
+                if (!isSupported) {
+                    logger.warn(`[CapabilitiesFilter] removed AdaptationSet (id: ${as.id}) with unsupported EssentialProperty on all Representations`);
+                }
+                return isSupported;
             });
 
             if (period.Preselection && period.Preselection.length) {
@@ -544,8 +550,12 @@ function CapabilitiesFilter() {
             if (period.Preselection) {
                 period.Preselection = period.Preselection.filter((prsl) => {
                     const prslComponents = String(prsl.preselectionComponents).split(' ');
-                    const adaptationSetIds = period.AdaptationSet.map(as => {return as.id});
-                    return prslComponents.every(c => {return adaptationSetIds.includes(c)});
+                    const adaptationSetIds = period.AdaptationSet.map(as => {
+                        return as.id
+                    });
+                    return prslComponents.every(c => {
+                        return adaptationSetIds.includes(c)
+                    });
                 });
             }
         });

--- a/test/unit/test/streaming/streaming.utils.Capabilities.js
+++ b/test/unit/test/streaming/streaming.utils.Capabilities.js
@@ -83,15 +83,25 @@ EssentialPropertyPrivateTransferFunction.init({
 describe('Capabilities', function () {
     beforeEach(function () {
         settings = Settings({}).getInstance();
+        settings.reset();
         capabilities = Capabilities({}).getInstance();
 
         capabilities.setConfig({
             settings: settings
         });
-        settings.reset();
     });
 
     describe('supports EssentialProperty', function () {
+        beforeEach(function () {
+            settings.update({
+                streaming: {
+                    capabilities: {
+                        filterVideoColorimetryEssentialProperties: false,
+                        filterHDRMetadataFormatEssentialProperties: false,
+                    }
+                }
+            })
+        });
         it('should return true if EssentialProperty value is known', function () {
             let res = capabilities.supportsEssentialProperty(EssentialPropertyThumbNail);
             expect(res).to.be.true;
@@ -113,6 +123,7 @@ describe('Capabilities', function () {
         });
 
         it('should return false if EssentialProperty value is absent for known schemeId+value', function () {
+            console.log(settings.get().streaming.capabilities.filterVideoColorimetryEssentialProperties);
             let res = capabilities.supportsEssentialProperty(EssentialPropertynoVal);
             expect(res).to.be.false;
         });

--- a/test/unit/test/streaming/streaming.utils.Capabilities.js
+++ b/test/unit/test/streaming/streaming.utils.Capabilities.js
@@ -123,7 +123,6 @@ describe('Capabilities', function () {
         });
 
         it('should return false if EssentialProperty value is absent for known schemeId+value', function () {
-            console.log(settings.get().streaming.capabilities.filterVideoColorimetryEssentialProperties);
             let res = capabilities.supportsEssentialProperty(EssentialPropertynoVal);
             expect(res).to.be.false;
         });


### PR DESCRIPTION
* Adds a warning message when an AdaptationSet is filtered because of unsupported EssentialProperties
* Allows `COLOUR_PRIMARIES_SCHEME_ID_URI` and `MATRIX_COEFFICIENTS_SCHEME_ID_URI` with value `9`