### PR TITLE
refactor(streaming): centralize CustomParametersModel callback registry logic

### DIFF
--- a/src/streaming/models/CustomParametersModel.js
+++ b/src/streaming/models/CustomParametersModel.js
@@ -38,18 +38,35 @@ import ExternalSubtitle from '../vo/ExternalSubtitle.js';
 
 const DEFAULT_XHR_WITH_CREDENTIALS = false;
 
+function createCallbackRegistry(callbacks = []) {
+    return {
+        add(callback) {
+            callbacks.push(callback);
+        },
+        getAll() {
+            return callbacks;
+        },
+        remove(callback) {
+            const index = callbacks.indexOf(callback);
+            if (index !== -1) {
+                callbacks.splice(index, 1);
+            }
+        }
+    };
+}
+
 function CustomParametersModel() {
 
     let instance,
         utcTimingSources,
         xhrWithCredentials,
-        requestInterceptors,
-        responseInterceptors,
-        licenseRequestFilters,
-        certificateRequestFilters,
-        certificateResponseFilters,
-        licenseResponseFilters,
-        customCapabilitiesFilters,
+        requestInterceptorRegistry,
+        responseInterceptorRegistry,
+        licenseRequestFilterRegistry,
+        certificateRequestFilterRegistry,
+        certificateResponseFilterRegistry,
+        licenseResponseFilterRegistry,
+        customCapabilitiesFilterRegistry,
         customInitialTrackSelectionFunction,
         externalSubtitles,
         customAbrRules,
@@ -67,18 +84,18 @@ function CustomParametersModel() {
     }
 
     function _resetInitialSettings() {
-        licenseRequestFilters = [];
-        licenseResponseFilters = [];
-        certificateRequestFilters = [];
-        certificateResponseFilters = [];
-        customCapabilitiesFilters = [];
+        licenseRequestFilterRegistry = createCallbackRegistry();
+        licenseResponseFilterRegistry = createCallbackRegistry();
+        certificateRequestFilterRegistry = createCallbackRegistry();
+        certificateResponseFilterRegistry = createCallbackRegistry();
+        customCapabilitiesFilterRegistry = createCallbackRegistry();
         customAbrRules = [];
         customInitialTrackSelectionFunction = null;
         utcTimingSources = [];
 
         // Initialize request interceptors with default CMCD interceptors
-        requestInterceptors = cmcdController.getCmcdRequestInterceptors();
-        responseInterceptors = cmcdController.getCmcdResponseReceivedInterceptors();
+        requestInterceptorRegistry = createCallbackRegistry(cmcdController.getCmcdRequestInterceptors());
+        responseInterceptorRegistry = createCallbackRegistry(cmcdController.getCmcdResponseReceivedInterceptors());
 
         externalSubtitles = new Set();
     }
@@ -124,7 +141,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getCertificateRequestFilters() {
-        return certificateRequestFilters;
+        return certificateRequestFilterRegistry.getAll();
     }
 
     /**
@@ -132,7 +149,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getCertificateResponseFilters() {
-        return certificateResponseFilters;
+        return certificateResponseFilterRegistry.getAll();
     }
 
     /**
@@ -142,7 +159,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license request filter callback
      */
     function registerCertificateRequestFilter(filter) {
-        certificateRequestFilters.push(filter);
+        certificateRequestFilterRegistry.add(filter);
     }
 
     /**
@@ -152,7 +169,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license response filter callback
      */
     function registerCertificateResponseFilter(filter) {
-        certificateResponseFilters.push(filter);
+        certificateResponseFilterRegistry.add(filter);
     }
 
     /**
@@ -160,7 +177,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license request filter callback
      */
     function unregisterCertificateRequestFilter(filter) {
-        _unregisterFilter(certificateRequestFilters, filter);
+        certificateRequestFilterRegistry.remove(filter);
     }
 
     /**
@@ -168,7 +185,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license response filter callback
      */
     function unregisterCertificateResponseFilter(filter) {
-        _unregisterFilter(certificateResponseFilters, filter);
+        certificateResponseFilterRegistry.remove(filter);
     }
 
     /**
@@ -176,7 +193,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getLicenseRequestFilters() {
-        return licenseRequestFilters;
+        return licenseRequestFilterRegistry.getAll();
     }
 
     /**
@@ -184,7 +201,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getLicenseResponseFilters() {
-        return licenseResponseFilters;
+        return licenseResponseFilterRegistry.getAll();
     }
 
     /**
@@ -194,7 +211,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license request filter callback
      */
     function registerLicenseRequestFilter(filter) {
-        licenseRequestFilters.push(filter);
+        licenseRequestFilterRegistry.add(filter);
     }
 
     /**
@@ -204,7 +221,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license response filter callback
      */
     function registerLicenseResponseFilter(filter) {
-        licenseResponseFilters.push(filter);
+        licenseResponseFilterRegistry.add(filter);
     }
 
     /**
@@ -212,7 +229,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license request filter callback
      */
     function unregisterLicenseRequestFilter(filter) {
-        _unregisterFilter(licenseRequestFilters, filter);
+        licenseRequestFilterRegistry.remove(filter);
     }
 
     /**
@@ -220,7 +237,7 @@ function CustomParametersModel() {
      * @param {function} filter - the license response filter callback
      */
     function unregisterLicenseResponseFilter(filter) {
-        _unregisterFilter(licenseResponseFilters, filter);
+        licenseResponseFilterRegistry.remove(filter);
     }
 
     /**
@@ -228,7 +245,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getCustomCapabilitiesFilters() {
-        return customCapabilitiesFilters;
+        return customCapabilitiesFilterRegistry.getAll();
     }
 
     /**
@@ -238,7 +255,7 @@ function CustomParametersModel() {
      * @param {function} filter - the custom capabilities filter callback
      */
     function registerCustomCapabilitiesFilter(filter) {
-        customCapabilitiesFilters.push(filter);
+        customCapabilitiesFilterRegistry.add(filter);
     }
 
     /**
@@ -246,27 +263,7 @@ function CustomParametersModel() {
      * @param {function} filter - the custom capabilities filter callback
      */
     function unregisterCustomCapabilitiesFilter(filter) {
-        _unregisterFilter(customCapabilitiesFilters, filter);
-    }
-
-    /**
-     * Unregister a filter from the list of existing filers.
-     * @param {array} filters
-     * @param {function} filter
-     * @private
-     */
-    function _unregisterFilter(filters, filter) {
-        let index = -1;
-        filters.some((item, i) => {
-            if (item === filter) {
-                index = i;
-                return true;
-            }
-        });
-        if (index < 0) {
-            return;
-        }
-        filters.splice(index, 1);
+        customCapabilitiesFilterRegistry.remove(filter);
     }
 
     /**
@@ -354,7 +351,7 @@ function CustomParametersModel() {
      * @param {function} interceptor - the request interceptor callback
      */
     function addRequestInterceptor(interceptor) {
-        requestInterceptors.push(interceptor);
+        requestInterceptorRegistry.add(interceptor);
     }
 
     /**
@@ -364,7 +361,7 @@ function CustomParametersModel() {
      * @param {function} interceptor - the response interceptor callback
      */
     function addResponseInterceptor(interceptor) {
-        responseInterceptors.push(interceptor);
+        responseInterceptorRegistry.add(interceptor);
     }
 
     /**
@@ -372,7 +369,7 @@ function CustomParametersModel() {
      * @param {function} interceptor - the request interceptor callback
      */
     function removeRequestInterceptor(interceptor) {
-        _unregisterFilter(requestInterceptors, interceptor);
+        requestInterceptorRegistry.remove(interceptor);
     }
 
     /**
@@ -380,7 +377,7 @@ function CustomParametersModel() {
      * @param {function} interceptor - the request interceptor callback
      */
     function removeResponseInterceptor(interceptor) {
-        _unregisterFilter(responseInterceptors, interceptor);
+        responseInterceptorRegistry.remove(interceptor);
     }
 
     /**
@@ -388,7 +385,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getRequestInterceptors() {
-        return requestInterceptors;
+        return requestInterceptorRegistry.getAll();
     }
 
     /**
@@ -396,7 +393,7 @@ function CustomParametersModel() {
      * @return {array}
      */
     function getResponseInterceptors() {
-        return responseInterceptors;
+        return responseInterceptorRegistry.getAll();
     }
 
     function addExternalSubtitle(externalSubtitleObj) {

--- a/test/unit/test/streaming/streaming.models.CustomParametersModel.js
+++ b/test/unit/test/streaming/streaming.models.CustomParametersModel.js
@@ -1,5 +1,6 @@
 import CustomParametersModel from '../../../../src/streaming/models/CustomParametersModel.js';
 import Constants from '../../../../src/streaming/constants/Constants.js';
+import CmcdController from '../../../../src/streaming/controllers/CmcdController.js';
 
 
 import chai from 'chai';
@@ -8,6 +9,8 @@ const expect = chai.expect;
 
 describe('CustomParametersModel', function () {
     const context = {};
+    const cmcdController = CmcdController(context).getInstance();
+    const noInitialCallbacks = () => [];
 
     let customParametersModel = CustomParametersModel(context).getInstance();
 
@@ -58,137 +61,66 @@ describe('CustomParametersModel', function () {
         expect(customInitialTrackSelectionFunction).to.be.null;
     })
 
-    it('Should add license request filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerLicenseRequestFilter(foo);
-        let licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+    describe('callback registries', () => {
+        const registryContracts = [
+            { name: 'request interceptors', add: 'addRequestInterceptor', remove: 'removeRequestInterceptor', get: 'getRequestInterceptors', getInitialCallbacks: () => cmcdController.getCmcdRequestInterceptors() },
+            { name: 'response interceptors', add: 'addResponseInterceptor', remove: 'removeResponseInterceptor', get: 'getResponseInterceptors', getInitialCallbacks: () => cmcdController.getCmcdResponseReceivedInterceptors() },
+            { name: 'license request filters', add: 'registerLicenseRequestFilter', remove: 'unregisterLicenseRequestFilter', get: 'getLicenseRequestFilters', getInitialCallbacks: noInitialCallbacks },
+            { name: 'license response filters', add: 'registerLicenseResponseFilter', remove: 'unregisterLicenseResponseFilter', get: 'getLicenseResponseFilters', getInitialCallbacks: noInitialCallbacks },
+            { name: 'certificate request filters', add: 'registerCertificateRequestFilter', remove: 'unregisterCertificateRequestFilter', get: 'getCertificateRequestFilters', getInitialCallbacks: noInitialCallbacks },
+            { name: 'certificate response filters', add: 'registerCertificateResponseFilter', remove: 'unregisterCertificateResponseFilter', get: 'getCertificateResponseFilters', getInitialCallbacks: noInitialCallbacks },
+            { name: 'custom capabilities filters', add: 'registerCustomCapabilitiesFilter', remove: 'unregisterCustomCapabilitiesFilter', get: 'getCustomCapabilitiesFilters', getInitialCallbacks: noInitialCallbacks }
+        ];
 
-        customParametersModel.registerLicenseRequestFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
-    })
+        registryContracts.forEach(({ name, add, remove, get, getInitialCallbacks }) => {
+            it(`should preserve ${name} order, removal and live-array identity`, () => {
+                const firstCallback = () => {};
+                const secondCallback = () => {};
+                const unknownCallback = () => {};
+                const callbacks = customParametersModel[get]();
+                const initialCallbacks = callbacks.slice();
+                expect(initialCallbacks).to.deep.equal(getInitialCallbacks());
 
-    it('Should remove license request filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerLicenseRequestFilter(foo);
-        let licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+                customParametersModel[add](firstCallback);
+                customParametersModel[add](secondCallback);
+                customParametersModel[add](firstCallback);
 
-        customParametersModel.registerLicenseRequestFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
+                expect(customParametersModel[get]()).to.equal(callbacks);
+                expect(callbacks).to.deep.equal([...initialCallbacks, firstCallback, secondCallback, firstCallback]);
 
-        customParametersModel.unregisterLicenseRequestFilter(foo);
-        licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+                customParametersModel.resetPlaybackSessionSpecificSettings();
+                expect(customParametersModel[get]()).to.equal(callbacks);
+                expect(callbacks).to.deep.equal([...initialCallbacks, firstCallback, secondCallback, firstCallback]);
 
-        customParametersModel.unregisterLicenseRequestFilter(foo);
-        licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+                customParametersModel[remove](unknownCallback);
+                expect(callbacks).to.deep.equal([...initialCallbacks, firstCallback, secondCallback, firstCallback]);
 
-        customParametersModel.unregisterLicenseRequestFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseRequestFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(0);
-    })
+                customParametersModel[remove](firstCallback);
+                expect(callbacks).to.deep.equal([...initialCallbacks, secondCallback, firstCallback]);
+            });
+        });
 
-    it('Should add license response filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerLicenseResponseFilter(foo);
-        let licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+        it('should keep registries isolated and restore their defaults on reset', () => {
+            const registrations = registryContracts.map(({ add, get, getInitialCallbacks }) => {
+                const callback = () => {};
+                const callbacks = customParametersModel[get]();
+                customParametersModel[add](callback);
+                return { callback, callbacks, get, getInitialCallbacks };
+            });
 
-        customParametersModel.registerLicenseResponseFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
-    })
+            registrations.forEach(({ callback, get, getInitialCallbacks }) => {
+                expect(customParametersModel[get]()).to.deep.equal([...getInitialCallbacks(), callback]);
+            });
 
-    it('Should remove license response filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerLicenseResponseFilter(foo);
-        let licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
+            customParametersModel.reset();
 
-        customParametersModel.registerLicenseResponseFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
-
-        customParametersModel.unregisterLicenseResponseFilter(foo);
-        licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.unregisterLicenseResponseFilter(foo);
-        licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.unregisterLicenseResponseFilter(bar);
-        licenseResponseFilters = customParametersModel.getLicenseResponseFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(0);
-    })
-
-    it('Should add custom capabilities filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerCustomCapabilitiesFilter(foo);
-        let licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.registerCustomCapabilitiesFilter(bar);
-        licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
-    })
-
-    it('Should remove custom capability filters', () => {
-        const foo = () => {
-            return;
-        };
-        const bar = () => {
-            return;
-        }
-        customParametersModel.registerCustomCapabilitiesFilter(foo);
-        let licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.registerCustomCapabilitiesFilter(bar);
-        licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(2);
-
-        customParametersModel.unregisterCustomCapabilitiesFilter(foo);
-        licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.unregisterCustomCapabilitiesFilter(foo);
-        licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(1);
-
-        customParametersModel.unregisterCustomCapabilitiesFilter(bar);
-        licenseResponseFilters = customParametersModel.getCustomCapabilitiesFilters();
-        expect(licenseResponseFilters).to.have.lengthOf(0);
-    })
+            registrations.forEach(({ callback, callbacks, get, getInitialCallbacks }) => {
+                expect(customParametersModel[get]()).to.not.equal(callbacks);
+                expect(customParametersModel[get]()).to.deep.equal(getInitialCallbacks());
+                expect(callbacks).to.include(callback);
+            });
+        });
+    });
 
     it('should manage custom ABR rules', function () {
         let customRules = customParametersModel.getAbrCustomRules();


### PR DESCRIPTION
## Summary

- add a small private callback registry for the seven interceptor/filter lists in `CustomParametersModel`
- keep all existing public method names and signatures as delegating wrappers
- replace duplicated registry tests with one contract matrix covering all seven lists

## Behavior preserved

- callbacks stay ordered and duplicates remain allowed
- unregistering removes only the first matching callback; unknown callbacks remain a no-op
- getters keep exposing the same live array until a full reset
- full reset recreates every registry and restores the two default CMCD interceptors
- playback-session reset keeps registered callbacks

## Impact

- direct callback-array operations are centralized from 9 sites to 3
- direct unit-test coverage increases from 3/7 registries to 7/7
- no public API or callback execution behavior changes

## Validation

- `npm test -- --grep "CustomParametersModel"` (26 cases / 52 browser executions)
- `npm run ci:verify` (TypeScript, 3,708 tests, full lint)
- independent review completed with no remaining findings

The commit history keeps the characterization tests separate and before the production refactor.

Closes #5061
