### PR TITLE
fix(Reference-UI): Restore LCEVC Dual-track Scalable Integration

### DIFF
--- a/contrib/controlbar/ControlBar.js
+++ b/contrib/controlbar/ControlBar.js
@@ -975,6 +975,9 @@ export class ControlBar {
                 const settings = this.player.getSettings();
                 const autoSwitch = settings?.streaming?.abr?.autoSwitchBitrate?.[type] !== false;
                 const currentRep = this.player.getCurrentRepresentationForType(type);
+                const selectedRep = type === 'video'
+                    ? this._getCurrentCompositeVideoRepresentation() || currentRep
+                    : currentRep;
 
                 reps.forEach((rep, idx) => {
                     const bitrate = Math.round(rep.bandwidth / 1000);
@@ -983,7 +986,7 @@ export class ControlBar {
                         label += ` (${rep.width}x${rep.height})`;
                     }
 
-                    const isCurrent = !autoSwitch && currentRep && currentRep.id === rep.id;
+                    const isCurrent = !autoSwitch && selectedRep && selectedRep.id === rep.id;
                     const item = createElement('div', {
                         className: `cb-menu-item ${isCurrent ? 'cb-menu-item-selected' : ''}`,
                         textContent: label,
@@ -1124,6 +1127,18 @@ export class ControlBar {
         default:
             return value ? `${value}ch` : null;
         }
+    }
+
+    /**
+     * Get the effective active video representation, including scalable selections.
+     * @returns {Representation|null}
+     */
+    _getCurrentCompositeVideoRepresentation() {
+        return this.player?.getActiveStream?.()
+            ?.getStreamProcessors?.()
+            ?.find((processor) => processor.getType() === 'video')
+            ?.getRepresentationController?.()
+            ?.getCurrentCompositeRepresentation?.() ?? null;
     }
 
     _rebuildCaptionMenu() {

--- a/samples/dash-if-reference-player/app/css/main.css
+++ b/samples/dash-if-reference-player/app/css/main.css
@@ -597,6 +597,20 @@ body {
     border-radius: inherit;
 }
 
+#enhancement-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 2;
+    border-radius: inherit;
+}
+
+#video-wrapper video.lcevc-hidden-video {
+    opacity: 0;
+}
+
 #video-wrapper.cb-fullscreen {
     border-radius: 0;
 }
@@ -608,7 +622,7 @@ body {
     width: 100%;
     height: 100%;
     pointer-events: none;
-    z-index: 1;
+    z-index: 3;
 }
 
 /* ---- Control Bar theme overrides (styles in contrib/controlbar/controlbar.css) ---- */

--- a/samples/dash-if-reference-player/app/js/LcevcController.js
+++ b/samples/dash-if-reference-player/app/js/LcevcController.js
@@ -1,0 +1,225 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  * list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  * this list of conditions and the following disclaimer in the documentation and/or
+ *  * other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  * contributors may be used to endorse or promote products derived from this software
+ *  * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const AUTO_RENDER_MODE = {
+    ENABLED: 1
+};
+
+export class LcevcController {
+    constructor(playerController) {
+        this.playerController = playerController;
+        this.player = playerController.player;
+        this.videoElement = null;
+        this.canvasElement = null;
+        this.toggleElement = null;
+        this.selectedItem = null;
+        this.decoder = null;
+        this.abrIndex = -1;
+        this._boundHandlers = null;
+    }
+
+    init({ videoElement, canvasElement, toggleElement }) {
+        this.videoElement = videoElement;
+        this.canvasElement = canvasElement;
+        this.toggleElement = toggleElement || null;
+
+        if (this.canvasElement) {
+            this.canvasElement.classList.add('d-none');
+        }
+
+        if (this.toggleElement) {
+            this.toggleElement.addEventListener('change', () => this.syncVisibility());
+        }
+    }
+
+    setSelectedItem(item) {
+        this.selectedItem = item || null;
+        this.syncVisibility();
+    }
+
+    async prepareForPlayback() {
+        this.stop();
+
+        const shouldEnable = this.shouldEnable();
+        if (!shouldEnable) {
+            this.syncVisibility(false);
+            return false;
+        }
+
+        this._forceToggleEnabled();
+        this.syncVisibility(true);
+
+        const lcevcNamespace = await this._getLcevcNamespace();
+        if (!lcevcNamespace) {
+            this.syncVisibility(false);
+            return false;
+        }
+
+        this._attachDecoder(lcevcNamespace);
+        return true;
+    }
+
+    stop() {
+        this._detachPlayerHooks();
+
+        if (this.decoder && typeof this.decoder.close === 'function') {
+            this.decoder.close();
+        }
+
+        this.decoder = null;
+        this.abrIndex = -1;
+
+        if (this.player) {
+            this.player.LCEVCdec = null;
+        }
+
+        this.syncVisibility(false);
+    }
+
+    shouldEnable() {
+        return this._isToggleEnabled() || this._isKnownLcevcStream();
+    }
+
+    syncVisibility(forceEnabled) {
+        const enabled = forceEnabled !== undefined ? forceEnabled : (this.shouldEnable() && !!this.decoder);
+
+        if (this.canvasElement) {
+            this.canvasElement.classList.toggle('d-none', !enabled);
+        }
+
+        if (this.videoElement) {
+            this.videoElement.classList.toggle('lcevc-hidden-video', enabled);
+        }
+    }
+
+    _forceToggleEnabled() {
+        if (this.toggleElement && !this.toggleElement.checked) {
+            this.toggleElement.checked = true;
+        }
+    }
+
+    _isToggleEnabled() {
+        return !!(this.toggleElement && this.toggleElement.checked);
+    }
+
+    _isKnownLcevcStream() {
+        return this.selectedItem?.provider === 'v-nova' || this.selectedItem?.tags?.includes('lcevc');
+    }
+
+    async _getLcevcNamespace() {
+        const lcevcNamespace = globalThis.LCEVCdec;
+        if (!lcevcNamespace) {
+            console.warn('LCEVC decoder library is not available. LCEVC playback will remain disabled.');
+            return null;
+        }
+
+        if (lcevcNamespace.ready && typeof lcevcNamespace.ready.then === 'function') {
+            try {
+                await lcevcNamespace.ready;
+            } catch (e) {
+                console.warn('LCEVC decoder library failed to initialize.', e);
+                return null;
+            }
+        }
+
+        return lcevcNamespace;
+    }
+
+    _attachDecoder(lcevcNamespace) {
+        if (!this.player || !this.videoElement || !this.canvasElement) {
+            return;
+        }
+
+        this.decoder = new lcevcNamespace.LCEVCdec(
+            this.videoElement,
+            this.canvasElement,
+            {
+                dynamicPerformanceScaling: false
+            }
+        );
+        this.player.LCEVCdec = this.decoder;
+
+        this._boundHandlers = {
+            qualityChangeRequested: (event) => {
+                if (!this.decoder || !event?.newRepresentation) {
+                    return;
+                }
+                if (event.mediaType === 'video' || event.mediaType === 'enhancement') {
+                    this.decoder.setLevelSwitching(event.newRepresentation.absoluteIndex, AUTO_RENDER_MODE.ENABLED);
+                }
+            },
+            fragmentLoadingCompleted: (event) => {
+                if (event?.mediaType === 'enhancement' && event.request?.representation) {
+                    this.abrIndex = event.request.representation.absoluteIndex;
+                }
+            },
+            representationSwitch: (event) => {
+                if (!this.decoder || (event?.mediaType !== 'video' && event?.mediaType !== 'enhancement')) {
+                    return;
+                }
+
+                const representation = event.currentRepresentation;
+                if (representation?.dependentRepresentation) {
+                    this.decoder.setLevelSwitching(representation.absoluteIndex, AUTO_RENDER_MODE.ENABLED);
+                }
+            },
+            externalSourceBufferUpdateStart: (event) => {
+                if (!this.decoder || !event) {
+                    return;
+                }
+
+                if (event.request === 'appendBuffer') {
+                    this.decoder.appendBuffer(event.data, 'video', this.abrIndex, 0, false);
+                } else if (event.request === 'remove') {
+                    this.decoder.flushBuffer(event.start, event.end);
+                }
+            }
+        };
+
+        this.player.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, this._boundHandlers.qualityChangeRequested);
+        this.player.on(dashjs.MediaPlayer.events.FRAGMENT_LOADING_COMPLETED, this._boundHandlers.fragmentLoadingCompleted);
+        this.player.on(dashjs.MediaPlayer.events.REPRESENTATION_SWITCH, this._boundHandlers.representationSwitch);
+        this.player.on('externalSourceBufferUpdateStart', this._boundHandlers.externalSourceBufferUpdateStart);
+    }
+
+    _detachPlayerHooks() {
+        if (!this.player || !this._boundHandlers || typeof this.player.off !== 'function') {
+            this._boundHandlers = null;
+            return;
+        }
+
+        this.player.off(dashjs.MediaPlayer.events.QUALITY_CHANGE_REQUESTED, this._boundHandlers.qualityChangeRequested);
+        this.player.off(dashjs.MediaPlayer.events.FRAGMENT_LOADING_COMPLETED, this._boundHandlers.fragmentLoadingCompleted);
+        this.player.off(dashjs.MediaPlayer.events.REPRESENTATION_SWITCH, this._boundHandlers.representationSwitch);
+        this.player.off('externalSourceBufferUpdateStart', this._boundHandlers.externalSourceBufferUpdateStart);
+        this._boundHandlers = null;
+    }
+}

--- a/samples/dash-if-reference-player/app/js/PlayerController.js
+++ b/samples/dash-if-reference-player/app/js/PlayerController.js
@@ -322,7 +322,9 @@ export class PlayerController extends EventEmitter {
             }
 
             // Index (playing) — from QUALITY_CHANGE_RENDERED event
-            const renderedRep = this._currentRenderedRep[type];
+            const renderedRep = type === 'video'
+                ? this._getCurrentCompositeVideoRepresentation()
+                : this._currentRenderedRep[type];
             if (renderedRep) {
                 const currentIdx = reps
                     ? reps.findIndex(r => r.id === renderedRep.id)
@@ -355,7 +357,9 @@ export class PlayerController extends EventEmitter {
 
             // Codec
             try {
-                const currentTrack = this.player.getCurrentTrackFor(type);
+                const currentTrack = type === 'video'
+                    ? this._getCurrentCompositeVideoRepresentation()?.mediaInfo
+                    : this.player.getCurrentTrackFor(type);
                 if (currentTrack && currentTrack.codec) {
                     metrics.codec = currentTrack.codec;
                 }
@@ -398,6 +402,18 @@ export class PlayerController extends EventEmitter {
         }
 
         return metrics;
+    }
+
+    /**
+     * Get the effective active video representation, including scalable selections.
+     * @returns {Representation|null}
+     */
+    _getCurrentCompositeVideoRepresentation() {
+        return this.player?.getActiveStream?.()
+            ?.getStreamProcessors?.()
+            ?.find((processor) => processor.getType() === 'video')
+            ?.getRepresentationController?.()
+            ?.getCurrentCompositeRepresentation?.() ?? null;
     }
 
     _calculateHTTPMetrics(type, dashMetrics) {

--- a/samples/dash-if-reference-player/app/js/main.js
+++ b/samples/dash-if-reference-player/app/js/main.js
@@ -13,6 +13,7 @@ import {DrmController} from './DrmController.js';
 import {MetricsDisplay} from './MetricsDisplay.js';
 import {ChartController} from './ChartController.js';
 import {NotificationPanel} from './NotificationPanel.js';
+import {LcevcController} from './LcevcController.js';
 
 // ---- State ----
 let playerController;
@@ -23,6 +24,7 @@ let drmController;
 let metricsDisplay;
 let chartController;
 let notificationPanel;
+let lcevcController;
 
 // ---- Initialization ----
 async function init() {
@@ -40,6 +42,7 @@ async function init() {
     }
 
     const videoElement = $('#video-element');
+    const enhancementCanvas = $('#enhancement-canvas');
 
     // 1. Create PlayerController and initialize dash.js
     playerController = new PlayerController();
@@ -71,6 +74,13 @@ async function init() {
     settingsController = new SettingsController(playerController);
     settingsController.init();
 
+    lcevcController = new LcevcController(playerController);
+    lcevcController.init({
+        videoElement,
+        canvasElement: enhancementCanvas,
+        toggleElement: $('#opt-enhancement-enabled')
+    });
+
     drmController = new DrmController();
     drmController.init();
 
@@ -88,7 +98,9 @@ async function init() {
     notificationPanel.init();
 
     // 5. Wire up button handlers
-    $('#btn-load').addEventListener('click', doLoad);
+    $('#btn-load').addEventListener('click', () => {
+        void doLoad();
+    });
     $('#btn-stop').addEventListener('click', doStop);
 
     // Copy URL (includes DRM protData from the DRM controller or the selected stream)
@@ -101,7 +113,7 @@ async function init() {
     // Allow Enter key in URL field to trigger load
     $('#stream-url').addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
-            doLoad();
+            void doLoad();
         }
     });
 
@@ -175,24 +187,30 @@ function onStreamSelected(item) {
     } else {
         drmController.clearAll();
     }
+
+    lcevcController.setSelectedItem(item);
 }
 
 // ---- Load / Stop ----
-function doLoad() {
+async function doLoad() {
     const url = streamCatalog.getUrl();
     if (!url) {
         return;
     }
 
+    const selectedItem = streamCatalog.getSelectedItem();
+    lcevcController.setSelectedItem(selectedItem);
+    const enhancementEnabled = await lcevcController.prepareForPlayback();
+
     // Build config from settings UI
     const config = settingsController.buildConfig();
+    config.streaming.enhancement.enabled = enhancementEnabled;
     playerController.updateSettings(config);
 
     // Set auto-play
     playerController.player.setAutoPlay(settingsController.autoPlay);
 
     // Build DRM protection data
-    const selectedItem = streamCatalog.getSelectedItem();
     let protData = drmController.buildProtectionData();
 
     // If stream item has embedded protData and user hasn't overridden, use stream's
@@ -225,6 +243,7 @@ function doLoad() {
 function doStop() {
     controlBar.disable();
     controlBar.reset();
+    lcevcController.stop();
     playerController.stop();
     chartController.clearAllData();
 }

--- a/samples/dash-if-reference-player/index.html
+++ b/samples/dash-if-reference-player/index.html
@@ -21,6 +21,8 @@
 
     <!-- Chart.js (UMD, exposes global Chart) -->
     <script src="vendor/chart.js/chart.umd.js"></script>
+    <!-- LCEVC Decoder -->
+    <script src="https://unpkg.com/lcevc_dec.js@latest/dist/lcevc_dec.min.js"></script>
 </head>
 <body>
 <div class="main-container">
@@ -479,6 +481,7 @@
         <div class="col-lg-8">
             <div id="video-wrapper">
                 <video id="video-element" disableRemotePlayback="true"></video>
+                <canvas id="enhancement-canvas" class="d-none"></canvas>
                 <div id="video-caption"></div>
                 <!-- Controlbar is injected here by ControlBar.js from contrib/controlbar -->
             </div>

--- a/test/unit/test/reference-player/refplayer.LcevcController.js
+++ b/test/unit/test/reference-player/refplayer.LcevcController.js
@@ -1,0 +1,133 @@
+/**
+ * Tests for the Reference Player LcevcController.
+ */
+
+import {expect} from 'chai';
+
+import {LcevcController} from '../../../../samples/dash-if-reference-player/app/js/LcevcController.js';
+
+describe('Reference Player - LcevcController', function () {
+    let originalDashjs;
+    let originalLcevcDec;
+    let mockPlayer;
+    let playerController;
+    let videoElement;
+    let canvasElement;
+    let toggleElement;
+    let closeCalls;
+    let registeredEvents;
+
+    function createMockPlayer() {
+        return {
+            LCEVCdec: null,
+            on: (eventName, handler) => {
+                registeredEvents.push({ eventName, handler });
+            },
+            off: (eventName, handler) => {
+                registeredEvents = registeredEvents.filter((entry) => {
+                    return !(entry.eventName === eventName && entry.handler === handler);
+                });
+            }
+        };
+    }
+
+    beforeEach(function () {
+        originalDashjs = globalThis.dashjs;
+        originalLcevcDec = globalThis.LCEVCdec;
+
+        closeCalls = 0;
+        registeredEvents = [];
+
+        globalThis.dashjs = {
+            MediaPlayer: {
+                events: {
+                    QUALITY_CHANGE_REQUESTED: 'qualityChangeRequested',
+                    FRAGMENT_LOADING_COMPLETED: 'fragmentLoadingCompleted',
+                    REPRESENTATION_SWITCH: 'representationSwitch'
+                }
+            }
+        };
+
+        globalThis.LCEVCdec = {
+            ready: Promise.resolve(),
+            LCEVCdec: class MockDecoder {
+                close() {
+                    closeCalls++;
+                }
+
+                setLevelSwitching() {}
+
+                appendBuffer() {}
+
+                flushBuffer() {}
+            }
+        };
+
+        mockPlayer = createMockPlayer();
+        playerController = { player: mockPlayer };
+
+        videoElement = document.createElement('video');
+        canvasElement = document.createElement('canvas');
+        toggleElement = document.createElement('input');
+        toggleElement.type = 'checkbox';
+
+        document.body.appendChild(videoElement);
+        document.body.appendChild(canvasElement);
+        document.body.appendChild(toggleElement);
+    });
+
+    afterEach(function () {
+        videoElement.remove();
+        canvasElement.remove();
+        toggleElement.remove();
+
+        globalThis.dashjs = originalDashjs;
+        globalThis.LCEVCdec = originalLcevcDec;
+    });
+
+    it('should auto-enable and attach the decoder for known LCEVC streams', async function () {
+        const controller = new LcevcController(playerController);
+        controller.init({
+            videoElement,
+            canvasElement,
+            toggleElement
+        });
+        controller.setSelectedItem({
+            provider: 'v-nova',
+            tags: ['lcevc']
+        });
+
+        const enabled = await controller.prepareForPlayback();
+
+        expect(enabled).to.be.true;
+        expect(toggleElement.checked).to.be.true;
+        expect(mockPlayer.LCEVCdec).to.exist;
+        expect(videoElement.classList.contains('lcevc-hidden-video')).to.be.true;
+        expect(canvasElement.classList.contains('d-none')).to.be.false;
+        expect(registeredEvents.map((entry) => entry.eventName)).to.deep.equal([
+            'qualityChangeRequested',
+            'fragmentLoadingCompleted',
+            'representationSwitch',
+            'externalSourceBufferUpdateStart'
+        ]);
+    });
+
+    it('should close the decoder and restore the base video on stop', async function () {
+        const controller = new LcevcController(playerController);
+        controller.init({
+            videoElement,
+            canvasElement,
+            toggleElement
+        });
+        toggleElement.checked = true;
+
+        await controller.prepareForPlayback();
+        controller.stop();
+
+        expect(closeCalls).to.equal(1);
+        expect(mockPlayer.LCEVCdec).to.equal(null);
+        expect(videoElement.classList.contains('lcevc-hidden-video')).to.be.false;
+        expect(canvasElement.classList.contains('d-none')).to.be.true;
+        expect(registeredEvents).to.have.lengthOf(0);
+    });
+});

--- a/test/unit/test/reference-player/refplayer.LcevcController.js
+++ b/test/unit/test/reference-player/refplayer.LcevcController.js
@@ -1,5 +1,9 @@
 /**
  * Tests for the Reference Player LcevcController.
+ *
+ * Covers the UI-side LCEVC lifecycle only:
+ * initialization for known LCEVC streams, decoder attachment,
+ * video/canvas visibility switching, and decoder/event-listener cleanup on stop.
  */
 
 import {expect} from 'chai';


### PR DESCRIPTION
## Summary

This PR restores MPEG-5 Part 2 LCEVC Dual-track Scalable Integration in the rewritten DASH-IF Reference UI.

The core dash.js LCEVC support was still present, but the new reference UI introduced in `#4974` no longer wired the UI to the LCEVC decoder runtime. As a result, LCEVC sample streams still appeared in the catalog and the UI still exposed the LCEVC checkbox, but the reference player no longer initialized the decoder or rendered enhancement output.

## What changed

- reintroduce the reference-player-side LCEVC integration in a dedicated `LcevcController`
- load the `lcevc_dec.js` decoder library in the new reference UI
- restore the enhancement canvas overlay required for rendered output
- wire stream selection, load, and stop lifecycle into LCEVC setup/cleanup
- automatically enable LCEVC for known LCEVC sample streams
- add unit tests covering LCEVC controller initialization and cleanup behavior
- adjust ControlBar UI selection logic to correctly highlight the effective selected representation during scalable video playback
- align Reference UI video metrics with the effective scalable video representation to avoid base-layer-only values being shown during dual-track playback

## Notes

This PR only restores the Reference UI integration path. It does not change the core dash.js LCEVC implementation.
