### PR TITLE
Fix/5087 multi period subtitles

### DIFF
--- a/build/webpack/modern/webpack.modern.dev.cjs
+++ b/build/webpack/modern/webpack.modern.dev.cjs
@@ -3,6 +3,9 @@ const { umdConfig } = require('./webpack.modern.base.cjs');
 const { devEntries } = require('../common/webpack.common.base.cjs');
 const path = require('path');
 
+// Prefer port 3000, fall back to the next free port if it is already taken (e.g. another dash.js dev server)
+process.env.WEBPACK_DEV_SERVER_BASE_PORT = process.env.WEBPACK_DEV_SERVER_BASE_PORT || '3000';
+
 const umdDevConfig = merge(umdConfig, {
     mode: 'development',
     entry: devEntries,
@@ -16,7 +19,7 @@ const umdDevConfig = merge(umdConfig, {
         open: ['samples/index.html'],
         hot: true,
         compress: true,
-        port: 3000
+        port: 'auto'
     }
 });
 

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -343,9 +343,9 @@ function TextSourceBuffer(config) {
         let i, j, k;
 
         const captionArray = [];
+        const timestampOffset = _getTimestampOffset();
         for (i = 0; i < sampleList.length; i++) {
             const sample = sampleList[i];
-            const timestampOffset = _getTimestampOffset();
             const start = timestampOffset + sample.cts / timescale;
             const end = start + sample.duration / timescale;
             instance.buffered.add(start, end);
@@ -393,7 +393,9 @@ function TextSourceBuffer(config) {
             }
         }
         if (captionArray.length > 0) {
-            textTracks.addCaptions(currFragmentedTrackIdx, 0, captionArray);
+            // Cue times are period-local media times; the MSE timestamp offset (Period@start - presentationTimeOffset)
+            // maps them to presentation time. Required for multiperiod content, see #5087.
+            textTracks.addCaptions(currFragmentedTrackIdx, timestampOffset, captionArray);
         }
     }
 

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -792,7 +792,7 @@ function TextTracks(config) {
     }
 
     function _getCueInformationForNonHtml(currentItem, timeOffset) {
-        let cue = new Cue(currentItem.start - timeOffset, currentItem.end - timeOffset, currentItem.data);
+        let cue = new Cue(currentItem.start + timeOffset, currentItem.end + timeOffset, currentItem.data);
         cue.cueID = Utils.generateUuid();
         return cue;
     }

--- a/test/unit/test/streaming/streaming.text.TextSourceBuffer.js
+++ b/test/unit/test/streaming/streaming.text.TextSourceBuffer.js
@@ -3,6 +3,7 @@ import TTMLParser from '../../../../src/streaming/utils/TTMLParser.js';
 import Errors from '../../../../src/core/errors/Errors.js';
 import ErrorHandlerMock from '../../mocks/ErrorHandlerMock.js';
 import AdapterMock from '../../mocks/AdapterMock.js';
+import CustomTimeRanges from '../../../../src/streaming/utils/CustomTimeRanges.js';
 
 import chai from 'chai';
 
@@ -33,5 +34,87 @@ describe('TextSourceBuffer', function () {
             }
         });
         expect(errorHandlerMock.errorCode).to.equal(Errors.TIMED_TEXT_ERROR_ID_PARSE_CODE);
+    });
+
+    describe('fragmented WebVTT', function () {
+        const TIMESCALE = 1000;
+        const BASE_MEDIA_DECODE_TIME = 10000; // 10s in media (period-local) time
+        const SAMPLE_DURATION = 2000;
+        const TIMESTAMP_OFFSET = 100; // MSE offset for a later period
+
+        function u16(v) {
+            return [(v >>> 8) & 0xFF, v & 0xFF];
+        }
+
+        function u32(v) {
+            return [(v >>> 24) & 0xFF, (v >>> 16) & 0xFF, (v >>> 8) & 0xFF, v & 0xFF];
+        }
+
+        function stringToBytes(str) {
+            return Array.from(str, c => c.charCodeAt(0));
+        }
+
+        function box(type, ...payloads) {
+            const payload = [].concat(...payloads);
+            return [...u32(8 + payload.length), ...stringToBytes(type), ...payload];
+        }
+
+        function fullBox(type, version, flags, ...payloads) {
+            return box(type, [version, (flags >>> 16) & 0xFF, (flags >>> 8) & 0xFF, flags & 0xFF], ...payloads);
+        }
+
+        function createInitSegment() {
+            const mdhd = fullBox('mdhd', 0, 0, u32(0), u32(0), u32(TIMESCALE), u32(0), u16(0), u16(0));
+            return new Uint8Array(box('moov', box('trak', box('mdia', mdhd)))).buffer;
+        }
+
+        function createMediaSegment(cueText) {
+            const vttc = box('vttc', box('payl', stringToBytes(cueText)));
+
+            function createMoof(dataOffset) {
+                const tfhd = fullBox('tfhd', 0, 0, u32(1));
+                const tfdt = fullBox('tfdt', 1, 0, u32(0), u32(BASE_MEDIA_DECODE_TIME));
+                // trun flags: data-offset, sample-duration and sample-size present
+                const trun = fullBox('trun', 0, 0x000301, u32(1), u32(dataOffset), u32(SAMPLE_DURATION), u32(vttc.length));
+                return box('moof', fullBox('mfhd', 0, 0, u32(1)), box('traf', tfhd, tfdt, trun));
+            }
+
+            const moofSize = createMoof(0).length;
+            const moof = createMoof(moofSize + 8); // sample data starts after the mdat header
+            return new Uint8Array([...moof, ...box('mdat', vttc)]).buffer;
+        }
+
+        it('should apply the timestamp offset when adding cues for fragmented WebVTT', function () {
+            const addCaptionsCalls = [];
+            const textTracksMock = {
+                addCaptions: (idx, timeOffset, captionArray) => {
+                    addCaptionsCalls.push({ idx, timeOffset, captionArray });
+                }
+            };
+            const buffer = TextSourceBuffer(context).create({
+                errHandler: errorHandlerMock,
+                textTracks: textTracksMock
+            });
+            buffer.buffered = CustomTimeRanges(context).create();
+            buffer.timestampOffset = TIMESTAMP_OFFSET;
+
+            const mediaInfo = {
+                type: 'text',
+                mimeType: 'application/mp4',
+                codec: 'application/mp4;codecs="wvtt"'
+            };
+            buffer.append(createInitSegment(), { segmentType: 'InitializationSegment', representation: { mediaInfo } });
+            buffer.append(createMediaSegment('Hello'), { segmentType: 'MediaSegment', representation: { mediaInfo } });
+
+            expect(addCaptionsCalls).to.have.lengthOf(1);
+            expect(addCaptionsCalls[0].timeOffset).to.equal(TIMESTAMP_OFFSET);
+            expect(addCaptionsCalls[0].captionArray).to.have.lengthOf(1);
+            expect(addCaptionsCalls[0].captionArray[0].data).to.equal('Hello');
+            expect(addCaptionsCalls[0].captionArray[0].start).to.equal(BASE_MEDIA_DECODE_TIME / TIMESCALE);
+            expect(addCaptionsCalls[0].captionArray[0].end).to.equal((BASE_MEDIA_DECODE_TIME + SAMPLE_DURATION) / TIMESCALE);
+            // Buffered range is in presentation time: timestampOffset + cts / timescale
+            expect(buffer.buffered.start(0)).to.equal(TIMESTAMP_OFFSET + BASE_MEDIA_DECODE_TIME / TIMESCALE);
+            expect(buffer.buffered.end(0)).to.equal(TIMESTAMP_OFFSET + (BASE_MEDIA_DECODE_TIME + SAMPLE_DURATION) / TIMESCALE);
+        });
     });
 });

--- a/test/unit/test/streaming/streaming.text.TextTracks.js
+++ b/test/unit/test/streaming/streaming.text.TextTracks.js
@@ -110,6 +110,26 @@ describe('TextTracks', function () {
             expect(videoModelMock.getCurrentCue(track).text).to.equal(SUBTITLE_DATA);
         });
 
+        it('should add the timeOffset to non-html cue times', function () {
+            textTracks.addTextTrackInfo({
+                index: 0,
+                kind: 'subtitles',
+                id: 'eng',
+                defaultTrack: true,
+                isTTML: true}, 1);
+
+            textTracks.createTracks();
+            let track = videoModelMock.getTextTrack('subtitles', 'eng');
+
+            // Period-local cue times plus the MSE timestamp offset of a later period
+            textTracks.addCaptions(0, 100, [{type: 'noHtml', data: SUBTITLE_DATA, start: 5, end: 7}]);
+            textTracks.updateTextTrackWindow(105);
+
+            const cue = videoModelMock.getCurrentCue(track);
+            expect(cue.startTime).to.equal(105);
+            expect(cue.endTime).to.equal(107);
+        });
+
         it('should eliminate duplicates', function () {
             textTracks.addTextTrackInfo({
                 index: 0,


### PR DESCRIPTION
This fix addresses issue #5087

- Pass the MSE timestamp offset (Period@start − presentationTimeOffset) to addCaptions() when appending fragmented WebVTT samples in TextSourceBuffer, so cue times are mapped from period-local media time to presentation time. 
- Fix an inconsistency in TextTracks._getCueInformationForNonHtml(), which subtracted the time offset while the HTML cue path adds it.
