### PR TITLE
improve track equality check

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -38,6 +38,7 @@ import {extendedFilter} from 'bcp-47-match';
 import MediaPlayerEvents from '../MediaPlayerEvents.js';
 import DashConstants from '../../dash/constants/DashConstants.js';
 import getNChanFromAudioChannelConfig from '../utils/AudioChannelConfiguration.js';
+import ObjectUtils from '../utils/ObjectUtils.js';
 
 function MediaController() {
 
@@ -368,15 +369,17 @@ function MediaController() {
             return false;
         }
 
+        let objectUtils = ObjectUtils(context).getInstance();
+
         const sameId = t1.id === t2.id;
-        const sameViewpoint = JSON.stringify(t1.viewpoint) === JSON.stringify(t2.viewpoint);
+        const sameViewpoint = objectUtils.areEqual(t1.viewpoint, t2.viewpoint);
         const sameLang = t1.lang === t2.lang;
         const sameCodec = t1.codec === t2.codec;
-        const sameRoles = JSON.stringify(t1.roles) === JSON.stringify(t2.roles);
-        const sameAccessibility = JSON.stringify(t1.accessibility) === JSON.stringify(t2.accessibility);
-        const sameAudioChannelConfiguration = JSON.stringify(t1.audioChannelConfiguration) === JSON.stringify(t2.audioChannelConfiguration);
-        const sameSupplementalProps = JSON.stringify(t1.supplementalProperties) === JSON.stringify(t2.supplementalProperties);
-        const sameEssentialProps = JSON.stringify(t1.essentialProperties) === JSON.stringify(t2.essentialProperties);
+        const sameRoles = objectUtils.areEqual(t1.roles, t2.roles);
+        const sameAccessibility = objectUtils.areEqual(t1.accessibility, t2.accessibility);
+        const sameAudioChannelConfiguration = objectUtils.areEqual(t1.audioChannelConfiguration, t2.audioChannelConfiguration);
+        const sameSupplementalProps = objectUtils.areEqual(t1.supplementalProperties, t2.supplementalProperties);
+        const sameEssentialProps = objectUtils.areEqual(t1.essentialProperties, t2.essentialProperties);
 
         return (sameId && sameCodec && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration && sameSupplementalProps && sameEssentialProps);
     }

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -180,10 +180,10 @@ function MediaController() {
         if (!track) {
             return;
         }
-        logger.info('addTrack with track.codec=\'' + track.codec + '\', track.type=\'' + track.type + '\'');
 
         const mediaType = track.type;
         if (!_isMultiTrackSupportedByType(mediaType)) {
+            logger.info('track not added (_isMultiTrackSupportedByType), track.index=' + track.index);
             return;
         }
 
@@ -196,10 +196,12 @@ function MediaController() {
         for (let i = 0, len = mediaTracks.length; i < len; ++i) {
             //track is already set.
             if (areTracksEqual(mediaTracks[i], track)) {
+                logger.info('track not added as it is already set (this track-index=' + track.index + ' - existing track.index=' + mediaTracks[i].index + ')');
                 return;
             }
         }
-
+        
+        logger.info('addTrack with track.codec=\'' + track.codec + '\', track.type=\'' + track.type + '\', track.id=\'' + track.id + '\', track.index=' + track.index);
         mediaTracks.push(track);
     }
 
@@ -373,8 +375,10 @@ function MediaController() {
         const sameRoles = JSON.stringify(t1.roles) === JSON.stringify(t2.roles);
         const sameAccessibility = JSON.stringify(t1.accessibility) === JSON.stringify(t2.accessibility);
         const sameAudioChannelConfiguration = JSON.stringify(t1.audioChannelConfiguration) === JSON.stringify(t2.audioChannelConfiguration);
+        const sameSupplementalProps = JSON.stringify(t1.supplementalProperties) === JSON.stringify(t2.supplementalProperties);
+        const sameEssentialProps = JSON.stringify(t1.essentialProperties) === JSON.stringify(t2.essentialProperties);
 
-        return (sameId && sameCodec && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration);
+        return (sameId && sameCodec && sameViewpoint && sameLang && sameRoles && sameAccessibility && sameAudioChannelConfiguration && sameSupplementalProps && sameEssentialProps);
     }
 
 

--- a/test/unit/test/streaming/streaming.controllers.MediaController.js
+++ b/test/unit/test/streaming/streaming.controllers.MediaController.js
@@ -166,6 +166,42 @@ describe('MediaController', function () {
             let equal = mediaController.areTracksEqual(track1, track2);
             expect(equal).to.be.true;
         });
+        
+        it('should return true if tracks contain the same properties', function () {
+
+            let track1 = {
+                id: 'id',
+                supplementalProperties: [
+                    { schemeIdUri: 'urn:test:scheme:1', value: '2' }, 
+                    { schemeIdUri: 'urn:test:scheme:2', value: 'ABC' }
+                ]
+            };
+
+            let track2 = {
+                id: 'id',
+                supplementalProperties: [
+                    { schemeIdUri: 'urn:test:scheme:1', value: '2' },
+                    { schemeIdUri: 'urn:test:scheme:2', value: 'ABC' }
+                ]
+            };
+            let equal = mediaController.areTracksEqual(track1, track2);
+            expect(equal).to.be.true;
+        });
+        
+        it('should return false if tracks differ in properties', function () {
+
+            let track1 = {
+                id: 'id',
+                supplementalProperties: [{ schemeIdUri: 'urn:test:scheme:ABC', value: 'ABC' }]
+            };
+
+            let track2 = {
+                id: 'id',
+                supplementalProperties: [{ schemeIdUri: 'urn:test:scheme:ABC', value: 'ABC' }, { schemeIdUri: 'urn:test:scheme:1', value: '2' }]
+            };
+            let equal = mediaController.areTracksEqual(track1, track2);
+            expect(equal).to.be.false;
+        });
 
         it('should return false if track1 is undefined or null', function () {
 


### PR DESCRIPTION
* add check for properties in areTracksEqual
* make use of utils
* add some info to logger

This solves the problem that an AdaptationSet gets ignored as duplicate if two AdaptationSets differ by e.g. SupplementalProperties.