### PR TITLE
fix(tests): improve test reliability — FileLoader errors, state cleanup, debug logs

### DIFF
--- a/test/unit/helpers/FileLoader.js
+++ b/test/unit/helpers/FileLoader.js
@@ -27,29 +27,24 @@ class FileLoader {
     }
 
     static async _loadFile(url, options, returnType) {
-        try {
-            url = HTTP_SERVER + url;
-            const response = await fetch(url, options);
+        url = HTTP_SERVER + url;
+        const response = await fetch(url, options);
 
-            if (!response.ok) {
-                console.log('Network response was not OK');
-            }
+        if (!response.ok) {
+            throw new Error(`FileLoader: ${url} returned ${response.status}`);
+        }
 
-            switch (returnType) {
-                case TYPES.TEXT:
-                    return response.text();
-                case TYPES.JSON:
-                    return response.json();
-                case TYPES.ARRAY_BUFFER:
-                    return response.arrayBuffer();
-                case TYPES.BLOB:
-                    return response.blob();
-                default:
-                    return response.text();
-
-            }
-        } catch (e) {
-            console.log(e);
+        switch (returnType) {
+            case TYPES.TEXT:
+                return response.text();
+            case TYPES.JSON:
+                return response.json();
+            case TYPES.ARRAY_BUFFER:
+                return response.arrayBuffer();
+            case TYPES.BLOB:
+                return response.blob();
+            default:
+                return response.text();
         }
     }
 }

--- a/test/unit/mocks/VideoModelMock.js
+++ b/test/unit/mocks/VideoModelMock.js
@@ -169,7 +169,6 @@ class VideoModelMock {
     getCurrentCue(textTrack) {
         const textTrackList = this.element.textTracks;
         const track = textTrackList.getTrackById(textTrack.id);
-        console.log('track', track);
         if (!track) {
             return null;
         }

--- a/test/unit/test/streaming/streaming.controllers.AbrController.js
+++ b/test/unit/test/streaming/streaming.controllers.AbrController.js
@@ -82,6 +82,7 @@ describe('AbrController', function () {
         abrCtrl.reset();
         settings.reset();
         eventBus.reset();
+        dummyRepresentations[0].segmentSequenceProperties = undefined;
     });
 
     describe('getOptimalRepresentationForBitrate()', function () {

--- a/test/unit/test/streaming/streaming.controllers.ExtUrlQueryInfoController.js
+++ b/test/unit/test/streaming/streaming.controllers.ExtUrlQueryInfoController.js
@@ -134,7 +134,7 @@ describe('ExtUrlQueryInfoController', () => {
 
             const expectedResult = [{key: 'urlParam1' , value: 'urlValue1'}, {key: 'urlParam2' , value: 'urlValue2'}];
             const result = extUrlQueryInfoController.getFinalQueryString(request);
-            console.log(result)
+
             expect(result).to.have.deep.members(expectedResult);
         });
     
@@ -269,7 +269,7 @@ describe('ExtUrlQueryInfoController', () => {
             }; 
             
             const result = extUrlQueryInfoController.getFinalQueryString(request);
-            console.log(result)
+
             expect(result).to.be.undefined;
         });
 

--- a/test/unit/test/streaming/streaming.controllers.ServiceDescriptionController.js
+++ b/test/unit/test/streaming/streaming.controllers.ServiceDescriptionController.js
@@ -86,7 +86,6 @@ describe('ServiceDescriptionController', () => {
             serviceDescriptionController.applyServiceDescription(dummyManifestInfo);
 
             const currentSettings = serviceDescriptionController.getServiceDescriptionSettings();
-            console.log('currentSettings', currentSettings)
             expect(currentSettings.liveDelay).to.be.NaN;
             expect(currentSettings.liveCatchup.maxDrift).to.be.NaN;
             expect(currentSettings.liveCatchup.playbackRate.min).to.be.NaN;


### PR DESCRIPTION
## Summary

Follow-up to #5012, addressing the remaining P1/P2/P3 items from #5011.

**P1 — FileLoader now throws on HTTP errors:**
`FileLoader._loadFile()` previously logged errors to console and returned `undefined`, letting tests silently operate on bad input. It now throws with a clear message (`FileLoader: <url> returned <status>`), making fixture-loading failures immediately visible as test failures.

**P2 — AbrController state cleanup:**
Tests in the `manuallySetPlaybackQuality` block modify `dummyRepresentations[0].segmentSequenceProperties` without restoring it. Added a reset in `afterEach` to prevent order-dependent test failures.

**P3 — Remove debug console.log:**
Removed leftover `console.log` calls from:
- `VideoModelMock.js` (line 172)
- `streaming.controllers.ExtUrlQueryInfoController.js` (lines 137, 272)
- `streaming.controllers.ServiceDescriptionController.js` (line 89)

**Not included:** The `StreamController` EventBus listener cleanup (P2) was investigated but causes a regression on Firefox due to test ordering dependencies in the `error management` block. This needs a deeper fix and is left for a separate PR.

## Test plan

- [ ] All unit tests pass in CI
- [ ] No regressions from FileLoader change (tests that load fixtures still work)
- [ ] AbrController tests pass regardless of execution order

Refs #5011

🤖 Generated with [Claude Code](https://claude.com/claude-code)