### PR TITLE
ci: deploy-specific build path and doc-only path filters

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
             -   name: Setup dash.js
                 uses: ./.github/actions/setup-dashjs
             -   name: Run build
-                run: npm run build
+                run: npm run build:dist
             -   name: Find and Replace
                 if: inputs.deploy_type == 'samples'
                 uses: jacobtomlinson/gha-find-replace@v2

--- a/.github/workflows/verify_branch.yml
+++ b/.github/workflows/verify_branch.yml
@@ -8,6 +8,11 @@ on:
             - '!development'
             - '!v4_main'
             - '!v4_development'
+        paths-ignore:
+            - '*.md'
+            - 'docs/**'
+            - 'proposals/**'
+            - 'LICENSES/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify_pull_request.yml
+++ b/.github/workflows/verify_pull_request.yml
@@ -4,6 +4,11 @@ on:
     pull_request:
         branches:
             - 'development'
+        paths-ignore:
+            - '*.md'
+            - 'docs/**'
+            - 'proposals/**'
+            - 'LICENSES/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Two CI changes from #5004 (P3).

Adds a `build:dist` script (`rimraf dist && tsc && webpack`, no tests or lint) for deploy workflows, where the code is already verified upstream. `deploy.yml` uses it instead of `build` for the nightly and v4 deploys.

Adds `paths-ignore` to `verify_pull_request` and `verify_branch` so changes limited to root `*.md`, `docs/**`, `proposals/**` or `LICENSES/**` no longer trigger a CI build.

Caveat: if `verify_pull_request` is a required check, `paths-ignore` can leave doc-only PRs pending, since the check never reports. If that becomes a problem we need a passthrough job or a `paths` filter instead.

`build:dist` is also added by #5008, so whichever lands second needs the duplicate line dropped.

Refs #5004
