### PR TITLE
Avoid Redundant DRM License Requests for Already-Usable Keys

### DIFF
--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -220,6 +220,37 @@ class CommonEncryption {
 
         return pssh;
     }
+    /**
+     * Extracts key IDs from PSSH boxes with version >= 1
+     *
+     * @param {ArrayBuffer|Uint8Array} data - concatenated PSSH box data
+     * @returns {string[]} array of key IDs as lowercase hex strings
+     */
+    static extractKeyIdsFromPssh(data) {
+        if (!data) {
+            return [];
+        }
+        const dv = new DataView(data.buffer || data);
+        const keyIds = [];
+        let byteCursor = 0;
+        while (byteCursor < dv.byteLength) {
+            const size = dv.getUint32(byteCursor);
+            if (dv.getUint32(byteCursor + 4) !== 0x70737368) { byteCursor += size; continue; }
+            const version = dv.getUint8(byteCursor + 8);
+            if (version >= 1) {
+                const kidCount = dv.getUint32(byteCursor + 28);
+                for (let i = 0; i < kidCount; i++) {
+                    const offset = 32 + (i * 16);
+                    const kidBytes = new Uint8Array(dv.buffer, byteCursor + offset, 16);
+                    const hex = Array.from(kidBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+                    keyIds.push(hex);
+                }
+            }
+            byteCursor += size;
+        }
+        return keyIds;
+    }
+
 
     static getLicenseServerUrlFromMediaInfo(mediaInfoArr, schemeIdUri) {
         try {

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -673,6 +673,12 @@ function ProtectionController(config) {
             return;
         }
 
+        // Check if the CDM already has a usable key for this KID (e.g. from a multi-key license)
+        if (keySystemMetadata && keySystemMetadata.keyId && _isKeyIdUsableInCdm(keySystemMetadata.keyId)) {
+            logger.debug('DRM: Skipping license request — CDM already has a usable key for KID: ' + keySystemMetadata.keyId);
+            return;
+        }
+
         // Enforce maximum number of open MediaKeySessions, if settings are provided
         _enforceMediaKeySessionLimit();
 
@@ -807,6 +813,23 @@ function ProtectionController(config) {
     }
 
     /**
+     * Checks if the CDM already reports a usable key status for the given key ID,
+     * even if no session was explicitly created for it (e.g. multi-key license).
+     * @param {string} keyId
+     * @return {boolean}
+     * @private
+     */
+    function _isKeyIdUsableInCdm(keyId) {
+        if (!keyId || keyStatusMap.size === 0) {
+            return false;
+        }
+        const normalizedKeyId = keyId.replace(/-/g, '').toLowerCase();
+        const status = keyStatusMap.get(normalizedKeyId);
+        return status === ProtectionConstants.MEDIA_KEY_STATUSES.USABLE;
+    }
+
+
+    /**
      * Checks if the provided init data is equal to one of the existing init data values
      * @param {any} initDataForKS
      * @return {boolean}
@@ -832,6 +855,25 @@ function ProtectionController(config) {
             return false;
         }
     }
+
+    function _areAllKeysUsableForInitData(initData) {
+        if (keyStatusMap.size === 0) {
+            return false;
+        }
+        try {
+            const keyIds = CommonEncryption.extractKeyIdsFromPssh(initData);
+            if (!keyIds || keyIds.length === 0) {
+                return false;
+            }
+            return keyIds.every((kid) => {
+                const status = keyStatusMap.get(kid);
+                return status === ProtectionConstants.MEDIA_KEY_STATUSES.USABLE;
+            });
+        } catch (e) {
+            return false;
+        }
+    }
+
 
     /**
      * Removes the given key session from persistent storage and closes the session
@@ -1432,6 +1474,12 @@ function ProtectionController(config) {
             if (initDataForCheck && _isInitDataDuplicate(initDataForCheck)) {
                 return;
             }
+        }
+
+        // ← NEW CHECK: extract KIDs from PSSH and check if CDM already has usable keys
+        if (selectedKeySystem && !isSinf && _areAllKeysUsableForInitData(abInitData)) {
+            logger.debug('DRM: Skipping license request — CDM already has usable key(s) for KID(s) in initData');
+            return;
         }
 
         logger.debug('DRM: initData:', String.fromCharCode.apply(null, new Uint8Array(abInitData)));

--- a/test/unit/test/streaming/streaming.protection.CommonEncryption.js
+++ b/test/unit/test/streaming/streaming.protection.CommonEncryption.js
@@ -136,4 +136,90 @@ describe('CommonEncryption', () => {
         })
 
     });
+
+    describe('extractKeyIdsFromPssh', () => {
+
+        it('should return empty array for null input', () => {
+            expect(CommonEncryption.extractKeyIdsFromPssh(null)).to.be.empty;
+        });
+
+        it('should return empty array for undefined input', () => {
+            expect(CommonEncryption.extractKeyIdsFromPssh(undefined)).to.be.empty;
+        });
+
+        it('should return empty array for version 0 PSSH (no KIDs)', () => {
+            // Build a minimal version 0 PSSH box: size(4) + 'pssh'(4) + version(1) + flags(3) + systemID(16) + dataSize(4) = 32 bytes
+            const buffer = new ArrayBuffer(32);
+            const dv = new DataView(buffer);
+            dv.setUint32(0, 32); // box size
+            dv.setUint32(4, 0x70737368); // 'pssh'
+            dv.setUint8(8, 0); // version 0
+            // flags (3 bytes) = 0, systemID (16 bytes) = 0, dataSize (4 bytes) = 0
+            dv.setUint32(28, 0); // data size
+
+            const result = CommonEncryption.extractKeyIdsFromPssh(buffer);
+            expect(result).to.be.an('array').that.is.empty;
+        });
+
+        it('should extract a single KID from a version 1 PSSH box', () => {
+            // version 1 PSSH: size(4) + 'pssh'(4) + version(1) + flags(3) + systemID(16) + kidCount(4) + KID(16) + dataSize(4) = 48 bytes
+            const buffer = new ArrayBuffer(52);
+            const dv = new DataView(buffer);
+            dv.setUint32(0, 52); // box size
+            dv.setUint32(4, 0x70737368); // 'pssh'
+            dv.setUint8(8, 1); // version 1
+            // flags = 0 (bytes 9-11)
+            // systemID (bytes 12-27) = 0
+            dv.setUint32(28, 1); // kidCount = 1
+            // KID at offset 32, 16 bytes: 01020304-0506-0708-090a-0b0c0d0e0f10
+            const kid = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10];
+            kid.forEach((b, i) => { dv.setUint8(32 + i, b); });
+            dv.setUint32(48, 0); // data size
+
+            const result = CommonEncryption.extractKeyIdsFromPssh(buffer);
+            expect(result).to.have.lengthOf(1);
+            expect(result[0]).to.equal('0102030405060708090a0b0c0d0e0f10');
+        });
+
+        it('should extract multiple KIDs from a version 1 PSSH box', () => {
+            // 2 KIDs: size(4) + 'pssh'(4) + version(1) + flags(3) + systemID(16) + kidCount(4) + 2*KID(32) + dataSize(4) = 68 bytes
+            const buffer = new ArrayBuffer(68);
+            const dv = new DataView(buffer);
+            dv.setUint32(0, 68); // box size
+            dv.setUint32(4, 0x70737368); // 'pssh'
+            dv.setUint8(8, 1); // version 1
+            dv.setUint32(28, 2); // kidCount = 2
+            // KID 1
+            for (let i = 0; i < 16; i++) { dv.setUint8(32 + i, 0xAA); }
+            // KID 2
+            for (let i = 0; i < 16; i++) { dv.setUint8(48 + i, 0xBB); }
+            dv.setUint32(64, 0); // data size
+
+            const result = CommonEncryption.extractKeyIdsFromPssh(buffer);
+            expect(result).to.have.lengthOf(2);
+            expect(result[0]).to.equal('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+            expect(result[1]).to.equal('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+        });
+
+        it('should skip non-PSSH boxes and still extract KIDs', () => {
+            // First box: non-PSSH (8 bytes), second box: version 1 PSSH with 1 KID (52 bytes)
+            const buffer = new ArrayBuffer(60);
+            const dv = new DataView(buffer);
+            // Non-PSSH box
+            dv.setUint32(0, 8); // size
+            dv.setUint32(4, 0x66726565); // 'free'
+            // PSSH box
+            dv.setUint32(8, 52); // size
+            dv.setUint32(12, 0x70737368); // 'pssh'
+            dv.setUint8(16, 1); // version 1
+            dv.setUint32(36, 1); // kidCount = 1
+            for (let i = 0; i < 16; i++) { dv.setUint8(40 + i, 0xCC); }
+            dv.setUint32(56, 0); // data size
+
+            const result = CommonEncryption.extractKeyIdsFromPssh(buffer);
+            expect(result).to.have.lengthOf(1);
+            expect(result[0]).to.equal('cccccccccccccccccccccccccccccccc');
+        });
+    });
 })

--- a/test/unit/test/streaming/streaming.protection.controllers.ProtectionController.js
+++ b/test/unit/test/streaming/streaming.protection.controllers.ProtectionController.js
@@ -197,5 +197,45 @@ describe('ProtectionController', function () {
             expect(protectionModelMock.getSessionTokens().map(s => s.keyId)).to.deep.equal(['session-1', 'session-2', 'session-3']);
         });
 
+        it('should skip createKeySession when CDM already has a usable key for the given keyId', function () {
+            CommonEncryption.getPSSHForKeySystem = (selectedKeySystem, initData) => initData;
+            protectionController.selectedKeySystem = { systemString: 'mock-system' };
+
+            // Simulate a usable key status for a KID
+            const keyId = 'abcdef01-2345-6789-abcd-ef0123456789';
+            const normalizedKeyId = keyId.replace(/-/g, '').toLowerCase();
+            protectionController.updateKeyStatusesMap({
+                sessionToken: { hasTriggeredKeyStatusMapUpdate: false },
+                parsedKeyStatuses: [{ keyId: CommonEncryption.hexKidToBufferSource(normalizedKeyId), status: 'usable' }]
+            });
+
+            // Attempt to create a session for the same KID — should be skipped
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: keyId, sessionType: 'temporary' });
+            expect(protectionModelMock.getSessionTokens().length).to.equal(0);
+        });
+
+        it('should create a session when CDM key status is not usable', function () {
+            CommonEncryption.getPSSHForKeySystem = (selectedKeySystem, initData) => initData;
+            protectionController.selectedKeySystem = { systemString: 'mock-system' };
+
+            const keyId = 'abcdef01-2345-6789-abcd-ef0123456789';
+            const normalizedKeyId = keyId.replace(/-/g, '').toLowerCase();
+            protectionController.updateKeyStatusesMap({
+                sessionToken: { hasTriggeredKeyStatusMapUpdate: false },
+                parsedKeyStatuses: [{ keyId: CommonEncryption.hexKidToBufferSource(normalizedKeyId), status: 'expired' }]
+            });
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: keyId, sessionType: 'temporary' });
+            expect(protectionModelMock.getSessionTokens().length).to.equal(1);
+        });
+
+        it('should create a session when keyStatusMap is empty', function () {
+            CommonEncryption.getPSSHForKeySystem = (selectedKeySystem, initData) => initData;
+            protectionController.selectedKeySystem = { systemString: 'mock-system' };
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: 'some-key-id', sessionType: 'temporary' });
+            expect(protectionModelMock.getSessionTokens().length).to.equal(1);
+        });
+
     });
 });


### PR DESCRIPTION
# Feature Request: Avoid Redundant DRM License Requests for Already-Usable Keys

## Summary

When a multi-key DRM license has already been acquired, dash.js currently issues redundant license requests for key IDs (KIDs) that the CDM already reports as `usable`. This feature adds checks at multiple points in the protection pipeline to skip unnecessary license exchanges, reducing network overhead and improving playback startup for multi-period or multi-key encrypted content.

## Motivation

In scenarios involving multi-key licenses (e.g. a single license response covers multiple KIDs), the player may encounter `needkey`/`encrypted` events or manifest-signaled init data for KIDs that are already available in the CDM. Without this optimization, each event triggers a full license server round-trip even though the CDM can already decrypt the content. This is wasteful and can introduce unnecessary latency, especially on low-bandwidth connections or with rate-limited license servers.

## Changes

### 1. `CommonEncryption.js` — Extract Key IDs from PSSH boxes

- **New static method**: `extractKeyIdsFromPssh(data)`
- Parses concatenated PSSH box data and extracts KIDs from version ≥ 1 PSSH boxes.
- Returns an array of hex-encoded key ID strings.
- Used by `ProtectionController` to determine which KIDs are referenced in incoming init data.

### 2. `ProtectionController.js` — Skip license requests when keys are already usable

- **New private function**: `_isKeyIdUsableInCdm(keyId)`
  - Checks the internal `keyStatusMap` for a normalized key ID.
  - Returns `true` if the CDM reports the key as `usable`.
  - Called in `createKeySession()` before creating a new session, short-circuiting if the key is already available.

- **New private function**: `_areAllKeysUsableForInitData(initData)`
  - Uses `CommonEncryption.extractKeyIdsFromPssh()` to get all KIDs from the init data.
  - Returns `true` only if every extracted KID is already `usable` in the CDM.
  - Called in `_onNeedKey()` to skip processing `encrypted` events when all referenced keys are already available.

- **Guard in `createKeySession()`**: Before enforcing session limits or creating a session, checks `_isKeyIdUsableInCdm()` and returns early with a debug log if the key is already usable.

- **Guard in `_onNeedKey()`**: After duplicate init data checks but before dispatching to key system selection, checks `_areAllKeysUsableForInitData()` and returns early for non-SINF init data when all keys are usable.
