### PR TITLE
fix(dash): avoid mutating Representation properties during aggregation

### DIFF
--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -672,7 +672,7 @@ function DashManifestModel() {
         }
 
         if (repr.length === 1) {
-            return propertiesOfFirstRepresentation;
+            return propertiesOfFirstRepresentation.slice();
         }
 
         // now, only return properties present on all Representations

--- a/test/unit/test/dash/dash.models.DashManifestModel.js
+++ b/test/unit/test/dash/dash.models.DashManifestModel.js
@@ -237,6 +237,56 @@ describe('DashManifestModel', function () {
                 expect(essPropArray[2].schemeIdUri).equals('test.scheme.B');
                 expect(essPropArray[2].value).equals(null);
             });
+
+            [
+                {
+                    propertyName: DashConstants.ESSENTIAL_PROPERTY,
+                    getterName: 'getCombinedEssentialPropertiesForAdaptationSet'
+                },
+                {
+                    propertyName: DashConstants.SUPPLEMENTAL_PROPERTY,
+                    getterName: 'getCombinedSupplementalPropertiesForAdaptationSet'
+                }
+            ].forEach(({propertyName, getterName}) => {
+                it(`should combine ${propertyName} consistently without mutating Representations`, () => {
+                    const representationProperty = Object.freeze({
+                        schemeIdUri: 'test.scheme.representation',
+                        value: 'representation'
+                    });
+                    const representationProperties = Object.freeze([representationProperty]);
+                    const adaptationProperty = Object.freeze({
+                        schemeIdUri: Constants.EXT_URL_QUERY_INFO_SCHEME,
+                        value: 'adaptation'
+                    });
+                    const adaptationProperties = Object.freeze([
+                        {schemeIdUri: representationProperty.schemeIdUri, value: representationProperty.value},
+                        adaptationProperty
+                    ]);
+                    const singleRepresentationAdaptation = {
+                        [propertyName]: adaptationProperties,
+                        Representation: [{[propertyName]: representationProperties}]
+                    };
+                    const multipleRepresentationAdaptation = {
+                        [propertyName]: adaptationProperties,
+                        Representation: [
+                            {[propertyName]: [representationProperty]},
+                            {[propertyName]: [representationProperty]}
+                        ]
+                    };
+
+                    const singleRepresentationResult = dashManifestModel[getterName](singleRepresentationAdaptation);
+                    const multipleRepresentationResult = dashManifestModel[getterName](multipleRepresentationAdaptation);
+                    const expectedValues = [
+                        [representationProperty.schemeIdUri, representationProperty.value],
+                        [adaptationProperty.schemeIdUri, adaptationProperty.value]
+                    ];
+
+                    expect(singleRepresentationResult.every(property => property instanceof DescriptorType)).to.be.true;
+                    expect(singleRepresentationResult.map(property => [property.schemeIdUri, property.value])).to.deep.equal(expectedValues);
+                    expect(multipleRepresentationResult.map(property => [property.schemeIdUri, property.value])).to.deep.equal(expectedValues);
+                    expect(singleRepresentationAdaptation.Representation[0][propertyName]).to.equal(representationProperties);
+                });
+            });
         });
             
         it('should return null when getAdaptationForId is called and id, manifest and periodIndex are undefined', () => {

--- a/test/unit/test/streaming/streaming.controllers.ExtUrlQueryInfoController.js
+++ b/test/unit/test/streaming/streaming.controllers.ExtUrlQueryInfoController.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import ExtUrlQueryInfoController from '../../../../src/streaming/controllers/ExtUrlQueryInfoController.js';
+import DashManifestModel from '../../../../src/dash/models/DashManifestModel.js';
 
 describe('ExtUrlQueryInfoController', () => {
 
@@ -519,6 +520,49 @@ describe('ExtUrlQueryInfoController', () => {
             expect(result).to.have.deep.members(expectedResult);
         });
 
+    });
+
+    it('should not duplicate adaptation query parameters after combined property aggregation', () => {
+        const queryProperty = {
+            schemeIdUri: 'urn:mpeg:dash:urlparam:2016',
+            ExtUrlQueryInfo: {
+                queryTemplate: '$querypart$',
+                queryString: 'token=abc',
+                includeInRequests: 'segment'
+            }
+        };
+        const representationProperty = {
+            schemeIdUri: 'urn:test:ordinary',
+            value: 'representation'
+        };
+        const representation = {
+            SupplementalProperty: [representationProperty]
+        };
+        const adaptation = {
+            SupplementalProperty: [queryProperty],
+            Representation: [representation]
+        };
+        const manifest = {
+            url: 'https://example.com/manifest.mpd',
+            Period: [{AdaptationSet: [adaptation]}]
+        };
+        const request = {
+            url: 'https://example.com/segment.m4s',
+            type: 'MediaSegment',
+            representation: {
+                index: 0,
+                adaptation: {
+                    index: 0,
+                    period: {index: 0}
+                }
+            }
+        };
+
+        DashManifestModel({}).getInstance().getCombinedSupplementalPropertiesForAdaptationSet(adaptation);
+        extUrlQueryInfoController.createFinalQueryStrings(manifest);
+
+        expect(extUrlQueryInfoController.getFinalQueryString(request)).to.deep.equal([{key: 'token', value: 'abc'}]);
+        expect(representation.SupplementalProperty).to.deep.equal([representationProperty]);
     });
 
     


### PR DESCRIPTION
## Problem

For an AdaptationSet with a single Representation, the common-property getter returns the Representation's original property array.

The combined-property getter then appends AdaptationSet properties to that array, mutating the parsed manifest. For URL query descriptors, the injected property is subsequently processed at both AdaptationSet and Representation levels, producing duplicate query parameters such as `token=abc&token=abc`.

## Change

- Return a shallow copy of the singleton Representation property array before combining properties.
- Preserve the existing union, deduplication, ordering, and descriptor semantics.
- Cover both `EssentialProperty` and `SupplementalProperty`.
- Cover the URL query duplication regression.

The production change is one line. It does not change public APIs, parser behavior, or multi-Representation behavior.

## TDD evidence

The history keeps the red and green phases separate:

1. `306f5299f` adds only the regression tests. They fail on Chrome and Firefox against the previous implementation.
2. `0d1c5237a` adds the `.slice()` fix. The same tests pass.

## Validation

- `npm run build-modern`: passed.
- Full unit suite: 3720 tests passed.
- TypeScript, ESLint, and Webpack checks: passed.
- Independent reviews: no findings.

Fixes #5079
