### PR TITLE
fix(tests): correct unit tests that pass without verifying behavior

### DIFF
--- a/src/dash/parser/DashParser.js
+++ b/src/dash/parser/DashParser.js
@@ -109,7 +109,7 @@ function DashParser(config) {
 
         manifest = parseXml(data);
 
-        if (!manifest) {
+        if (!manifest || (!manifest.MPD && !manifest.Patch)) {
             throw new Error('failed to parse the manifest');
         }
 

--- a/test/unit/test/dash/dash.DashParser.js
+++ b/test/unit/test/dash/dash.DashParser.js
@@ -15,17 +15,17 @@ const dashManifestModel = DashManifestModel(context).getInstance();
 describe('DashParser', function () {
 
     it('should throw an error when parse is called without data and config object has been set properly', () => {
-        expect(dashParser.parse.bind('')).to.be.throw('failed to parse the manifest');
+        expect(() => dashParser.parse('')).to.throw('failed to parse the manifest');
     });
 
     it('should throw an error when parse is called with invalid data', async () => {
         let manifest = await FileLoader.loadTextFile('/data/dash/manifest_error.xml');
-        expect(dashParser.parse.bind(manifest)).to.be.throw('failed to parse the manifest');
+        expect(() => dashParser.parse(manifest)).to.throw('failed to parse the manifest');
     });
 
     it('should return an Object when parse is called with correct data', async () => {
         let manifest = await FileLoader.loadTextFile('/data/dash/manifest.xml');
-        expect(dashParser.parse.bind(manifest)).to.be.instanceOf(Object);
+        expect(dashParser.parse(manifest)).to.be.instanceOf(Object);
     });
 
     describe('DashParser matchers', function () {
@@ -61,14 +61,18 @@ describe('DashParser', function () {
         });
     });
 
-    describe('DashParser - ObjectIron', async () => {
+    describe('DashParser - ObjectIron', () => {
+        let manifest_prop;
+
+        before(async () => {
+            manifest_prop = await FileLoader.loadTextFile('/data/dash/manifest_properties.xml');
+        });
+
         beforeEach(function () {
             dashManifestModel.setConfig({
                 errHandler: errorHandlerMock
             });
         });
-
-        let manifest_prop = await FileLoader.loadTextFile('/data/dash/manifest_properties.xml');
 
         it('should map AudioChannelConfig even if another instance is present on Representation', async () => {
             let parsedMpd = dashParser.parse(manifest_prop);

--- a/test/unit/test/dash/dash.DashParser.js
+++ b/test/unit/test/dash/dash.DashParser.js
@@ -28,6 +28,22 @@ describe('DashParser', function () {
         expect(dashParser.parse(manifest)).to.be.instanceOf(Object);
     });
 
+    it('should return a parsed Patch object when parse is called with valid patch data', () => {
+        const patchManifest = `<?xml version="1.0" encoding="UTF-8"?>
+<Patch mpdId="foobar"
+       publishTime="2020-01-01T00:00:01Z"
+       originalPublishTime="2020-01-01T00:00:00Z">
+    <replace sel="/MPD/@publishTime">2020-01-01T00:00:01Z</replace>
+</Patch>`;
+        const parsedPatch = dashParser.parse(patchManifest);
+
+        expect(parsedPatch).to.be.instanceOf(Object);
+        expect(parsedPatch.protocol).to.equal('DASH');
+        expect(parsedPatch.mpdId).to.equal('foobar');
+        expect(parsedPatch.replace).to.be.instanceOf(Array);
+        expect(parsedPatch.replace).to.have.lengthOf(1);
+    });
+
     describe('DashParser matchers', function () {
         let manifest;
 
@@ -120,6 +136,5 @@ describe('DashParser', function () {
 
     });
 })
-
 
 

--- a/test/unit/test/mss/mss.parser.MssParser.js
+++ b/test/unit/test/mss/mss.parser.MssParser.js
@@ -59,7 +59,7 @@ describe('MssParser', function () {
     });
 
     it('should throw an error when parse is called with invalid smooth data', function () {
-        expect(mssParser.parse.bind('<SmoothStreamingMedia')).to.be.throw('parsing the manifest failed');
+        expect(() => mssParser.parse('<SmoothStreamingMedia')).to.throw('parsing the manifest failed');
     });
 
     it('should map mss subtype to dash role', async () => {

--- a/test/unit/test/streaming/streaming.Stream.js
+++ b/test/unit/test/streaming/streaming.Stream.js
@@ -90,11 +90,9 @@ describe('Stream', function () {
             expect(processors).to.be.empty; // jshint ignore:line
         });
 
-        it('should trigger MANIFEST_ERROR_ID_NOSTREAMS_CODE error when setMediaSource is called but streamProcessors array is empty', () => {
-            stream.setMediaSource()
-                .then(() => {
-                    expect(errHandlerMock.errorCode).to.be.equal(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE); // jshint ignore:line
-                })
+        it('should trigger MANIFEST_ERROR_ID_NOSTREAMS_CODE error when setMediaSource is called but streamProcessors array is empty', async () => {
+            await stream.setMediaSource();
+            expect(errHandlerMock.errorCode).to.be.equal(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE); // jshint ignore:line
         });
 
         it('should return an null when getId is called but streamInfo attribute is null or undefined', () => {


### PR DESCRIPTION
## Summary

Fixes 4 unit tests that counted as "passed" without actually exercising the code they describe, fixes the parser bug they were hiding, and adds a missing test for Patch parsing. See #5011 for the full analysis.

**Test fixes (commit 1):**

1. **`dash.DashParser.js` lines 17-28** — replace `.bind()` with arrow functions so `parse()` is actually called
2. **`mss.parser.MssParser.js` line 62** — same `.bind()` fix
3. **`dash.DashParser.js` line 64** — move `await` from unsupported `async describe()` into a `before()` hook
4. **`streaming.Stream.js` lines 93-98** — `await` the Promise from `setMediaSource()` so the assertion runs before Mocha marks the test as passed

**Parser fix (commit 2):**

Fixing the `.bind()` pattern revealed that `DashParser.parse()` does not reject non-MPD XML input. `parseXml()` returns a non-null object for any parseable string, so the existing `if (!manifest)` guard passes, and the code crashes later on `.protocol` access.

The fix strengthens the validation gate to check for `MPD` or `Patch` root elements: `if (!manifest || (!manifest.MPD && !manifest.Patch))`.

**New test (commit 3):**

Adds a test verifying that `parse()` correctly handles valid Patch XML input (MPD Patch per DASH-IF spec), exercising the `manifest.Patch` branch that was previously untested.

## Impact

| Metric | Before (development) | After (this PR) |
|---|---|---|
| Tests executed | 3612 | 3616 |
| Tests passing | 3612 | 3616 |
| Tests failing | 0 | 0 |
| Silently ineffective tests | 8 | 0 |
| Parser bug hidden by tests | 1 | **fixed** |

## Test plan

- [ ] All unit tests pass in CI (Chrome + Firefox)
- [ ] DashParser correctly rejects non-MPD input with `'failed to parse the manifest'`
- [ ] DashParser correctly parses valid Patch XML
- [ ] MssParser correctly rejects invalid MSS input

Fixes #5011

🤖 Generated with [Claude Code](https://claude.com/claude-code)