### PR TITLE
Fix unbounded SegmentTimeline seek recovery after manifest validity changes

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -397,8 +397,27 @@ function DashHandler(config) {
                 return NaN;
             }
 
+            // For dynamic SegmentTimeline representations, segments are only ever appended at the end of
+            // the timeline as the manifest is refreshed. If the target time is beyond the last segment the
+            // manifest has signaled so far, no amount of probing ahead can find a valid time - the data
+            // simply does not exist yet. Detect this up front and bound the probe window to it, instead of
+            // scanning blindly. This also protects against a period.duration that is unexpectedly large or
+            // corrupted (see MANIFEST_VALIDITY_CHANGED handling in RepresentationController), which would
+            // otherwise turn the loop below into an effectively infinite scan.
+            let lastSignaledPresentationEndTime = NaN;
+            if (isDynamicManifest && representation.segmentInfoType === DashConstants.SEGMENT_TIMELINE &&
+                representation.mediaFinishedInformation && !isNaN(representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment)) {
+                lastSignaledPresentationEndTime = timelineConverter.calcPresentationTimeFromMediaTime(representation.mediaFinishedInformation.mediaTimeOfLastSignaledSegment, representation);
+                if (time > lastSignaledPresentationEndTime) {
+                    return NaN;
+                }
+            }
+
             // If we have a duration look until the end of the duration, otherwise maximum 30 seconds
-            const end = isFinite(representation.adaptation.period.duration) ? representation.adaptation.period.start + representation.adaptation.period.duration : time + 30;
+            let end = isFinite(representation.adaptation.period.duration) ? representation.adaptation.period.start + representation.adaptation.period.duration : time + 30;
+            if (!isNaN(lastSignaledPresentationEndTime)) {
+                end = Math.min(end, lastSignaledPresentationEndTime);
+            }
             let currentUpperTime = Math.min(time + targetThreshold, end);
             let adjustedTime = NaN;
             let targetRequest = null;

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -328,7 +328,16 @@ function RepresentationController(config) {
             const representation = getCurrentRepresentation();
             if (representation && representation.adaptation.period) {
                 const period = representation.adaptation.period;
-                period.duration = e.newDuration;
+                // e.newDuration (EventController._handleManifestReloadEvent) is an absolute point on the
+                // presentation timeline - the moment the manifest is valid until - not a length. period.duration
+                // is relative to period.start. Convert before storing, or period.duration ends up holding an
+                // absolute timestamp, which on presentation timelines anchored away from zero (e.g.
+                // availabilityStartTime far from the epoch, or a large period.start) silently produces a wildly
+                // oversized duration and defeats every isFinite(period.duration) guard downstream.
+                const relativeDuration = e.newDuration - period.start;
+                if (relativeDuration > 0) {
+                    period.duration = relativeDuration;
+                }
             }
         }
     }

--- a/test/unit/helpers/ObjectsHelper.js
+++ b/test/unit/helpers/ObjectsHelper.js
@@ -68,6 +68,7 @@ class ObjectsHelper {
                 return { start, end };
             },
             calcMediaTimeFromPresentationTime: () => undefined,
+            calcPresentationTimeFromMediaTime: (mediaTime) => mediaTime,
             calcSegmentAvailabilityWindowForRepresentation: () => {
                 return { start: start, end: end };
             },

--- a/test/unit/test/dash/dash.DashHandler.js
+++ b/test/unit/test/dash/dash.DashHandler.js
@@ -236,6 +236,20 @@ describe('DashHandler', function () {
             expect(result).to.be.NaN;
         })
 
+        it('should return NaN without probing ahead if requested time is beyond the last signaled segment', () => {
+            dummyRepresentation.adaptation.period.duration = 1000000000;
+            dummyRepresentation.mediaFinishedInformation = {
+                mediaTimeOfLastSignaledSegment: 30
+            };
+            segRequestStub.restore();
+            segRequestStub = sinon.stub(segmentsController, 'getSegmentByTime').returns(null);
+
+            const result = dashHandler.getValidTimeAheadOfTargetTime(31, dummyMediaInfo, dummyRepresentation, 0.5)
+
+            expect(result).to.be.NaN;
+            expect(segRequestStub.calledOnce).to.be.true;
+        })
+
         it('should return valid time if requested time is smaller than period start', () => {
             const result = dashHandler.getValidTimeAheadOfTargetTime(-0.5, dummyMediaInfo, dummyRepresentation, 0.5)
 

--- a/test/unit/test/dash/dash.controllers.RepresentationController.js
+++ b/test/unit/test/dash/dash.controllers.RepresentationController.js
@@ -100,12 +100,15 @@ describe('RepresentationController', function () {
                 expect(currentRepresentation.id).to.equal(voRepresentations[1].id); // jshint ignore:line
             });
 
-            it('when a MANIFEST_VALIDITY_CHANGED event occurs, should update current representation', function () {
+            it('when a MANIFEST_VALIDITY_CHANGED event occurs, should store the duration relative to the period start', function () {
                 let currentRepresentation = representationController.getCurrentRepresentation();
-                expect(currentRepresentation.adaptation.period.duration).to.equal(100); // jshint ignore:line
+                currentRepresentation.adaptation.period.start = 50;
+                currentRepresentation.adaptation.period.duration = 40;
                 eventBus.trigger(Events.MANIFEST_VALIDITY_CHANGED, { sender: {}, newDuration: 150 });
 
-                expect(currentRepresentation.adaptation.period.duration).to.equal(150); // jshint ignore:line
+                expect(currentRepresentation.adaptation.period.duration).to.equal(100); // jshint ignore:line
+                currentRepresentation.adaptation.period.start = 0;
+                currentRepresentation.adaptation.period.duration = 100;
             });
 
             it('should switch correctly when prepareQualityChange is called with an enhancement representation', function () {


### PR DESCRIPTION
## Summary

`MANIFEST_VALIDITY_CHANGED` provides an absolute point on the presentation timeline, but `RepresentationController` stores it directly in `period.duration`, which is defined relative to `period.start`. For periods whose start is not zero, this inflates the duration seen by downstream code.

If a seek into a stale dynamic `SegmentTimeline` cannot resolve to a segment, `DashHandler.getValidTimeAheadOfTargetTime()` uses that duration to bound its forward recovery scan. An unexpectedly large duration can therefore produce a very large number of probes even though no segment can exist beyond the end of the timeline currently signaled by the manifest.

## Changes

- Convert the absolute manifest-validity timestamp to a duration relative to `period.start` before storing it, and preserve the existing duration when the result is not positive.
- For dynamic `SegmentTimeline` representations, return `NaN` when the seek target is beyond the last signaled segment and otherwise clamp the recovery window to that boundary.

The second change is defense in depth: seek recovery remains bounded even if another producer supplies an unexpectedly large period duration.

## Relationship to #5071

#5071 already maps an unknown inband `event_duration` of `0xFFFFFFFF` to `NaN` in `DashAdapter`, which prevents the originally observed inband sentinel from becoming a large finite duration. This PR does not duplicate that parser fix. It addresses two independent downstream issues that remain:

1. absolute manifest-validity timestamps are still assigned to a relative duration field for known finite durations; and
2. seek recovery still trusts that duration instead of stopping at the final segment signaled by a dynamic timeline.

The `EventController` and manifest-declared event changes from the initial version of this PR were removed after accounting for #5071.

## Validation

- Added a `DashHandler` regression test verifying that no forward probes occur beyond the last signaled segment.
- Updated the `RepresentationController` manifest-validity test to use a nonzero `period.start` and verify the stored relative duration.
- ESLint passed for the modified source and test files.
- `node --check` and `git diff --check` passed.
- The filtered Karma/webpack test bundle compiled successfully. Chrome and Firefox could not be launched in the preparation environment, so browser execution is left to CI.

## Reproduction

1. Use a dynamic `SegmentTimeline` presentation whose period starts away from zero.
2. Process an MPD-reload event with a known finite duration so that `MANIFEST_VALIDITY_CHANGED.newDuration` is an absolute presentation-timeline value.
3. Let manifest refreshes fall behind so the signaled timeline becomes stale.
4. Seek beyond the last signaled segment through `seekToCurrentLive()` or catch-up's automatic `maxDrift` seek.

Without these changes, the period duration is inflated by `period.start` and the recovery loop may probe far beyond the available timeline. With the changes, the duration stays relative and recovery stops at the last signaled segment.
