### PR TITLE
perf(cmcd): reuse the top-bitrate representation list within a request

### DIFF
--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -72,7 +72,8 @@ function CmcdModel() {
         _rebufferingStartTime = {},
         _rebufferingDuration = {},
         _streamType,
-        _streamingFormat;
+        _streamingFormat,
+        _topBitrateCache;
 
     let context = this.context;
 
@@ -300,10 +301,19 @@ function CmcdModel() {
 
     function _getTopBitrateByType(mediaInfo) {
         try {
+            // Within a single request's data build the same representation list backs both tb and
+            // tpb. Reuse the result so the list is rebuilt once per mediaInfo, not per key.
+            if (_topBitrateCache && _topBitrateCache.has(mediaInfo)) {
+                return _topBitrateCache.get(mediaInfo);
+            }
             const bitrates = abrController.getPossibleVoRepresentationsFilteredBySettings(mediaInfo).map((rep) => {
                 return rep.bitrateInKbit
             });
-            return Math.max(...bitrates)
+            const tb = Math.max(...bitrates);
+            if (_topBitrateCache) {
+                _topBitrateCache.set(mediaInfo, tb);
+            }
+            return tb;
         } catch (e) {
             return null;
         }
@@ -730,6 +740,10 @@ function CmcdModel() {
     }
 
     function deriveCmcdDataForRequest(request) {
+        // Share one top-bitrate computation across this request's data build (tb and tpb both
+        // resolve it from the representation list). Scoped to the call, so a later request still
+        // recomputes and runtime setting changes remain reflected.
+        _topBitrateCache = new Map();
         try {
             _updateLastMediaTypeRequest(request.type, request.mediaType);
             let cmcdData = {};
@@ -753,6 +767,8 @@ function CmcdModel() {
             return cmcdData;
         } catch (e) {
             return null;
+        } finally {
+            _topBitrateCache = null;
         }
     }
 

--- a/test/unit/test/streaming/streaming.models.CmcdModel.js
+++ b/test/unit/test/streaming/streaming.models.CmcdModel.js
@@ -105,6 +105,39 @@ describe('CmcdModel', function () {
             expect(data.d).to.equal(4000); // duration in ms
         });
 
+        it('should rebuild the top-bitrate list once when tb and tpb share the media info', function () {
+            const mediaInfo = { type: Constants.VIDEO };
+            let rebuilds = 0;
+            abrControllerMock.getPossibleVoRepresentationsFilteredBySettings = () => {
+                rebuilds++;
+                return [{ bitrateInKbit: 2000 }];
+            };
+            // A video stream processor whose media info is the same object the request carries, so
+            // tb (request media info) and tpb (processor media info) resolve the same list.
+            const videoSp = {
+                getType: () => Constants.VIDEO,
+                getMediaInfo: () => mediaInfo,
+                probeNextRequest: () => undefined
+            };
+            playbackControllerMock.getStreamController().getActiveStream().getStreamProcessors = () => [videoSp];
+            cmcdModel.reset(); // repopulates streamProcessors from the configured playback controller
+
+            const request = {
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: Constants.VIDEO,
+                bandwidth: 1000000,
+                duration: 4,
+                url: 'http://example.com/seg.m4s',
+                representation: { mediaInfo }
+            };
+
+            const data = cmcdModel.deriveCmcdDataForRequest(request);
+            expect(data).to.exist;
+            expect(data).to.have.property('tb');
+            expect(data).to.have.property('tpb');
+            expect(rebuilds).to.equal(1);
+        });
+
         it('should return CMCD data for init segment requests', function () {
             const request = {
                 type: HTTPRequest.INIT_SEGMENT_TYPE,


### PR DESCRIPTION
Fixes #5054.

## Change

Building CMCD data for a media segment computed the top bitrate twice: once for `tb` (from the request's media info) and once for `tpb` (from the stream processor's media info), each rebuilding the full representation list via `abrController.getPossibleVoRepresentationsFilteredBySettings(...)`.

`_getTopBitrateByType` is now memoized per media info for the duration of one `deriveCmcdDataForRequest` call. When `tb` and `tpb` resolve to the same media info (the active track, the common case), the list is rebuilt once instead of twice. The cache is created at the start of the call and cleared at the end, so a later request recomputes and any runtime `maxBitrate` setting change stays reflected.

## Why

See #5054. `getRepresentationsForAdaptation` reconstructs every `Representation` and re-sorts/filters them; measured at about 1 µs per rendition (8 µs at 8 renditions, 90 µs at 96). This removes one such rebuild per media-segment CMCD build. CMCD is opt-in, so this only affects sessions with CMCD enabled; it is a small, conditional cleanup.

## Correctness

The cached value is keyed on the media info object, so two different media infos still compute independently. Behaviour is unchanged: the existing CMCD suite passes, plus a new test asserting the list is rebuilt once when `tb` and `tpb` share the media info.

## Note

The same uncached rebuild also happens in `AbrController.getPossibleVoRepresentations`, called once per ABR rule per decision. Caching the representation list across calls is a larger, separate change and is not addressed here.
