### PR TITLE
perf: index SegmentTimeline lookups instead of rescanning from the first segment

### DIFF
--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -38,6 +38,10 @@ function TimelineSegmentsGetter(config, isDynamic) {
     config = config || {};
     const timelineConverter = config.timelineConverter;
     const dashMetrics = config.dashMetrics;
+    // Per-representation index of the SegmentTimeline. Keyed on the representation so it is dropped
+    // automatically when the representation is. Invalidated in _getCachedLookup when the parsed S
+    // array changes; never stored for open-ended (negative-@r) timelines, see _computeLookup.
+    const segmentLookupCache = new WeakMap();
 
     let instance;
 
@@ -68,212 +72,252 @@ function TimelineSegmentsGetter(config, isDynamic) {
             requestedPresentationTime = null;
         }
 
-        let segment = null;
         const requiredMediaTime = timelineConverter.calcMediaTimeFromPresentationTime(requestedPresentationTime, representation);
+        const fTimescale = representation.timescale;
+        const requiredMediaTimeInTimescaleUnits = _precisionRound(requiredMediaTime * fTimescale);
+        const segmentLookup = _getSegmentLookup(representation);
+        const blockIndex = _findBlockIndexByMediaTime(segmentLookup, requiredMediaTimeInTimescaleUnits);
 
-        _iterateSegments(representation, function (data) {
-            // In some cases when requiredMediaTime = actual end time of the last segment
-            // it is possible that this time a bit exceeds the declared end time of the last segment.
-            // in this case we still need to include the last segment in the segment list.
-            const fTimescale = representation.timescale;
-            const requiredMediaTimeInTimescaleUnits = _precisionRound(requiredMediaTime * fTimescale);
+        if (blockIndex === -1) {
+            return null;
+        }
 
-            return _handleIteration(requiredMediaTimeInTimescaleUnits, data)
+        const block = segmentLookup.blocks[blockIndex];
+        const durationInTimescale = block.currentSElement.d;
+        // The block spans repeat+1 segments of equal duration; pick the one whose half-open
+        // [start, start + d) interval contains the requested time (matches the per-segment check of
+        // the previous linear scan). Clamp to block.repeat to absorb floating point at the end edge.
+        const repeatOffset = Math.min(
+            Math.floor((requiredMediaTimeInTimescaleUnits - block.mediaTime) / durationInTimescale),
+            block.repeat
+        );
+        const mediaTime = block.mediaTime + repeatOffset * durationInTimescale;
+        const sElementCounterIncludingRepeats = block.sElementCounterIncludingRepeatsStart + repeatOffset;
+        const totalNumberOfPartialSegments = getTotalNumberOfPartialSegments(block.currentSElement);
+        const subNumberOfPartialSegmentToRequest = _getSubNumberOfPartialSegmentToRequestByTime({
+            durationInTimescale,
+            requiredMediaTimeInTimescaleUnits,
+            mediaTime,
+            totalNumberOfPartialSegments
         });
 
-        return segment;
+        representation.segmentDuration = durationInTimescale / fTimescale;
 
-        function _handleIteration(requiredMediaTimeInTimescaleUnits, data) {
-            const {
-                mediaTime,
-                segmentBase,
-                segmentURL,
-                currentSElement,
-                sElementCounterIncludingRepeats,
-                sElementCounter
-            } = data
-            const targetDurationInTimescale = currentSElement.d;
-            const fTimescale = representation.timescale;
-            const mediaStartTime = mediaTime;
-            const mediaEndTime = mediaTime + targetDurationInTimescale;
-
-            if (requiredMediaTimeInTimescaleUnits < mediaEndTime && requiredMediaTimeInTimescaleUnits >= mediaStartTime) {
-                _onSegmentFound({
-                    segmentBase,
-                    segmentURL,
-                    sElementCounter,
-                    currentSElement,
-                    mediaTime: mediaStartTime,
-                    durationInTimescale: targetDurationInTimescale,
-                    fTimescale,
-                    requiredMediaTimeInTimescaleUnits,
-                    sElementCounterIncludingRepeats,
-                });
-                return true;
-            }
-
-            return false;
-        }
-
-        function _onSegmentFound(data) {
-            const {
-                segmentBase,
-                segmentURL,
-                sElementCounter,
-                currentSElement,
-                mediaTime,
-                durationInTimescale,
-                fTimescale,
-                requiredMediaTimeInTimescaleUnits,
-                sElementCounterIncludingRepeats
-            } = data
-            let mediaUrl = _getMediaUrl(segmentBase, segmentURL, sElementCounter);
-            let mediaRange = _getMediaRange(currentSElement, segmentURL, sElementCounter);
-            const totalNumberOfPartialSegments = getTotalNumberOfPartialSegments(currentSElement);
-            const subNumberOfPartialSegmentToRequest = _getSubNumberOfPartialSegmentToRequestByTime({
-                durationInTimescale,
-                requiredMediaTimeInTimescaleUnits,
-                mediaTime,
-                totalNumberOfPartialSegments
-            })
-
-            segment = getTimeBasedSegment({
-                timelineConverter,
-                isDynamic,
-                representation,
-                mediaTime,
-                durationInTimescale,
-                fTimescale,
-                mediaUrl,
-                mediaRange,
-                index: sElementCounterIncludingRepeats,
-                tManifest: currentSElement.tManifest,
-                totalNumberOfPartialSegments,
-                subNumberOfPartialSegmentToRequest
-            });
-        }
+        return getTimeBasedSegment({
+            timelineConverter,
+            isDynamic,
+            representation,
+            mediaTime,
+            durationInTimescale,
+            fTimescale,
+            // blockIndex equals the source <S> position (one block per <S>), so it indexes SegmentURL.
+            mediaUrl: _getMediaUrl(segmentLookup.segmentBase, segmentLookup.segmentURL, blockIndex),
+            mediaRange: _getMediaRange(block.currentSElement, segmentLookup.segmentURL, blockIndex),
+            index: sElementCounterIncludingRepeats,
+            tManifest: block.currentSElement.tManifest,
+            totalNumberOfPartialSegments,
+            subNumberOfPartialSegmentToRequest
+        });
     }
 
     function getMediaFinishedInformation(representation) {
         if (!representation) {
             return 0;
         }
+        // Only the counts are needed here. Reuse the cached index when present, otherwise count in a
+        // light pass without materializing the per-block array. This avoids allocating the full block
+        // list on every MPD update for representations that are never actively buffered.
+        const lookup = _getCachedLookup(representation) || _computeLookup(representation, false);
 
-        const base = representation.adaptation.period.mpd.manifest.Period[representation.adaptation.period.index].AdaptationSet[representation.adaptation.index].Representation[representation.index].SegmentTemplate ||
-            representation.adaptation.period.mpd.manifest.Period[representation.adaptation.period.index].AdaptationSet[representation.adaptation.index].Representation[representation.index].SegmentList;
-        const timeline = base.SegmentTimeline;
-
-        let mediaTime = 0;
-        let mediaTimeInSeconds = 0;
-        let availableSegments = 0;
-
-        let fragments,
-            frag,
-            i,
-            j,
-            repeat,
-            fTimescale;
-
-        fTimescale = representation.timescale;
-        fragments = timeline.S;
-
-        const length = fragments.length;
-
-        for (i = 0; i < length; i++) {
-            frag = fragments[i];
-            repeat = 0;
-            if (frag.hasOwnProperty('r')) {
-                repeat = frag.r;
-            }
-
-            // For a repeated S element, t belongs only to the first segment
-            if (frag.hasOwnProperty('t')) {
-                mediaTime = frag.t;
-                mediaTimeInSeconds = mediaTime / fTimescale;
-            }
-
-            // This is a special case: "A negative value of the @r attribute of the S element indicates that the duration indicated in @d attribute repeats until the start of the next S element, the end of the Period or until the
-            // next MPD update."
-            if (repeat < 0) {
-                const nextFrag = fragments[i + 1];
-                repeat = _calculateRepeatCountForNegativeR(representation, nextFrag, frag, fTimescale, mediaTimeInSeconds);
-            }
-
-            for (j = 0; j <= repeat; j++) {
-                availableSegments++;
-
-                mediaTime += frag.d;
-                mediaTimeInSeconds = mediaTime / fTimescale;
-            }
-        }
-
-        // We need to account for the index of the segments starting at 0. We subtract 1
-        return { numberOfSegments: availableSegments, mediaTimeOfLastSignaledSegment: mediaTimeInSeconds };
-    }
-
-    function _iterateSegments(representation, iterFunc) {
-        const segmentBase = _getSegmentBase(representation);
-        const segmentTimeline = segmentBase.SegmentTimeline;
-        const segmentURL = segmentBase.SegmentURL;
-
-        let mediaTime = 0;
-        let sElementCounterIncludingRepeats = -1;
-        let parsedSElements,
-            currentSElement,
-            sElementCounter,
-            j,
-            repeat,
-            fTimescale;
-
-        fTimescale = representation.timescale;
-        parsedSElements = segmentTimeline.S;
-
-        let breakIterator = false;
-        const numberOfSElements = parsedSElements.length;
-
-        for (sElementCounter = 0; sElementCounter < numberOfSElements && !breakIterator; sElementCounter++) {
-            currentSElement = parsedSElements[sElementCounter];
-            repeat = 0;
-            if (currentSElement.hasOwnProperty('r')) {
-                repeat = currentSElement.r;
-            }
-
-            // For a repeated S element, t belongs only to the first segment
-            if (currentSElement.hasOwnProperty('t')) {
-                mediaTime = currentSElement.t;
-            }
-
-            // This is a special case: "A negative value of the @r attribute of the S element indicates that the duration indicated in @d attribute repeats until the start of the next S element, the end of the Period or until the
-            // next MPD update."
-            if (repeat < 0) {
-                const nextFrag = parsedSElements[sElementCounter + 1];
-                repeat = _calculateRepeatCountForNegativeR(representation, nextFrag, currentSElement, fTimescale, mediaTime / fTimescale);
-            }
-
-            for (j = 0; j <= repeat && !breakIterator; j++) {
-                sElementCounterIncludingRepeats++;
-
-                breakIterator = iterFunc({
-                    mediaTime,
-                    segmentBase,
-                    segmentURL,
-                    currentSElement,
-                    sElementCounterIncludingRepeats,
-                    sElementCounter
-                });
-
-                if (breakIterator) {
-                    representation.segmentDuration = currentSElement.d / fTimescale;
-                }
-
-                mediaTime += currentSElement.d;
-            }
-        }
+        return {
+            numberOfSegments: lookup.numberOfSegments,
+            mediaTimeOfLastSignaledSegment: lookup.mediaTimeOfLastSignaledSegment
+        };
     }
 
     function _getSegmentBase(representation) {
         return representation.adaptation.period.mpd.manifest.Period[representation.adaptation.period.index].AdaptationSet[representation.adaptation.index].Representation[representation.index].SegmentTemplate ||
             representation.adaptation.period.mpd.manifest.Period[representation.adaptation.period.index].AdaptationSet[representation.adaptation.index].Representation[representation.index].SegmentList;
+    }
+
+    function _getCachedLookup(representation) {
+        const segmentBase = _getSegmentBase(representation);
+        const parsedSElements = segmentBase.SegmentTimeline.S;
+        const cached = segmentLookupCache.get(representation);
+        const length = parsedSElements.length;
+
+        // Validate the cache against the parsed timeline. The identity of the S array does not change
+        // on in-place updates (MSS appends/splices the same array), so we also compare its length and
+        // first/last element identity to catch a sliding window that keeps the same length.
+        if (
+            cached &&
+            cached.segmentBase === segmentBase &&
+            cached.parsedSElements === parsedSElements &&
+            cached.numberOfSElements === length &&
+            cached.firstSElement === parsedSElements[0] &&
+            cached.lastSElement === parsedSElements[length - 1] &&
+            cached.fTimescale === representation.timescale
+        ) {
+            return cached;
+        }
+
+        return null;
+    }
+
+    function _getSegmentLookup(representation) {
+        const cached = _getCachedLookup(representation);
+        if (cached) {
+            return cached;
+        }
+
+        const lookup = _computeLookup(representation, true);
+
+        // An open-ended negative-@r timeline depends on the live DVR window / period end, which
+        // advances over time. Caching it would freeze the segment count and hide newly available
+        // live-edge segments between MPD updates, so recompute it on every call instead.
+        if (!lookup.timeDependent) {
+            segmentLookupCache.set(representation, lookup);
+        }
+
+        return lookup;
+    }
+
+    /**
+     * Walk the SegmentTimeline once. Always returns the total segment count and the media time of the
+     * last signaled segment; only materializes the per-block index when withBlocks is true.
+     */
+    function _computeLookup(representation, withBlocks) {
+        const segmentBase = _getSegmentBase(representation);
+        const segmentURL = segmentBase.SegmentURL;
+        const parsedSElements = segmentBase.SegmentTimeline.S;
+        const fTimescale = representation.timescale;
+        const numberOfSElements = parsedSElements.length;
+        const blocks = withBlocks ? [] : null;
+
+        let mediaTime = 0;
+        let sElementCounterIncludingRepeats = -1;
+        let mediaTimeOfLastSignaledSegment = 0;
+        let numberOfSegments = 0;
+        let timeDependent = false;
+        let monotonic = true;
+        let previousEndTime = -Infinity;
+
+        for (let sElementCounter = 0; sElementCounter < numberOfSElements; sElementCounter++) {
+            const currentSElement = parsedSElements[sElementCounter];
+            let repeat = currentSElement.hasOwnProperty('r') ? currentSElement.r : 0;
+
+            // For a repeated S element, @t belongs only to the first segment.
+            if (currentSElement.hasOwnProperty('t')) {
+                mediaTime = currentSElement.t;
+            }
+
+            // A negative @r repeats the duration until the start of the next S element, the end of the
+            // Period, or the next MPD update. When there is no following @t the count is derived from
+            // the (advancing) Period end / DVR window, so the result must not be cached.
+            if (repeat < 0) {
+                const nextFrag = parsedSElements[sElementCounter + 1];
+                if (!(nextFrag && nextFrag.hasOwnProperty('t'))) {
+                    timeDependent = true;
+                }
+                repeat = _calculateRepeatCountForNegativeR(representation, nextFrag, currentSElement, fTimescale, mediaTime / fTimescale);
+            }
+
+            const segmentCount = repeat + 1;
+            const startTime = mediaTime;
+            const endTime = mediaTime + segmentCount * currentSElement.d;
+
+            // Ascending, non-overlapping blocks let getSegmentByTime use a binary search. A
+            // non-conformant timeline whose @t goes backwards falls back to a linear scan.
+            if (startTime < previousEndTime) {
+                monotonic = false;
+            }
+            previousEndTime = endTime;
+
+            if (withBlocks) {
+                blocks.push({
+                    currentSElement,
+                    mediaTime: startTime,
+                    endTime,
+                    repeat,
+                    sElementCounterIncludingRepeatsStart: sElementCounterIncludingRepeats + 1
+                });
+            }
+
+            sElementCounterIncludingRepeats += segmentCount;
+            numberOfSegments += segmentCount;
+            mediaTime = endTime;
+            mediaTimeOfLastSignaledSegment = mediaTime / fTimescale;
+        }
+
+        return {
+            blocks,
+            fTimescale,
+            firstSElement: parsedSElements[0],
+            lastSElement: parsedSElements[numberOfSElements - 1],
+            mediaTimeOfLastSignaledSegment,
+            monotonic,
+            numberOfSElements,
+            numberOfSegments,
+            parsedSElements,
+            segmentBase,
+            segmentURL,
+            timeDependent
+        };
+    }
+
+    function _blockContainsMediaTime(block, requiredMediaTimeInTimescaleUnits) {
+        return !!block && requiredMediaTimeInTimescaleUnits >= block.mediaTime && requiredMediaTimeInTimescaleUnits < block.endTime;
+    }
+
+    /**
+     * Returns the index of the block whose [mediaTime, endTime) interval contains the requested time,
+     * or -1. Sequential playback advances one block at a time, so the last matched block (and its
+     * successor) are checked first; otherwise a binary search is used, falling back to a linear scan
+     * for non-monotonic timelines.
+     */
+    function _findBlockIndexByMediaTime(segmentLookup, requiredMediaTimeInTimescaleUnits) {
+        // A NaN time (e.g. an unknown last-segment duration) matches no segment, as before.
+        if (isNaN(requiredMediaTimeInTimescaleUnits)) {
+            return -1;
+        }
+
+        const blocks = segmentLookup.blocks;
+
+        if (segmentLookup.monotonic) {
+            const hint = segmentLookup.lastBlockIndex;
+            if (hint !== undefined) {
+                if (_blockContainsMediaTime(blocks[hint], requiredMediaTimeInTimescaleUnits)) {
+                    return hint;
+                }
+                if (_blockContainsMediaTime(blocks[hint + 1], requiredMediaTimeInTimescaleUnits)) {
+                    segmentLookup.lastBlockIndex = hint + 1;
+                    return hint + 1;
+                }
+            }
+
+            let low = 0;
+            let high = blocks.length - 1;
+            while (low <= high) {
+                const mid = (low + high) >> 1;
+                const block = blocks[mid];
+                if (requiredMediaTimeInTimescaleUnits < block.mediaTime) {
+                    high = mid - 1;
+                } else if (requiredMediaTimeInTimescaleUnits >= block.endTime) {
+                    low = mid + 1;
+                } else {
+                    segmentLookup.lastBlockIndex = mid;
+                    return mid;
+                }
+            }
+            return -1;
+        }
+
+        for (let i = 0; i < blocks.length; i++) {
+            if (_blockContainsMediaTime(blocks[i], requiredMediaTimeInTimescaleUnits)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     function _calculateRepeatCountForNegativeR(representation, nextFrag, frag, fTimescale, scaledTime) {

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -40,7 +40,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
     const dashMetrics = config.dashMetrics;
     // Per-representation index of the SegmentTimeline. Keyed on the representation so it is dropped
     // automatically when the representation is. Invalidated in _getCachedLookup when the parsed S
-    // array changes; never stored for open-ended (negative-@r) timelines, see _computeLookup.
+    // array or its timing boundaries change; never stored for open-ended (negative-@r) timelines, see _computeLookup.
     const segmentLookupCache = new WeakMap();
 
     let instance;
@@ -145,17 +145,22 @@ function TimelineSegmentsGetter(config, isDynamic) {
         const parsedSElements = segmentBase.SegmentTimeline.S;
         const cached = segmentLookupCache.get(representation);
         const length = parsedSElements.length;
+        const firstSElement = parsedSElements[0];
+        const lastSElement = parsedSElements[length - 1];
 
         // Validate the cache against the parsed timeline. The identity of the S array does not change
         // on in-place updates (MSS appends/splices the same array), so we also compare its length and
-        // first/last element identity to catch a sliding window that keeps the same length.
+        // first/last element identity/timing to catch a sliding window that keeps the same length.
         if (
             cached &&
             cached.segmentBase === segmentBase &&
+            cached.segmentURL === segmentBase.SegmentURL &&
             cached.parsedSElements === parsedSElements &&
             cached.numberOfSElements === length &&
-            cached.firstSElement === parsedSElements[0] &&
-            cached.lastSElement === parsedSElements[length - 1] &&
+            cached.firstSElement === firstSElement &&
+            cached.lastSElement === lastSElement &&
+            cached.firstSElementSignature === _getSElementSignature(firstSElement) &&
+            cached.lastSElementSignature === _getSElementSignature(lastSElement) &&
             cached.fTimescale === representation.timescale
         ) {
             return cached;
@@ -253,7 +258,9 @@ function TimelineSegmentsGetter(config, isDynamic) {
             blocks,
             fTimescale,
             firstSElement: parsedSElements[0],
+            firstSElementSignature: _getSElementSignature(parsedSElements[0]),
             lastSElement: parsedSElements[numberOfSElements - 1],
+            lastSElementSignature: _getSElementSignature(parsedSElements[numberOfSElements - 1]),
             mediaTimeOfLastSignaledSegment,
             monotonic,
             numberOfSElements,
@@ -263,6 +270,16 @@ function TimelineSegmentsGetter(config, isDynamic) {
             segmentURL,
             timeDependent
         };
+    }
+
+    function _getSElementSignature(sElement) {
+        if (!sElement) {
+            return '';
+        }
+
+        const t = sElement.hasOwnProperty('t') ? sElement.t : '';
+        const r = sElement.hasOwnProperty('r') ? sElement.r : '';
+        return `${t}|${sElement.d}|${r}`;
     }
 
     function _blockContainsMediaTime(block, requiredMediaTimeInTimescaleUnits) {

--- a/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
@@ -321,6 +321,21 @@ describe('TimelineSegmentsGetter', () => {
             expect(seg.duration).to.equal(2);
         });
 
+        it('should resolve non-monotonic timelines with the linear fallback', () => {
+            const representation = createTimelineRepresentation({
+                timescale: 1,
+                S: [
+                    { t: 20, d: 10 },
+                    { t: 0, d: 10 }
+                ]
+            });
+
+            const seg = timelineSegmentsGetter.getSegmentByTime(representation, 5);
+            expect(seg).to.exist; // jshint ignore:line
+            expect(seg.index).to.equal(1);
+            expect(seg.presentationStartTime).to.equal(0);
+        });
+
         it('should fall back to full segment (not partial) when time is exactly at end boundary of a segment with partials', () => {
             const representation = createTimelineRepresentation({
                 timescale: 3,

--- a/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
@@ -264,6 +264,50 @@ describe('TimelineSegmentsGetter', () => {
             expect(seg.replacementSubNumber).to.equal(1);
         });
 
+        it('should resolve segment indexes correctly across repeated S blocks', () => {
+            const voHelper = new VoHelper();
+            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
+            representation.timescale = 10;
+            representation.presentationTimeOffset = 0;
+            representation.adaptation.period.duration = 11;
+            representation.SegmentTemplate = {
+                timescale: 10,
+                initialization: 'init-$RepresentationID$.m4s',
+                SegmentTimeline: {
+                    S: [
+                        { t: 0, d: 10, r: 4 },
+                        { t: 50, d: 20, r: 2 }
+                    ]
+                },
+                media: 'seg-$Time$.m4s'
+            };
+            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+
+            let seg = timelineSegmentsGetter.getSegmentByTime(representation, 3.1);
+            expect(seg).to.exist;
+            expect(seg.index).to.equal(3);
+            expect(seg.presentationStartTime).to.equal(3);
+            expect(seg.duration).to.equal(1);
+
+            seg = timelineSegmentsGetter.getSegmentByTime(representation, 5.1);
+            expect(seg).to.exist;
+            expect(seg.index).to.equal(5);
+            expect(seg.presentationStartTime).to.equal(5);
+            expect(seg.duration).to.equal(2);
+
+            seg = timelineSegmentsGetter.getSegmentByTime(representation, 8.5);
+            expect(seg).to.exist;
+            expect(seg.index).to.equal(6);
+            expect(seg.presentationStartTime).to.equal(7);
+            expect(seg.duration).to.equal(2);
+
+            seg = timelineSegmentsGetter.getSegmentByTime(representation, 10.5);
+            expect(seg).to.exist;
+            expect(seg.index).to.equal(7);
+            expect(seg.presentationStartTime).to.equal(9);
+            expect(seg.duration).to.equal(2);
+        });
+
         it('should fall back to full segment (not partial) when time is exactly at end boundary of a segment with partials', () => {
             const voHelper = new VoHelper();
             const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
@@ -277,6 +321,73 @@ describe('TimelineSegmentsGetter', () => {
             representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
             // Request time exactly at end (1.0s) -> outside first and only segment -> null
             const seg = timelineSegmentsGetter.getSegmentByTime(representation, 1.0);
+            expect(seg).to.be.null; // jshint ignore:line
+        });
+    });
+
+    describe('cache invalidation and edge cases', () => {
+        it('should not cache open-ended negative @r counts so the advancing DVR window is tracked', () => {
+            const dvr = { end: 50 };
+            const getter = TimelineSegmentsGetter(context).create({
+                timelineConverter: timelineConverter,
+                dashMetrics: { getCurrentDVRInfo: () => dvr }
+            }, false);
+            const voHelper = new VoHelper();
+            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
+            representation.timescale = 100;
+            representation.presentationTimeOffset = 0;
+            representation.adaptation.period.start = 0;
+            representation.adaptation.period.duration = NaN; // force the DVR-window branch
+            representation.SegmentTemplate = {
+                timescale: 100,
+                initialization: 'init-$RepresentationID$.m4s',
+                SegmentTimeline: { S: [{ t: 0, d: 100, r: -1 }] }, // 1s segments, open-ended
+                media: 'seg-$Time$.m4s'
+            };
+            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+
+            expect(getter.getMediaFinishedInformation(representation).numberOfSegments).to.equal(50);
+            expect(getter.getSegmentByTime(representation, 60)).to.be.null; // jshint ignore:line
+
+            dvr.end = 70; // the live DVR window advances
+            expect(getter.getMediaFinishedInformation(representation).numberOfSegments).to.equal(70);
+            const seg = getter.getSegmentByTime(representation, 60);
+            expect(seg).to.exist; // jshint ignore:line
+            expect(seg.index).to.equal(60);
+        });
+
+        it('should invalidate the cache when the S array is updated in place with the same length', () => {
+            const voHelper = new VoHelper();
+            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
+            representation.timescale = 1;
+            representation.presentationTimeOffset = 0;
+            representation.adaptation.period.start = 0;
+            const S = [{ t: 0, d: 10 }, { t: 10, d: 10 }, { t: 20, d: 10 }];
+            representation.SegmentTemplate = {
+                timescale: 1,
+                initialization: 'init.m4s',
+                SegmentTimeline: { S },
+                media: 'seg-$Time$.m4s'
+            };
+            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+
+            expect(timelineSegmentsGetter.getMediaFinishedInformation(representation).mediaTimeOfLastSignaledSegment).to.equal(30);
+            // slide the window: drop the oldest, append the newest, length unchanged
+            S.shift();
+            S.push({ t: 30, d: 10 });
+            expect(timelineSegmentsGetter.getMediaFinishedInformation(representation).mediaTimeOfLastSignaledSegment).to.equal(40);
+            const seg = timelineSegmentsGetter.getSegmentByTime(representation, 35);
+            expect(seg).to.exist; // jshint ignore:line
+            expect(seg.presentationStartTime).to.equal(30);
+        });
+
+        it('should return null when the requested time resolves to NaN', () => {
+            const representation = createRepresentationMock();
+            const seg = timelineSegmentsGetter.getSegmentByIndex(representation, {
+                presentationStartTime: 8.008,
+                mediaStartTime: 8.008,
+                duration: NaN
+            });
             expect(seg).to.be.null; // jshint ignore:line
         });
     });

--- a/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
@@ -37,6 +37,32 @@ function createRepresentationMock() {
     return representation;
 }
 
+function createTimelineRepresentation({
+    timescale,
+    S,
+    duration = NaN,
+    start = 0,
+    presentationTimeOffset = 0,
+    initialization = 'init.m4s',
+    media = 'seg-$Time$.m4s'
+}) {
+    const voHelper = new VoHelper();
+    const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
+    representation.timescale = timescale;
+    representation.presentationTimeOffset = presentationTimeOffset;
+    representation.adaptation.period.start = start;
+    representation.adaptation.period.duration = duration;
+    representation.SegmentTemplate = {
+        timescale,
+        initialization,
+        SegmentTimeline: { S },
+        media
+    };
+    representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+
+    return representation;
+}
+
 describe('TimelineSegmentsGetter', () => {
     const context = {};
 
@@ -81,23 +107,17 @@ describe('TimelineSegmentsGetter', () => {
         });
 
         it('should handle negative repeat count using next S element (r = -1)', () => {
-            const voHelper = new VoHelper();
-            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.timescale = 100; // 100 units per second
-            representation.adaptation.period.duration = 50; // seconds
             // S[0] repeats until start time of next S (t=5000 units => 50 seconds) with d=100 (1 second)
-            representation.SegmentTemplate = {
+            const representation = createTimelineRepresentation({
                 timescale: 100,
+                duration: 50, // seconds
                 initialization: 'init-$RepresentationID$.m4s',
-                SegmentTimeline: {
-                    S: [
-                        { t: 0, d: 100, r: -1 },
-                        { t: 5000, d: 100 } // next fragment defines end of negative repeat range
-                    ]
-                },
+                S: [
+                    { t: 0, d: 100, r: -1 },
+                    { t: 5000, d: 100 } // next fragment defines end of negative repeat range
+                ],
                 media: 'seg-$Time$.m4s'
-            };
-            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+            });
 
             const info = timelineSegmentsGetter.getMediaFinishedInformation(representation);
             // From 0 to <50s with 1s duration -> 50 segments (first S produces 50 segments), plus the final S element yields 1 more
@@ -265,23 +285,16 @@ describe('TimelineSegmentsGetter', () => {
         });
 
         it('should resolve segment indexes correctly across repeated S blocks', () => {
-            const voHelper = new VoHelper();
-            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.timescale = 10;
-            representation.presentationTimeOffset = 0;
-            representation.adaptation.period.duration = 11;
-            representation.SegmentTemplate = {
+            const representation = createTimelineRepresentation({
                 timescale: 10,
+                duration: 11,
                 initialization: 'init-$RepresentationID$.m4s',
-                SegmentTimeline: {
-                    S: [
-                        { t: 0, d: 10, r: 4 },
-                        { t: 50, d: 20, r: 2 }
-                    ]
-                },
+                S: [
+                    { t: 0, d: 10, r: 4 },
+                    { t: 50, d: 20, r: 2 }
+                ],
                 media: 'seg-$Time$.m4s'
-            };
-            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+            });
 
             let seg = timelineSegmentsGetter.getSegmentByTime(representation, 3.1);
             expect(seg).to.exist;
@@ -309,16 +322,12 @@ describe('TimelineSegmentsGetter', () => {
         });
 
         it('should fall back to full segment (not partial) when time is exactly at end boundary of a segment with partials', () => {
-            const voHelper = new VoHelper();
-            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.timescale = 3; // simple timescale
-            representation.SegmentTemplate = {
+            const representation = createTimelineRepresentation({
                 timescale: 3,
                 initialization: 'init.m4s',
-                SegmentTimeline: { S: [{ t: 0, d: 3, k: 3 }] }, // segment duration = 1s (3/3)
+                S: [{ t: 0, d: 3, k: 3 }], // segment duration = 1s (3/3)
                 media: 's-$Time$-$SubNumber$.m4s'
-            };
-            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+            });
             // Request time exactly at end (1.0s) -> outside first and only segment -> null
             const seg = timelineSegmentsGetter.getSegmentByTime(representation, 1.0);
             expect(seg).to.be.null; // jshint ignore:line
@@ -332,19 +341,13 @@ describe('TimelineSegmentsGetter', () => {
                 timelineConverter: timelineConverter,
                 dashMetrics: { getCurrentDVRInfo: () => dvr }
             }, false);
-            const voHelper = new VoHelper();
-            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.timescale = 100;
-            representation.presentationTimeOffset = 0;
-            representation.adaptation.period.start = 0;
-            representation.adaptation.period.duration = NaN; // force the DVR-window branch
-            representation.SegmentTemplate = {
+            const representation = createTimelineRepresentation({
                 timescale: 100,
+                duration: NaN, // force the DVR-window branch
                 initialization: 'init-$RepresentationID$.m4s',
-                SegmentTimeline: { S: [{ t: 0, d: 100, r: -1 }] }, // 1s segments, open-ended
+                S: [{ t: 0, d: 100, r: -1 }], // 1s segments, open-ended
                 media: 'seg-$Time$.m4s'
-            };
-            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+            });
 
             expect(getter.getMediaFinishedInformation(representation).numberOfSegments).to.equal(50);
             expect(getter.getSegmentByTime(representation, 60)).to.be.null; // jshint ignore:line
@@ -357,19 +360,11 @@ describe('TimelineSegmentsGetter', () => {
         });
 
         it('should invalidate the cache when the S array is updated in place with the same length', () => {
-            const voHelper = new VoHelper();
-            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
-            representation.timescale = 1;
-            representation.presentationTimeOffset = 0;
-            representation.adaptation.period.start = 0;
             const S = [{ t: 0, d: 10 }, { t: 10, d: 10 }, { t: 20, d: 10 }];
-            representation.SegmentTemplate = {
+            const representation = createTimelineRepresentation({
                 timescale: 1,
-                initialization: 'init.m4s',
-                SegmentTimeline: { S },
-                media: 'seg-$Time$.m4s'
-            };
-            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+                S
+            });
 
             expect(timelineSegmentsGetter.getMediaFinishedInformation(representation).mediaTimeOfLastSignaledSegment).to.equal(30);
             // slide the window: drop the oldest, append the newest, length unchanged
@@ -379,6 +374,23 @@ describe('TimelineSegmentsGetter', () => {
             const seg = timelineSegmentsGetter.getSegmentByTime(representation, 35);
             expect(seg).to.exist; // jshint ignore:line
             expect(seg.presentationStartTime).to.equal(30);
+        });
+
+        it('should invalidate the cache when boundary S timing is mutated in place', () => {
+            const S = [{ t: 0, d: 10 }, { t: 10, d: 10 }];
+            const representation = createTimelineRepresentation({
+                timescale: 1,
+                S
+            });
+
+            expect(timelineSegmentsGetter.getSegmentByTime(representation, 15).duration).to.equal(10);
+            S[1].d = 20;
+
+            expect(timelineSegmentsGetter.getMediaFinishedInformation(representation).mediaTimeOfLastSignaledSegment).to.equal(30);
+            const seg = timelineSegmentsGetter.getSegmentByTime(representation, 25);
+            expect(seg).to.exist; // jshint ignore:line
+            expect(seg.presentationStartTime).to.equal(10);
+            expect(seg.duration).to.equal(20);
         });
 
         it('should return null when the requested time resolves to NaN', () => {


### PR DESCRIPTION
Fixes #5050.

## Change

`TimelineSegmentsGetter` resolved every lookup by scanning from the first `<S>`. This replaces that with an indexed lookup.

- `_computeLookup(representation)` walks the timeline once, producing one block per `<S>` (media start/end, `@r`, cumulative index) plus the total segment count and last media time. `_getSegmentLookup` caches it in a `WeakMap` per representation.
- `getSegmentByTime`/`getSegmentByIndex` binary-search the block by media time, then compute the segment by arithmetic. The last matched block is checked first, so sequential playback is O(1) per fetch.
- `getMediaFinishedInformation` returns the counts from a lightweight pass and does not materialise the block list for representations that are never buffered.
- `_precisionRound` is computed once per lookup instead of once per segment.

## Why

See #5050. Sequential playback was O(N^2) and the live edge O(W) per fetch. In a 30 s Chrome profile of the `livesim2` 6h-DVR stream, `_iterateSegments` was the top application function (409 ms, about 53% of non-idle main-thread CPU).

## Numbers

Full sequential playthrough, output identical with and without the change:

| 8000 segments | before | after |
| --- | --- | --- |
| one `<S r>` | 10949 ms | 6.9 ms |
| distinct `<S>` | 11356 ms | 7.4 ms |

Real `livesim2` 6h-DVR manifest, per-call: live-edge fetch 1.6-1.8 ms before, about 1 us after.

## Correctness

Behaviour matches the previous linear scan. Verified byte-identical for full sequential playback, 50 random seeks, and `getMediaFinishedInformation` across both timeline shapes and N = 1, 2, 10, 137, 1000. The following cases that the cache could have broken are handled and covered by unit tests:

- Open-ended negative `@r` (`<S r="-1">`) depends on the advancing DVR window / period end, so those lookups are recomputed per call rather than cached.
- The index is invalidated when the parsed `<S>` array changes reference, length, first/last element, first/last timing (`@t`, `@d`, `@r`), or `SegmentURL` array.
- A NaN required time returns null, and a non-monotonic (out-of-order `@t`) timeline falls back to a linear scan.

## Review notes

- `_precisionRound` semantics, partial segments (`@k`), and period boundaries are unchanged from the previous implementation.
- Cache validation intentionally stays O(1): it checks representation/timescale identity, timeline array identity/length, boundary identity/timing, and `SegmentURL` identity instead of rescanning every `<S>` on each lookup.
