### PR TITLE
fix(StreamController): don't reuse previous-period SourceBuffers when changeType is unavailable

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -435,11 +435,20 @@ function StreamController() {
 
             let keepBuffers = false;
             let representationsFromPreviousPeriod = [];
-            let sourceBufferSinksFromPreviousPeriod = _getSourceBufferSinksFromPreviousPeriod(previousStream);
+            // Only reuse the previous period's SourceBuffers when the platform supports
+            // SourceBuffer.changeType(). On platforms without it (e.g. Chrome 68 / LG WebOS <= 5)
+            // reusing a buffer across a period boundary fails with MEDIA_ERR_SRC_NOT_SUPPORTED at
+            // the first period transition, so fall back to a fresh-SourceBuffer ("cold") switch.
+            // This restores the pre-5.1.0 behaviour for those platforms while leaving the reuse
+            // path unchanged where changeType() is available.
+            let sourceBufferSinksFromPreviousPeriod = new Map();
             activeStream = targetStream;
 
             if (previousStream) {
                 keepBuffers = _canSourceBuffersBeKept(targetStream, previousStream);
+                if (capabilities.supportsChangeType()) {
+                    sourceBufferSinksFromPreviousPeriod = _getSourceBufferSinksFromPreviousPeriod(previousStream);
+                }
                 representationsFromPreviousPeriod = _getRepresentationsFromPreviousPeriod(previousStream);
                 previousStream.deactivate(keepBuffers);
             }


### PR DESCRIPTION
Fixes #5038 

## Problem
Multiperiod streams stall and then fail with `MEDIA_ERR_SRC_NOT_SUPPORTED` at the
**first period transition** on platforms that lack `SourceBuffer.changeType()`
(e.g. Chrome 68 / LG WebOS ≤ 5). The picture goes black and the media element errors out.

Works in **v5.0.3**, broken since **v5.1.0**.

## Root cause
Introduced by #4871 (commit `2e7e9a91`, released in v5.1.0). Before that change,
`_activateStream()` reused the previous period's buffers only on a `keepBuffers` switch
(`activeStream.activate(mediaSource, inputParameters.keepBuffers ? bufferSinks : undefined, ...)`).

Since #4871, `StreamController._switchStream()` populates `sourceBufferSinksFromPreviousPeriod`
**unconditionally** via `_getSourceBufferSinksFromPreviousPeriod(previousStream)` and passes it
to `Stream.activate()`, so the previous period's `SourceBuffer`s are always reused across the
period boundary. Reconfiguring a reused buffer for the next period's init segment requires
`changeType()`; on platforms without it this reconfiguration fails and the media element errors.

Note that `_canSourceBuffersBeKept()` already requires `supportsChangeType()`, so `keepBuffers`
is always `false` on these platforms — yet the sink map was still populated and reused, which is
the regression.

## Fix
Initialise `sourceBufferSinksFromPreviousPeriod` to an empty `Map` and only populate it from the
previous stream when `capabilities.supportsChangeType()` is `true`:

- Where `changeType()` is available (modern browsers): reuse path is unchanged.
- Where it is missing: fall back to a fresh-SourceBuffer ("cold") switch, restoring the
  pre-5.1.0 behaviour.

Gating on `supportsChangeType()` (rather than `keepBuffers`) is intentional: `keepBuffers` can be
`false` on changeType-capable platforms for some manifests, and those should stay on the upstream
reuse path. `_getSourceBufferSinksFromPreviousPeriod()` already returns an empty `Map` when there
is no previous stream, so moving the call inside the `if (previousStream)` block is behaviourally
equivalent.

## Reproduction
Play a multiperiod stream in an environment without `SourceBuffer.prototype.changeType`
(force `capabilities.supportsChangeType()` to return `false`, or test on Chrome 68 / LG WebOS ≤ 5).
- **Before:** `MEDIA_ERR_SRC_NOT_SUPPORTED` at the first period boundary (black screen).
- **After:** smooth cold-switch transition into the next period.

## Testing
- `tsc`, ESLint, the full unit suite (1836 tests, ChromeHeadless) and the modern webpack build all pass.
- Verified on real hardware (LG WebOS 4.5) and Chrome/macOS via a local dash.js patch carrying this exact change.