### PR TITLE
Fix a bad manifest with no Periods throwing exceptions

### DIFF
--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -213,7 +213,7 @@ function ManifestLoader(config) {
                     if (settings &&
                         settings.get().streaming.enableManifestDurationMismatchFix &&
                         manifest.mediaPresentationDuration &&
-                        manifest.Period.length > 1) {
+                        manifest.Period?.length > 1) {
                         const sumPeriodDurations = manifest.Period.reduce((totalDuration, period) => totalDuration + period.duration, 0);
                         if (!isNaN(sumPeriodDurations) && manifest.mediaPresentationDuration > sumPeriodDurations) {
                             logger.warn('Media presentation duration greater than duration of all periods. Setting duration to total period duration');


### PR DESCRIPTION
If you have a manifest with no Periods (you shouldn't because it's not allowed, but still...), you'll trigger an exception here. This fixes it so we'll get through to the `MANIFEST_ERROR_ID_NOSTREAMS_CODE` instead. 