### PR TITLE
fix(ttml): use endTimeSegment as fallback for last cue end time

### DIFF
--- a/src/streaming/utils/TTMLParser.js
+++ b/src/streaming/utils/TTMLParser.js
@@ -144,7 +144,9 @@ function TTMLParser() {
             if (isd.contents.some(topLevelContents => topLevelContents.contents.length)) {
                 //be sure that mediaTimeEvents values are in the mp4 segment time ranges.
                 startTime = mediaTimeEvents[i] + offsetTime;
-                endTime = mediaTimeEvents[i + 1] + offsetTime;
+                endTime = (i + 1 < mediaTimeEvents.length)
+                    ? mediaTimeEvents[i + 1] + offsetTime
+                    : endTimeSegment;
 
                 if (startTime < endTime) {
                     captionArray.push({

--- a/test/unit/data/subtitles/ttmlLastCue.ttml
+++ b/test/unit/data/subtitles/ttmlLastCue.ttml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xml:lang="en" xml:space="default"
+    ttp:timeBase="media" ttp:cellResolution="40 24">
+
+    <head>
+        <styling>
+            <style xml:id="S0" tts:wrapOption="wrap" tts:fontFamily="UnitTestFont,Arial,Roboto,proportionalSansSerif, default" tts:textAlign="center" tts:fontSize="80%" />
+        </styling>
+        <layout>
+            <region xml:id="R1" tts:origin="12.5% 75%" tts:extent="75% 20%" tts:overflow="hidden" tts:displayAlign="before"/>
+        </layout>
+    </head>
+    <body style="S0">
+        <div region="R1">
+            <p xml:id="p1" begin="00:00:00">
+                Last cue without explicit end
+            </p>
+        </div>
+    </body>
+</tt>

--- a/test/unit/test/streaming/streaming.utils.TTMLParser.js
+++ b/test/unit/test/streaming/streaming.utils.TTMLParser.js
@@ -5,6 +5,7 @@ import {expect} from 'chai';
 const context = {};
 const ttmlParser = TTMLParser(context).getInstance();
 let ttml_file;
+let ttml_last_cue_file;
 
 describe('TTMLParser', function () {
 
@@ -12,6 +13,7 @@ describe('TTMLParser', function () {
 
         before(async function () {
             ttml_file = await FileLoader.loadTextFile('/data/subtitles/ttmlSample.ttml');
+            ttml_last_cue_file = await FileLoader.loadTextFile('/data/subtitles/ttmlLastCue.ttml');
         });
 
         it('should return an empty array when parse is called and parameters are undefined', () => {
@@ -24,6 +26,14 @@ describe('TTMLParser', function () {
             expect(captionsArray).to.have.lengthOf(2);
             expect(captionsArray[0].start).to.equal(0);
             expect(captionsArray[0].end).to.equal(5);
+        });
+
+        it('should use endTimeSegment as fallback for the last cue end time', () => {
+            const endTimeSegment = 10;
+            const captionsArray = ttmlParser.parse(ttml_last_cue_file, 0, 0, endTimeSegment, []);
+            expect(captionsArray).to.have.lengthOf(1);
+            expect(captionsArray[0].start).to.equal(0);
+            expect(captionsArray[0].end).to.equal(endTimeSegment);
         });
     });
 });


### PR DESCRIPTION
Fixes #4985

## Root cause

`TTMLParser.js:147` computes each cue's end time from the next entry in `mediaTimeEvents`:

```javascript
endTime = mediaTimeEvents[i + 1] + offsetTime;
```

On the last iteration, `mediaTimeEvents[i + 1]` is `undefined`. `undefined + offsetTime = NaN`. The guard `startTime < NaN` is always `false`, so the last cue is silently dropped.

The function signature already declares an `endTimeSegment` parameter for this purpose. It is documented in JSDoc and passed by the caller (`TextSourceBuffer.js:331`), but never referenced in the function body.

## Fix

Use `endTimeSegment` as fallback when there is no next media time event:

```javascript
endTime = (i + 1 < mediaTimeEvents.length)
    ? mediaTimeEvents[i + 1] + offsetTime
    : endTimeSegment;
```

No behavior change for cues that have a subsequent event (all existing content).

## Test plan
- [x] New test: TTML with a cue without explicit `end` — verifies `endTimeSegment` is used as fallback
- [x] Existing TTMLParser test still passes (explicit timing, behavior unchanged)