### PR TITLE
Add setting hybridSwitchBufferTime for switching between Bola/Throughput rules

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1863,7 +1863,7 @@ export class MediaPlayerSettingClass {
             usePixelRatioInLimitBitrateByPortal?: boolean;
             limitBitrateByPortalMinimum?: number,
             enableSupplementalPropertyAdaptationSetSwitching?: boolean,
-            hybridSwitchBufferTime: number,
+            hybridSwitchBufferTime?: number,
             rules?: {
                 throughputRule?: {
                     active?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -1863,6 +1863,7 @@ export class MediaPlayerSettingClass {
             usePixelRatioInLimitBitrateByPortal?: boolean;
             limitBitrateByPortalMinimum?: number,
             enableSupplementalPropertyAdaptationSetSwitching?: boolean,
+            hybridSwitchBufferTime: number,
             rules?: {
                 throughputRule?: {
                     active?: boolean

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -238,6 +238,7 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *             abr: {
  *                 limitBitrateByPortal: false,
  *                 usePixelRatioInLimitBitrateByPortal: false,
+ *                 hybridSwitchBufferTime: 12,
  *                rules: {
  *                     throughputRule: {
  *                         active: true

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -780,6 +780,9 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * Sets a minimum bitrate in kbps for limitBitrateByPortal. Representations at this bitrate or below it will not be limited by the portal size. Useful if the player can be resized.
  *
  * Useful on, for example, retina displays.
+ * @property {number} [hybridSwitchBufferTime=12]
+ * When the throughput rule and the Bola rule are both active, this value defines the buffer level in seconds when the player will switch from throughput to Bola.
+ *
  * @property {module:Settings~AbrRules} [rules]
  * Enable/Disable individual ABR rules. Note that if the throughputRule and the bolaRule are activated at the same time we switch to a dynamic mode.
  * In the dynamic mode either ThroughputRule or BolaRule are active but not both at the same time.
@@ -1402,6 +1405,7 @@ function Settings() {
                 usePixelRatioInLimitBitrateByPortal: false,
                 limitBitrateByPortalMinimum: 0,
                 enableSupplementalPropertyAdaptationSetSwitching: true,
+                hybridSwitchBufferTime: 12,
                 rules: {
                     throughputRule: {
                         active: true,

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -992,9 +992,9 @@ function AbrController() {
      */
     function _updateDynamicAbrStrategy(mediaType, bufferLevel) {
         try {
-            const bufferTimeDefault = mediaPlayerModel.getBufferTimeDefault();
-            const switchOnThreshold = bufferTimeDefault;
-            const switchOffThreshold = 0.5 * bufferTimeDefault;
+            const hybridSwitchBufferTime = settings.get().streaming.abr.hybridSwitchBufferTime;
+            const switchOnThreshold = hybridSwitchBufferTime;
+            const switchOffThreshold = 0.5 * hybridSwitchBufferTime;
 
             const isUsingBolaRule = abrRulesCollection.getBolaState(mediaType)
             const shouldUseBolaRule = bufferLevel >= (isUsingBolaRule ? switchOffThreshold : switchOnThreshold); // use hysteresis to avoid oscillating rules

--- a/test/unit/test/streaming/streaming.controllers.AbrController.js
+++ b/test/unit/test/streaming/streaming.controllers.AbrController.js
@@ -2,6 +2,7 @@ import VoHelper from '../../helpers/VOHelper.js';
 import ObjectsHelper from '../../helpers/ObjectsHelper.js';
 import AbrController from '../../../../src/streaming/controllers/AbrController.js';
 import Constants from '../../../../src/streaming/constants/Constants.js';
+import MetricsConstants from '../../../../src/streaming/constants/MetricsConstants.js';
 import Settings from '../../../../src/core/Settings.js';
 import VideoModelMock from '../../mocks/VideoModelMock.js';
 import DomStorageMock from '../../mocks/DomStorageMock.js';
@@ -16,6 +17,7 @@ import PlaybackControllerMock from '../../mocks/PlaybackControllerMock.js';
 import ThroughputControllerMock from '../../mocks/ThroughputControllerMock.js';
 import {expect, assert} from 'chai';
 import EventBus from '../../../../src/core/EventBus.js';
+import FactoryMaker from '../../../../src/core/FactoryMaker.js';
 import MediaPlayerEvents from '../../../../src/streaming/MediaPlayerEvents.js';
 import sinon from 'sinon';
 import CapabilitiesMock from '../../mocks/CapabilitiesMock.js';
@@ -669,6 +671,70 @@ describe('AbrController', function () {
     })
 
     describe('Additional Tests', function () {
+        it('should apply hybridSwitchBufferTime thresholds when toggling dynamic ABR strategy', function () {
+            let capturedAbrRulesCollection = null;
+
+            FactoryMaker.extend('ABRRulesCollection', function () {
+                capturedAbrRulesCollection = this.parent;
+                return {};
+            }, true, context);
+
+            try {
+                settings.update({
+                    streaming: {
+                        abr: {
+                            hybridSwitchBufferTime: 10,
+                            rules: {
+                                bolaRule: {
+                                    active: true
+                                },
+                                throughputRule: {
+                                    active: true
+                                }
+                            }
+                        }
+                    }
+                });
+
+                abrCtrl.reset();
+                abrCtrl.initialize();
+                abrCtrl.registerStreamType(Constants.VIDEO, streamProcessor);
+
+                expect(capturedAbrRulesCollection).to.exist;
+                expect(capturedAbrRulesCollection.getBolaState(Constants.VIDEO)).to.be.false;
+
+                eventBus.trigger(MediaPlayerEvents.METRIC_ADDED, {
+                    metric: MetricsConstants.BUFFER_LEVEL,
+                    mediaType: Constants.VIDEO,
+                    value: {
+                        level: 10000
+                    }
+                });
+                expect(capturedAbrRulesCollection.getBolaState(Constants.VIDEO)).to.be.true;
+
+                // With BOLA already active, switch-off threshold is 0.5 * hybridSwitchBufferTime.
+                eventBus.trigger(MediaPlayerEvents.METRIC_ADDED, {
+                    metric: MetricsConstants.BUFFER_LEVEL,
+                    mediaType: Constants.VIDEO,
+                    value: {
+                        level: 6000
+                    }
+                });
+                expect(capturedAbrRulesCollection.getBolaState(Constants.VIDEO)).to.be.true;
+
+                eventBus.trigger(MediaPlayerEvents.METRIC_ADDED, {
+                    metric: MetricsConstants.BUFFER_LEVEL,
+                    mediaType: Constants.VIDEO,
+                    value: {
+                        level: 4000
+                    }
+                });
+                expect(capturedAbrRulesCollection.getBolaState(Constants.VIDEO)).to.be.false;
+            } finally {
+                delete context.ABRRulesCollection;
+            }
+        });
+
         it('should return null when attempting to get abandonment state when abandonmentStateDict array is empty', function () {
             const state = abrCtrl.getAbandonmentStateFor('1', Constants.AUDIO);
             expect(state).to.be.null;


### PR DESCRIPTION
When both the Bola and Throughput rules are activated, they are switched between when the buffer exceeds `bufferTimeDefault`. This value is used in multiple places in the codebase too, including within the Bola rule itself to set the top Bola level.

It is desirable to change the `bufferTimeDefault` to make Bola target higher buffer levels without changing the level at which the switch between Throughput/Bola happens. This PR adds a new setting `hybridSwitchBufferTime` to separate this functionality.

It also returns the `hybridSwitchBufferTime` value back to 12 seconds from the 18 it has changed to; so that the Bola rule is being used more often. I picked the 12 second value as formerly what `bufferTimeDefault` used to be in previous versions, but this could be tuned to some other value. I'm certain it's too high at 18s, and I think it definitely should be shorter than whatever value is being used by Bola, otherwise the Bola rule is being switched at a buffer level so high it will only indicate the top bitrate (because of the hysteresis, when buffer levels are falling it will have a few more options.)