### PR TITLE
Abort retrieveManifest requests after reset

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -170,7 +170,7 @@ function MediaPlayer() {
         domStorage,
         segmentBaseController,
         clientDataReportingController,
-        retrieveManifestLoader;
+        retrieveManifestRequest;
 
     /*
     ---------------------------------------------------------------------------
@@ -480,8 +480,9 @@ function MediaPlayer() {
             offlineController = null;
         }
 
-        if (retrieveManifestLoader) {
-            retrieveManifestLoader.reset();
+        if (retrieveManifestRequest) {
+            retrieveManifestRequest.resetLoader();
+            retrieveManifestRequest = null;
         }
     }
 
@@ -2174,23 +2175,33 @@ function MediaPlayer() {
      * @instance
      */
     function retrieveManifest(url, callback) {
-        retrieveManifestLoader = _createManifestLoader();
-        let self = this;
+        if (retrieveManifestRequest) {
+            retrieveManifestRequest.resetLoader();
+        }
 
-        const handler = function (e) {
+        const manifestLoader = _createManifestLoader();
+        const resetLoader = () => {
+            eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, this);
+            manifestLoader.reset();
+            retrieveManifestRequest = null;
+        };
+
+        retrieveManifestRequest = { manifestLoader, resetLoader };
+
+        const handler = (e) => {
             if (!e.error) {
                 callback(e.manifest);
             } else {
                 callback(null, e.error);
             }
-            eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
-            retrieveManifestLoader.reset();
+
+            resetLoader();
         };
 
-        eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+        eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, this);
 
         uriFragmentModel.initialize(url);
-        retrieveManifestLoader.load(url);
+        manifestLoader.load(url);
     }
 
     /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2189,10 +2189,12 @@ function MediaPlayer() {
         retrieveManifestRequest = { manifestLoader, resetLoader };
 
         const handler = (e) => {
-            if (!e.error) {
-                callback(e.manifest);
-            } else {
-                callback(null, e.error);
+            if (typeof callback == 'function') {
+                if (!e.error) {
+                    callback(e.manifest);
+                } else {
+                    callback(null, e.error);
+                }
             }
 
             resetLoader();

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -169,7 +169,8 @@ function MediaPlayer() {
         uriFragmentModel,
         domStorage,
         segmentBaseController,
-        clientDataReportingController;
+        clientDataReportingController,
+        retrieveManifestLoader;
 
     /*
     ---------------------------------------------------------------------------
@@ -477,6 +478,10 @@ function MediaPlayer() {
         if (offlineController) {
             offlineController.reset();
             offlineController = null;
+        }
+
+        if (retrieveManifestLoader) {
+            retrieveManifestLoader.reset();
         }
     }
 
@@ -2169,7 +2174,7 @@ function MediaPlayer() {
      * @instance
      */
     function retrieveManifest(url, callback) {
-        let manifestLoader = _createManifestLoader();
+        retrieveManifestLoader = _createManifestLoader();
         let self = this;
 
         const handler = function (e) {
@@ -2179,13 +2184,13 @@ function MediaPlayer() {
                 callback(null, e.error);
             }
             eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
-            manifestLoader.reset();
+            retrieveManifestLoader.reset();
         };
 
         eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
 
         uriFragmentModel.initialize(url);
-        manifestLoader.load(url);
+        retrieveManifestLoader.load(url);
     }
 
     /**

--- a/test/unit/test/streaming/streaming.MediaPlayer.js
+++ b/test/unit/test/streaming/streaming.MediaPlayer.js
@@ -1389,5 +1389,50 @@ describe('MediaPlayer with context injected', () => {
                 expect(stub.calledWith(null, 'Mocked!')).to.be.true;
             });
         })
-    })
+    });
+
+    describe('retrieveManifest', () => {
+        it('retrieveManifest callback should be invoked when INTERNAL_MANIFEST_LOADED is triggered', () => {
+            player.initialize(videoElementMock, null, false);
+
+            const stub = sinon.spy();
+
+            player.retrieveManifest(specHelper.getDummyUrl(), stub);
+
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {});
+
+            expect(stub.calledOnce).to.be.true;
+        });
+
+        it('retrieveManifest handler should be unregistered after reset so a later INTERNAL_MANIFEST_LOADED does not invoke the callback', () => {
+            player.initialize(videoElementMock, null, false);
+
+            const stub = sinon.spy();
+
+            player.retrieveManifest(specHelper.getDummyUrl(), stub);
+
+            player.reset();
+
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {});
+
+            expect(stub.called).to.be.false;
+        });
+
+        it('retrieveManifest -> reset -> retrieveManifest should only invoke the most recent callback', () => {
+            player.initialize(videoElementMock, null, false);
+
+            const firstStub = sinon.spy();
+            player.retrieveManifest(specHelper.getDummyUrl(), firstStub);
+
+            player.reset();
+
+            const secondStub = sinon.spy();
+            player.retrieveManifest(specHelper.getDummyUrl() + '2', secondStub);
+
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {});
+
+            expect(firstStub.called).to.be.false;
+            expect(secondStub.calledOnce).to.be.true;
+        });
+    });
 })


### PR DESCRIPTION
Calling `reset()` whilst a request from `retrieveManifest()` is running does not abort the request.

This can cause a second retrieveManifest call to succeed with the manifest from the first call, like so:
1. retrieveManifest(url1)
2. reset()
3. retrieveManifest(url2)
4. mpd at url1 plays

