### PR TITLE
Avoid redundant DRM license requests for already-usable keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1716,6 +1716,7 @@ export class MediaPlayerSettingClass {
             ignoreEmeEncryptedEvent?: boolean,
             detectPlayreadyMessageFormat?: boolean,
             ignoreKeyStatuses?: boolean,
+            skipLicenseRequestsForUsableKeys?: boolean,
         },
         buffer?: {
             enableSeekDecorrelationFix?: boolean,

--- a/samples/drm/key-rotation.html
+++ b/samples/drm/key-rotation.html
@@ -30,7 +30,8 @@
     // plus a number of upcoming "future" keys, so playback can continue across several
     // crypto periods without a new license request once skipLicenseRequestsForUsableKeys
     // recognizes those keys are already usable.
-    // Note: hosted on an internal Irdeto network; may not be reachable from all locations.
+    // Note: this is a shared Irdeto test/staging environment (not production), also used
+    // by Irdeto partners for integration testing.
     var STREAM_URL = 'https://control-cdn.dev.ott.irdeto.com/dashjs-test-streams/video-content2.mpd';
     var PROT_DATA = {
         'com.widevine.alpha': {
@@ -162,7 +163,7 @@
     import { initSamplePage, createControlBar } from '../lib/sample-template.js';
     initSamplePage({
         title: 'Key Rotation (Future Keys)',
-        description: 'Plays Widevine/PlayReady-protected content whose content key rotates roughly every 10 seconds. Each license response also includes a number of upcoming ("future") keys, so once a key has been reported as usable by the CDM, dash.js does not need to request a license for it again. Toggle <code>streaming.protection.skipLicenseRequestsForUsableKeys</code> below, then use "(Re)attach source" to restart playback and compare the counters: with the setting enabled (the default), both counters should stop growing once the CDM already holds the upcoming keys; with it disabled, a new MediaKeySession and license request is issued for every crypto period. <br><br>Note: this reference stream and license servers are hosted on an internal Irdeto network and may not be reachable from all locations.',
+        description: 'Plays Widevine/PlayReady-protected content whose content key rotates roughly every 10 seconds. Each license response also includes a number of upcoming ("future") keys, so once a key has been reported as usable by the CDM, dash.js does not need to request a license for it again. Toggle <code>streaming.protection.skipLicenseRequestsForUsableKeys</code> below, then use "(Re)attach source" to restart playback and compare the counters: with the setting enabled (the default), both counters should stop growing once the CDM already holds the upcoming keys; with it disabled, a new MediaKeySession and license request is issued for every crypto period. <br><br>Note: this reference stream and license servers run on a shared Irdeto test/staging environment (not production), also used by Irdeto partners for integration testing.',
         category: 'DRM',
         httpWarning: true,
         layout: 'custom',

--- a/samples/drm/key-rotation.html
+++ b/samples/drm/key-rotation.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Key Rotation (Future Keys)</title>
+    <script src="../../dist/modern/umd/dash.all.debug.js"></script>
+    <link href="../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../lib/bootstrap-icons/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="../lib/sample.css" rel="stylesheet">
+    <link href="../../contrib/controlbar/controlbar.css" rel="stylesheet">
+    <style>
+        #event-log {
+            height: 220px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+    </style>
+</head>
+<body>
+
+<script class="code">
+    var keySessionCount = 0;
+    var licenseRequestCount = 0;
+    var player;
+
+    // Reference content: video/audio encrypted with a new key roughly every 10 seconds
+    // (High Frequency Key Rotation). Each license response includes the current key
+    // plus a number of upcoming "future" keys, so playback can continue across several
+    // crypto periods without a new license request once skipLicenseRequestsForUsableKeys
+    // recognizes those keys are already usable.
+    // Note: hosted on an internal Irdeto network; may not be reachable from all locations.
+    var STREAM_URL = 'https://control-cdn.dev.ott.irdeto.com/dashjs-test-streams/video-content2.mpd';
+    var PROT_DATA = {
+        'com.widevine.alpha': {
+            serverURL: 'https://dub-tctr-control.test.ott.irdeto.com/licenseServer/widevine/v1/irdeto-poc/license?contentId=video-content2'
+        },
+        'com.microsoft.playready': {
+            serverURL: 'https://dub-tctr-control.test.ott.irdeto.com/licenseServer/playready/v1/irdeto-poc/license?contentId=video-content2'
+        }
+    };
+
+    async function init(video, wrapper) {
+        player = dashjs.MediaPlayer().create();
+
+        var protectionEvents = dashjs.Protection.events;
+        player.on(protectionEvents.KEY_SESSION_CREATED, function (e) {
+            if (e.error) {
+                log('KEY_SESSION_CREATED error: ' + e.error);
+                return;
+            }
+            keySessionCount++;
+            updateCounters();
+            log('KEY_SESSION_CREATED (MediaKeySession #' + keySessionCount + ')');
+        });
+        player.on(protectionEvents.LICENSE_REQUEST_COMPLETE, function (e) {
+            if (e.error) {
+                log('LICENSE_REQUEST_COMPLETE error: ' + e.error);
+                return;
+            }
+            licenseRequestCount++;
+            updateCounters();
+            log('LICENSE_REQUEST_COMPLETE (#' + licenseRequestCount + ')');
+        });
+        player.on(dashjs.MediaPlayer.events.ERROR, function (e) {
+            log('ERROR: ' + JSON.stringify(e.error));
+        });
+
+        document.getElementById('attach_button').onclick = function () {
+            attach();
+        };
+
+        player.initialize(video, null, true);
+        player.setProtectionData(PROT_DATA);
+
+        await createControlBar(player, video, wrapper);
+        attach();
+    }
+
+    function attach() {
+        clearLog();
+        keySessionCount = 0;
+        licenseRequestCount = 0;
+        updateCounters();
+
+        var skipUsableKeys = document.getElementById('skip-usable-keys-checkbox').checked;
+        player.updateSettings({
+            streaming: {
+                protection: {
+                    skipLicenseRequestsForUsableKeys: skipUsableKeys
+                }
+            }
+        });
+        player.attachSource(STREAM_URL);
+    }
+
+    function updateCounters() {
+        document.getElementById('key-session-count').textContent = keySessionCount;
+        document.getElementById('license-request-count').textContent = licenseRequestCount;
+    }
+
+    function log(message) {
+        var logPanel = document.getElementById('event-log');
+        var entry = document.createElement('div');
+        entry.textContent = '[' + new Date().toISOString().substr(11, 8) + '] ' + message;
+        logPanel.appendChild(entry);
+        logPanel.scrollTop = logPanel.scrollHeight;
+    }
+
+    function clearLog() {
+        document.getElementById('event-log').innerHTML = '';
+    }
+</script>
+
+<div class="sample-content-custom">
+    <div class="row mt-2">
+        <div class="col-md-12">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="skip-usable-keys-checkbox" checked>
+                <label class="form-check-label" for="skip-usable-keys-checkbox">
+                    streaming.protection.skipLicenseRequestsForUsableKeys
+                </label>
+            </div>
+            <button type="button" class="btn btn-primary mt-2" id="attach_button">(Re)attach source</button>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-md-12">
+            <div class="sample-video-wrapper" id="video-wrapper">
+                <video></video>
+            </div>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-md-6">
+            <div class="sample-metrics">
+                <div class="sample-metrics-header">MediaKeySessions created</div>
+                <div class="sample-metrics-body"><span id="key-session-count">0</span></div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="sample-metrics">
+                <div class="sample-metrics-header">License requests completed</div>
+                <div class="sample-metrics-body"><span id="license-request-count">0</span></div>
+            </div>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-md-12">
+            <div class="sample-metrics">
+                <div class="sample-metrics-header">Protection events</div>
+                <div class="sample-metrics-body">
+                    <div class="sample-log" id="event-log"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="module">
+    import { initSamplePage, createControlBar } from '../lib/sample-template.js';
+    initSamplePage({
+        title: 'Key Rotation (Future Keys)',
+        description: 'Plays Widevine/PlayReady-protected content whose content key rotates roughly every 10 seconds. Each license response also includes a number of upcoming ("future") keys, so once a key has been reported as usable by the CDM, dash.js does not need to request a license for it again. Toggle <code>streaming.protection.skipLicenseRequestsForUsableKeys</code> below, then use "(Re)attach source" to restart playback and compare the counters: with the setting enabled (the default), both counters should stop growing once the CDM already holds the upcoming keys; with it disabled, a new MediaKeySession and license request is issued for every crypto period. <br><br>Note: this reference stream and license servers are hosted on an internal Irdeto network and may not be reachable from all locations.',
+        category: 'DRM',
+        httpWarning: true,
+        layout: 'custom',
+        onInit: (video, container, wrapper) => init(video, wrapper)
+    });
+</script>
+</body>
+</html>

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -557,6 +557,20 @@
                     "Widevine",
                     "Protection"
                 ]
+            },
+            {
+                "title": "Key Rotation (Future Keys)",
+                "description": "Plays back content with a rotating content key and a license response that includes upcoming keys, demonstrating the skipLicenseRequestsForUsableKeys setting.",
+                "href": "drm/key-rotation.html",
+                "image": "lib/img/dashjs-logo-border.png",
+                "labels": [
+                    "VoD",
+                    "DRM",
+                    "Widevine",
+                    "Playready",
+                    "Video",
+                    "Audio"
+                ]
             }
         ]
     },

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -111,6 +111,7 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *                ignoreEmeEncryptedEvent: false,
  *                detectPlayreadyMessageFormat: true,
  *                ignoreKeyStatuses: false,
+ *                skipLicenseRequestsForUsableKeys: true,
  *            },
  *            buffer: {
  *                enableSeekDecorrelationFix: false,
@@ -754,6 +755,10 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * @property {boolean} [ignoreKeyStatuses=false]
  * If set to true the player will ignore the status of a key and try to play the corresponding track regardless whether the key is usable or not.
  *
+ * @property {boolean} [skipLicenseRequestsForUsableKeys=true]
+ * If set to true the player will not create a new key session, and therefore not issue a new license request, when every key ID
+ * referenced by a version 1+ PSSH's key ID list is already reported as "usable" by the CDM.
+ *
 
 /**
  * @typedef {Object} Capabilities
@@ -1267,6 +1272,7 @@ function Settings() {
                 ignoreEmeEncryptedEvent: false,
                 detectPlayreadyMessageFormat: true,
                 ignoreKeyStatuses: false,
+                skipLicenseRequestsForUsableKeys: true,
             },
             buffer: {
                 enableSeekDecorrelationFix: false,

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -288,6 +288,27 @@ class Utils {
         return hex;
     }
 
+    /**
+     * Normalizes a key ID (UUID string, hex string, or BufferSource) into a canonical
+     * lowercase 32-character hex string suitable for comparison, e.g. against a key status map.
+     * @param {string|BufferSource} keyId
+     * @returns {string|null} normalized key ID, or null if it cannot be normalized to a 32-character hex string
+     */
+    static normalizeKeyId(keyId) {
+        if (keyId === null || keyId === undefined) {
+            return null;
+        }
+        let hex;
+        if (typeof keyId === 'string') {
+            hex = keyId.replace(/[{}-]/g, '').toLowerCase();
+        } else if (keyId instanceof ArrayBuffer || ArrayBuffer.isView(keyId)) {
+            hex = Utils.bufferSourceToHex(keyId);
+        } else {
+            return null;
+        }
+        return /^[0-9a-f]{32}$/.test(hex) ? hex : null;
+    }
+
     static toDataView(bufferSource, Type) {
         const buffer = Utils.getArrayBuffer(bufferSource);
         let bytesPerElement = 1;

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -42,6 +42,7 @@ import {normalizeBcp47} from '../streaming/utils/BCP47Utils.js';
 import {getId3Frames} from '@svta/cml-id3';
 import Constants from '../streaming/constants/Constants.js';
 import Settings from '../core/Settings.js';
+import Utils from '../core/Utils.js';
 
 /**
  * @module DashAdapter
@@ -1196,8 +1197,9 @@ function DashAdapter() {
     function _getNormalizedKeyIds(contentProtection) {
         const normalizedKeyIds = new Set();
         contentProtection.forEach((contentProtectionElement) => {
-            if (contentProtectionElement.cencDefaultKid && typeof contentProtectionElement.cencDefaultKid === 'string') {
-                normalizedKeyIds.add(contentProtectionElement.cencDefaultKid.replace(/-/g, '').toLowerCase());
+            const normalizedKeyId = Utils.normalizeKeyId(contentProtectionElement.cencDefaultKid);
+            if (normalizedKeyId) {
+                normalizedKeyIds.add(normalizedKeyId);
             }
         })
 

--- a/src/streaming/protection/CommonEncryption.js
+++ b/src/streaming/protection/CommonEncryption.js
@@ -30,6 +30,7 @@
  */
 import DashConstants from '../../dash/constants/DashConstants.js';
 import ProtectionConstants from '../constants/ProtectionConstants.js';
+import Utils from '../../core/Utils.js';
 
 const LICENSE_SERVER_MANIFEST_CONFIGURATIONS = {
     prefixes: ['clearkey', 'dashif', 'ck']
@@ -96,7 +97,25 @@ class CommonEncryption {
     static getPSSHForKeySystem(keySystem, initData) {
         let psshList = CommonEncryption.parsePSSHList(initData);
         if (keySystem && psshList.hasOwnProperty(keySystem.uuid.toLowerCase())) {
-            return psshList[keySystem.uuid.toLowerCase()];
+            return psshList[keySystem.uuid.toLowerCase()].box;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the key IDs signalled by the version 1+ PSSH box associated with the given key system,
+     * from the concatenated list of PSSH boxes in the given initData
+     *
+     * @param {KeySystem} keySystem the desired key system
+     * @param {ArrayBuffer} initData 'cenc' initialization data. Concatenated list of PSSH.
+     * @returns {string[]|null} normalized (lowercase, 32-character hex) key IDs found in the PSSH box,
+     * an empty array if the box does not signal any key IDs (e.g. version 0), or null if no PSSH box
+     * could be found for the given key system.
+     */
+    static getKeyIdsForKeySystem(keySystem, initData) {
+        let psshList = CommonEncryption.parsePSSHList(initData);
+        if (keySystem && psshList.hasOwnProperty(keySystem.uuid.toLowerCase())) {
+            return psshList[keySystem.uuid.toLowerCase()].keyIds;
         }
         return null;
     }
@@ -126,8 +145,9 @@ class CommonEncryption {
      * @param {ArrayBuffer} data - the concatenated list of PSSH boxes as provided by
      * CDM as initialization data when CommonEncryption content is detected
      * @returns {Object|Array} an object that has a property named according to each of
-     * the detected key system UUIDs (e.g. 00000000-0000-0000-0000-0000000000)
-     * and a ArrayBuffer (the entire PSSH box) as the property value
+     * the detected key system UUIDs (e.g. 00000000-0000-0000-0000-0000000000) and, as
+     * the property value, an object with the entire PSSH box (`box`), its `version`,
+     * and the normalized key IDs signalled by version 1+ boxes (`keyIds`, empty for version 0)
      */
     static parsePSSHList(data) {
 
@@ -210,11 +230,40 @@ class CommonEncryption {
 
             systemID = systemID.toLowerCase();
 
+            /* Version 1+ PSSH boxes signal an explicit list of key IDs before the data */
+            let keyIds = [];
+            if (version === 1) {
+                if (byteCursor + 4 > nextBox || byteCursor + 4 > dv.buffer.byteLength) {
+                    byteCursor = nextBox;
+                    continue;
+                }
+                const kidCount = dv.getUint32(byteCursor);
+                byteCursor += 4;
+
+                const kidListEnd = byteCursor + (kidCount * 16);
+                if (kidListEnd > nextBox || kidListEnd > dv.buffer.byteLength) {
+                    byteCursor = nextBox;
+                    continue;
+                }
+
+                for (let k = 0; k < kidCount; k++) {
+                    const keyId = Utils.normalizeKeyId(new Uint8Array(dv.buffer, byteCursor, 16));
+                    if (keyId) {
+                        keyIds.push(keyId);
+                    }
+                    byteCursor += 16;
+                }
+            }
+
             /* PSSH Data Size */
             byteCursor += 4;
 
             /* PSSH Data */
-            pssh[systemID] = dv.buffer.slice(boxStart, nextBox);
+            pssh[systemID] = {
+                box: dv.buffer.slice(boxStart, nextBox),
+                version,
+                keyIds
+            };
             byteCursor = nextBox;
         }
 

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -683,6 +683,11 @@ function ProtectionController(config) {
                 return;
             }
 
+            // Check if the CDM already reports every key referenced by this PSSH as usable
+            if (_shouldSkipKeySessionForUsableKeys(keySystemMetadata)) {
+                return;
+            }
+
             try {
                 keySystemMetadata.initData = initDataForKS;
                 protectionModel.createKeySession(keySystemMetadata);
@@ -700,6 +705,34 @@ function ProtectionController(config) {
                 error: new DashJSError(ProtectionErrors.KEY_SESSION_CREATED_ERROR_CODE, ProtectionErrors.KEY_SESSION_CREATED_ERROR_MESSAGE + 'Selected key system is ' + (selectedKeySystem ? selectedKeySystem.systemString : null) + '.  needkey/encrypted event contains no initData corresponding to that key system!')
             });
         }
+    }
+
+    /**
+     * Determines whether creating a new key session can be skipped because the CDM already
+     * reports every key ID referenced by this key system's PSSH as usable.
+     * @description Deliberately conservative: unlike areKeyIdsUsable(), this never assumes a key
+     * is usable when there is any uncertainty, since skipping incorrectly would prevent acquiring
+     * a still-missing key. Only an explicit 'usable' status for every referenced key ID skips the request.
+     * @param {object} keySystemMetadata
+     * @return {boolean}
+     * @private
+     */
+    function _shouldSkipKeySessionForUsableKeys(keySystemMetadata) {
+        if (!settings.get().streaming.protection.skipLicenseRequestsForUsableKeys) {
+            return false;
+        }
+
+        const keyIds = CommonEncryption.getKeyIdsForKeySystem(selectedKeySystem, keySystemMetadata ? keySystemMetadata.initData : null);
+        if (!keyIds || keyIds.length === 0 || keyStatusMap.size === 0) {
+            return false;
+        }
+
+        const allKeyIdsUsable = keyIds.every((keyId) => keyStatusMap.get(keyId) === ProtectionConstants.MEDIA_KEY_STATUSES.USABLE);
+        if (allKeyIdsUsable) {
+            logger.debug('DRM: Skipping key session creation - all key IDs referenced by the init data are already usable');
+        }
+
+        return allKeyIdsUsable;
     }
 
     /**

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -287,7 +287,7 @@ function ProtectionKeyController() {
             if (ks.uuid in pssh) {
                 supportedKS.push({
                     ks: ks,
-                    initData: pssh[ks.uuid],
+                    initData: pssh[ks.uuid].box,
                     protData: protData,
                     cdmData: ks.getCDMData(protData ? protData.cdmData : null),
                     sessionId: _getSessionId(protData),

--- a/src/streaming/protection/models/DefaultProtectionModel.js
+++ b/src/streaming/protection/models/DefaultProtectionModel.js
@@ -45,6 +45,7 @@ import KeyMessage from '../vo/KeyMessage.js';
 import KeySystemAccess from '../vo/KeySystemAccess.js';
 import ProtectionConstants from '../../constants/ProtectionConstants.js';
 import FactoryMaker from '../../../core/FactoryMaker.js';
+import Utils from '../../../core/Utils.js';
 
 const SYSTEM_STRING_PRIORITY = {};
 SYSTEM_STRING_PRIORITY[ProtectionConstants.PLAYREADY_KEYSTEM_STRING] = [ProtectionConstants.PLAYREADY_KEYSTEM_STRING, ProtectionConstants.PLAYREADY_RECOMMENDATION_KEYSTEM_STRING];
@@ -467,7 +468,7 @@ function DefaultProtectionModel(config) {
         const token = { // Implements SessionToken
             session: session,
             keyId: keySystemMetadata.keyId,
-            normalizedKeyId: keySystemMetadata && keySystemMetadata.keyId && typeof keySystemMetadata.keyId === 'string' ? keySystemMetadata.keyId.replace(/-/g, '').toLowerCase() : '',
+            normalizedKeyId: Utils.normalizeKeyId(keySystemMetadata && keySystemMetadata.keyId) || '',
             initData: keySystemMetadata.initData,
             sessionId: keySystemMetadata.sessionId,
             sessionType: keySystemMetadata.sessionType,

--- a/src/streaming/protection/models/ProtectionModel_01b.js
+++ b/src/streaming/protection/models/ProtectionModel_01b.js
@@ -46,6 +46,7 @@ import KeySystemAccess from '../vo/KeySystemAccess.js';
 import ProtectionErrors from '../errors/ProtectionErrors.js';
 import FactoryMaker from '../../../core/FactoryMaker.js';
 import ProtectionConstants from '../../constants/ProtectionConstants.js';
+import Utils from '../../../core/Utils.js';
 
 function ProtectionModel_01b(config) {
 
@@ -222,7 +223,7 @@ function ProtectionModel_01b(config) {
             const newSession = { // Implements SessionToken
                 sessionId: null,
                 keyId: ksInfo.keyId,
-                normalizedKeyId: ksInfo && ksInfo.keyId && typeof ksInfo.keyId === 'string' ? ksInfo.keyId.replace(/-/g, '').toLowerCase() : '',
+                normalizedKeyId: Utils.normalizeKeyId(ksInfo && ksInfo.keyId) || '',
                 initData: ksInfo.initData,
                 hasTriggeredKeyStatusMapUpdate: false,
 

--- a/src/streaming/protection/models/ProtectionModel_3Feb2014.js
+++ b/src/streaming/protection/models/ProtectionModel_3Feb2014.js
@@ -47,6 +47,7 @@ import KeySystemConfiguration from '../vo/KeySystemConfiguration.js';
 import KeySystemAccess from '../vo/KeySystemAccess.js';
 import FactoryMaker from '../../../core/FactoryMaker.js';
 import ProtectionConstants from '../../constants/ProtectionConstants.js';
+import Utils from '../../../core/Utils.js';
 
 function ProtectionModel_3Feb2014(config) {
 
@@ -337,7 +338,7 @@ function ProtectionModel_3Feb2014(config) {
             // Implements SessionToken
             session: keySession,
             keyId: ksInfo.keyId,
-            normalizedKeyId: ksInfo && ksInfo.keyId && typeof ksInfo.keyId === 'string' ? ksInfo.keyId.replace(/-/g, '').toLowerCase() : '',
+            normalizedKeyId: Utils.normalizeKeyId(ksInfo && ksInfo.keyId) || '',
             initData: ksInfo.initData,
             hasTriggeredKeyStatusMapUpdate: false,
 

--- a/test/functional/config/test-configurations/streams/drm.json
+++ b/test/functional/config/test-configurations/streams/drm.json
@@ -80,6 +80,28 @@
       ]
     },
     {
+      "name": "Key Rotation - High Frequency Key Rotation with future keys (Widevine + PlayReady, 1 key per ~10s crypto period)",
+      "url": "https://control-cdn.dev.ott.irdeto.com/dashjs-test-streams/video-content2.mpd",
+      "type": "vod",
+      "drm": {
+        "com.widevine.alpha": {
+          "serverURL": "https://dub-tctr-control.test.ott.irdeto.com/licenseServer/widevine/v1/irdeto-poc/license?contentId=video-content2"
+        },
+        "com.microsoft.playready": {
+          "serverURL": "https://dub-tctr-control.test.ott.irdeto.com/licenseServer/playready/v1/irdeto-poc/license?contentId=video-content2"
+        }
+      },
+      "moreInfo": "Reference content for dash.js#5016 (Avoid Redundant DRM License Requests for Already-Usable Keys). Content key rotates roughly every 10 seconds; each license response includes the current key plus a number of upcoming keys. Hosted on an internal Irdeto network - not reachable without access to that network.",
+      "includedTestfiles": [
+        "playback/*"
+      ],
+      "excludedPlatforms": [
+        {
+          "browser": "safari"
+        }
+      ]
+    },
+    {
       "name": "1080p with PlayReady and Widevine DRM, multiple keys",
       "type": "vod",
       "url": "https://media.axprod.net/TestVectors/v7-MultiDRM-MultiKey/Manifest_1080p.mpd",

--- a/test/functional/config/test-configurations/streams/drm.json
+++ b/test/functional/config/test-configurations/streams/drm.json
@@ -91,7 +91,7 @@
           "serverURL": "https://dub-tctr-control.test.ott.irdeto.com/licenseServer/playready/v1/irdeto-poc/license?contentId=video-content2"
         }
       },
-      "moreInfo": "Reference content for dash.js#5016 (Avoid Redundant DRM License Requests for Already-Usable Keys). Content key rotates roughly every 10 seconds; each license response includes the current key plus a number of upcoming keys. Hosted on an internal Irdeto network - not reachable without access to that network.",
+      "moreInfo": "Reference content for dash.js#5016 (Avoid Redundant DRM License Requests for Already-Usable Keys). Content key rotates roughly every 10 seconds; each license response includes the current key plus a number of upcoming keys. Hosted on a shared Irdeto test/staging environment (not production), also used by Irdeto partners for integration testing.",
       "includedTestfiles": [
         "playback/*"
       ],

--- a/test/unit/test/core/core.Utils.js
+++ b/test/unit/test/core/core.Utils.js
@@ -298,4 +298,65 @@ describe('Utils', () => {
             expect(result.browser).to.have.property('name');
         })
     })
+
+    describe('normalizeKeyId', () => {
+
+        it('should normalize a hyphenated UUID string', () => {
+            expect(Utils.normalizeKeyId('00112233-4455-6677-8899-aabbccddeeff')).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should normalize an uppercase hyphenated UUID string', () => {
+            expect(Utils.normalizeKeyId('00112233-4455-6677-8899-AABBCCDDEEFF')).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should normalize a compact lowercase hex string', () => {
+            expect(Utils.normalizeKeyId('00112233445566778899aabbccddeeff')).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should normalize a compact uppercase hex string', () => {
+            expect(Utils.normalizeKeyId('00112233445566778899AABBCCDDEEFF')).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should strip braces around a UUID string', () => {
+            expect(Utils.normalizeKeyId('{00112233-4455-6677-8899-aabbccddeeff}')).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should normalize a Uint8Array', () => {
+            const bytes = Uint8Array.from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+            expect(Utils.normalizeKeyId(bytes)).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should normalize an ArrayBuffer', () => {
+            const bytes = Uint8Array.from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+            expect(Utils.normalizeKeyId(bytes.buffer)).to.equal('00112233445566778899aabbccddeeff');
+        })
+
+        it('should return null for null', () => {
+            expect(Utils.normalizeKeyId(null)).to.equal(null);
+        })
+
+        it('should return null for undefined', () => {
+            expect(Utils.normalizeKeyId(undefined)).to.equal(null);
+        })
+
+        it('should return null for an empty string', () => {
+            expect(Utils.normalizeKeyId('')).to.equal(null);
+        })
+
+        it('should return null for a malformed string', () => {
+            expect(Utils.normalizeKeyId('not-a-key-id')).to.equal(null);
+        })
+
+        it('should return null for a string that is too short', () => {
+            expect(Utils.normalizeKeyId('00112233-4455-6677-8899-aabbccddee')).to.equal(null);
+        })
+
+        it('should return null for a non-hex string of correct length', () => {
+            expect(Utils.normalizeKeyId('gg112233445566778899aabbccddeeff')).to.equal(null);
+        })
+
+        it('should return null for an unsupported type', () => {
+            expect(Utils.normalizeKeyId(12345)).to.equal(null);
+        })
+    })
 })

--- a/test/unit/test/streaming/streaming.protection.CommonEncryption.js
+++ b/test/unit/test/streaming/streaming.protection.CommonEncryption.js
@@ -136,4 +136,157 @@ describe('CommonEncryption', () => {
         })
 
     });
+
+    describe('parsePSSHList / getPSSHForKeySystem / getKeyIdsForKeySystem', () => {
+        const WIDEVINE_SYSTEM_ID = 'edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
+        const PLAYREADY_SYSTEM_ID = '9a04f079-9840-4286-ab92-e65be0885f95';
+        const KID_1 = '00112233445566778899aabbccddeeff';
+        const KID_2 = 'ffeeddccbbaa00998877665544332211';
+        const widevineKeySystem = { uuid: WIDEVINE_SYSTEM_ID };
+        const playreadyKeySystem = { uuid: PLAYREADY_SYSTEM_ID };
+
+        function hexToBytes(hex) {
+            const bytes = [];
+            for (let i = 0; i < hex.length; i += 2) {
+                bytes.push(parseInt(hex.substr(i, 2), 16));
+            }
+            return bytes;
+        }
+
+        // Builds a single PSSH box per ISO/IEC 23001-7, optionally with a version 1+ key ID list
+        function buildPsshBox({ systemId, version = 0, keyIds = [], data = [] }) {
+            const systemIdBytes = hexToBytes(systemId.replace(/-/g, ''));
+            const keyIdBytes = keyIds.map((keyId) => hexToBytes(keyId));
+            const dataBytes = new Uint8Array(data);
+
+            let size = 4 + 4 + 1 + 3 + 16;
+            if (version >= 1) {
+                size += 4 + keyIdBytes.length * 16;
+            }
+            size += 4 + dataBytes.length;
+
+            const buffer = new ArrayBuffer(size);
+            const dv = new DataView(buffer);
+            let offset = 0;
+            dv.setUint32(offset, size);
+            offset += 4;
+            dv.setUint32(offset, 0x70737368); // 'pssh'
+            offset += 4;
+            dv.setUint8(offset, version);
+            offset += 1;
+            offset += 3; // flags, always 0
+            systemIdBytes.forEach((b) => {
+                dv.setUint8(offset, b);
+                offset++;
+            });
+            if (version >= 1) {
+                dv.setUint32(offset, keyIdBytes.length);
+                offset += 4;
+                keyIdBytes.forEach((kid) => {
+                    kid.forEach((b) => {
+                        dv.setUint8(offset, b);
+                        offset++;
+                    });
+                });
+            }
+            dv.setUint32(offset, dataBytes.length);
+            offset += 4;
+            dataBytes.forEach((b) => {
+                dv.setUint8(offset, b);
+                offset++;
+            });
+
+            return buffer;
+        }
+
+        function concatBoxes(boxes) {
+            const total = boxes.reduce((sum, box) => sum + box.byteLength, 0);
+            const result = new Uint8Array(total);
+            let offset = 0;
+            boxes.forEach((box) => {
+                result.set(new Uint8Array(box), offset);
+                offset += box.byteLength;
+            });
+            return result.buffer;
+        }
+
+        it('should return an empty object for null or undefined init data', () => {
+            expect(CommonEncryption.parsePSSHList(null)).to.deep.equal([]);
+            expect(CommonEncryption.parsePSSHList(undefined)).to.deep.equal([]);
+        })
+
+        it('should return an empty object for an empty buffer', () => {
+            expect(CommonEncryption.parsePSSHList(new ArrayBuffer(0))).to.deep.equal({});
+        })
+
+        it('should parse a version 0 box with no key IDs', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 0 });
+
+            const psshList = CommonEncryption.parsePSSHList(initData);
+
+            expect(psshList[WIDEVINE_SYSTEM_ID].version).to.equal(0);
+            expect(psshList[WIDEVINE_SYSTEM_ID].keyIds).to.deep.equal([]);
+            expect(psshList[WIDEVINE_SYSTEM_ID].box.byteLength).to.equal(initData.byteLength);
+        })
+
+        it('should return an empty key ID array for a version 0 box', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 0 });
+
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.deep.equal([]);
+        })
+
+        it('should parse a version 1 box with a single key ID', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1] });
+
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.deep.equal([KID_1]);
+        })
+
+        it('should parse a version 1 box with multiple key IDs, preserving order', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1, KID_2] });
+
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.deep.equal([KID_1, KID_2]);
+        })
+
+        it('should preserve duplicate key IDs within a version 1 box', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1, KID_1] });
+
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.deep.equal([KID_1, KID_1]);
+        })
+
+        it('should parse concatenated version 0 and version 1 boxes for different DRM systems', () => {
+            const initData = concatBoxes([
+                buildPsshBox({ systemId: PLAYREADY_SYSTEM_ID, version: 0 }),
+                buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1, KID_2] })
+            ]);
+
+            expect(CommonEncryption.getKeyIdsForKeySystem(playreadyKeySystem, initData)).to.deep.equal([]);
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.deep.equal([KID_1, KID_2]);
+            expect(CommonEncryption.getPSSHForKeySystem(widevineKeySystem, initData)).to.not.be.null;
+        })
+
+        it('should return null from getPSSHForKeySystem and getKeyIdsForKeySystem when the key system is not present', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1] });
+
+            expect(CommonEncryption.getPSSHForKeySystem(playreadyKeySystem, initData)).to.be.null;
+            expect(CommonEncryption.getKeyIdsForKeySystem(playreadyKeySystem, initData)).to.be.null;
+        })
+
+        it('should skip a version 1 box whose key ID list overflows the box boundary', () => {
+            const initData = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1] });
+            // Box only has room for 1 key ID; claim there are 5 so the list overruns the box
+            new DataView(initData).setUint32(28, 5);
+
+            expect(CommonEncryption.parsePSSHList(initData)).to.deep.equal({});
+            expect(CommonEncryption.getPSSHForKeySystem(widevineKeySystem, initData)).to.be.null;
+            expect(CommonEncryption.getKeyIdsForKeySystem(widevineKeySystem, initData)).to.be.null;
+        })
+
+        it('should skip a truncated version 1 box that cannot even hold the key ID count', () => {
+            const fullBox = buildPsshBox({ systemId: WIDEVINE_SYSTEM_ID, version: 1, keyIds: [KID_1] });
+            const truncated = fullBox.slice(0, 29); // cuts into the KID_count field
+
+            expect(CommonEncryption.parsePSSHList(truncated)).to.deep.equal({});
+        })
+
+    });
 })

--- a/test/unit/test/streaming/streaming.protection.controllers.ProtectionController.js
+++ b/test/unit/test/streaming/streaming.protection.controllers.ProtectionController.js
@@ -224,6 +224,148 @@ describe('ProtectionController', function () {
 
     });
 
+    describe('skipLicenseRequestsForUsableKeys guard', function () {
+        let protectionModelMock, settingsMock;
+        let originalGetPSSHForKeySystem, originalGetKeyIdsForKeySystem;
+        const KID_1 = '00112233445566778899aabbccddeeff';
+        const KID_2 = 'ffeeddccbbaa00998877665544332211';
+
+        function hexToUint8Array(hex) {
+            const bytes = new Uint8Array(hex.length / 2);
+            for (let i = 0; i < hex.length; i += 2) {
+                bytes[i / 2] = parseInt(hex.substr(i, 2), 16);
+            }
+            return bytes;
+        }
+
+        function setKeyStatus(keyId, status) {
+            protectionController.updateKeyStatusesMap({
+                sessionToken: {},
+                parsedKeyStatuses: [{ keyId: hexToUint8Array(keyId), status }]
+            });
+        }
+
+        beforeEach(function () {
+            originalGetPSSHForKeySystem = CommonEncryption.getPSSHForKeySystem;
+            originalGetKeyIdsForKeySystem = CommonEncryption.getKeyIdsForKeySystem;
+
+            const protectionKeyControllerMock = new ProtectionKeyControllerMock();
+            settingsMock = { get: () => ({ streaming: { protection: { skipLicenseRequestsForUsableKeys: true } } }) };
+            protectionModelMock = new ProtectionModelMock({ events: ProtectionEvents, eventBus: eventBus });
+            protectionController = ProtectionController(context).create({
+                protectionKeyController: protectionKeyControllerMock,
+                events: ProtectionEvents,
+                debug: new DebugMock(),
+                protectionModel: protectionModelMock,
+                eventBus: eventBus,
+                constants: Constants,
+                settings: settingsMock
+            });
+
+            // Init data itself is irrelevant here; getKeyIdsForKeySystem is stubbed per test instead
+            CommonEncryption.getPSSHForKeySystem = () => new ArrayBuffer(8);
+        });
+
+        afterEach(function () {
+            CommonEncryption.getPSSHForKeySystem = originalGetPSSHForKeySystem;
+            CommonEncryption.getKeyIdsForKeySystem = originalGetKeyIdsForKeySystem;
+            protectionController.reset();
+        });
+
+        it('should skip creating a session when all referenced key IDs are already usable', function () {
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+            setKeyStatus(KID_1, 'usable');
+            setKeyStatus(KID_2, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.be.empty;
+        });
+
+        it('should create a session when one of several referenced key IDs is missing (multi-key case)', function () {
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+            setKeyStatus(KID_1, 'usable');
+            // KID_2 has no entry in the key status map at all
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        ['expired', 'output-restricted', 'status-pending', 'released', 'internal-error'].forEach((status) => {
+            it(`should create a session when one of several referenced key IDs has status "${status}"`, function () {
+                CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+                setKeyStatus(KID_1, 'usable');
+                setKeyStatus(KID_2, status);
+
+                protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+                expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+            });
+        });
+
+        it('should create a session when no key IDs can be extracted from the init data (e.g. version 0 PSSH)', function () {
+            CommonEncryption.getKeyIdsForKeySystem = () => [];
+            setKeyStatus(KID_1, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        it('should create a session when the selected key system has no matching PSSH box', function () {
+            CommonEncryption.getKeyIdsForKeySystem = () => null;
+            setKeyStatus(KID_1, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        it('should create a session when the key status map is still empty', function () {
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+            // updateKeyStatusesMap is never called
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        it('should never skip when the setting is disabled, even if all keys are usable', function () {
+            settingsMock.get = () => ({ streaming: { protection: { skipLicenseRequestsForUsableKeys: false } } });
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+            setKeyStatus(KID_1, 'usable');
+            setKeyStatus(KID_2, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        it('should never skip when the setting is left unspecified in the config object', function () {
+            settingsMock.get = () => ({ streaming: { protection: {} } });
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1, KID_2];
+            setKeyStatus(KID_1, 'usable');
+            setKeyStatus(KID_2, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: null, sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+
+        it('should leave FairPlay/sinf init data (no matching PSSH box) unaffected by the guard', function () {
+            // Simulates the sinf path: getPSSHForKeySystem finds no PSSH for the selected key system,
+            // so createKeySession() never reaches the guard at all.
+            CommonEncryption.getPSSHForKeySystem = () => null;
+            CommonEncryption.getKeyIdsForKeySystem = () => [KID_1];
+            setKeyStatus(KID_1, 'usable');
+
+            protectionController.createKeySession({ initData: new ArrayBuffer(8), keyId: 'fairplay-kid', sessionType: 'temporary' });
+
+            expect(protectionModelMock.getSessionTokens()).to.have.lengthOf(1);
+        });
+    });
+
     describe('CMCD integration', function () {
         let protectionModelMock, settingsMock, cmcdControllerMock, customParametersModelMock, protectionKeyControllerMock;
         let xhrMock, requests;


### PR DESCRIPTION
Supersedes #5016. Reimplements the same feature from scratch against the current
`development` branch, incorporating every review comment left on #5016 from the
outset. Credit to @petegalt for the original idea and investigation.

## Problem

When a DRM license already covers multiple key IDs (e.g. HFKC / "future keys"),
dash.js currently issues a new license request for every new PSSH it encounters,
even when the CDM already reports the referenced key(s) as `usable`. This is
wasteful and gets worse the more frequently keys rotate.

## What changed

- `Utils.normalizeKeyId()`: a single shared key-ID normalization helper, replacing
  4 duplicated inline implementations (DashAdapter + 3 protection models) —
  addresses the "move to a Utils function" comment on #5016.
- `CommonEncryption.parsePSSHList()` now also returns the PSSH `version` and, for
  version 1+ boxes, the key IDs it declares. `getKeyIdsForKeySystem()` exposes this.
  Neither of the project's existing box-parsing dependencies could do this:
  `@svta/cml-*` has no ISO-BMFF support at all, and `codem-isoboxer`'s `pssh` box
  processor reads `SystemID`/`DataSize`/`Data` but skips the v1 `KID_count`/KID
  array entirely — this answers the "can we use CML" comment on #5016.
- A new opt-out setting, `streaming.protection.skipLicenseRequestsForUsableKeys`
  (default `true`). When enabled, `createKeySession()` skips creating a new
  MediaKeySession only if **every** key ID referenced by the selected key system's
  PSSH is already reported as `usable`.

  This replaces the single-KID early return proposed in #5016
  (`keySystemMetadata.keyId`), which doesn't work for segment-level/rotating-key
  PSSH at all (that field is never populated on that path) and could not
  correctly handle a PSSH with multiple KIDs where only one is usable — the
  multi-key correctness concern raised in review of #5016.

- Safety invariant: skip only when the setting is on, at least one key ID was
  extracted, and every extracted key ID has status exactly `usable`. Any
  uncertainty (version-0 PSSH, parse failure, empty/partial key-status map, any
  non-usable status) preserves today's behavior unchanged. FairPlay/sinf is
  untouched since the guard only runs on the PSSH-derived path.

## Testing

- New unit tests: KID normalization (`core.Utils.js`), PSSH v1 parsing
  (`streaming.protection.CommonEncryption.js`), and the guard itself — including
  the exact multi-key negative case raised in review of #5016 (`core.Utils.js`) —
  in `streaming.protection.controllers.ProtectionController.js`.
- Full suite: 1901 tests passing locally (Karma/Chrome).
- Manual end-to-end validation against a rotating-key 
  (audio/hd tracks with separate encryption keys, ~10s crypto period, future-keys in license response) 
  reference stream on both Chrome/Widevine and Edge/PlayReady:
  - 1 new license request per track per ~100s with the setting on 
    vs 1 new license request per track per ~10s with it off, no errors.
  - First license response contains 1 current + 1..10 future-keys, 
    then always 1 current + 9 future-keys.
  - A new session/license is still requested once the future-keys
    window is exhausted — the optimization never gets "stuck".
- New sample: `samples/drm/key-rotation.html` (toggle the setting, watch the
  session/license counters live) and a matching entry in
  `test/functional/config/test-configurations/streams/drm.json`. Both URLs point at an
  Irdeto reference stream.

## Known limitation

The guard does not itself correct for PlayReady KID byte-order; it relies on the
existing Edge-specific correction in `updateKeyStatusesMap()`. Verified working on
Edge; other (non-Edge) PlayReady CDMs simply won't get the optimization (they
fail closed to today's behavior, no regression).

## Out of scope

- FairPlay/sinf behavior changes
- Packager-side PSSH v0/v1 signaling choices
- ExoPlayer/Shaka application-layer fixes (referenced only as prior art)
- Changing the public semantics of `areKeyIdsUsable()` / `areKeyIdsExpired()`