### PR TITLE
Feature/testapp npm pack

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -25,8 +25,14 @@ jobs:
             -   name: Install
                 run: npm ci
 
-            # Packs the tarball (prepack runs build:dist), asserts its contents, installs it
-            # into a consumer app and runs a playback smoke test. Publish only runs if this passes.
+            # The pack below runs with --ignore-scripts, so the prepack hook (and with it the
+            # prebuild -> ci:verify chain) never runs in this workflow. Gate explicitly.
+            -   name: Run unit tests and lint
+                run: npm run ci:verify
+
+            # Runs build:dist itself, packs the tarball with --ignore-scripts, asserts its
+            # contents, installs it into a consumer app and runs a playback smoke test.
+            # Publish only runs if this passes.
             -   name: Pack and verify tarball
                 run: npm run test:package
 

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -25,5 +25,11 @@ jobs:
             -   name: Install
                 run: npm ci
 
-            -   name: Publish
-                run: npm publish
+            # Packs the tarball (prepack runs build:dist), asserts its contents, installs it
+            # into a consumer app and runs a playback smoke test. Publish only runs if this passes.
+            -   name: Pack and verify tarball
+                run: npm run test:package
+
+            # Publishing the tarball path skips prepack, so the exact verified artifact ships.
+            -   name: Publish verified tarball
+                run: npm publish dashjs-*.tgz

--- a/.github/workflows/verify_pull_request.yml
+++ b/.github/workflows/verify_pull_request.yml
@@ -83,13 +83,6 @@ jobs:
                     path: dist/
             -   name: Run compliance tests
                 run: npm run test:compliance
-            # --no-build packs the downloaded dist artifacts as-is instead of rebuilding.
-            # Must run AFTER test:compliance: both steps share vite-consumer/node_modules/dashjs.
-            # test:compliance:vite installs the "file:" source dependency (CJS-in-ESM check,
-            # see #5026), then this step overwrites it with the tarball install. Reordering
-            # silently loses one of the two coverages.
-            -   name: Verify npm package tarball
-                run: node test/package/verify-package.mjs --no-build
 
     run_functional_test_single_stream_lambdatest:
         if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/verify_pull_request.yml
+++ b/.github/workflows/verify_pull_request.yml
@@ -83,7 +83,11 @@ jobs:
                     path: dist/
             -   name: Run compliance tests
                 run: npm run test:compliance
-            # --no-build packs the downloaded dist artifacts as-is instead of rebuilding
+            # --no-build packs the downloaded dist artifacts as-is instead of rebuilding.
+            # Must run AFTER test:compliance: both steps share vite-consumer/node_modules/dashjs.
+            # test:compliance:vite installs the "file:" source dependency (CJS-in-ESM check,
+            # see #5026), then this step overwrites it with the tarball install. Reordering
+            # silently loses one of the two coverages.
             -   name: Verify npm package tarball
                 run: node test/package/verify-package.mjs --no-build
 

--- a/.github/workflows/verify_pull_request.yml
+++ b/.github/workflows/verify_pull_request.yml
@@ -83,6 +83,9 @@ jobs:
                     path: dist/
             -   name: Run compliance tests
                 run: npm run test:compliance
+            # --no-build packs the downloaded dist artifacts as-is instead of rebuilding
+            -   name: Verify npm package tarball
+                run: node test/package/verify-package.mjs --no-build
 
     run_functional_test_single_stream_lambdatest:
         if: github.event.pull_request.head.repo.fork == false

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ test/functional/apps/webos/test-app/com.dashjs.app_1.0.0_all.ipk
 test-results
 
 .claude/settings.local.json
+
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-samples
-docs
-build/temp
-build/jsdoc
-test
-.travis.yml
-mochahook.js
-reports
-.idea

--- a/build/webpack/modern/webpack.modern.base.cjs
+++ b/build/webpack/modern/webpack.modern.base.cjs
@@ -41,7 +41,6 @@ const esmConfig = merge(modernConfig, {
         library: {
             type: 'module',
         },
-        libraryExport: 'default',
     },
 });
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "doc": "jsdoc -c build/jsdoc/jsdoc_conf.json -d docs/jsdoc",
     "lint": "eslint \"src/**/*.js\" \"test/unit/mocks/*.js\" \"test/unit/test/**/*.js\"",
     "prebuild": "npm run ci:verify",
-    "prepack": "npm run build",
+    "prepack": "npm run build:dist",
     "prepare": "node githook.cjs",
     "start": "webpack serve --config build/webpack/modern/webpack.modern.dev.cjs",
     "test": "karma start test/unit/config/karma.unit.conf.cjs",
@@ -45,6 +45,7 @@
     "test:compliance:esm": "es-check es2021 \"dist/modern/esm/*.js\" --module",
     "test:compliance:package": "publint",
     "test:compliance:vite": "npm --prefix test/compliance/vite-consumer install --no-audit --no-fund && npm --prefix test/compliance/vite-consumer run build",
+    "test:package": "node test/package/verify-package.mjs",
     "test-refplayer": "karma start test/unit/config/karma.unit.conf.cjs --grep \"Reference Player\"",
     "test-functional": "karma start test/functional/config/karma.functional.conf.cjs --configfile=local --streamsfile=smoke",
     "webpack-build-legacy": "webpack --config build/webpack/legacy/webpack.legacy.prod.cjs",
@@ -123,6 +124,7 @@
     "index.d.ts",
     "dist",
     "contrib/akamai",
+    "contrib/controlbar",
     "contrib/videojs-vtt.js/vtt.min.js"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "doc": "jsdoc -c build/jsdoc/jsdoc_conf.json -d docs/jsdoc",
     "lint": "eslint \"src/**/*.js\" \"test/unit/mocks/*.js\" \"test/unit/test/**/*.js\"",
     "prebuild": "npm run ci:verify",
-    "prepack": "npm run build:dist",
+    "prepack": "npm run build",
     "prepare": "node githook.cjs",
     "start": "webpack serve --config build/webpack/modern/webpack.modern.dev.cjs",
     "test": "karma start test/unit/config/karma.unit.conf.cjs",

--- a/test/package/karma.package.conf.cjs
+++ b/test/package/karma.package.conf.cjs
@@ -1,0 +1,70 @@
+const path = require('path');
+
+// Runs the package smoke test in headless Chrome. The spec imports 'dashjs', which is
+// resolved from the tarball installed into test/compliance/vite-consumer/node_modules
+// by test/package/verify-package.mjs - run that script instead of this config directly.
+module.exports = function (config) {
+    config.set({
+
+        basePath: '../../',
+
+        frameworks: ['mocha', 'chai', 'webpack'],
+
+        plugins: [
+            'karma-*',
+            '@*/karma-*',
+        ],
+
+        files: [
+            { pattern: 'test/package/smoke.spec.js', watched: false },
+        ],
+
+        client: {
+            useIframe: false,
+            mocha: {
+                timeout: 60000
+            }
+        },
+
+        preprocessors: {
+            'test/package/smoke.spec.js': ['webpack'],
+        },
+
+        reporters: ['mocha'],
+
+        webpack: {
+            mode: 'development',
+            resolve: {
+                // Resolve 'dashjs' from the consumer app's node_modules, i.e. the
+                // tarball install, through the package's real exports map.
+                modules: [
+                    path.resolve(__dirname, '../compliance/vite-consumer/node_modules'),
+                    'node_modules',
+                ],
+            },
+        },
+
+        port: 9998,
+
+        colors: true,
+
+        logLevel: config.LOG_WARN,
+
+        autoWatch: false,
+
+        customLaunchers: {
+            ChromeHeadlessAutoplay: {
+                base: 'ChromeHeadless',
+                flags: ['--autoplay-policy=no-user-gesture-required', '--mute-audio']
+            }
+        },
+
+        browsers: ['ChromeHeadlessAutoplay'],
+
+        singleRun: true,
+
+        browserNoActivityTimeout: 90000,
+
+        concurrency: 1
+    })
+}

--- a/test/package/smoke.spec.js
+++ b/test/package/smoke.spec.js
@@ -1,0 +1,75 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// 'dashjs' resolves to the npm pack tarball installed into
+// test/compliance/vite-consumer/node_modules - see test/package/verify-package.mjs.
+import dashjs from 'dashjs';
+// Exercises the './mss' entry of the package exports map (registers itself on import).
+import 'dashjs/mss';
+
+const STREAM_URL = 'https://dash.akamaized.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd';
+const MIN_PLAYBACK_TIME = 3;
+
+describe('npm package smoke test', () => {
+
+    it('exposes MediaPlayer and Version through the package exports', () => {
+        expect(dashjs.MediaPlayer).to.be.a('function');
+        expect(dashjs.Version).to.be.a('string');
+    });
+
+    it(`plays a stream for at least ${MIN_PLAYBACK_TIME} seconds`, (done) => {
+        const videoElement = document.createElement('video');
+        videoElement.muted = true;
+        document.body.appendChild(videoElement);
+
+        const player = dashjs.MediaPlayer().create();
+
+        function finish(error) {
+            player.destroy();
+            videoElement.remove();
+            done(error);
+        }
+
+        player.on(dashjs.MediaPlayer.events.ERROR, (e) => {
+            finish(new Error(`Player error: ${JSON.stringify(e.error)}`));
+        });
+        player.on(dashjs.MediaPlayer.events.PLAYBACK_ERROR, (e) => {
+            finish(new Error(`Playback error: ${JSON.stringify(e.error)}`));
+        });
+        player.on(dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED, (e) => {
+            if (e.time >= MIN_PLAYBACK_TIME) {
+                finish();
+            }
+        });
+
+        player.initialize(videoElement, STREAM_URL, true);
+    });
+});

--- a/test/package/smoke.spec.js
+++ b/test/package/smoke.spec.js
@@ -32,8 +32,8 @@
 // 'dashjs' resolves to the npm pack tarball installed into
 // test/compliance/vite-consumer/node_modules - see test/package/verify-package.mjs.
 import dashjs from 'dashjs';
-// Exercises the './mss' entry of the package exports map (registers itself on import).
-import 'dashjs/mss';
+// Exercises the './mss' entry of the package exports map.
+import { MssHandler } from 'dashjs/mss';
 
 const STREAM_URL = 'https://dash.akamaized.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd';
 const MIN_PLAYBACK_TIME = 3;
@@ -43,6 +43,7 @@ describe('npm package smoke test', () => {
     it('exposes MediaPlayer and Version through the package exports', () => {
         expect(dashjs.MediaPlayer).to.be.a('function');
         expect(dashjs.Version).to.be.a('string');
+        expect(MssHandler).to.be.a('function');
     });
 
     it(`plays a stream for at least ${MIN_PLAYBACK_TIME} seconds`, (done) => {
@@ -52,7 +53,16 @@ describe('npm package smoke test', () => {
 
         const player = dashjs.MediaPlayer().create();
 
+        // destroy() does not unregister player.on() listeners and the EventBus dispatches
+        // synchronously, so a second event (e.g. ERROR followed by PLAYBACK_ERROR for the
+        // same failure) would call mocha's done() twice without the latch.
+        let finished = false;
+
         function finish(error) {
+            if (finished) {
+                return;
+            }
+            finished = true;
             player.destroy();
             videoElement.remove();
             done(error);
@@ -62,7 +72,9 @@ describe('npm package smoke test', () => {
             finish(new Error(`Player error: ${JSON.stringify(e.error)}`));
         });
         player.on(dashjs.MediaPlayer.events.PLAYBACK_ERROR, (e) => {
-            finish(new Error(`Playback error: ${JSON.stringify(e.error)}`));
+            // e.error is a native MediaError whose fields are prototype getters, so
+            // JSON.stringify would print '{}'.
+            finish(new Error(`Playback error: code=${e.error?.code} message=${e.error?.message}`));
         });
         player.on(dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED, (e) => {
             if (e.time >= MIN_PLAYBACK_TIME) {

--- a/test/package/verify-package.mjs
+++ b/test/package/verify-package.mjs
@@ -93,8 +93,8 @@ function fail(message) {
     process.exit(1);
 }
 
-// 1. Build the bundles, then pack. The pack itself runs with --ignore-scripts so the
-// prepack output cannot pollute the --json output on stdout.
+// 1. Build the bundles, then pack. The pack itself runs with --ignore-scripts so prepack
+// does not rebuild everything (npm still runs prepare despite the flag, see parse below).
 run('npm', ['run', 'build:dist']);
 
 // Remove stale tarballs so "npm publish dashjs-*.tgz" can only match the one packed below.
@@ -114,9 +114,16 @@ if (pack.status !== 0) {
     console.error(pack.stderr);
     fail(`npm pack exited with status ${pack.status}`);
 }
+// npm runs the prepare script during pack even with --ignore-scripts (npm bug), so
+// lifecycle output (e.g. githook.cjs hook creation) can precede the JSON on stdout.
+// Parse from the first line that is exactly "[" - the start of the pretty-printed array.
 let packInfo;
 try {
-    packInfo = JSON.parse(pack.stdout)[0];
+    const jsonStart = pack.stdout.search(/^\[$/m);
+    if (jsonStart === -1) {
+        throw new Error('no JSON array found in output');
+    }
+    packInfo = JSON.parse(pack.stdout.slice(jsonStart))[0];
 } catch (e) {
     console.error(pack.stdout);
     fail(`npm pack --json produced unparseable output: ${e.message}`);

--- a/test/package/verify-package.mjs
+++ b/test/package/verify-package.mjs
@@ -1,0 +1,121 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Verifies the npm package before publishing:
+ * 1. Packs the tarball (npm pack) and asserts all required files are inside it.
+ * 2. Installs the tarball into the vite consumer app (exercises the "files" allowlist,
+ *    unlike its regular "file:" dependency which copies the whole repo).
+ * 3. Builds the consumer app with Vite (resolves dashjs through the package exports map).
+ * 4. Runs a playback smoke test in headless Chrome against the installed tarball.
+ *
+ * Usage: node test/package/verify-package.mjs [--no-build]
+ *   --no-build  Skip the build step (use the existing dist/ as-is, for CI jobs that
+ *               already built the bundles).
+ */
+
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const consumerDir = path.join(repoRoot, 'test/compliance/vite-consumer');
+const noBuild = process.argv.includes('--no-build');
+
+const REQUIRED_FILES = [
+    'dist/modern/esm/dash.all.min.js',
+    'dist/modern/umd/dash.all.min.js',
+    'dist/modern/esm/dash.mss.min.js',
+    'dist/modern/umd/dash.mss.min.js',
+    'dist/legacy/umd/dash.all.min.js',
+    'index.d.ts',
+    'githook.cjs',
+    'contrib/akamai/controlbar/ControlBar.js',
+    'contrib/controlbar/ControlBar.js',
+    'contrib/controlbar/controlbar.css',
+    'contrib/videojs-vtt.js/vtt.min.js',
+];
+
+function run(command, args, options = {}) {
+    console.log(`\n> ${command} ${args.join(' ')}`);
+    const result = spawnSync(command, args, { cwd: repoRoot, stdio: 'inherit', ...options });
+    if (result.status !== 0) {
+        fail(`"${command} ${args.join(' ')}" exited with status ${result.status}`);
+    }
+    return result;
+}
+
+function fail(message) {
+    console.error(`\nPackage verification FAILED: ${message}`);
+    process.exit(1);
+}
+
+// 1. Build the bundles, then pack. The pack itself runs with --ignore-scripts so the
+// prepack output cannot pollute the --json output on stdout.
+if (!noBuild) {
+    run('npm', ['run', 'build:dist']);
+}
+const packArgs = ['pack', '--json', '--ignore-scripts'];
+console.log(`\n> npm ${packArgs.join(' ')}`);
+const pack = spawnSync('npm', packArgs, { cwd: repoRoot, encoding: 'utf8' });
+if (pack.status !== 0) {
+    console.error(pack.stderr);
+    fail(`npm pack exited with status ${pack.status}`);
+}
+const packInfo = JSON.parse(pack.stdout)[0];
+const tarball = path.join(repoRoot, packInfo.filename);
+console.log(`Packed ${packInfo.filename} (${packInfo.entryCount} files)`);
+
+// 2. Assert required files are inside the tarball (catches "files" allowlist regressions).
+const packedPaths = new Set(packInfo.files.map((file) => file.path));
+const missing = REQUIRED_FILES.filter((file) => !packedPaths.has(file));
+if (missing.length > 0) {
+    fail(`tarball is missing required files:\n  ${missing.join('\n  ')}`);
+}
+console.log('All required files present in tarball.');
+
+// 3. Install the tarball into the consumer app (also installs its vite devDependency).
+run('npm', ['install', '--no-save', '--no-audit', '--no-fund', tarball], { cwd: consumerDir });
+
+// Guard: a "file:" directory dependency would be a symlink; the tarball install must not be.
+const installedPackage = path.join(consumerDir, 'node_modules/dashjs');
+if (fs.lstatSync(installedPackage).isSymbolicLink()) {
+    fail('node_modules/dashjs in the consumer app is a symlink - the tarball was not installed');
+}
+
+// 4. Bundle the consumer app - resolves dashjs through the real package exports map.
+run('npm', ['run', 'build'], { cwd: consumerDir });
+
+// 5. Playback smoke test in headless Chrome against the tarball-installed package.
+run('npx', ['karma', 'start', 'test/package/karma.package.conf.cjs']);
+
+console.log(`\nPackage verification PASSED: ${packInfo.filename}`);

--- a/test/package/verify-package.mjs
+++ b/test/package/verify-package.mjs
@@ -37,9 +37,7 @@
  * 3. Builds the consumer app with Vite (resolves dashjs through the package exports map).
  * 4. Runs a playback smoke test in headless Chrome against the installed tarball.
  *
- * Usage: node test/package/verify-package.mjs [--no-build]
- *   --no-build  Skip the build step (use the existing dist/ as-is, for CI jobs that
- *               already built the bundles).
+ * Usage: node test/package/verify-package.mjs
  */
 
 import { spawnSync } from 'child_process';
@@ -49,7 +47,6 @@ import fs from 'fs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const consumerDir = path.join(repoRoot, 'test/compliance/vite-consumer');
-const noBuild = process.argv.includes('--no-build');
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 
@@ -98,9 +95,7 @@ function fail(message) {
 
 // 1. Build the bundles, then pack. The pack itself runs with --ignore-scripts so the
 // prepack output cannot pollute the --json output on stdout.
-if (!noBuild) {
-    run('npm', ['run', 'build:dist']);
-}
+run('npm', ['run', 'build:dist']);
 
 // Remove stale tarballs so "npm publish dashjs-*.tgz" can only match the one packed below.
 for (const staleTarball of fs.readdirSync(repoRoot).filter((file) => /^dashjs-.*\.tgz$/.test(file))) {

--- a/test/package/verify-package.mjs
+++ b/test/package/verify-package.mjs
@@ -51,13 +51,20 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 const consumerDir = path.join(repoRoot, 'test/compliance/vite-consumer');
 const noBuild = process.argv.includes('--no-build');
 
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+
+// Every bundle referenced by the exports map must be in the tarball - derived from
+// package.json so a new subpath export is verified automatically.
+const EXPORTED_FILES = [...new Set(
+    Object.values(packageJson.exports)
+        .flatMap((entry) => Object.values(entry))
+        .map((file) => file.replace(/^\.\//, ''))
+)];
+
+// Files consumers rely on that the exports map does not cover.
 const REQUIRED_FILES = [
-    'dist/modern/esm/dash.all.min.js',
-    'dist/modern/umd/dash.all.min.js',
-    'dist/modern/esm/dash.mss.min.js',
-    'dist/modern/umd/dash.mss.min.js',
+    ...EXPORTED_FILES,
     'dist/legacy/umd/dash.all.min.js',
-    'index.d.ts',
     'githook.cjs',
     'contrib/akamai/controlbar/ControlBar.js',
     'contrib/controlbar/ControlBar.js',
@@ -65,11 +72,21 @@ const REQUIRED_FILES = [
     'contrib/videojs-vtt.js/vtt.min.js',
 ];
 
+// Catches accidental broadening of the "files" allowlist (e.g. samples/ or docs/).
+// Baseline: dashjs@5.2.0 unpacks to ~130 MB (bundles + sourcemaps).
+const MAX_UNPACKED_SIZE_BYTES = 200 * 1024 * 1024;
+
 function run(command, args, options = {}) {
     console.log(`\n> ${command} ${args.join(' ')}`);
-    const result = spawnSync(command, args, { cwd: repoRoot, stdio: 'inherit', ...options });
+    const result = spawnSync(command, args, {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        shell: process.platform === 'win32', // npm/npx are .cmd shims on Windows
+        ...options,
+    });
     if (result.status !== 0) {
-        fail(`"${command} ${args.join(' ')}" exited with status ${result.status}`);
+        const cause = result.error ? ` (${result.error.message})` : '';
+        fail(`"${command} ${args.join(' ')}" exited with status ${result.status}${cause}`);
     }
     return result;
 }
@@ -84,14 +101,31 @@ function fail(message) {
 if (!noBuild) {
     run('npm', ['run', 'build:dist']);
 }
+
+// Remove stale tarballs so "npm publish dashjs-*.tgz" can only match the one packed below.
+for (const staleTarball of fs.readdirSync(repoRoot).filter((file) => /^dashjs-.*\.tgz$/.test(file))) {
+    console.log(`Removing stale tarball ${staleTarball}`);
+    fs.rmSync(path.join(repoRoot, staleTarball));
+}
+
 const packArgs = ['pack', '--json', '--ignore-scripts'];
 console.log(`\n> npm ${packArgs.join(' ')}`);
-const pack = spawnSync('npm', packArgs, { cwd: repoRoot, encoding: 'utf8' });
+const pack = spawnSync('npm', packArgs, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+});
 if (pack.status !== 0) {
     console.error(pack.stderr);
     fail(`npm pack exited with status ${pack.status}`);
 }
-const packInfo = JSON.parse(pack.stdout)[0];
+let packInfo;
+try {
+    packInfo = JSON.parse(pack.stdout)[0];
+} catch (e) {
+    console.error(pack.stdout);
+    fail(`npm pack --json produced unparseable output: ${e.message}`);
+}
 const tarball = path.join(repoRoot, packInfo.filename);
 console.log(`Packed ${packInfo.filename} (${packInfo.entryCount} files)`);
 
@@ -101,15 +135,22 @@ const missing = REQUIRED_FILES.filter((file) => !packedPaths.has(file));
 if (missing.length > 0) {
     fail(`tarball is missing required files:\n  ${missing.join('\n  ')}`);
 }
-console.log('All required files present in tarball.');
+if (packInfo.unpackedSize > MAX_UNPACKED_SIZE_BYTES) {
+    fail(`unpacked size ${packInfo.unpackedSize} bytes exceeds the ${MAX_UNPACKED_SIZE_BYTES} byte ceiling - was the "files" allowlist broadened?`);
+}
+console.log(`All required files present in tarball (${packInfo.unpackedSize} bytes unpacked).`);
 
 // 3. Install the tarball into the consumer app (also installs its vite devDependency).
 run('npm', ['install', '--no-save', '--no-audit', '--no-fund', tarball], { cwd: consumerDir });
 
 // Guard: a "file:" directory dependency would be a symlink; the tarball install must not be.
 const installedPackage = path.join(consumerDir, 'node_modules/dashjs');
-if (fs.lstatSync(installedPackage).isSymbolicLink()) {
-    fail('node_modules/dashjs in the consumer app is a symlink - the tarball was not installed');
+try {
+    if (fs.lstatSync(installedPackage).isSymbolicLink()) {
+        fail('node_modules/dashjs in the consumer app is a symlink - the tarball was not installed');
+    }
+} catch (e) {
+    fail(`node_modules/dashjs is missing from the consumer app - the tarball was not installed (${e.message})`);
 }
 
 // 4. Bundle the consumer app - resolves dashjs through the real package exports map.


### PR DESCRIPTION
- Automated npm package verification (npm run test:package): packs the tarball, asserts all required files are included, installs it into a consumer app and runs a headless-Chrome playback smoke test through the package exports. Runs as a gate in publish_npm.yml (the exact verified tarball is published) and on PRs.
- Fix broken default export in modern ESM bundles: libraryExport: 'default' made the published ESM bundle export default: undefined, breaking import dashjs from 'dashjs' for all ESM consumers. Removed the option from the ESM config; UMD builds are unchanged.
- Include new controlbar in npm package
