### PR TITLE
Feature: add support for onRequest XLink

### DIFF
--- a/samples/dash-if-reference-player/app/data/sources.json
+++ b/samples/dash-if-reference-player/app/data/sources.json
@@ -438,6 +438,17 @@
                     ]
                 },
                 {
+                    "url": "https://livesim.dashif.org/livesim2/segtimeline_1/tsbd_600/periods_60/xlink_1/testpic_2s/Manifest.mpd",
+                    "name": "Multiperiod SegmentTimeline with remote periods via XLink",
+                    "provider": "dashif",
+                    "tags": [
+                        "live",
+                        "segmenttimeline",
+                        "xlink",
+                        "dashif"
+                    ]
+                },
+                {
                     "url": " https://livesim2.dashif.org/livesim2/ato_10/testpic_2s/Manifest.mpd",
                     "name": "10 seconds availabilityTimeOffset (livesim)",
                     "provider": "dashif",

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -1248,6 +1248,7 @@ function DashAdapter() {
         streamInfo.manifestInfo = convertMpdToManifestInfo(period.mpd);
         streamInfo.isLast = period.mpd.manifest.Period.length === 1 || Math.abs((streamInfo.start + streamInfo.duration) - streamInfo.manifestInfo.duration) < THRESHOLD;
         streamInfo.isEncrypted = period.isEncrypted;
+        streamInfo.isResolved = period.isResolved;
 
         return streamInfo;
     }

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -328,7 +328,7 @@ function DashManifestModel() {
     }
 
     function getRealAdaptations(manifest, periodIndex) {
-        return manifest && manifest.Period && isInteger(periodIndex) ? manifest.Period[periodIndex] ? manifest.Period[periodIndex].AdaptationSet : [] : [];
+        return manifest && manifest.Period && isInteger(periodIndex) ? manifest.Period[periodIndex] ? manifest.Period[periodIndex].AdaptationSet ? manifest.Period[periodIndex].AdaptationSet : [] : [] : [];
     }
 
     function getRealPeriods(manifest) {
@@ -486,6 +486,10 @@ function DashManifestModel() {
         const contentProtectionElements = getContentProtectionByPeriod(period);
 
         return contentProtectionElements && contentProtectionElements.length > 0;
+    }
+
+    function isPeriodResolved(period) {
+        return !period.hasOwnProperty('xlink:href');
     }
 
     function getContentProtectionByManifest(manifest) {
@@ -1172,6 +1176,7 @@ function DashManifestModel() {
                 voPeriod.index = i;
                 voPeriod.mpd = mpd;
                 voPeriod.isEncrypted = isPeriodEncrypted(realPeriod);
+                voPeriod.isResolved = isPeriodResolved(realPeriod);
 
                 if (realPeriod.hasOwnProperty(DashConstants.DURATION)) {
                     voPeriod.duration = realPeriod.duration;

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -268,6 +268,10 @@ function TimelineConverter() {
                     periodRange.start = currentVoPeriod.start;
                     periodRange.end = Math.max(now, currentVoPeriod.start + currentVoPeriod.duration);
                 }
+            } else {
+                // If period is not resolved yet, use signaled start and duration
+                periodRange.start = stream.getStartTime();
+                periodRange.end = periodRange.start + stream.getDuration();
             }
 
             if (!isNaN(periodRange.start) && (isNaN(range.start) || range.start > periodRange.start)) {

--- a/src/dash/vo/Period.js
+++ b/src/dash/vo/Period.js
@@ -41,6 +41,7 @@ class Period {
         this.mpd = null;
         this.nextPeriodId = null;
         this.isEncrypted = false;
+        this.isResolved = true;
     }
 }
 

--- a/src/dash/vo/StreamInfo.js
+++ b/src/dash/vo/StreamInfo.js
@@ -41,6 +41,7 @@ class StreamInfo {
         this.manifestInfo = null;
         this.isLast = true;
         this.isEncrypted = false;
+        this.isResolved = true;
     }
 }
 

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -55,7 +55,8 @@ function ManifestLoader(config) {
         logger,
         urlLoader,
         xlinkController,
-        parser;
+        parser,
+        mpd;
 
     let mssHandler = config.mssHandler;
     let errHandler = config.errHandler;
@@ -78,13 +79,16 @@ function ManifestLoader(config) {
             errHandler: errHandler,
             dashMetrics: config.dashMetrics,
             mediaPlayerModel: config.mediaPlayerModel,
+            baseURLController: config.baseURLController,
             settings: config.settings
         });
 
         parser = null;
+        mpd = null;
     }
 
     function onXlinkReady(event) {
+        mpd = event.manifest;
         eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: event.manifest });
     }
 
@@ -223,7 +227,7 @@ function ManifestLoader(config) {
 
                     manifest.baseUri = baseUri;
                     manifest.loadedTime = new Date();
-                    xlinkController.resolveManifestOnLoad(manifest);
+                    xlinkController.resolveManifestOnLoad(manifest, mpd);
 
                     eventBus.trigger(Events.ORIGINAL_MANIFEST_LOADED, { originalManifest: data });
                 } else {
@@ -248,6 +252,14 @@ function ManifestLoader(config) {
         });
     }
 
+    function resolvePeriod(periodId) {
+        if (!xlinkController) {
+            return;
+        }
+        logger.info('Resolve period ' + periodId);
+        xlinkController.resolvePeriodOnRequest(periodId)
+    }
+
     function reset() {
         eventBus.off(Events.XLINK_READY, onXlinkReady, instance);
 
@@ -268,6 +280,7 @@ function ManifestLoader(config) {
 
     instance = {
         load: load,
+        resolvePeriod: resolvePeriod,
         reset: reset
     };
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2695,6 +2695,7 @@ function MediaPlayer() {
             dashMetrics: dashMetrics,
             mediaPlayerModel: mediaPlayerModel,
             mssHandler: mssHandler,
+            baseURLController: baseURLController,
             settings: settings
         });
     }

--- a/src/streaming/controllers/ExtUrlQueryInfoController.js
+++ b/src/streaming/controllers/ExtUrlQueryInfoController.js
@@ -133,7 +133,7 @@ function ExtUrlQueryInfoController() {
             };
             _generateQueryParams(periodObject, period, mpdUrlQuery, mpdQueryStringInformation, DashConstants.PERIOD);
 
-            period.AdaptationSet.forEach((adaptationSet) => {
+            period.AdaptationSet?.forEach((adaptationSet) => {
                 const adaptationObject = {
                     representation: []
                 };

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -65,7 +65,8 @@ function StreamController() {
         autoPlay, isStreamSwitchingInProgress, hasMediaError, hasInitialisationError, mediaSource, videoModel,
         playbackController, serviceDescriptionController, mediaPlayerModel, customParametersModel, isPaused,
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
-        firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation;
+        firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
+        switchSeekTime, switchTargetStream;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -265,6 +266,11 @@ function StreamController() {
                     return new Promise((resolve, reject) => {
                         if (!activeStream) {
                             _initializeForFirstStream(streamsInfo, resolve, reject);
+                        } else if (switchSeekTime !== null && switchTargetStream !== null) {
+                            // On-going stream switching on a remote period (onRequest)
+                            _switchStream(switchTargetStream, activeStream, switchSeekTime);
+                            switchTargetStream = switchSeekTime = null;
+                            resolve();
                         } else {
                             resolve();
                         }
@@ -424,6 +430,15 @@ function StreamController() {
     function _switchStream(targetStream, previousStream, seekTime) {
         try {
             if (isStreamSwitchingInProgress || !targetStream || (previousStream === targetStream && targetStream.getIsActive())) {
+                return;
+            }
+
+            // Resolve period in case of onRequest xlink
+            const targetStreamInfo = targetStream.getStreamInfo();
+            if (!targetStreamInfo.isResolved) {
+                switchSeekTime = seekTime;
+                switchTargetStream = targetStream;
+                manifestLoader.resolvePeriod(targetStreamInfo.id);
                 return;
             }
 
@@ -942,10 +957,17 @@ function StreamController() {
 
         while (i < upcomingStreams.length) {
             const stream = upcomingStreams[i];
+            const streamInfo = stream.getStreamInfo();
             const previousStream = i === 0 ? activeStream : upcomingStreams[i - 1];
 
             // If the preloading for the current stream is not scheduled, but its predecessor has finished buffering we can start prebuffering this stream
             if (!stream.getPreloaded() && previousStream.getHasFinishedBuffering()) {
+                // If the stream's period is not resolved yet (onRequest xlink) then load it first
+                if (!streamInfo.isResolved) {
+                    manifestLoader.resolvePeriod(streamInfo.id);
+                    return;
+                }
+
                 _onStreamCanLoadNext(stream, previousStream);
             }
             i += 1;
@@ -1678,6 +1700,8 @@ function StreamController() {
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;
+        switchSeekTime = null;
+        switchTargetStream = null;
         errorInformation = {
             counts: {
                 mediaErrorDecode: 0

--- a/src/streaming/controllers/XlinkController.js
+++ b/src/streaming/controllers/XlinkController.js
@@ -37,6 +37,7 @@ import DashConstants from '../../dash/constants/DashConstants.js';
 
 const RESOLVE_TYPE_ONLOAD = 'onLoad';
 const RESOLVE_TYPE_ONACTUATE = 'onActuate';
+const RESOLVE_TYPE_ONREQUEST = 'onRequest';
 const RESOLVE_TO_ZERO = 'urn:mpeg:dash:resolve-to-zero:2013';
 
 function XlinkController(config) {
@@ -49,10 +50,13 @@ function XlinkController(config) {
     let instance,
         parser,
         manifest,
-        xlinkLoader;
+        xlinkLoader,
+        baseURLController;
 
     function setup() {
         eventBus.on(Events.XLINK_ELEMENT_LOADED, onXlinkElementLoaded, instance);
+
+        baseURLController = config.baseURLController;
 
         xlinkLoader = XlinkLoader(context).create({
             errHandler: config.errHandler,
@@ -72,17 +76,33 @@ function XlinkController(config) {
      * <p>Triggers the resolution of the xlink.onLoad attributes in the manifest file </p>
      * @param {Object} mpd - the manifest
      */
-    function resolveManifestOnLoad(mpd) {
+    function resolveManifestOnLoad(mpd, previousMpd) {
         let elements;
-        // First resolve all periods, so unnecessary requests inside onLoad Periods with Default content are avoided
-        manifest = mpd;
 
+        // First merge all periods previsouly resolved (in case iof manifest update)
+        manifest = mergeResolvedPeriods(mpd, previousMpd)
+
+        // Resolve all periods, so unnecessary requests inside onLoad Periods with Default content are avoided
         if (manifest.Period) {
             elements = getElementsToResolve(manifest.Period, manifest, DashConstants.PERIOD, RESOLVE_TYPE_ONLOAD);
             resolve(elements, DashConstants.PERIOD, RESOLVE_TYPE_ONLOAD);
         } else {
             eventBus.trigger(Events.XLINK_READY, {manifest: manifest});
         }
+    }
+
+    /**
+     * <p>Triggers the resolution of the period(s) with xlink.onRequest attributes and optionnaly identified by provided period id </p>
+     * @param {Object} mpd - the manifest
+     */
+    function resolvePeriodOnRequest(periodId) {
+        let elements;
+        if (!manifest.Period) {
+            return;
+        }
+
+        elements = getElementsToResolve(manifest.Period, manifest, DashConstants.PERIOD, RESOLVE_TYPE_ONREQUEST, periodId);
+        resolve(elements, DashConstants.PERIOD, RESOLVE_TYPE_ONREQUEST);
     }
 
     function reset() {
@@ -111,7 +131,9 @@ function XlinkController(config) {
             if (urlUtils.isHTTPURL(element.url)) {
                 url = element.url;
             } else {
-                url = element.originalContent.BaseURL + element.url;
+                // url = element.originalContent.BaseURL + element.url;
+                const baseUrl = baseURLController.resolve(element.path);
+                url = urlUtils.resolve(element.url, baseUrl ? baseUrl.url : element.originalContent.BaseURL);
             }
             xlinkLoader.load(url, element, resolveObject);
         }
@@ -149,7 +171,7 @@ function XlinkController(config) {
             obj;
 
         mergeElementsBack(resolveObject);
-        if (resolveObject.resolveType === RESOLVE_TYPE_ONACTUATE) {
+        if (resolveObject.resolveType === RESOLVE_TYPE_ONACTUATE || resolveObject.resolveType === RESOLVE_TYPE_ONREQUEST) {
             eventBus.trigger(Events.XLINK_READY, { manifest: manifest });
         }
         if (resolveObject.resolveType === RESOLVE_TYPE_ONLOAD) {
@@ -176,7 +198,7 @@ function XlinkController(config) {
     }
 
     // Returns the elements with the specific resolve Type
-    function getElementsToResolve(elements, parentElement, type, resolveType) {
+    function getElementsToResolve(elements, parentElement, type, resolveType, id) {
         let toResolve = [];
         let element,
             i,
@@ -192,8 +214,10 @@ function XlinkController(config) {
         for (i = 0; i < elements.length; i++) {
             element = elements[i];
             if (element.hasOwnProperty('xlink:href') && element.hasOwnProperty('xlink:actuate') && element['xlink:actuate'] === resolveType) {
-                xlinkObject = createXlinkObject(element['xlink:href'], parentElement, type, i, resolveType, element);
-                toResolve.push(xlinkObject);
+                if (!id || element['id'] === id) {
+                    xlinkObject = createXlinkObject(element['xlink:href'], parentElement, type, i, resolveType, element);
+                    toResolve.push(xlinkObject);
+                }
             }
         }
         return toResolve;
@@ -238,6 +262,31 @@ function XlinkController(config) {
         }
     }
 
+    function mergeResolvedPeriods(mpd, previousMpd) {
+        if (!previousMpd) {
+            return mpd;
+        }
+        let i;
+
+        for (i = 0; i < mpd.Period.length; i++) {
+            if (isLinkedElement(mpd.Period[i])) {
+                const resolvedPeriod = getResolvedPeriod(previousMpd, mpd.Period[i].id)
+                if (resolvedPeriod) {
+                    mpd.Period[i] = resolvedPeriod
+                }
+            }
+        }
+        return mpd;
+    }
+
+    function isLinkedElement(element) {
+        return element.hasOwnProperty('xlink:href') && element.hasOwnProperty('xlink:actuate') 
+    }
+
+    function getResolvedPeriod(mpd, id) {
+        return mpd.Period.find(period => period.id === id && !isLinkedElement(period))
+    }
+
     function createXlinkObject(url, parentElement, type, index, resolveType, originalContent) {
         return {
             url: url,
@@ -271,6 +320,7 @@ function XlinkController(config) {
 
     instance = {
         resolveManifestOnLoad: resolveManifestOnLoad,
+        resolvePeriodOnRequest: resolvePeriodOnRequest,
         setParser: setParser,
         reset: reset
     };

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -205,7 +205,7 @@ function CapabilitiesFilter() {
         const configurations = [];
 
         manifest.Period.forEach((period) => {
-            period.AdaptationSet.forEach((as) => {
+            period.AdaptationSet?.forEach((as) => {
                 if (adapter.getIsTypeOf(as, type)) {
                     as.Representation.forEach((rep, i) => {
                         const codec = adapter.getCodec(as, i, false);
@@ -464,6 +464,9 @@ function CapabilitiesFilter() {
         }
 
         manifest.Period.forEach((period) => {
+            if (!period.AdaptationSet) {
+                return;
+            }
             period.AdaptationSet = period.AdaptationSet.filter((as) => {
 
                 if (!as.Representation || as.Representation.length === 0) {

--- a/test/unit/mocks/StreamMock.js
+++ b/test/unit/mocks/StreamMock.js
@@ -27,6 +27,14 @@ StreamMock.prototype.setStreamInfo = function (streamInfo) {
     this.streamInfo = streamInfo;
 };
 
+StreamMock.prototype.getStartTime = function () {
+    return this.streamInfo ? this.streamInfo.start : NaN;
+};
+
+StreamMock.prototype.getDuration = function () {
+    return this.streamInfo ? this.streamInfo.duration : NaN;
+};
+
 StreamMock.prototype.getFragmentController = function () {
     return {
         getModel: () => {


### PR DESCRIPTION
This PR adds support for MPD assembly of remote periods with xlink:onActuate="onRequest".
A test stream from Livesim2 has been added ([https://livesim.dashif.org/livesim2/segtimeline_1/tsbd_600/periods_60/xlink_1/testpic_2s/Manifest.mpd](https://livesim.dashif.org/livesim2/segtimeline_1/tsbd_600/periods_60/xlink_1/testpic_2s/Manifest.mpd)) for testing/validation purpose.