### PR TITLE
fix: handle VOD tail buffering completion

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -517,8 +517,10 @@ function StreamProcessor(config) {
             const period = representation.adaptation.period;
             const periodEnd = period.start + period.duration;
 
-            // If there is no valid target time ahead and the buffering time is within the duration of one segment we slightly adjust it
-            if (isFinite(periodEnd) && bufferingTime < periodEnd && bufferingTime >= periodEnd - representation.segmentDuration) {
+            // If there is no valid target time ahead and the buffering time is within the duration of one segment we slightly adjust it.
+            // Restrict the tail-time fallback to the final period — for any earlier period, an inter-period gap jump should advance into the
+            // next period rather than seeking backward inside the current one.
+            if (streamInfo.isLast && isFinite(periodEnd) && bufferingTime < periodEnd && bufferingTime >= periodEnd - representation.segmentDuration) {
                 adjustedTime = Math.max(period.start, bufferingTime - 0.1);
             }
         }

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -478,6 +478,14 @@ function StreamProcessor(config) {
     function _noMediaRequestGenerated(rescheduleIfNoRequest) {
         const representation = representationController.getCurrentRepresentation();
 
+        // A missing media request can also mean that the last segment has already
+        // been requested. Handle completion before applying gap seek fixes;
+        // otherwise a static VOD tail can be misclassified as a manifest gap.
+        const hasHandledBufferingComplete = checkAndHandleCompletedBuffering();
+        if (hasHandledBufferingComplete) {
+            return
+        }
+
         // If  this statement is true we might be stuck. A static manifest does not change and we did not find a valid request for the target time
         // There is no point in trying again. We need to adjust the time in order to find a valid request. This can happen if the user/app seeked into a gap.
         // For dynamic manifests this can also happen especially if we jump over the gap in the previous period and are using SegmentTimeline and in case there is a positive eptDelta at the beginning of the period we are stuck.
@@ -498,12 +506,6 @@ function StreamProcessor(config) {
             logger.error(e);
         }
 
-        // Check if the media is finished. If so, no need to schedule another request
-        const hasHandledBufferingComplete = checkAndHandleCompletedBuffering();
-        if (hasHandledBufferingComplete) {
-            return
-        }
-
         if (rescheduleIfNoRequest) {
             _noValidRequest();
         }
@@ -512,9 +514,12 @@ function StreamProcessor(config) {
     function _getAdjustedTimeForStaticManifest(representation) {
         let adjustedTime = dashHandler.getValidTimeAheadOfTargetTime(bufferingTime, currentMediaInfo, representation, settings.get().streaming.gaps.threshold);
         if (isNaN(adjustedTime)) {
+            const period = representation.adaptation.period;
+            const periodEnd = period.start + period.duration;
+
             // If there is no valid target time ahead and the buffering time is within the duration of one segment we slightly adjust it
-            if (bufferingTime >= representation.adaptation.period.mpd.mediaPresentationDuration - representation.segmentDuration) {
-                adjustedTime = bufferingTime - 0.1;
+            if (isFinite(periodEnd) && bufferingTime < periodEnd && bufferingTime >= periodEnd - representation.segmentDuration) {
+                adjustedTime = Math.max(period.start, bufferingTime - 0.1);
             }
         }
 


### PR DESCRIPTION
## Summary
This change fixes a false-positive gap recovery path at the tail of static VOD playback. In some assets, once the last media segment has already been requested, `StreamProcessor` can enter the "no media request generated" path even though playback is effectively complete. The previous ordering applied static-manifest gap adjustment before checking for completed buffering, so the VOD tail could be treated like a manifest gap and trigger an unnecessary internal seek near the end of the period.

The fix handles completed buffering first and only falls back to gap recovery when playback is not actually finished. It also uses the current period end, rather than the MPD presentation duration, when deciding whether a small tail-time adjustment is still valid for static content.

## Why this is needed
- static VOD tail conditions should not be classified as manifest gaps
- once the final segment has already been requested, the player should prefer completion handling over another seek-recovery attempt
- period-local end checks are safer than MPD-wide duration checks for tail handling, especially in multi-period content

## Testing
- not run