### PR TITLE
Fix unreachable code warning in MediaController, update eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,5 +60,6 @@ export default [{
         'space-infix-ops': ['error', {
             int32Hint: true,
         }],
+        'no-unreachable': 'error',
     },
 }];

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -525,8 +525,8 @@ function MediaController() {
 
             return (matchLang && matchIndex && matchViewPoint && (matchRole || (track.type === Constants.AUDIO && isTrackActive)) && matchAccessibility && matchAudioChannelConfiguration);
         } catch (e) {
-            return false;
             logger.error(e);
+            return false;
         }
     }
 


### PR DESCRIPTION
Fix unreachable code warning in MediaController and update eslint config to prevent future occurences.