### PR TITLE
Fix/4291

### DIFF
--- a/contrib/controlbar/ControlBar.js
+++ b/contrib/controlbar/ControlBar.js
@@ -178,7 +178,7 @@ export class ControlBar {
         this.seekbarBuffer.style.width = '0%';
         this.timeDisplay.textContent = '00:00';
         this.durationDisplay.textContent = '00:00';
-        this.durationDisplay.classList.remove('cb-live-indicator', 'cb-static-indicator', 'cb-at-live-edge');
+        this.durationDisplay.classList.remove('cb-live-indicator', 'cb-at-live-edge');
         if (this.timeSeparator) {
             this.timeSeparator.classList.remove('cb-hidden-element');
         }
@@ -503,7 +503,6 @@ export class ControlBar {
 
                 this.durationDisplay.innerHTML = '<i class="bi bi-circle-fill"></i> LIVE';
                 this.durationDisplay.classList.add('cb-live-indicator');
-                this.durationDisplay.classList.remove('cb-static-indicator');
 
                 // Hide separator for live
                 if (this.timeSeparator) {
@@ -516,9 +515,12 @@ export class ControlBar {
                 this.durationDisplay.classList.toggle('cb-at-live-edge', atLiveEdge);
             } else {
                 this.timeDisplay.textContent = formatTime(time);
-                this.durationDisplay.textContent = 'STATIC';
                 this.durationDisplay.classList.remove('cb-live-indicator', 'cb-at-live-edge');
-                this.durationDisplay.classList.add('cb-static-indicator');
+                this.durationDisplay.textContent = formatTime(duration);
+                this.durationDisplay.appendChild(createElement('span', {
+                    className: 'cb-static-indicator',
+                    textContent: ' STATIC'
+                }));
 
                 // Show separator for VoD
                 if (this.timeSeparator) {

--- a/contrib/controlbar/ControlBar.js
+++ b/contrib/controlbar/ControlBar.js
@@ -178,7 +178,7 @@ export class ControlBar {
         this.seekbarBuffer.style.width = '0%';
         this.timeDisplay.textContent = '00:00';
         this.durationDisplay.textContent = '00:00';
-        this.durationDisplay.classList.remove('cb-live-indicator', 'cb-at-live-edge');
+        this.durationDisplay.classList.remove('cb-live-indicator', 'cb-static-indicator', 'cb-at-live-edge');
         if (this.timeSeparator) {
             this.timeSeparator.classList.remove('cb-hidden-element');
         }
@@ -503,6 +503,7 @@ export class ControlBar {
 
                 this.durationDisplay.innerHTML = '<i class="bi bi-circle-fill"></i> LIVE';
                 this.durationDisplay.classList.add('cb-live-indicator');
+                this.durationDisplay.classList.remove('cb-static-indicator');
 
                 // Hide separator for live
                 if (this.timeSeparator) {
@@ -515,8 +516,9 @@ export class ControlBar {
                 this.durationDisplay.classList.toggle('cb-at-live-edge', atLiveEdge);
             } else {
                 this.timeDisplay.textContent = formatTime(time);
-                this.durationDisplay.textContent = formatTime(duration);
+                this.durationDisplay.textContent = 'STATIC';
                 this.durationDisplay.classList.remove('cb-live-indicator', 'cb-at-live-edge');
+                this.durationDisplay.classList.add('cb-static-indicator');
 
                 // Show separator for VoD
                 if (this.timeSeparator) {

--- a/contrib/controlbar/controlbar.css
+++ b/contrib/controlbar/controlbar.css
@@ -225,6 +225,10 @@
     vertical-align: middle;
 }
 
+.cb-static-indicator {
+    color: #8a8aa0;
+}
+
 /* ---- Thumbnail preview ---- */
 .cb-thumbnail-container {
     position: absolute;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1680,6 +1680,7 @@ export class MediaPlayerSettingClass {
         applyServiceDescription?: boolean,
         applyProducerReferenceTime?: boolean,
         applyContentSteering?: boolean,
+        ignoreFinalStaticManifestOnDynamicToStaticTransition?: boolean,
         enableManifestDurationMismatchFix?: boolean,
         parseInbandPrft?: boolean,
         enableManifestTimescaleMismatchFix?: boolean,

--- a/samples/dash-if-reference-player/app/data/sources.json
+++ b/samples/dash-if-reference-player/app/data/sources.json
@@ -473,7 +473,7 @@
                         "live",
                         "dashif"
                     ]
-                },                
+                },
                 {
                     "url": "https://livesim2.dashif.org/livesim2/startrel_-20/stoprel_6/testpic_2s/Manifest.mpd",
                     "name": "Dynamic to static transition with LiveSim2 using an MPD Location element",
@@ -603,7 +603,7 @@
                         "dashif"
                     ]
                 },
-              {
+                {
                     "url": "https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd",
                     "name": "Akamai Low Latency Stream (Single Rate)",
                     "provider": "akamai",

--- a/samples/dash-if-reference-player/app/data/sources.json
+++ b/samples/dash-if-reference-player/app/data/sources.json
@@ -473,6 +473,15 @@
                         "live",
                         "dashif"
                     ]
+                },                
+                {
+                    "url": "https://livesim2.dashif.org/livesim2/startrel_-20/stoprel_6/testpic_2s/Manifest.mpd",
+                    "name": "Dynamic to static transition with LiveSim2 using an MPD Location element",
+                    "provider": "dashif",
+                    "tags": [
+                        "live",
+                        "dashif"
+                    ]
                 },
                 {
                     "url": "https://demo.unified-streaming.com/k8s/live/scte35.isml/.mpd",

--- a/samples/dash-if-reference-player/app/js/PlayerController.js
+++ b/samples/dash-if-reference-player/app/js/PlayerController.js
@@ -173,6 +173,7 @@ export class PlayerController extends EventEmitter {
 
         this.player.on(events.ERROR, (e) => this._onError(e));
         this.player.on(events.MANIFEST_LOADED, (e) => this._onManifestLoaded(e));
+        this.player.on(events.DYNAMIC_TO_STATIC, () => this._onDynamicToStatic());
         this.player.on(events.REPRESENTATION_SWITCH, (e) => this._onRepresentationSwitch(e));
         this.player.on(events.PERIOD_SWITCH_COMPLETED, (e) => this._onPeriodSwitchCompleted(e));
         this.player.on(events.QUALITY_CHANGE_RENDERED, (e) => this._onQualityChangeRendered(e));
@@ -193,6 +194,14 @@ export class PlayerController extends EventEmitter {
             this.isDynamic = e.data.type === 'dynamic';
             this.periodCount = e.data.Period ? e.data.Period.length : 0;
         }
+        this.emit('manifestLoaded', {
+            isDynamic: this.isDynamic,
+            periodCount: this.periodCount
+        });
+    }
+
+    _onDynamicToStatic() {
+        this.isDynamic = false;
         this.emit('manifestLoaded', {
             isDynamic: this.isDynamic,
             periodCount: this.periodCount

--- a/samples/live-streaming/dynamic-to-static.html
+++ b/samples/live-streaming/dynamic-to-static.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic to static transition</title>
+    <script src="../../dist/modern/umd/dash.all.debug.js"></script>
+    <link href="../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../lib/bootstrap-icons/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="../lib/sample.css" rel="stylesheet">
+    <link href="../../contrib/controlbar/controlbar.css" rel="stylesheet">
+</head>
+<body>
+
+<div class="sample-content-custom">
+    <div class="row mt-4">
+        <div class="col-md-7">
+            <div class="sample-video-wrapper"><video></video></div>
+        </div>
+        <div class="col-md-5">
+            <div class="sample-metrics">
+                <div class="sample-metrics-header">Transition status</div>
+                <div class="sample-metrics-body">
+                    <div class="metric-row">
+                        <span class="metric-label">MPD type</span>
+                        <span class="metric-value" id="mpd-type">dynamic</span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">DYNAMIC_TO_STATIC event</span>
+                        <span class="metric-value" id="transition-event">Waiting</span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">Final duration</span>
+                        <span class="metric-value" id="final-duration">Waiting</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script class="code">
+    async function init() {
+        var url = 'https://livesim2.dashif.org/livesim2/startrel_-20/stoprel_6/testpic_2s/Manifest.mpd';
+        var video = document.querySelector('video');
+        var player = dashjs.MediaPlayer().create();
+        var mpdType = document.getElementById('mpd-type');
+        var transitionEvent = document.getElementById('transition-event');
+        var finalDuration = document.getElementById('final-duration');
+        var transitionPending = false;
+
+        player.on(dashjs.MediaPlayer.events.DYNAMIC_TO_STATIC, function () {
+            transitionPending = true;
+            transitionEvent.textContent = 'Received';
+        });
+
+        video.addEventListener('durationchange', function () {
+            if (transitionPending && !player.isDynamic() && isFinite(video.duration)) {
+                mpdType.textContent = 'static';
+                finalDuration.textContent = video.duration.toFixed(2) + ' s';
+                transitionPending = false;
+            }
+        });
+
+        player.initialize(video, url, true);
+        await createControlBar(player, video, document.querySelector('.sample-video-wrapper'));
+    }
+</script>
+<script type="module">
+    import { initSamplePage, createControlBar } from '../lib/sample-template.js';
+    initSamplePage({
+        title: 'Dynamic to static transition',
+        description: 'Plays a LiveSim2 stream that ends shortly after loading and publishes a final static MPD. After the final MPD is applied, the controlbar changes from LIVE to STATIC and the duration becomes finite.',
+        category: 'Live',
+        layout: 'custom',
+        onInit: () => init()
+    });
+</script>
+</body>
+</html>

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -145,6 +145,17 @@
                 ]
             },
             {
+                "title": "Dynamic to static transition",
+                "description": "Shows a live stream transitioning to a final static MPD.",
+                "href": "live-streaming/dynamic-to-static.html",
+                "image": "lib/img/livesim-1.jpg",
+                "labels": [
+                    "Live",
+                    "Video",
+                    "Audio"
+                ]
+            },
+            {
                 "title": "Synchronized live playback",
                 "description": "Shows synchronized live playback of two videos using the live playback catchup mode.",
                 "href": "live-streaming/synchronized-live-playback.html",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -69,6 +69,7 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *            applyServiceDescription: true,
  *            applyProducerReferenceTime: true,
  *            applyContentSteering: true,
+ *            ignoreFinalStaticManifestOnDynamicToStaticTransition: false,
  *            enableManifestDurationMismatchFix: true,
  *            parseInbandPrft: false,
  *            enableManifestTimescaleMismatchFix: false,
@@ -1058,6 +1059,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * Set to true if dash.js should use the parameters defined in ProducerReferenceTime elements in combination with ServiceDescription elements.
  * @property {boolean} [applyContentSteering=true]
  * Set to true if dash.js should apply content steering during playback.
+ * @property {boolean} [ignoreFinalStaticManifestOnDynamicToStaticTransition=false]
+ * Set to true if dash.js should ignore the final static manifest when a stream transitions from dynamic to static (legacy behavior up to v5.2.0). When set to false the duration, the seekable range and the segment information are derived from the final static manifest.
  * @property {boolean} [enableManifestDurationMismatchFix=true]
  * For multi-period streams, overwrite the manifest mediaPresentationDuration attribute with the sum of period durations if the manifest mediaPresentationDuration is greater than the sum of period durations
  * @property {boolean} [enableManifestTimescaleMismatchFix=false]
@@ -1219,6 +1222,7 @@ function Settings() {
             applyServiceDescription: true,
             applyProducerReferenceTime: true,
             applyContentSteering: true,
+            ignoreFinalStaticManifestOnDynamicToStaticTransition: false,
             enableManifestDurationMismatchFix: true,
             parseInbandPrft: false,
             enableManifestTimescaleMismatchFix: false,

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -45,7 +45,8 @@ function RepresentationController(config) {
     const type = config.type;
     const streamInfo = config.streamInfo;
     const segmentsController = config.segmentsController;
-    const isDynamic = config.isDynamic;
+
+    let isDynamic = config.isDynamic;
 
     let instance,
         voAvailableRepresentations,
@@ -69,6 +70,10 @@ function RepresentationController(config) {
         if (!abrController || !dashMetrics || !playbackController || !timelineConverter) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
         }
+    }
+
+    function setIsDynamic(value) {
+        isDynamic = value;
     }
 
     function getCurrentRepresentation() {
@@ -341,6 +346,7 @@ function RepresentationController(config) {
         getType,
         prepareQualityChange,
         reset,
+        setIsDynamic,
         updateData,
     };
 

--- a/src/dash/utils/TimelineConverter.js
+++ b/src/dash/utils/TimelineConverter.js
@@ -180,21 +180,24 @@ function TimelineConverter() {
     }
 
     function _calcTimeshiftBufferForStaticManifest(streams) {
-        // Static Range Finder. We iterate over all periods and return the total duration
+        // Static Range Finder. Account for periods that are not contiguous.
         const range = { start: NaN, end: NaN };
-        let duration = 0;
         let start = NaN;
+        let end = NaN;
         streams.forEach((stream) => {
             const streamInfo = stream.getStreamInfo();
-            duration += streamInfo.duration;
 
             if (isNaN(start) || streamInfo.start < start) {
                 start = streamInfo.start;
             }
+            const streamEnd = streamInfo.start + streamInfo.duration;
+            if (isNaN(end) || streamEnd > end) {
+                end = streamEnd;
+            }
         });
 
         range.start = start;
-        range.end = start + duration;
+        range.end = end;
 
         return range;
     }

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -247,12 +247,16 @@ function ManifestUpdater() {
         }
 
         // See DASH-IF IOP v4.3 section 4.6.4 "Transition Phase between Live and On-Demand"
-        // Stop manifest update, ignore static manifest and signal end of dynamic stream to detect end of stream
-        if (manifestModel.getValue() && manifestModel.getValue().type === DashConstants.DYNAMIC && manifest.type === DashConstants.STATIC) {
+        // Stop the manifest updates and signal the end of the dynamic stream. If enabled, apply the final static manifest so that duration, seekable range and segment information reflect the static MPD.
+        const currentManifest = manifestModel.getValue();
+        if (currentManifest && currentManifest.type === DashConstants.DYNAMIC && manifest.type === DashConstants.STATIC) {
             eventBus.trigger(Events.DYNAMIC_TO_STATIC);
-            isUpdating = false;
             isStopped = true;
-            return;
+            if (settings.get().streaming.ignoreFinalStaticManifestOnDynamicToStaticTransition) {
+                // Legacy behavior: ignore the final static manifest
+                isUpdating = false;
+                return;
+            }
         }
 
         manifestModel.setValue(manifest);

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -1199,6 +1199,11 @@ function StreamProcessor(config) {
 
     function updateStreamInfo(newStreamInfo) {
         streamInfo = newStreamInfo;
+        if (streamInfo.manifestInfo.isDynamic !== isDynamic) {
+            isDynamic = streamInfo.manifestInfo.isDynamic;
+            dashHandler.initialize(isDynamic);
+            representationController.setIsDynamic(isDynamic);
+        }
         if (!isBufferingCompleted()) {
             return bufferController.updateAppendWindow();
         }

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -108,12 +108,32 @@ function MediaSourceController() {
             value = Math.pow(2, 32);
         }
 
-        if (!isBufferUpdating(mediaSource)) {
+        if (!_isBufferUpdating(mediaSource)) {
+            // Setting the duration below the highest presentation timestamp of any buffered coded frames throws an InvalidStateError. Clamp the duration to the highest buffered end time, for instance when applying the final duration after a transition from dynamic to static.
+            const highestBufferedEnd = _getHighestBufferedEnd(mediaSource);
+            if (highestBufferedEnd > value) {
+                value = highestBufferedEnd;
+            }
             logger.info('Set MediaSource duration:' + value);
             mediaSource.duration = value;
         } else {
             setTimeout(setDuration.bind(null, value), 50);
         }
+    }
+
+    function _getHighestBufferedEnd(source) {
+        let highestBufferedEnd = NaN;
+        const buffers = source.sourceBuffers;
+        for (let i = 0; i < buffers.length; i++) {
+            const buffered = buffers[i].buffered;
+            if (buffered && buffered.length > 0) {
+                const end = buffered.end(buffered.length - 1);
+                if (isNaN(highestBufferedEnd) || end > highestBufferedEnd) {
+                    highestBufferedEnd = end;
+                }
+            }
+        }
+        return highestBufferedEnd;
     }
 
     function setSeekable(start, end) {
@@ -143,8 +163,8 @@ function MediaSourceController() {
         source.endOfStream();
     }
 
-    function isBufferUpdating(source) {
-        let buffers = source.sourceBuffers;
+    function _isBufferUpdating(mediaSource) {
+        let buffers = mediaSource.sourceBuffers;
         for (let i = 0; i < buffers.length; i++) {
             if (buffers[i].updating) {
                 return true;

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -144,6 +144,12 @@ function MediaSourceController() {
         }
     }
 
+    function clearSeekableRange() {
+        if (mediaSource && typeof mediaSource.clearLiveSeekableRange === 'function' && mediaSource.readyState === 'open') {
+            mediaSource.clearLiveSeekableRange();
+        }
+    }
+
     function signalEndOfStream(source) {
         if (!source || source.readyState !== 'open') {
             return;
@@ -163,8 +169,8 @@ function MediaSourceController() {
         source.endOfStream();
     }
 
-    function _isBufferUpdating(mediaSource) {
-        let buffers = mediaSource.sourceBuffers;
+    function _isBufferUpdating(source) {
+        let buffers = source.sourceBuffers;
         for (let i = 0; i < buffers.length; i++) {
             if (buffers[i].updating) {
                 return true;
@@ -188,6 +194,7 @@ function MediaSourceController() {
 
     instance = {
         attachMediaSource,
+        clearSeekableRange,
         createMediaSource,
         detachMediaSource,
         setConfig,

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -97,7 +97,7 @@ function MediaSourceController() {
         if (!mediaSource || mediaSource.readyState !== 'open') {
             return;
         }
-        if (value === null && isNaN(value)) {
+        if (value === null || isNaN(value)) {
             return;
         }
         if (mediaSource.duration === value) {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -865,6 +865,12 @@ function PlaybackController() {
      */
     function _onStreamsComposed() {
         manifestUpdateInProgress = false;
+
+        // Refresh the cached streamInfo so values such as the duration reflect the updated manifest
+        const activeStreamInfo = streamController ? streamController.getActiveStreamInfo() : null;
+        if (activeStreamInfo && streamInfo && activeStreamInfo.id === streamInfo.id) {
+            streamInfo = activeStreamInfo;
+        }
     }
 
     function _checkEnableLowLatency(mediaInfo) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -295,6 +295,10 @@ function StreamController() {
      * @private
      */
     function _onDynamicToStatic() {
+        if (settings.get().streaming.ignoreFinalStaticManifestOnDynamicToStaticTransition) {
+            // Legacy behavior: the final static manifest is not applied, no update required
+            return;
+        }
         pendingDynamicToStaticUpdate = true;
     }
 
@@ -310,10 +314,8 @@ function StreamController() {
         _setMediaDuration();
         // Recalculate the range using the final static manifest instead of the previous live DVR window.
         addDVRMetric();
-        const dvrInfo = dashMetrics.getCurrentDVRInfo();
-        if (dvrInfo && dvrInfo.range) {
-            mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end);
-        }
+        // With a finite duration the seekable range is derived from the duration, the live seekable range only applies while the duration is Infinity. Clear it so it does not linger.
+        mediaSourceController.clearSeekableRange();
     }
 
     /**

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -308,6 +308,8 @@ function StreamController() {
         }
         pendingDynamicToStaticUpdate = false;
         _setMediaDuration();
+        // Recalculate the range using the final static manifest instead of the previous live DVR window.
+        addDVRMetric();
         const dvrInfo = dashMetrics.getCurrentDVRInfo();
         if (dvrInfo && dvrInfo.range) {
             mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -65,7 +65,8 @@ function StreamController() {
         autoPlay, isStreamSwitchingInProgress, hasMediaError, hasInitialisationError, mediaSource, videoModel,
         playbackController, serviceDescriptionController, mediaPlayerModel, customParametersModel, isPaused,
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
-        firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation;
+        firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
+        pendingDynamicToStaticUpdate;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -134,6 +135,7 @@ function StreamController() {
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_UPDATED, _onBufferLevelUpdated, instance);
         eventBus.on(MediaPlayerEvents.QUALITY_CHANGE_REQUESTED, _onQualityChanged, instance);
         eventBus.on(MediaPlayerEvents.CONTENT_STEERING_REQUEST_COMPLETED, _onSteeringManifestUpdated, instance);
+        eventBus.on(MediaPlayerEvents.DYNAMIC_TO_STATIC, _onDynamicToStatic, instance);
 
 
         if (Events.KEY_SESSION_UPDATED) {
@@ -162,6 +164,7 @@ function StreamController() {
         eventBus.off(MediaPlayerEvents.BUFFER_LEVEL_UPDATED, _onBufferLevelUpdated, instance);
         eventBus.off(MediaPlayerEvents.QUALITY_CHANGE_REQUESTED, _onQualityChanged, instance);
         eventBus.off(MediaPlayerEvents.CONTENT_STEERING_REQUEST_COMPLETED, _onSteeringManifestUpdated, instance);
+        eventBus.off(MediaPlayerEvents.DYNAMIC_TO_STATIC, _onDynamicToStatic, instance);
 
         if (Events.KEY_SESSION_UPDATED) {
             eventBus.off(Events.KEY_SESSION_UPDATED, _onKeySessionUpdated, instance);
@@ -272,6 +275,7 @@ function StreamController() {
                 })
                 .then(() => {
                     eventBus.trigger(Events.STREAMS_COMPOSED);
+                    _handlePendingDynamicToStaticUpdate();
                     // Additional periods might have been added after an MPD update. Check again if we can start prebuffering.
                     _checkIfPrebufferingCanStart();
                 })
@@ -283,6 +287,30 @@ function StreamController() {
             errHandler.error(new DashJSError(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE, e.message + ' nostreamscomposed', manifestModel.getValue()));
             hasInitialisationError = true;
             reset();
+        }
+    }
+
+    /**
+     * The stream transitioned from dynamic to static. Once the final static manifest has been applied and the streams have been recomposed, update the MediaSource duration and the seekable range.
+     * @private
+     */
+    function _onDynamicToStatic() {
+        pendingDynamicToStaticUpdate = true;
+    }
+
+    /**
+     * Updates the MediaSource duration and seekable range after the transition from dynamic to static.
+     * @private
+     */
+    function _handlePendingDynamicToStaticUpdate() {
+        if (!pendingDynamicToStaticUpdate || adapter.getIsDynamic() || !mediaSource) {
+            return;
+        }
+        pendingDynamicToStaticUpdate = false;
+        _setMediaDuration();
+        const dvrInfo = dashMetrics.getCurrentDVRInfo();
+        if (dvrInfo && dvrInfo.range) {
+            mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end);
         }
     }
 
@@ -1678,6 +1706,7 @@ function StreamController() {
         isPaused = false;
         autoPlay = true;
         playbackEndedTimerInterval = null;
+        pendingDynamicToStaticUpdate = false;
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;

--- a/test/functional/config/test-configurations/streams/smoke.json
+++ b/test/functional/config/test-configurations/streams/smoke.json
@@ -431,6 +431,20 @@
       }
     },
     {
+      "name": "Dynamic to static transition with LiveSim2 using an MPD Location element",
+      "type": "live",
+      "url": "https://livesim2.dashif.org/livesim2/startrel_-20/stoprel_6/testpic_2s/Manifest.mpd",
+      "includedTestfiles": [
+        "feature-support/dynamic-to-static"
+      ],
+      "testdata": {
+        "dynamicToStatic": {
+          "runtime": 20000,
+          "checkReplay": true
+        }
+      }
+    },
+    {
       "name": "BBB 30fps VoD CMCD v2",
       "type": "vod",
       "url": "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd",

--- a/test/functional/test/common/common.js
+++ b/test/functional/test/common/common.js
@@ -19,10 +19,48 @@ export async function checkIsNotProgressing(playerAdapter) {
 }
 
 export function checkNoCriticalErrors(playerAdapter) {
+    const sanitizeUrl = (url) => {
+        if (!url) {
+            return url;
+        }
+
+        try {
+            const parsedUrl = new URL(url);
+            return `${parsedUrl.origin}${parsedUrl.pathname}${parsedUrl.search ? '?[redacted]' : ''}`;
+        } catch (e) {
+            return url.split('?')[0];
+        }
+    };
     const logEvents = playerAdapter.getLogEvents();
-    expect(logEvents[dashjs.Debug.LOG_LEVEL_ERROR]).to.be.empty;
     const errorEvents = playerAdapter.getErrorEvents();
-    expect(errorEvents).to.be.empty;
+    const errorLogs = logEvents[dashjs.Debug.LOG_LEVEL_ERROR];
+    const diagnostics = JSON.stringify({
+        errorEvents: errorEvents.map((event) => {
+            const error = event.error || event;
+            const data = error.data || {};
+            const request = data.request || {};
+            const response = data.response || {};
+
+            return {
+                code: error.code,
+                message: error.message,
+                request: {
+                    mediaType: request.mediaType,
+                    range: request.range,
+                    type: request.type,
+                    url: sanitizeUrl(request.url)
+                },
+                response: {
+                    status: response.status,
+                    statusText: response.statusText,
+                    url: sanitizeUrl(response.url)
+                }
+            };
+        }),
+        errorLogs
+    }, null, 2);
+    expect(errorLogs, diagnostics).to.be.empty;
+    expect(errorEvents, diagnostics).to.be.empty;
 }
 
 export function checkEventHasBeenTriggered(playerAdapter, eventName) {

--- a/test/functional/test/feature-support/dynamic-to-static.js
+++ b/test/functional/test/feature-support/dynamic-to-static.js
@@ -1,5 +1,6 @@
 import Constants from '../../src/Constants.js';
 import Utils from '../../src/Utils.js';
+import { expect } from 'chai'
 import {
     checkEventHasBeenTriggered,
     checkIsPlaying,
@@ -53,6 +54,24 @@ Utils.getTestvectorsForTestcase(TESTCASE).forEach((item) => {
 
         it(`PLAYBACK_ENDED event has been thrown`, async () => {
             checkEventHasBeenTriggered(playerAdapter, dashjs.MediaPlayer.events.PLAYBACK_ENDED);
+        });
+
+        it(`Player is not dynamic anymore`, () => {
+            expect(playerAdapter.isDynamic()).to.be.false;
+        });
+
+        it(`Duration is finite`, () => {
+            expect(playerAdapter.getDuration()).to.be.a('number');
+            expect(playerAdapter.getDuration()).to.be.finite;
+        });
+
+        it(`Seek back to start replaying the stream`, async function () {
+            if (!item.testdata.dynamicToStatic.checkReplay) {
+                this.skip();
+            }
+            playerAdapter.seek(0);
+            playerAdapter.play();
+            await checkIsProgressing(playerAdapter);
         });
 
         it(`Expect no critical errors to be thrown`, () => {

--- a/test/functional/test/feature-support/dynamic-to-static.js
+++ b/test/functional/test/feature-support/dynamic-to-static.js
@@ -1,6 +1,6 @@
 import Constants from '../../src/Constants.js';
 import Utils from '../../src/Utils.js';
-import { expect } from 'chai'
+import { expect } from 'chai';
 import {
     checkEventHasBeenTriggered,
     checkIsPlaying,

--- a/test/functional/test/feature-support/dynamic-to-static.js
+++ b/test/functional/test/feature-support/dynamic-to-static.js
@@ -65,6 +65,17 @@ Utils.getTestvectorsForTestcase(TESTCASE).forEach((item) => {
             expect(playerAdapter.getDuration()).to.be.finite;
         });
 
+        it(`DVR window covers the final static presentation`, () => {
+            const dvrWindow = playerAdapter.getDvrWindow();
+            expect(dvrWindow.start).to.be.closeTo(0, 0.001);
+            expect(dvrWindow.end).to.be.closeTo(playerAdapter.getDuration(), 0.001);
+
+            const seekable = playerAdapter.getVideoElement().seekable;
+            expect(seekable.length).to.be.greaterThan(0);
+            expect(seekable.start(0)).to.be.closeTo(0, 0.001);
+            expect(seekable.end(seekable.length - 1)).to.be.closeTo(playerAdapter.getDuration(), 0.001);
+        });
+
         it(`Seek back to start replaying the stream`, async function () {
             if (!item.testdata.dynamicToStatic.checkReplay) {
                 this.skip();

--- a/test/unit/test/dash/dash.utils.TimelineConverter.js
+++ b/test/unit/test/dash/dash.utils.TimelineConverter.js
@@ -355,6 +355,17 @@ describe('TimelineConverter', function () {
                 expect(range.end).to.be.equal(100);
             });
 
+            it('with non-contiguous periods', function () {
+                streamTwoMock.setStreamInfo({
+                    start: 75,
+                    duration: 50
+                });
+                streams.push(streamOneMock, streamTwoMock);
+                const range = timelineConverter.calcTimeShiftBufferWindow(streams, false);
+                expect(range.start).to.be.equal(0);
+                expect(range.end).to.be.equal(125);
+            });
+
             it('with SegmentTimeline and one period and shouldCalculateFromTimeline set to true', function () {
                 settings.update({
                     streaming: {
@@ -1374,4 +1385,3 @@ describe('TimelineConverter', function () {
         });
     });
 });
-

--- a/test/unit/test/streaming/streaming.ManifestUpdater.js
+++ b/test/unit/test/streaming/streaming.ManifestUpdater.js
@@ -2,6 +2,8 @@ import ManifestUpdater from './../../../../src/streaming/ManifestUpdater.js';
 import Events from '../../../../src/core/events/Events.js';
 import EventBus from '../../../../src/core/EventBus.js';
 import Errors from '../../../../src/core/errors/Errors.js';
+import Settings from '../../../../src/core/Settings.js';
+import DashConstants from '../../../../src/dash/constants/DashConstants.js';
 import AdapterMock from '../../mocks/AdapterMock.js';
 import ManifestModelMock from '../../mocks/ManifestModelMock.js';
 import ManifestLoaderMock from '../../mocks/ManifestLoaderMock.js';
@@ -24,6 +26,8 @@ describe('ManifestUpdater', function () {
     const errHandlerMock = new ErrorHandlerMock();
     const contentSteeringControllerMock = new ContentSteeringControllerMock();
 
+    const settings = Settings(context).getInstance();
+
     const manifestErrorMockText = `Mock Failed detecting manifest type or manifest type unsupported`;
 
     manifestUpdater.setConfig({
@@ -31,7 +35,8 @@ describe('ManifestUpdater', function () {
         manifestModel: manifestModelMock,
         manifestLoader: manifestLoaderMock,
         errHandler: errHandlerMock,
-        contentSteeringController: contentSteeringControllerMock
+        contentSteeringController: contentSteeringControllerMock,
+        settings: settings
     });
 
     manifestUpdater.initialize();
@@ -184,6 +189,79 @@ describe('ManifestUpdater', function () {
         applyPatchStub.restore();
         publishTimeStub.restore();
         loaderStub.restore();
+    });
+
+    describe('dynamic to static transition', function () {
+
+        afterEach(function () {
+            manifestModelMock.setValue(null);
+            settings.reset();
+        });
+
+        it('should trigger DYNAMIC_TO_STATIC and apply the static manifest when a static manifest follows a dynamic one', function () {
+            manifestModelMock.setValue({ type: DashConstants.DYNAMIC, loadedTime: new Date() });
+
+            const dynamicToStaticSpy = sinon.spy();
+            const manifestUpdatedSpy = sinon.spy();
+            eventBus.on(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.on(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+
+            const staticManifest = { type: DashConstants.STATIC, loadedTime: new Date() };
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: staticManifest });
+
+            expect(dynamicToStaticSpy.calledOnce).to.be.true;
+            expect(manifestModelMock.getValue()).to.equal(staticManifest);
+            expect(manifestUpdatedSpy.calledOnce).to.be.true;
+            expect(manifestUpdatedSpy.firstCall.args[0].manifest).to.equal(staticManifest);
+
+            eventBus.off(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.off(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+        });
+
+        it('should not trigger DYNAMIC_TO_STATIC again on subsequent static updates', function () {
+            manifestModelMock.setValue({ type: DashConstants.DYNAMIC, loadedTime: new Date() });
+
+            const dynamicToStaticSpy = sinon.spy();
+            const manifestUpdatedSpy = sinon.spy();
+            eventBus.on(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.on(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: { type: DashConstants.STATIC, loadedTime: new Date() }
+            });
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: { type: DashConstants.STATIC, loadedTime: new Date() }
+            });
+
+            expect(dynamicToStaticSpy.calledOnce).to.be.true;
+            expect(manifestUpdatedSpy.calledTwice).to.be.true;
+
+            eventBus.off(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.off(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+        });
+
+        it('should ignore the static manifest when ignoreFinalStaticManifestOnDynamicToStaticTransition is enabled', function () {
+            settings.update({ streaming: { ignoreFinalStaticManifestOnDynamicToStaticTransition: true } });
+
+            const dynamicManifest = { type: DashConstants.DYNAMIC, loadedTime: new Date() };
+            manifestModelMock.setValue(dynamicManifest);
+
+            const dynamicToStaticSpy = sinon.spy();
+            const manifestUpdatedSpy = sinon.spy();
+            eventBus.on(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.on(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: { type: DashConstants.STATIC, loadedTime: new Date() }
+            });
+
+            expect(dynamicToStaticSpy.calledOnce).to.be.true;
+            expect(manifestModelMock.getValue()).to.equal(dynamicManifest);
+            expect(manifestUpdatedSpy.called).to.be.false;
+
+            eventBus.off(Events.DYNAMIC_TO_STATIC, dynamicToStaticSpy);
+            eventBus.off(Events.MANIFEST_UPDATED, manifestUpdatedSpy);
+        });
     });
 
     describe('refresh manifest location', function () {

--- a/test/unit/test/streaming/streaming.controllers.MediaSourceController.js
+++ b/test/unit/test/streaming/streaming.controllers.MediaSourceController.js
@@ -65,6 +65,36 @@ describe('MediaSourceController', function () {
             video.src = window.URL.createObjectURL(source);
         });
 
+        it('should clamp the duration to the highest buffered end time to avoid setting it below buffered coded frames', function (done) {
+            function _onSourceOpen() {
+                Object.defineProperty(source, 'sourceBuffers', {
+                    get: function () {
+                        return [{
+                            updating: false,
+                            buffered: {
+                                length: 1,
+                                start: function () {
+                                    return 0;
+                                },
+                                end: function () {
+                                    return 26.5;
+                                }
+                            }
+                        }];
+                    }
+                });
+                mediaSourceController.setDuration(26);
+                expect(source.duration).to.equal(26.5);
+                done();
+            }
+
+            let source = mediaSourceController.createMediaSource();
+            let video = document.createElement('video');
+
+            source.addEventListener('sourceopen', _onSourceOpen)
+            video.src = window.URL.createObjectURL(source);
+        });
+
         it('should not update source seekable range if not in readystate open', function () {
             let source = mediaSourceController.createMediaSource();
 


### PR DESCRIPTION
This PR addresses #4291 .

* Takes updates to the MPD into account when the type of the MPD changes from `dynamic` to `static`
* The controlbar shows the type of the content either `dynamic` or `static`
* The legacy behavior of not taking information from the last MPD update into account is hidden behind a settings flag `ignoreFinalStaticManifestOnDynamicToStaticTransition` which is set to `false` by default
* Adds a sample and a reference stream based on LiveSim2 content
* Adds a functional test based on LiveSim2 content