### PR TITLE
Fix blacklist controller not being active after reset

### DIFF
--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -104,6 +104,8 @@ function ManifestUpdater() {
     function initialize() {
         resetInitialSettings();
 
+        locationSelector.initialize();
+
         eventBus.on(Events.STREAMS_COMPOSED, _onStreamsComposed, this);
         eventBus.on(MediaPlayerEvents.PLAYBACK_STARTED, _onPlaybackStarted, this);
         eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, _onPlaybackPaused, this);
@@ -123,11 +125,12 @@ function ManifestUpdater() {
     }
 
     function reset() {
-
         eventBus.off(MediaPlayerEvents.PLAYBACK_STARTED, _onPlaybackStarted, this);
         eventBus.off(MediaPlayerEvents.PLAYBACK_PAUSED, _onPlaybackPaused, this);
         eventBus.off(Events.STREAMS_COMPOSED, _onStreamsComposed, this);
         eventBus.off(Events.INTERNAL_MANIFEST_LOADED, _onManifestLoaded, this);
+
+        locationSelector.reset();
 
         resetInitialSettings();
     }

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -132,6 +132,7 @@ function Stream(config) {
      * Initialize the events
      */
     function initialize() {
+        segmentBlacklistController.initialize();
         registerEvents();
         registerProtectionEvents();
         textController.initializeForStream(streamInfo);

--- a/src/streaming/controllers/BaseURLController.js
+++ b/src/streaming/controllers/BaseURLController.js
@@ -58,8 +58,6 @@ function BaseURLController() {
     function setup() {
         baseURLTreeModel = BaseURLTreeModel(context).create();
         baseURLSelector = BaseURLSelector(context).create();
-
-        eventBus.on(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, onBlackListChanged, instance);
     }
 
     function setConfig(config) {
@@ -117,6 +115,7 @@ function BaseURLController() {
     }
 
     function reset() {
+        eventBus.off(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, onBlackListChanged, instance);
         baseURLTreeModel.reset();
         baseURLSelector.reset();
     }
@@ -126,12 +125,14 @@ function BaseURLController() {
     }
 
     function initialize(data) {
-
+        eventBus.on(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, onBlackListChanged, instance);
         // report config to baseURLTreeModel and baseURLSelector
         baseURLTreeModel.setConfig({
             adapter,
             contentSteeringController
         });
+
+        baseURLSelector.initialize();
 
         update(data);
     }

--- a/src/streaming/controllers/BlacklistController.js
+++ b/src/streaming/controllers/BlacklistController.js
@@ -93,7 +93,7 @@ function BlackListController(config) {
         return settings.get().streaming.blacklistExpiryTime;
     }
 
-    function setup() {
+    function initialize() {
         if (addBlacklistEventName) {
             eventBus.on(addBlacklistEventName, onAddBlackList, instance);
         }
@@ -115,10 +115,10 @@ function BlackListController(config) {
         add: add,
         remove: remove,
         contains: contains,
+        initialize: initialize,
         reset: reset
     };
 
-    setup();
     return instance;
 }
 

--- a/src/streaming/utils/BaseURLSelector.js
+++ b/src/streaming/utils/BaseURLSelector.js
@@ -132,12 +132,17 @@ function BaseURLSelector() {
         return selectedBaseUrl;
     }
 
+    function initialize() {
+        serviceLocationBlacklistController.initialize();
+    }
+
     function reset() {
         serviceLocationBlacklistController.reset();
     }
 
     instance = {
         chooseSelector: chooseSelector,
+        initialize: initialize,
         select: select,
         reset: reset,
         setConfig: setConfig

--- a/src/streaming/utils/LocationSelector.js
+++ b/src/streaming/utils/LocationSelector.js
@@ -54,6 +54,10 @@ function LocationSelector() {
         contentSteeringController = ContentSteeringController(context).getInstance();
     }
 
+    function initialize() {
+        blacklistController.initialize();
+    }
+
     function setConfig(config) {
         if (config.blacklistController) {
             blacklistController = config.blacklistController;
@@ -121,6 +125,7 @@ function LocationSelector() {
     }
 
     instance = {
+        initialize,
         select,
         setConfig,
         reset

--- a/test/unit/test/streaming/streaming.controllers.BaseURLController.js
+++ b/test/unit/test/streaming/streaming.controllers.BaseURLController.js
@@ -2,6 +2,8 @@ import BaseURLController from '../../../../src/streaming/controllers/BaseURLCont
 import BasicSelector from '../../../../src/streaming/utils/baseUrlResolution/BasicSelector.js';
 import BaseURLSelector from '../../../../src/streaming/utils/BaseURLSelector.js';
 import BaseURL from '../../../../src/dash/vo/BaseURL.js';
+import EventBus from '../../../../src/core/EventBus.js';
+import Events from '../../../../src/core/events/Events.js';
 import ContentSteeringSelectorMock from '../../mocks/ContentSteeringSelectorMock.js';
 import chai from 'chai';
 
@@ -32,6 +34,57 @@ const dummyBlacklistController = {
 };
 
 describe('BaseURLController', function () {
+
+    it('should add event handlers again after reset', () => {
+        const localContext = {};
+        const localEventBus = EventBus(localContext).getInstance();
+        const invalidateSpy = chai.spy();
+        const localAdapter = {
+            getIsDVB: () => false
+        };
+        const localBaseURLTreeModel = {
+            invalidateSelectedIndexes: invalidateSpy,
+            setConfig: () => {
+            },
+            update: () => {
+            },
+            reset: () => {
+            },
+            getForPath: () => [],
+            getBaseUrls: () => []
+        };
+        const localBaseURLSelector = {
+            chooseSelector: () => {
+            },
+            initialize: () => {
+            },
+            reset: () => {
+            },
+            select: () => {
+            }
+        };
+
+        const localBaseURLController = BaseURLController(localContext).create();
+        localBaseURLController.setConfig({
+            adapter: localAdapter,
+            baseURLTreeModel: localBaseURLTreeModel,
+            baseURLSelector: localBaseURLSelector
+        });
+        localBaseURLController.initialize({});
+
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, { entry: 'a' });
+        expect(invalidateSpy).to.have.been.called.exactly(1);
+
+        localBaseURLController.reset();
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, { entry: 'b' });
+        expect(invalidateSpy).to.have.been.called.exactly(1);
+
+        localBaseURLController.initialize({});
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_CHANGED, { entry: 'c' });
+        expect(invalidateSpy).to.have.been.called.exactly(2);
+
+        localBaseURLController.reset();
+    });
 
     it('should return undefined if resolution fails at any level', () => {
 

--- a/test/unit/test/streaming/streaming.controllers.BlacklistController.js
+++ b/test/unit/test/streaming/streaming.controllers.BlacklistController.js
@@ -93,6 +93,7 @@ describe('BlacklistController', function () {
             addBlacklistEventName: EVENT_NAME
         };
         const blacklistController = BlacklistController(context).create(config);
+        blacklistController.initialize();
 
         eventBus.trigger(EVENT_NAME, {
             entry: SERVICE_LOCATION
@@ -101,6 +102,35 @@ describe('BlacklistController', function () {
         const contains = blacklistController.contains(SERVICE_LOCATION);
 
         expect(contains).to.be.true; // jshint ignore:line
+    });
+
+    it('should add event handlers again after reset', () => {
+        const config = {
+            updateEventName: '',
+            addBlacklistEventName: EVENT_NAME
+        };
+        const blacklistController = BlacklistController(context).create(config);
+        blacklistController.initialize();
+
+        eventBus.trigger(EVENT_NAME, {
+            entry: SERVICE_LOCATION
+        });
+        expect(blacklistController.contains(SERVICE_LOCATION)).to.be.true;
+
+        blacklistController.reset();
+        expect(blacklistController.contains(SERVICE_LOCATION)).to.be.false;
+
+        // Listener has been removed by reset(), so this event should be ignored.
+        eventBus.trigger(EVENT_NAME, {
+            entry: SERVICE_LOCATION
+        });
+        expect(blacklistController.contains(SERVICE_LOCATION)).to.be.false;
+
+        blacklistController.initialize();
+        eventBus.trigger(EVENT_NAME, {
+            entry: SERVICE_LOCATION
+        });
+        expect(blacklistController.contains(SERVICE_LOCATION)).to.be.true;
     });
 
     it('should not trigger an update event if a duplicate entry is added', () => {

--- a/test/unit/test/streaming/streaming.utils.BaseURLSelector.js
+++ b/test/unit/test/streaming/streaming.utils.BaseURLSelector.js
@@ -1,5 +1,9 @@
 import BaseURLSelector from '../../../../src/streaming/utils/BaseURLSelector.js';
+import BaseURL from '../../../../src/dash/vo/BaseURL.js';
 import Constants from '../../../../src/streaming/constants/Constants.js';
+import EventBus from '../../../../src/core/EventBus.js';
+import Events from '../../../../src/core/events/Events.js';
+import Settings from '../../../../src/core/Settings.js';
 
 import {expect} from 'chai';
 
@@ -15,5 +19,48 @@ describe('BaseURLSelector', function () {
         const selector = baseURLSelector.select();
 
         expect(selector).to.be.undefined; // jshint ignore:line
+    });
+
+    it('should clear and re-add event handlers on reset and initialize', function () {
+        const localContext = {};
+        const localSettings = Settings(localContext).getInstance();
+        localSettings.update({ streaming: { applyContentSteering: false } });
+        const localBaseURLSelector = BaseURLSelector(localContext).create();
+        const localEventBus = EventBus(localContext).getInstance();
+        const data = {
+            baseUrls: [
+                new BaseURL('http://www.example.com/', 'a'),
+                new BaseURL('http://www2.example.com/', 'b')
+            ],
+            selectedIdx: NaN
+        };
+
+        localBaseURLSelector.initialize();
+
+        let selected = localBaseURLSelector.select(data);
+        expect(selected.serviceLocation).to.equal('a');
+
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_ADD, {
+            entry: 'a'
+        });
+        data.selectedIdx = NaN;
+        selected = localBaseURLSelector.select(data);
+        expect(selected.serviceLocation).to.equal('b');
+
+        localBaseURLSelector.reset();
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_ADD, {
+            entry: 'b'
+        });
+        data.selectedIdx = NaN;
+        selected = localBaseURLSelector.select(data);
+        expect(selected.serviceLocation).to.equal('a');
+
+        localBaseURLSelector.initialize();
+        localEventBus.trigger(Events.SERVICE_LOCATION_BASE_URL_BLACKLIST_ADD, {
+            entry: 'a'
+        });
+        data.selectedIdx = NaN;
+        selected = localBaseURLSelector.select(data);
+        expect(selected.serviceLocation).to.equal('b');
     });
 });

--- a/test/unit/test/streaming/streaming.utils.LocationSelector.js
+++ b/test/unit/test/streaming/streaming.utils.LocationSelector.js
@@ -1,0 +1,56 @@
+import LocationSelector from '../../../../src/streaming/utils/LocationSelector.js';
+import BaseURL from '../../../../src/dash/vo/BaseURL.js';
+import EventBus from '../../../../src/core/EventBus.js';
+import Events from '../../../../src/core/events/Events.js';
+import Settings from '../../../../src/core/Settings.js';
+
+import {expect} from 'chai';
+
+describe('LocationSelector', function () {
+    it('should listen to blacklist add events again after reset', function () {
+        const context = {};
+        const settings = Settings(context).getInstance();
+        settings.update({ streaming: { applyContentSteering: true } });
+
+        const eventBus = EventBus(context).getInstance();
+        const locationSelector = LocationSelector(context).create();
+        locationSelector.setConfig({
+            contentSteeringController: {
+                getCurrentSteeringResponseData: () => {
+                    return {
+                        pathwayPriority: ['a', 'b']
+                    };
+                }
+            }
+        });
+        const mpdLocations = [
+            new BaseURL('http://www.example.com/', 'a'),
+            new BaseURL('http://www2.example.com/', 'b')
+        ];
+
+        locationSelector.initialize();
+
+        let selected = locationSelector.select(mpdLocations);
+        expect(selected.serviceLocation).to.equal('a');
+
+        eventBus.trigger(Events.SERVICE_LOCATION_LOCATION_BLACKLIST_ADD, {
+            entry: 'a'
+        });
+        selected = locationSelector.select(mpdLocations);
+        expect(selected.serviceLocation).to.equal('b');
+
+        locationSelector.reset();
+        eventBus.trigger(Events.SERVICE_LOCATION_LOCATION_BLACKLIST_ADD, {
+            entry: 'b'
+        });
+        selected = locationSelector.select(mpdLocations);
+        expect(selected.serviceLocation).to.equal('a');
+
+        locationSelector.initialize();
+        eventBus.trigger(Events.SERVICE_LOCATION_LOCATION_BLACKLIST_ADD, {
+            entry: 'a'
+        });
+        selected = locationSelector.select(mpdLocations);
+        expect(selected.serviceLocation).to.equal('b');
+    });
+});


### PR DESCRIPTION
Fixes a problem with service locations not being blacklisted properly #5062 

The issue arises because the reset() call deregisters the event handler, but it is never applied again. This could be fixed by leaving the event handler attached on upon reset, but this PR amends BlacklistController and associated classes to use a initialize/reset pattern to match other classes in the codebase and to avoid making a special case here.