### PR TITLE
fix(dvb): correct off-by-one in DVBSelector weighted BaseURL selection

### DIFF
--- a/src/streaming/utils/baseUrlResolution/DVBSelector.js
+++ b/src/streaming/utils/baseUrlResolution/DVBSelector.js
@@ -111,7 +111,7 @@ function DVBSelector(config) {
                 });
 
                 // pick a random number between zero and totalWeight
-                rn = Math.floor(Math.random() * (totalWeight - 1));
+                rn = Math.floor(Math.random() * totalWeight);
 
                 // select the index for the range rn falls within
                 cumulWeights.every((limit, index) => {

--- a/src/streaming/utils/baseUrlResolution/DVBSelector.js
+++ b/src/streaming/utils/baseUrlResolution/DVBSelector.js
@@ -110,7 +110,7 @@ function DVBSelector(config) {
                     cumulWeights.push(totalWeight);
                 });
 
-                // pick a random number between zero and totalWeight
+                // pick a random number between zero (inclusive) and totalWeight (exclusive)
                 rn = Math.floor(Math.random() * totalWeight);
 
                 // select the index for the range rn falls within

--- a/test/unit/test/streaming/streaming.utils.DVBSelector.js
+++ b/test/unit/test/streaming/streaming.utils.DVBSelector.js
@@ -158,7 +158,7 @@ describe('BaseURLResolution/DVBSelector', function () {
         stub.restore();
     });
 
-    it('should select all equal-weight baseUrls with fair distribution (RFC 2782)', () => {
+    it('should be able to select both equal-weight baseUrls (RFC 2782)', () => {
         const baseUrls = [
             { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-a' },
             { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-b' }

--- a/test/unit/test/streaming/streaming.utils.DVBSelector.js
+++ b/test/unit/test/streaming/streaming.utils.DVBSelector.js
@@ -154,6 +154,63 @@ describe('BaseURLResolution/DVBSelector', function () {
 
         const fourthSelection = dvbSelector.select(baseUrls);
         expect(fourthSelection).to.be.undefined;
+
+        stub.restore();
+    });
+
+    it('should select all equal-weight baseUrls with fair distribution (RFC 2782)', () => {
+        const baseUrls = [
+            { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-a' },
+            { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-b' }
+        ];
+
+        const stub = sinon.stub(Math, 'random');
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+
+        // With totalWeight=2 and cumulWeights=[1,2]:
+        // Math.random()=0.0 → rn=0 → 0<1 → cdn-a
+        stub.returns(0.0);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-a');
+
+        // Math.random()=0.4 → rn=0 → 0<1 → cdn-a
+        stub.returns(0.4);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-a');
+
+        // Math.random()=0.5 → rn=1 → 1<2 → cdn-b
+        stub.returns(0.5);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-b');
+
+        // Math.random()=0.99 → rn=1 → 1<2 → cdn-b
+        stub.returns(0.99);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-b');
+
+        stub.restore();
+    });
+
+    it('should select all three equal-weight baseUrls (multi-CDN without dvb:weight)', () => {
+        const baseUrls = [
+            { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-a' },
+            { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-b' },
+            { dvbPriority: 1, dvbWeight: 1, serviceLocation: 'cdn-c' }
+        ];
+
+        const stub = sinon.stub(Math, 'random');
+        const dvbSelector = DVBSelector(context).create(defaultConfig);
+
+        // With totalWeight=3 and cumulWeights=[1,2,3]:
+        // Math.random()=0.0 → rn=0 → 0<1 → cdn-a
+        stub.returns(0.0);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-a');
+
+        // Math.random()=0.5 → rn=1 → 1<2 → cdn-b
+        stub.returns(0.5);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-b');
+
+        // Math.random()=0.8 → rn=2 → 2<3 → cdn-c
+        stub.returns(0.8);
+        expect(dvbSelector.select(baseUrls).serviceLocation).to.equal('cdn-c');
+
+        stub.restore();
     });
 
     it('should not select baseUrls with invalid priority when there is another option', () => {

--- a/test/unit/test/streaming/streaming.utils.DVBSelector.js
+++ b/test/unit/test/streaming/streaming.utils.DVBSelector.js
@@ -141,8 +141,8 @@ describe('BaseURLResolution/DVBSelector', function () {
         expect(secondSelection.dvbPriority).to.equal(3);
         expect(secondSelection.serviceLocation).to.equal('C');
 
-        // Math.random (called in select()) will return 1
-        stub.returns(1);
+        // Math.random (called in select()) will return 0.99 (valid range: [0, 1))
+        stub.returns(0.99);
 
         blacklist.push(secondSelection.serviceLocation);
 


### PR DESCRIPTION
## Summary
- Fix off-by-one in `DVBSelector.js:114`: `Math.random() * (totalWeight - 1)` → `Math.random() * totalWeight`. The `- 1` excluded the last CDN from selection (e.g. with 2 equal-weight CDNs, only the first was ever picked).
- Add `stub.restore()` to existing DVB A168 test to prevent sinon stub leak.
- Add 2 unit tests proving equal-weight selection works for 2 and 3 CDNs.

## Why the existing test didn't catch it
The test uses weights `[10, 30, 60]` (totalWeight=100) with `Math.random()` stubbed to `0.3` and `1.0`. These values produce identical results with `* 99` and `* 100`. Equal weights (the default when `dvb:weight` is omitted) expose the bug deterministically.

## Test plan
- [x] New test: 2 equal-weight CDNs — verifies both are reachable at different `Math.random()` values
- [x] New test: 3 equal-weight CDNs — verifies all three are reachable
- [x] Existing DVB A168 test still passes (unchanged behavior for non-equal weights)

Fixes #4981