### PR TITLE
Use responseStart for resourceTiming.responseStart

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -556,7 +556,7 @@ function HTTPLoader(cfg) {
         // Update CommonMediaResponse Resource Timing info
         httpResponse.resourceTiming.startTime = resource.startTime;
         httpResponse.resourceTiming.encodedBodySize = resource.encodedBodySize;
-        httpResponse.resourceTiming.responseStart = resource.startTime;
+        httpResponse.resourceTiming.responseStart = resource.responseStart;
         httpResponse.resourceTiming.responseEnd = resource.responseEnd;
         httpResponse.resourceTiming.duration = resource.duration;
     }


### PR DESCRIPTION
This addresses the comment in #5022 

> Just curious why you fill httpResponse.resourceTiming.responseStart with resource.startTime, but use resource.responseStart for throughput computation ?