### PR TITLE
Feature/return unfiltered representations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2158,6 +2158,8 @@ export interface MediaPlayerClass {
 
     getRepresentationsByType(type: MediaType, streamId?: string | null): Representation[];
 
+    getRepresentationsByTypeUnfiltered(type: MediaType, streamId?: string | null): Representation[];
+
     getSafeAverageThroughput(type: MediaType, calculationMode?: string | null, sampleSize?: number): number;
 
     getSettings(): MediaPlayerSettingClass;
@@ -2173,8 +2175,6 @@ export interface MediaPlayerClass {
     getTracksFor(type: MediaType): MediaInfo[];
 
     getTracksForTypeFromManifest(type: MediaType, manifest: object, streamInfo: StreamInfo): MediaInfo[];
-
-    getUnfilteredRepresentationsByType(type: MediaType, streamId?: string | null): Representation[];
 
     getVersion(): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2021,7 +2021,7 @@ export interface MediaPlayerClass {
     on(type: MetricEvent['type'], listener: (e: MetricEvent) => void, scope?: object): void;
 
     on(type: MetricChangedEvent['type'], listener: (e: MetricChangedEvent) => void, scope?: object): void;
-    
+
     on(type: NewTrackSelectedEvent['type'], listener: (e: NewTrackSelectedEvent) => void, scope?: object): void;
 
     on(type: OfflineRecordEvent['type'], listener: (e: OfflineRecordEvent) => void, scope?: object): void;
@@ -2055,7 +2055,7 @@ export interface MediaPlayerClass {
     on(type: StreamInitializedEvent['type'], listener: (e: StreamInitializedEvent) => void, scope?: object): void;
 
     on(type: TextTracksAddedEvent['type'], listener: (e: TextTracksAddedEvent) => void, scope?: object): void;
-    
+
     on(type: TrackChangeRenderedEvent['type'], listener: (e: TrackChangeRenderedEvent) => void, scope?: object): void;
 
     on(type: TtmlParsedEvent['type'], listener: (e: TtmlParsedEvent) => void, scope?: object): void;
@@ -2173,6 +2173,8 @@ export interface MediaPlayerClass {
     getTracksFor(type: MediaType): MediaInfo[];
 
     getTracksForTypeFromManifest(type: MediaType, manifest: object, streamInfo: StreamInfo): MediaInfo[];
+
+    getUnfilteredRepresentationsByType(type: MediaType, streamId?: string | null): Representation[];
 
     getVersion(): string;
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -78,7 +78,7 @@ import VideoModel from './models/VideoModel.js';
 import {HTTPRequest} from './vo/metrics/HTTPRequest.js';
 import {checkParameterType} from './utils/SupervisorTools.js';
 import {getVersionString} from '../core/Version.js';
-import { Cta608Parser } from '@svta/cml-608';
+import {Cta608Parser} from '@svta/cml-608';
 
 /**
  * The media types
@@ -1658,6 +1658,8 @@ function MediaPlayer() {
     }
 
     /**
+     * This method returns the list of all available representations for a given media type. The returned list is filtered according to the current ABR rules (e.g. max/min bitrate and limitBitrateByPortal).
+     * If you want to get the unfiltered list of representations then use getUnfilteredRepresentationsByType() instead.
      * @param {MediaType} type
      * @param {string} streamId
      * @returns {Array}
@@ -1666,11 +1668,29 @@ function MediaPlayer() {
      * @instance
      */
     function getRepresentationsByType(type, streamId = null) {
+        return _getRepresentations(type, streamId, true);
+    }
+
+    /**
+     * This method returns the list of all available representations for a given media type. The returned list is unfiltered and settings like max/min bitrate and limitBitrateByPortal are not taken into account.
+     * If you want to get the filtered list of representations then use getRepresentationsByType() instead.
+     * @param {MediaType} type
+     * @param {string} streamId
+     * @returns {Array}
+     * @memberof module:MediaPlayer
+     * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
+     * @instance
+     */
+    function getUnfilteredRepresentationsByType(type, streamId = null) {
+        return _getRepresentations(type, streamId, false);
+    }
+
+    function _getRepresentations(type, streamId, filterBySettings = true) {
         if (!streamingInitialized) {
             throw STREAMING_NOT_INITIALIZED_ERROR;
         }
         let stream = streamId ? streamController.getStreamById(streamId) : getActiveStream();
-        return stream ? stream.getRepresentationsByType(type) : [];
+        return stream ? stream.getRepresentationsByType(type, filterBySettings) : [];
     }
 
     /**
@@ -2891,6 +2911,7 @@ function MediaPlayer() {
         getTargetLiveDelay,
         getTracksFor,
         getTracksForTypeFromManifest,
+        getUnfilteredRepresentationsByType,
         getVersion,
         getVideoElement,
         getVolume,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1681,7 +1681,7 @@ function MediaPlayer() {
      * @throws {@link module:MediaPlayer~STREAMING_NOT_INITIALIZED_ERROR STREAMING_NOT_INITIALIZED_ERROR} if called before initializePlayback function
      * @instance
      */
-    function getUnfilteredRepresentationsByType(type, streamId = null) {
+    function getRepresentationsByTypeUnfiltered(type, streamId = null) {
         return _getRepresentations(type, streamId, false);
     }
 
@@ -2903,6 +2903,7 @@ function MediaPlayer() {
         getProtectionController,
         getRawThroughputData,
         getRepresentationsByType,
+        getRepresentationsByTypeUnfiltered,
         getSafeAverageThroughput,
         getSettings,
         getSource,
@@ -2911,7 +2912,6 @@ function MediaPlayer() {
         getTargetLiveDelay,
         getTracksFor,
         getTracksForTypeFromManifest,
-        getUnfilteredRepresentationsByType,
         getVersion,
         getVideoElement,
         getVolume,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1659,7 +1659,7 @@ function MediaPlayer() {
 
     /**
      * This method returns the list of all available representations for a given media type. The returned list is filtered according to the current ABR rules (e.g. max/min bitrate and limitBitrateByPortal).
-     * If you want to get the unfiltered list of representations then use getUnfilteredRepresentationsByType() instead.
+     * If you want to get the unfiltered list of representations then use getRepresentationsByTypeUnfiltered() instead.
      * @param {MediaType} type
      * @param {string} streamId
      * @returns {Array}

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -719,10 +719,11 @@ function Stream(config) {
 
     /**
      * @param {string} type
+     * @param filterBySettings
      * @returns {Array}
      * @memberof Stream#
      */
-    function getRepresentationsByType(type) {
+    function getRepresentationsByType(type, filterBySettings = true) {
         checkConfig();
         if (type === Constants.IMAGE) {
             if (!thumbnailController) {
@@ -731,7 +732,7 @@ function Stream(config) {
             return thumbnailController.getPossibleVoRepresentations();
         }
         const mediaInfo = _getMediaInfo(type);
-        return abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true);
+        return filterBySettings ? abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo, true) : abrController.getPossibleVoRepresentations(mediaInfo, true);
     }
 
     /**

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -3,11 +3,11 @@ import StreamMock from './StreamMock.js';
 class StreamControllerMock {
 
     constructor() {
+        this.streamId = 'DUMMY_STREAM-01';
+        this.activeStream = new StreamMock();
     }
 
     setup() {
-        this.streamId = 'DUMMY_STREAM-01';
-        this.activeStream = new StreamMock();
     }
 
     initialize(streams) {
@@ -63,12 +63,7 @@ class StreamControllerMock {
     }
 
     getStreamById() {
-        return {
-            id: this.streamId,
-            getBitrateListFor: function () {
-                return [1, 2];
-            }
-        };
+        return this.activeStream;
     }
 
     load() {

--- a/test/unit/mocks/StreamMock.js
+++ b/test/unit/mocks/StreamMock.js
@@ -11,6 +11,8 @@ function StreamMock() {
         new StreamProcessorMock(TYPE_VIDEO),
         new StreamProcessorMock(TYPE_AUDIO)
     ];
+    this._representations = {};
+    this._unfilteredRepresentations = {};
 }
 
 StreamMock.prototype.initialize = function (streamInfo) {
@@ -55,5 +57,21 @@ StreamMock.prototype.getStreamProcessors = function () {
 StreamMock.prototype.getCurrentRepresentationForType = function () {
     return null;
 }
+
+StreamMock.prototype.setRepresentationsByType = function (type, filtered, unfiltered) {
+    this._representations[type] = filtered;
+    this._unfilteredRepresentations[type] = unfiltered;
+};
+
+StreamMock.prototype.getRepresentationsByType = function (type, filterBySettings) {
+    if (filterBySettings) {
+        return this._representations[type] || [];
+    }
+    return this._unfilteredRepresentations[type] || [];
+};
+
+StreamMock.prototype.getBitrateListFor = function () {
+    return [1, 2];
+};
 
 export default StreamMock;

--- a/test/unit/test/streaming/streaming.MediaPlayer.js
+++ b/test/unit/test/streaming/streaming.MediaPlayer.js
@@ -989,6 +989,14 @@ describe('MediaPlayer', function () {
                 expect(player.getCurrentRepresentationForType).to.throw('You must first call initialize() and set a source before calling this method');
             });
 
+            it('Method getRepresentationsByType should throw an exception', function () {
+                expect(player.getRepresentationsByType).to.throw(STREAMING_NOT_INITIALIZED_ERROR);
+            });
+
+            it('Method getRepresentationsByTypeUnfiltered should throw an exception', function () {
+                expect(player.getRepresentationsByTypeUnfiltered).to.throw(STREAMING_NOT_INITIALIZED_ERROR);
+            });
+
             it('Method getStreamsFromManifest should throw an exception', function () {
                 expect(player.getStreamsFromManifest).to.throw('You must first call initialize() and set a source before calling this method');
             });
@@ -1144,6 +1152,92 @@ describe('MediaPlayer', function () {
 
                 currentTrack = mediaControllerMock.isCurrentTrack('audio');
                 expect(currentTrack).to.be.true;
+            });
+        });
+    });
+
+    describe('getRepresentationsByType and getRepresentationsByTypeUnfiltered', function () {
+        const filteredVideoReps = [
+            { id: 'rep1', bandwidth: 500000 },
+            { id: 'rep2', bandwidth: 1000000 }
+        ];
+        const unfilteredVideoReps = [
+            { id: 'rep1', bandwidth: 500000 },
+            { id: 'rep2', bandwidth: 1000000 },
+            { id: 'rep3', bandwidth: 3000000 }
+        ];
+        const filteredAudioReps = [{ id: 'audioRep1', bandwidth: 128000 }];
+        const unfilteredAudioReps = [
+            { id: 'audioRep1', bandwidth: 128000 },
+            { id: 'audioRep2', bandwidth: 256000 }
+        ];
+
+        beforeEach(function () {
+            player.initialize(videoElementMock, dummyUrl, false);
+            streamControllerMock.getActiveStream().setRepresentationsByType('video', filteredVideoReps, unfilteredVideoReps);
+            streamControllerMock.getActiveStream().setRepresentationsByType('audio', filteredAudioReps, unfilteredAudioReps);
+        });
+
+        describe('getRepresentationsByType', function () {
+            it('should return filtered representations from the active stream when no streamId is provided', function () {
+                const reps = player.getRepresentationsByType('video');
+                expect(reps).to.deep.equal(filteredVideoReps);
+            });
+
+            it('should return filtered representations for a specific streamId', function () {
+                const reps = player.getRepresentationsByType('video', 'DUMMY_STREAM-01');
+                expect(reps).to.deep.equal(filteredVideoReps);
+            });
+
+            it('should return filtered audio representations', function () {
+                const reps = player.getRepresentationsByType('audio');
+                expect(reps).to.have.lengthOf(1);
+                expect(reps[0].id).to.equal('audioRep1');
+            });
+
+            it('should return empty array when no stream is available', function () {
+                streamControllerMock.getActiveStreamInfo = function () { return null; };
+                const reps = player.getRepresentationsByType('video');
+                expect(reps).to.be.empty;
+            });
+
+            it('should return empty array for a type with no representations configured', function () {
+                const reps = player.getRepresentationsByType('text');
+                expect(reps).to.be.empty;
+            });
+        });
+
+        describe('getRepresentationsByTypeUnfiltered', function () {
+            it('should return unfiltered representations from the active stream when no streamId is provided', function () {
+                const reps = player.getRepresentationsByTypeUnfiltered('video');
+                expect(reps).to.deep.equal(unfilteredVideoReps);
+            });
+
+            it('should return unfiltered representations for a specific streamId', function () {
+                const reps = player.getRepresentationsByTypeUnfiltered('video', 'DUMMY_STREAM-01');
+                expect(reps).to.deep.equal(unfilteredVideoReps);
+            });
+
+            it('should return unfiltered audio representations', function () {
+                const reps = player.getRepresentationsByTypeUnfiltered('audio');
+                expect(reps).to.have.lengthOf(2);
+            });
+
+            it('should return more representations than the filtered method', function () {
+                const filtered = player.getRepresentationsByType('video');
+                const unfiltered = player.getRepresentationsByTypeUnfiltered('video');
+                expect(unfiltered.length).to.be.greaterThan(filtered.length);
+            });
+
+            it('should return empty array when no stream is available', function () {
+                streamControllerMock.getActiveStreamInfo = function () { return null; };
+                const reps = player.getRepresentationsByTypeUnfiltered('video');
+                expect(reps).to.be.empty;
+            });
+
+            it('should return empty array for a type with no representations configured', function () {
+                const reps = player.getRepresentationsByTypeUnfiltered('text');
+                expect(reps).to.be.empty;
             });
         });
     });


### PR DESCRIPTION
Add a new method getRepresentationsByTypeUnfiltered. This allows applications to get all Representations regardless of any filter settings. Addresses https://github.com/Dash-Industry-Forum/dash.js/issues/4959#issuecomment-3929738701