### PR TITLE
Fix multiple memory leaks on Cta608Parser and ResizeObserver

### DIFF
--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -859,6 +859,9 @@ function DashAdapter() {
 
     function reset() {
         voPeriods = [];
+    }
+
+    function destroy() {
         cea608parser = null;
     }
 
@@ -1316,6 +1319,7 @@ function DashAdapter() {
         applyPatchToManifest,
         areMediaInfosEqual,
         convertAdaptationToMediaInfo,
+        destroy,
         getAllMediaInfoForType,
         getAvailabilityStartTime,
         getBandwidthForRepresentation,

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -859,6 +859,7 @@ function DashAdapter() {
 
     function reset() {
         voPeriods = [];
+        cea608parser = null;
     }
 
     /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -484,6 +484,11 @@ function MediaPlayer() {
             retrieveManifestRequest.resetLoader();
             retrieveManifestRequest = null;
         }
+
+        if (videoModel) {
+            videoModel.reset();
+            videoModel = null;
+        }
     }
 
     /**

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -484,11 +484,6 @@ function MediaPlayer() {
             retrieveManifestRequest.resetLoader();
             retrieveManifestRequest = null;
         }
-
-        if (videoModel) {
-            videoModel.reset();
-            videoModel = null;
-        }
     }
 
     /**
@@ -499,6 +494,16 @@ function MediaPlayer() {
      */
     function destroy() {
         reset();
+
+        if (videoModel) {
+            videoModel.destroy();
+            videoModel = null;
+        }
+
+        if (adapter) {
+            adapter.destroy();
+        }
+
         FactoryMaker.deleteSingletonInstances(context);
     }
 

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -94,13 +94,21 @@ function VideoModel() {
         _disposeResizeObserver();
     }
 
+    function destroy() {
+        reset();
+        element = null;
+        TTMLRenderingDiv = null;
+        vttRenderingDiv = null;
+    }
+
     function _disposeResizeObserver() {
         try {
             if (resizeObserver && element) {
                 resizeObserver.unobserve(element);
+            }
+            if (resizeObserver) {
                 resizeObserver.disconnect();
                 resizeObserver = null;
-                element = null;
             }
         } catch (e) {
 
@@ -209,19 +217,21 @@ function VideoModel() {
     }
 
     function setElement(value) {
-        //add check of value type
-        if (value === null || value === undefined) {
-            _disposeResizeObserver();
+        // In case there was already an element stored in model
+        const isNewElement = element !== value;
+        if (element && !isNewElement) {
             return;
         }
+
+        _unregisterResizeObserver(element);
+        element = value;
+
+        //add check of value type
+        if (value === null || value === undefined) {
+            return;
+        }
+
         if (value && /^(VIDEO|AUDIO)$/i.test(value.nodeName)) {
-            // In case there was already an element stored in model
-            const isNewElement = element !== value;
-            if (element && !isNewElement) {
-                _unregisterResizeObserver(element);
-                return;
-            }
-            element = value;
             _registerResizeObserver(element);
             return;
         }
@@ -577,6 +587,7 @@ function VideoModel() {
         addEventListener,
         addTextTrack,
         appendChild,
+        destroy,
         getBufferRange,
         getClientHeight,
         getClientWidth,

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -100,6 +100,7 @@ function VideoModel() {
                 resizeObserver.unobserve(element);
                 resizeObserver.disconnect();
                 resizeObserver = null;
+                element = null;
             }
         } catch (e) {
 
@@ -209,12 +210,22 @@ function VideoModel() {
 
     function setElement(value) {
         //add check of value type
-        if (value === null || value === undefined || (value && (/^(VIDEO|AUDIO)$/i).test(value.nodeName))) {
+        if (value === null || value === undefined) {
+            _disposeResizeObserver();
+            return;
+        }
+        if (value && /^(VIDEO|AUDIO)$/i.test(value.nodeName)) {
+            // In case there was already an element stored in model
+            const isNewElement = element !== value;
+            if (element && !isNewElement) {
+                _unregisterResizeObserver(element);
+                return;
+            }
             element = value;
             _registerResizeObserver(element);
-        } else {
-            throw VIDEO_MODEL_WRONG_ELEMENT_TYPE;
+            return;
         }
+        throw VIDEO_MODEL_WRONG_ELEMENT_TYPE;
     }
 
     function _registerResizeObserver(element) {
@@ -226,6 +237,15 @@ function VideoModel() {
         } catch (e) {
 
         }
+    }
+
+    function _unregisterResizeObserver(element) {
+        try {
+            if (!resizeObserver || !element) {
+                return;
+            }
+            resizeObserver.unobserve(element);
+        } catch (e) {}
     }
 
     function setSource(source) {


### PR DESCRIPTION
Fixes #5041

Note: I did not add any fixes for the `TextTracks` leak since doing a `pause()` before the `destroy()` or `reset()` seems to fix the leak, but a fix should be considered.