### PR TITLE
refactor(dash): centralize descriptor materialization

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -256,14 +256,7 @@ function DashManifestModel() {
     }
 
     function getViewpointForAdaptation(adaptation) {
-        if (!adaptation || !adaptation.hasOwnProperty(DashConstants.VIEWPOINT) || !adaptation[DashConstants.VIEWPOINT].length) {
-            return [];
-        }
-        return adaptation[DashConstants.VIEWPOINT].map(viewpoint => {
-            const vp = new DescriptorType();
-            vp.init(viewpoint);
-            return vp
-        });
+        return _getDescriptorTypes(DashConstants.VIEWPOINT, adaptation);
     }
 
     function getRolesForAdaptation(adaptation) {
@@ -283,36 +276,15 @@ function DashManifestModel() {
     }
 
     function getAccessibilityForAdaptation(adaptation) {
-        if (!adaptation || !adaptation.hasOwnProperty(DashConstants.ACCESSIBILITY) || !adaptation[DashConstants.ACCESSIBILITY].length) {
-            return [];
-        }
-        return adaptation[DashConstants.ACCESSIBILITY].map(accessibility => {
-            const a = new DescriptorType();
-            a.init(accessibility);
-            return a
-        });
+        return _getDescriptorTypes(DashConstants.ACCESSIBILITY, adaptation);
     }
 
     function getAudioChannelConfigurationForAdaptation(adaptation) {
-        if (!adaptation || !adaptation.hasOwnProperty(DashConstants.AUDIO_CHANNEL_CONFIGURATION) || !adaptation[DashConstants.AUDIO_CHANNEL_CONFIGURATION].length) {
-            return [];
-        }
-        return adaptation[DashConstants.AUDIO_CHANNEL_CONFIGURATION].map(audioChanCfg => {
-            const acc = new DescriptorType();
-            acc.init(audioChanCfg);
-            return acc
-        });
+        return _getDescriptorTypes(DashConstants.AUDIO_CHANNEL_CONFIGURATION, adaptation);
     }
 
     function getAudioChannelConfigurationForRepresentation(representation) {
-        if (!representation || !representation.hasOwnProperty(DashConstants.AUDIO_CHANNEL_CONFIGURATION) || !representation[DashConstants.AUDIO_CHANNEL_CONFIGURATION].length) {
-            return [];
-        }
-        return representation[DashConstants.AUDIO_CHANNEL_CONFIGURATION].map(audioChanCfg => {
-            const acc = new DescriptorType();
-            acc.init(audioChanCfg);
-            return acc
-        });
+        return _getDescriptorTypes(DashConstants.AUDIO_CHANNEL_CONFIGURATION, representation);
     }
 
     function getRepresentationSortFunction() {
@@ -647,16 +619,15 @@ function DashManifestModel() {
         }
     }
 
-    // propertyType is one of { DashConstants.ESSENTIAL_PROPERTY, DashConstants.SUPPLEMENTAL_PROPERTY }
-    function _getProperties(propertyType, element) {
-        if (!element || !element.hasOwnProperty(propertyType) || !element[propertyType].length) {
+    function _getDescriptorTypes(propertyName, element) {
+        if (!element || !element.hasOwnProperty(propertyName) || !element[propertyName].length) {
             return [];
         }
 
-        return element[propertyType].map((property) => {
-            const s = new DescriptorType();
-            s.init(property);
-            return s
+        return element[propertyName].map((data) => {
+            const descriptor = new DescriptorType();
+            descriptor.init(data);
+            return descriptor
         });
     }
 
@@ -713,7 +684,7 @@ function DashManifestModel() {
     }
 
     function getEssentialProperties(element) {
-        return _getProperties(DashConstants.ESSENTIAL_PROPERTY, element);
+        return _getDescriptorTypes(DashConstants.ESSENTIAL_PROPERTY, element);
     }
 
     function getCombinedEssentialPropertiesForAdaptationSet(adaptation) {
@@ -721,7 +692,7 @@ function DashManifestModel() {
     }
 
     function getSupplementalProperties(element) {
-        return _getProperties(DashConstants.SUPPLEMENTAL_PROPERTY, element);
+        return _getDescriptorTypes(DashConstants.SUPPLEMENTAL_PROPERTY, element);
     }
 
     function getCombinedSupplementalPropertiesForAdaptationSet(adaptation) {

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -102,28 +102,70 @@ describe('DashManifestModel', function () {
             expect(language).to.equal(EMPTY_STRING);
         });
 
-        describe('handling of descriptors', function () {
-            it('should return an empty array when getViewpointForAdaptation is called and adaptation is undefined', () => {
-                const viewPoint = dashManifestModel.getViewpointForAdaptation();
-    
-                expect(viewPoint).to.be.instanceOf(Array);
-                expect(viewPoint).to.be.empty;
+        describe('descriptor materialization', function () {
+            const descriptorGetterCases = [
+                { methodName: 'getViewpointForAdaptation', propertyName: DashConstants.VIEWPOINT },
+                { methodName: 'getAccessibilityForAdaptation', propertyName: DashConstants.ACCESSIBILITY },
+                { methodName: 'getAudioChannelConfigurationForAdaptation', propertyName: DashConstants.AUDIO_CHANNEL_CONFIGURATION },
+                { methodName: 'getAudioChannelConfigurationForRepresentation', propertyName: DashConstants.AUDIO_CHANNEL_CONFIGURATION },
+                { methodName: 'getEssentialProperties', propertyName: DashConstants.ESSENTIAL_PROPERTY },
+                { methodName: 'getSupplementalProperties', propertyName: DashConstants.SUPPLEMENTAL_PROPERTY }
+            ];
+
+            descriptorGetterCases.forEach(({ methodName, propertyName }) => {
+                describe(methodName, function () {
+                    it('should return an empty array for missing descriptors', () => {
+                        expect(dashManifestModel[methodName]()).to.deep.equal([]);
+                        expect(dashManifestModel[methodName]({})).to.deep.equal([]);
+                        expect(dashManifestModel[methodName]({ [propertyName]: [] })).to.deep.equal([]);
+                    });
+
+                    it('should materialize a single DescriptorType without mutating the source', () => {
+                        const descriptor = Object.freeze({
+                            schemeIdUri: 'test.scheme.single',
+                            value: 0,
+                            id: 'single',
+                            [DashConstants.DVB_URL]: 'https://example.com'
+                        });
+                        const descriptors = Object.freeze([descriptor]);
+                        const element = { [propertyName]: descriptors };
+
+                        const result = dashManifestModel[methodName](element);
+
+                        expect(result).to.have.lengthOf(1);
+                        expect(result[0]).to.be.instanceOf(DescriptorType);
+                        expect(result[0]).not.to.equal(descriptor);
+                        expect(result[0].schemeIdUri).to.equal('test.scheme.single');
+                        expect(result[0].value).to.equal('0');
+                        expect(result[0].id).to.equal('single');
+                        expect(result[0].dvbUrl).to.equal('https://example.com');
+                        expect(element[propertyName]).to.equal(descriptors);
+                    });
+
+                    it('should preserve descriptor order without mutating the source', () => {
+                        const firstDescriptor = Object.freeze({ schemeIdUri: 'test.scheme.first', value: 'first' });
+                        const secondDescriptor = Object.freeze({ schemeIdUri: 'test.scheme.second', value: false });
+                        const descriptors = Object.freeze([firstDescriptor, secondDescriptor]);
+                        const element = { [propertyName]: descriptors };
+
+                        const result = dashManifestModel[methodName](element);
+
+                        expect(result).to.have.lengthOf(2);
+                        expect(result.every(descriptor => descriptor instanceof DescriptorType)).to.be.true;
+                        expect(result.map(descriptor => descriptor.schemeIdUri)).to.deep.equal([
+                            'test.scheme.first',
+                            'test.scheme.second'
+                        ]);
+                        expect(result.map(descriptor => descriptor.value)).to.deep.equal(['first', 'false']);
+                        expect(result[0]).not.to.equal(firstDescriptor);
+                        expect(result[1]).not.to.equal(secondDescriptor);
+                        expect(element[propertyName]).to.equal(descriptors);
+                    });
+                });
             });
-    
-            it('should return an empty array when getAudioChannelConfigurationForAdaptation is called and adaptation is undefined', () => {
-                const AudioChannelConfigurationArray = dashManifestModel.getAudioChannelConfigurationForAdaptation();
-    
-                expect(AudioChannelConfigurationArray).to.be.instanceOf(Array);
-                expect(AudioChannelConfigurationArray).to.be.empty;
-            });
-    
-            it('should return an empty array when getAccessibilityForAdaptation is called and adaptation is undefined', () => {
-                const accessibilityArray = dashManifestModel.getAccessibilityForAdaptation();
-    
-                expect(accessibilityArray).to.be.instanceOf(Array);
-                expect(accessibilityArray).to.be.empty;
-            });
-    
+        });
+
+        describe('role descriptor normalization', function () {
             it('should return an empty array when getRolesForAdaptation is called and adaptation is undefined', () => {
                 const rolesArray = dashManifestModel.getRolesForAdaptation();
     
@@ -146,64 +188,7 @@ describe('DashManifestModel', function () {
             });
         });
 
-        describe('handling of Property descriptors', function () {
-            
-            it('should return an empty array when getEssentialProperties', () => {
-                const suppPropArray = dashManifestModel.getEssentialProperties();
-                
-                expect(suppPropArray).to.be.instanceOf(Object);
-                expect(suppPropArray).to.be.empty;
-            });
-            
-            it('should return an empty array when getEssentialProperties', () => {
-                const suppPropArray = dashManifestModel.getEssentialProperties();
-                
-                expect(suppPropArray).to.be.instanceOf(Array);
-                expect(suppPropArray).to.be.empty;
-            });
-            
-            it('should return correct array of DescriptorType when getEssentialProperties is called', () => {
-                const essPropArray = dashManifestModel.getEssentialProperties({
-                    EssentialProperty: [{ schemeIdUri: 'test.scheme', value: 'testVal' }, {
-                        schemeIdUri: 'test.scheme',
-                        value: 'test2Val'
-                    }]
-                });
-                
-                expect(essPropArray).to.be.instanceOf(Array);
-                expect(essPropArray.length).to.equal(2);
-                expect(essPropArray[0]).to.be.instanceOf(DescriptorType);
-                expect(essPropArray[0].schemeIdUri).equals('test.scheme');
-                expect(essPropArray[0].value).equals('testVal');
-                expect(essPropArray[1].schemeIdUri).equals('test.scheme');
-                expect(essPropArray[1].value).equals('test2Val');
-            });
-            
-            it('should return an empty array when getEssentialProperties', () => {
-                const essPropArray = dashManifestModel.getEssentialProperties();
-                
-                expect(essPropArray).to.be.instanceOf(Object);
-                expect(essPropArray).to.be.empty;
-            });
-            
-            it('should return an empty array when getEssentialProperties', () => {
-                const essPropArray = dashManifestModel.getEssentialProperties();
-                
-                expect(essPropArray).to.be.instanceOf(Array);
-                expect(essPropArray).to.be.empty;
-            });
-            
-            it('should return correct array of DescriptorType when getEssentialProperties is called', () => {
-                const essPropArray = dashManifestModel.getEssentialProperties({
-                    EssentialProperty: [{ schemeIdUri: 'test.scheme', value: 'testVal' }]
-                });
-                
-                expect(essPropArray).to.be.instanceOf(Array);
-                expect(essPropArray[0]).to.be.instanceOf(DescriptorType);
-                expect(essPropArray[0].schemeIdUri).equals('test.scheme');
-                expect(essPropArray[0].value).equals('testVal');
-            });
-
+        describe('handling of combined Property descriptors', function () {
             it('should return correct array of DescriptorType when getCombinedEssentialPropertiesForAdaptationSet is called', () => {
                 const essPropArray = dashManifestModel.getCombinedEssentialPropertiesForAdaptationSet({
                     Representation: [

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -161,6 +161,23 @@ describe('DashManifestModel', function () {
                         expect(result[1]).not.to.equal(secondDescriptor);
                         expect(element[propertyName]).to.equal(descriptors);
                     });
+
+                    it('should preserve descriptors sharing the same schemeIdUri', () => {
+                        const descriptors = Object.freeze([
+                            Object.freeze({ schemeIdUri: 'test.scheme.shared', value: '1' }),
+                            Object.freeze({ schemeIdUri: 'test.scheme.shared', value: '2' })
+                        ]);
+                        const element = { [propertyName]: descriptors };
+
+                        const result = dashManifestModel[methodName](element);
+
+                        expect(result).to.have.lengthOf(2);
+                        expect(result.map(descriptor => descriptor.schemeIdUri)).to.deep.equal([
+                            'test.scheme.shared',
+                            'test.scheme.shared'
+                        ]);
+                        expect(result.map(descriptor => descriptor.value)).to.deep.equal(['1', '2']);
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Summary

- add characterization tests for the six public descriptor getters
- centralize descriptor conversion in one private `DashManifestModel` helper
- preserve parsing, Role normalization, combined-property handling, descriptor order, and source immutability

## Impact

No public API or intended behavior changes.

- production: `+12/-41` lines (`-29` net)
- complete diff: `+93/-120` lines (`-27` net)

## Test-first sequence

1. `test: characterize descriptor materialization` adds the behavior matrix before the production change.
2. `refactor: centralize descriptor materialization` performs the extraction.
3. `test(dash): cover descriptors sharing the same schemeIdUri` strengthens regression coverage after review.

## Validation

Current GitHub checks pass:

- validation and unit tests
- modern and legacy builds
- compliance tests

`git diff --check` also passes against the PR base.

Closes #5076
