### PR TITLE
feat(c2pa): add native C2PA §19.3/§19.4 provenance validation for live streams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1980,6 +1980,11 @@ export class MediaPlayerSettingClass {
                 etpWeightRatio?: number
             }
         },
+        c2pa?: {
+            enabled?: boolean,
+            method?: 'auto' | '19.3' | '19.4',
+            mediaTypes?: Array<'video' | 'audio'>
+        },
         defaultSchemeIdUri?: {
             viewpoint?: string,
             audioChannelConfiguration?: string,
@@ -2405,6 +2410,9 @@ export interface MediaPlayerEvents {
     BUFFER_LOADED: 'bufferLoaded';
     BUFFER_LEVEL_STATE_CHANGED: 'bufferStateChanged';
     BUFFER_LEVEL_UPDATED: 'bufferLevelUpdated';
+    C2PA_INIT_PROCESSED: 'c2paInitProcessed';
+    C2PA_SEGMENT_VALIDATED: 'c2paSegmentValidated';
+    C2PA_ERROR: 'c2paError';
     CAN_PLAY: 'canPlay';
     CAN_PLAY_THROUGH: 'canPlayThrough';
     CAPTION_RENDERED: 'captionRendered';

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "karma-mocha-reporter": "^2.2.5",
         "karma-safarinative-launcher": "^1.1.0",
         "karma-webpack": "^5.0.1",
-        "mermaid": "^11.16.0",
         "mocha": "^11.7.5",
         "nise": "^6.1.1",
         "publint": "^0.3.21",
@@ -67,8 +66,6 @@
         "string-replace-loader": "^3.2.0",
         "timers-browserify": "^2.0.12",
         "typescript": "^5.9.3",
-        "vitepress": "^1.6.4",
-        "vitepress-plugin-mermaid": "^2.0.17",
         "webpack": "5.94.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2",
@@ -77,278 +74,9 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
-      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
       },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/autocomplete-core": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
-      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
-        "@algolia/autocomplete-shared": "1.17.7"
-      }
-    },
-    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
-      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.7"
-      },
-      "peerDependencies": {
-        "search-insights": ">= 1 < 3"
-      }
-    },
-    "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
-      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.7"
-      },
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
-      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
-      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
-      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
-      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-insights": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
-      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
-      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
-      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
-      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/ingestion": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
-      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/monitoring": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
-      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/recommend": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
-      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
-      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
-      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
-      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@antfu/install-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
+      "optionalDependencies": {
+        "@svta/cml-c2pa": "1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1937,19 +1665,89 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@braintree/sanitize-url": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
     },
-    "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-      "dev": true,
-      "license": "Apache-2.0"
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "node_modules/@chiragrupani/karma-chromium-edge-launcher": {
       "version": "2.4.1",
@@ -1974,448 +1772,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/@docsearch/css": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
-      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@docsearch/js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
-      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@docsearch/react": "3.8.2",
-        "preact": "^10.0.0"
-      }
-    },
-    "node_modules/@docsearch/react": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
-      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-core": "1.17.7",
-        "@algolia/autocomplete-preset-algolia": "1.17.7",
-        "@docsearch/css": "3.8.2",
-        "algoliasearch": "^5.14.2"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 19.0.0",
-        "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0",
-        "search-insights": ">= 1 < 3"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "search-insights": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2648,35 +2004,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.91",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.91.tgz",
-      "integrity": "sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "@iconify/types": "*"
-      }
-    },
-    "node_modules/@iconify/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@iconify/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
-        "@iconify/types": "^2.0.0",
-        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2942,11 +2269,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -3096,41 +2422,6 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
-    },
-    "node_modules/@mermaid-js/mermaid-mindmap": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
-      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@braintree/sanitize-url": "^6.0.0",
-        "cytoscape": "^3.23.0",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.1.0",
-        "d3": "^7.0.0",
-        "khroma": "^2.0.0",
-        "non-layered-tidy-tree-layout": "^2.0.2"
-      }
-    },
-    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/types": "~11.1.2"
-      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -3378,482 +2669,6 @@
         "url": "https://bjornlu.com/sponsor"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@shikijs/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-javascript": "2.5.0",
-        "@shikijs/engine-oniguruma": "2.5.0",
-        "@shikijs/types": "2.5.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
-      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "2.5.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^3.1.0"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
-      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "2.5.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
-      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "2.5.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
-      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "2.5.0"
-      }
-    },
-    "node_modules/@shikijs/transformers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
-      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "2.5.0",
-        "@shikijs/types": "2.5.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -3917,6 +2732,21 @@
         "node": ">=20"
       }
     },
+    "node_modules/@svta/cml-c2pa": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.0.1.tgz",
+      "integrity": "sha512-2PYCtdRcYDhlHCGAtIj0j4mCjB1G/h3l75y/ETmL1X4hbpdsI9gSO/qj/WqOH46Kp7iLgV8Q6DnbTCAohLle6g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-iso-bmff": ">=1.0.1",
+        "@svta/cml-utils": ">=1.0.0",
+        "cbor-x": "^1.6.4"
+      }
+    },
     "node_modules/@svta/cml-cmcd": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-2.3.2.tgz",
@@ -3975,6 +2805,20 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-id3/-/cml-id3-1.0.6.tgz",
       "integrity": "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-iso-bmff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.2.tgz",
+      "integrity": "sha512-c9UgY1z16zgvTEa6fS++9E9zxLuPtLJ4Dw5ebOgEDtwIw+PIhbh3URGXjv30tyDU2QQTXstI6U1q6h/Q4SkxGQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -4079,294 +2923,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
-      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4393,23 +2953,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/hast": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
-      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -4448,16 +2991,6 @@
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
       }
     },
     "node_modules/@types/mdurl": {
@@ -4539,28 +3072,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/web-bluetooth": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -4569,300 +3080,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@upsetjs/venn.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
-      }
-    },
-    "node_modules/@vitejs/plugin-vue": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0",
-        "vue": "^3.2.25"
-      }
-    },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
-      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.40",
-        "entities": "^7.0.1",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-core/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
-      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.40",
-        "@vue/shared": "3.5.40"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
-      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.40",
-        "@vue/compiler-dom": "3.5.40",
-        "@vue/compiler-ssr": "3.5.40",
-        "@vue/shared": "3.5.40",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.21",
-        "postcss": "^8.5.19",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
-      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.40",
-        "@vue/shared": "3.5.40"
-      }
-    },
-    "node_modules/@vue/devtools-api": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
-      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-kit": "^7.7.10"
-      }
-    },
-    "node_modules/@vue/devtools-kit": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
-      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-shared": "^7.7.10",
-        "birpc": "^2.3.0",
-        "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
-      }
-    },
-    "node_modules/@vue/devtools-shared": {
-      "version": "7.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
-      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
-      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.40"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
-      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.40",
-        "@vue/shared": "3.5.40"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
-      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.40",
-        "@vue/runtime-core": "3.5.40",
-        "@vue/shared": "3.5.40",
-        "csstype": "^3.2.3"
-      }
-    },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
-      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.40",
-        "@vue/runtime-dom": "3.5.40",
-        "@vue/shared": "3.5.40"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
-      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vueuse/core": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
-      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "12.8.2",
-        "@vueuse/shared": "12.8.2",
-        "vue": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/integrations": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
-      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vueuse/core": "12.8.2",
-        "@vueuse/shared": "12.8.2",
-        "vue": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "async-validator": "^4",
-        "axios": "^1",
-        "change-case": "^5",
-        "drauu": "^0.4",
-        "focus-trap": "^7",
-        "fuse.js": "^7",
-        "idb-keyval": "^6",
-        "jwt-decode": "^4",
-        "nprogress": "^0.2",
-        "qrcode": "^1.5",
-        "sortablejs": "^1",
-        "universal-cookie": "^7"
-      },
-      "peerDependenciesMeta": {
-        "async-validator": {
-          "optional": true
-        },
-        "axios": {
-          "optional": true
-        },
-        "change-case": {
-          "optional": true
-        },
-        "drauu": {
-          "optional": true
-        },
-        "focus-trap": {
-          "optional": true
-        },
-        "fuse.js": {
-          "optional": true
-        },
-        "idb-keyval": {
-          "optional": true
-        },
-        "jwt-decode": {
-          "optional": true
-        },
-        "nprogress": {
-          "optional": true
-        },
-        "qrcode": {
-          "optional": true
-        },
-        "sortablejs": {
-          "optional": true
-        },
-        "universal-cookie": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vueuse/metadata": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
-      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
-      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vue": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5191,32 +3408,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/algoliasearch": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
-      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/abtesting": "1.22.0",
-        "@algolia/client-abtesting": "5.56.0",
-        "@algolia/client-analytics": "5.56.0",
-        "@algolia/client-common": "5.56.0",
-        "@algolia/client-insights": "5.56.0",
-        "@algolia/client-personalization": "5.56.0",
-        "@algolia/client-query-suggestions": "5.56.0",
-        "@algolia/client-search": "5.56.0",
-        "@algolia/ingestion": "1.56.0",
-        "@algolia/monitoring": "1.56.0",
-        "@algolia/recommend": "5.56.0",
-        "@algolia/requester-browser-xhr": "5.56.0",
-        "@algolia/requester-fetch": "5.56.0",
-        "@algolia/requester-node-http": "5.56.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -5494,16 +3685,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/birpc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5511,9 +3692,9 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5615,9 +3796,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5886,15 +4067,38 @@
         "node": ">= 10"
       }
     },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
+    "node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "hasInstallScript": true,
       "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
+      "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
       }
     },
     "node_modules/chai": {
@@ -5950,28 +4154,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -6102,17 +4284,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -6185,15 +4356,15 @@
       "dev": true
     },
     "node_modules/concurrently": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
-      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.9.0",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -6429,22 +4600,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-anything": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-what": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.47.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
@@ -6491,16 +4646,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cose-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^1.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6516,582 +4661,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
-    },
-    "node_modules/cytoscape": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
-      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/cytoscape-cose-bilkent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^1.0.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^2.2.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/cose-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^2.0.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/layout-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-sankey": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1 - 2",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-sankey/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dagre-d3-es": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
-      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d3": "^7.9.0",
-        "lodash-es": "^4.17.21"
-      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -7101,13 +4675,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -7197,16 +4764,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delaunator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
-      }
-    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -7214,16 +4771,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -7237,25 +4784,22 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -7295,16 +4839,6 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-case": {
@@ -7357,13 +4891,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/emoji-regex-xs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -7548,17 +5075,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-toolkit": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
-    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -7572,45 +5088,6 @@
       "dev": true,
       "dependencies": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -7971,13 +5448,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8186,9 +5656,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -8335,16 +5805,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/focus-trap": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
-      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tabbable": "^6.4.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -8625,13 +6085,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/hachure-fill": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -8672,44 +6125,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -8718,13 +6133,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/hookable": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -8779,17 +6187,6 @@
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-deceiver": {
@@ -9074,17 +6471,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/imsc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
@@ -9123,16 +6509,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -9328,19 +6704,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-what": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -9957,9 +7320,9 @@
       }
     },
     "node_modules/karma-webpack/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10072,33 +7435,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "dev": true,
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10107,12 +7443,6 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
-    },
-    "node_modules/khroma": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
-      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -10153,13 +7483,6 @@
         "shell-quote": "^1.8.4"
       }
     },
-    "node_modules/layout-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10182,9 +7505,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
       "funding": [
         {
@@ -10243,13 +7566,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -10323,23 +7639,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/mark.js": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/markdown-it": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
@@ -10398,28 +7697,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdurl": {
@@ -10482,63 +7759,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@braintree/sanitize-url": "^7.1.2",
-        "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
-        "@types/d3": "^7.4.3",
-        "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.2.0",
-        "d3": "^7.9.0",
-        "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
-        "dompurify": "^3.3.3",
-        "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
-        "khroma": "^2.1.0",
-        "marked": "^16.3.0",
-        "roughjs": "^4.6.6",
-        "stylis": "^4.3.6",
-        "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-      }
-    },
-    "node_modules/mermaid/node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -10548,100 +7768,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10729,20 +7855,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minisearch": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
-      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -10756,9 +7868,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
-      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10808,9 +7920,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11061,25 +8173,6 @@
         "multicast-dns": "cli.js"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -11125,20 +8218,28 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/non-layered-tidy-tree-layout": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
-      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -11207,18 +8308,6 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/oniguruma-to-es": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
-      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^6.0.1",
-        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -11390,13 +8479,6 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
-    "node_modules/path-data-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11476,13 +8558,6 @@
         "node": "*"
       }
     },
-    "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11520,72 +8595,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/points-on-curve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/points-on-path": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-data-parser": "0.1.0",
-        "points-on-curve": "0.2.0"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/preact": {
-      "version": "10.29.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
-      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      },
-      "peerDependencies": {
-        "preact-render-to-string": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "preact-render-to-string": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11600,17 +8609,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
-    },
-    "node_modules/property-information": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
-      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -11891,33 +8889,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -12107,16 +9078,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -12180,71 +9151,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.9"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/roughjs": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hachure-fill": "^0.5.2",
-        "path-data-parser": "^0.1.0",
-        "points-on-curve": "^0.2.0",
-        "points-on-path": "^0.2.1"
-      }
-    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -12280,13 +9186,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -12357,14 +9256,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -12620,9 +9511,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12630,23 +9521,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
-      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "2.5.0",
-        "@shikijs/engine-javascript": "2.5.0",
-        "@shikijs/engine-oniguruma": "2.5.0",
-        "@shikijs/langs": "2.5.0",
-        "@shikijs/themes": "2.5.0",
-        "@shikijs/types": "2.5.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/showdown": {
@@ -12878,9 +9752,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
-      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12936,16 +9810,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -12954,17 +9818,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/spdy": {
@@ -13009,16 +9862,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/speakingurl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -13167,21 +10010,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -13220,26 +10048,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/superjson": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "copy-anything": "^4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13263,13 +10071,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13461,27 +10262,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/ts-dedent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
-      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.10"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -13623,79 +10403,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -13788,152 +10495,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitepress": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
-      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@docsearch/css": "3.8.2",
-        "@docsearch/js": "3.8.2",
-        "@iconify-json/simple-icons": "^1.2.21",
-        "@shikijs/core": "^2.1.0",
-        "@shikijs/transformers": "^2.1.0",
-        "@shikijs/types": "^2.1.0",
-        "@types/markdown-it": "^14.1.2",
-        "@vitejs/plugin-vue": "^5.2.1",
-        "@vue/devtools-api": "^7.7.0",
-        "@vue/shared": "^3.5.13",
-        "@vueuse/core": "^12.4.0",
-        "@vueuse/integrations": "^12.4.0",
-        "focus-trap": "^7.6.4",
-        "mark.js": "8.11.1",
-        "minisearch": "^7.1.1",
-        "shiki": "^2.1.0",
-        "vite": "^5.4.14",
-        "vue": "^3.5.13"
-      },
-      "bin": {
-        "vitepress": "bin/vitepress.js"
-      },
-      "peerDependencies": {
-        "markdown-it-mathjax3": "^4",
-        "postcss": "^8"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it-mathjax3": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitepress-plugin-mermaid": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
-      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "@mermaid-js/mermaid-mindmap": "^9.3.0"
-      },
-      "peerDependencies": {
-        "mermaid": "10 || 11",
-        "vitepress": "^1.0.0 || ^1.0.0-alpha"
-      }
-    },
     "node_modules/void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -13941,28 +10502,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vue": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
-      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.40",
-        "@vue/compiler-sfc": "3.5.40",
-        "@vue/runtime-dom": "3.5.40",
-        "@vue/server-renderer": "3.5.40",
-        "@vue/shared": "3.5.40"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/watchpack": {
@@ -14159,9 +10698,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
-      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14183,7 +10722,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.14.1",
+        "launch-editor": "^2.6.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
@@ -14304,11 +10843,10 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
-      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -14683,17 +11221,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@svta/cml-608": "1.0.2",
+        "@svta/cml-c2pa": "^1.1.0",
         "@svta/cml-cmcd": "2.3.2",
         "@svta/cml-cmsd": "1.0.6",
         "@svta/cml-dash": "1.0.6",
@@ -76,7 +77,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@svta/cml-c2pa": "1.0.1"
+        "@svta/cml-c2pa": "^1.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2733,9 +2734,9 @@
       }
     },
     "node_modules/@svta/cml-c2pa": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.0.1.tgz",
-      "integrity": "sha512-2PYCtdRcYDhlHCGAtIj0j4mCjB1G/h3l75y/ETmL1X4hbpdsI9gSO/qj/WqOH46Kp7iLgV8Q6DnbTCAohLle6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.1.0.tgz",
+      "integrity": "sha512-FKN3f6PB5ghw/WCKyNDPW0ysf+mmnusIzeYWO+9Jiu0XF2fVexhvo6KhJ4403jvvuiNxO32Ulno0NhMWzBj4uw==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@svta/cml-608": "1.0.2",
-        "@svta/cml-c2pa": "^1.1.0",
+        "@svta/cml-c2pa": "^1.1.1",
         "@svta/cml-cmcd": "2.3.2",
         "@svta/cml-cmsd": "1.0.6",
         "@svta/cml-dash": "1.0.6",
@@ -77,7 +77,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@svta/cml-c2pa": "^1.1.0"
+        "@svta/cml-c2pa": "^1.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2734,9 +2734,9 @@
       }
     },
     "node_modules/@svta/cml-c2pa": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.1.0.tgz",
-      "integrity": "sha512-FKN3f6PB5ghw/WCKyNDPW0ysf+mmnusIzeYWO+9Jiu0XF2fVexhvo6KhJ4403jvvuiNxO32Ulno0NhMWzBj4uw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.1.1.tgz",
+      "integrity": "sha512-zFkVOt7453ArgMXoyCpEIK7OUCq5x7dgQbZLgkJ0ffeutv+LniP/lfJTdFTTizcpOHxfjCCjWXa9TDzzC2bPfQ==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@svta/cml-608": "1.0.2",
-        "@svta/cml-c2pa": "^1.1.1",
+        "@svta/cml-c2pa": "1.1.1",
         "@svta/cml-cmcd": "2.3.2",
         "@svta/cml-cmsd": "1.0.6",
         "@svta/cml-dash": "1.0.6",
@@ -75,9 +75,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "@svta/cml-c2pa": "^1.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2738,7 +2735,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-c2pa/-/cml-c2pa-1.1.1.tgz",
       "integrity": "sha512-zFkVOt7453ArgMXoyCpEIK7OUCq5x7dgQbZLgkJ0ffeutv+LniP/lfJTdFTTizcpOHxfjCCjWXa9TDzzC2bPfQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -2818,7 +2814,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.2.tgz",
       "integrity": "sha512-c9UgY1z16zgvTEa6fS++9E9zxLuPtLJ4Dw5ebOgEDtwIw+PIhbh3URGXjv30tyDU2QQTXstI6U1q6h/Q4SkxGQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -4096,7 +4091,6 @@
       "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
       "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "optionalDependencies": {
         "cbor-extract": "^2.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "karma-mocha-reporter": "^2.2.5",
         "karma-safarinative-launcher": "^1.1.0",
         "karma-webpack": "^5.0.1",
+        "mermaid": "^11.16.0",
         "mocha": "^11.7.5",
         "nise": "^6.1.1",
         "publint": "^0.3.21",
@@ -67,6 +68,8 @@
         "string-replace-loader": "^3.2.0",
         "timers-browserify": "^2.0.12",
         "typescript": "^5.9.3",
+        "vitepress": "^1.6.4",
+        "vitepress-plugin-mermaid": "^2.0.17",
         "webpack": "5.94.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2",
@@ -75,6 +78,278 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -470,13 +745,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1650,9 +1925,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1662,6 +1937,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
       "version": "2.2.2",
@@ -1747,6 +2029,13 @@
       ],
       "peer": true
     },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@chiragrupani/karma-chromium-edge-launcher": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@chiragrupani/karma-chromium-edge-launcher/-/karma-chromium-edge-launcher-2.4.1.tgz",
@@ -1770,6 +2059,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2002,6 +2733,35 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2267,10 +3027,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -2420,6 +3181,41 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
+      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.0.0",
+        "khroma": "^2.0.0",
+        "non-layered-tidy-tree-layout": "^2.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -2666,6 +3462,482 @@
       "funding": {
         "url": "https://bjornlu.com/sponsor"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -2919,10 +4191,294 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2949,6 +4505,23 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -2987,6 +4560,16 @@
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/mdurl": {
@@ -3068,6 +4651,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3076,6 +4681,300 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3404,6 +5303,32 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/algoliasearch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -3679,6 +5604,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/bluebird": {
@@ -4096,6 +6031,17 @@
         "cbor-extract": "^2.2.2"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -4149,6 +6095,28 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -4278,6 +6246,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "10.0.1",
@@ -4595,6 +6574,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.47.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
@@ -4641,6 +6636,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4656,11 +6661,582 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+      "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -4670,6 +7246,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -4759,6 +7342,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4766,6 +7359,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -4795,6 +7398,20 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -4834,6 +7451,16 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-case": {
@@ -4886,6 +7513,13 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -5070,6 +7704,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -5083,6 +7729,45 @@
       "dev": true,
       "dependencies": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -5443,6 +8128,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5801,6 +8493,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -6080,6 +8782,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -6120,6 +8829,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -6128,6 +8875,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -6182,6 +8936,17 @@
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-deceiver": {
@@ -6466,6 +9231,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imsc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
@@ -6504,6 +9280,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -6699,6 +9485,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -7430,6 +10229,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7438,6 +10264,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -7477,6 +10309,13 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.4"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -7564,6 +10403,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7634,6 +10480,23 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/markdown-it": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
@@ -7692,6 +10555,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdurl": {
@@ -7754,6 +10639,63 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mermaid": {
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -7763,6 +10705,100 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7849,6 +10885,20 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -8168,6 +11218,25 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8236,6 +11305,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -8303,6 +11380,18 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -8474,6 +11563,13 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8553,6 +11649,13 @@
         "node": "*"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8590,6 +11693,72 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8604,6 +11773,17 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -8884,6 +12064,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -9146,6 +12353,71 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -9181,6 +12453,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -9251,6 +12530,14 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -9516,6 +12803,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/showdown": {
@@ -9805,6 +13109,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -9813,6 +13127,17 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/spdy": {
@@ -9857,6 +13182,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -10005,6 +13340,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -10043,6 +13393,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -10066,6 +13436,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10257,6 +13634,27 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10398,6 +13796,79 @@
         "node": ">=4"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -10490,6 +13961,152 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress-plugin-mermaid": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
+      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@mermaid-js/mermaid-mindmap": "^9.3.0"
+      },
+      "peerDependencies": {
+        "mermaid": "10 || 11",
+        "vitepress": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
     "node_modules/void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -10497,6 +14114,28 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/watchpack": {
@@ -11216,6 +14855,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "path-browserify": "^1.0.1"
   },
   "optionalDependencies": {
-    "@svta/cml-c2pa": "^1.1.0"
+    "@svta/cml-c2pa": "^1.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "path-browserify": "^1.0.1"
   },
   "optionalDependencies": {
-    "@svta/cml-c2pa": "1.0.1"
+    "@svta/cml-c2pa": "^1.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,9 @@
     "localforage": "^1.10.0",
     "path-browserify": "^1.0.1"
   },
+  "optionalDependencies": {
+    "@svta/cml-c2pa": "1.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Dash-Industry-Forum/dash.js.git"

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "dependencies": {
     "@svta/cml-608": "1.0.2",
+    "@svta/cml-c2pa": "1.1.1",
     "@svta/cml-cmcd": "2.3.2",
     "@svta/cml-cmsd": "1.0.6",
     "@svta/cml-dash": "1.0.6",
@@ -120,9 +121,6 @@
     "imsc": "^1.1.5",
     "localforage": "^1.10.0",
     "path-browserify": "^1.0.1"
-  },
-  "optionalDependencies": {
-    "@svta/cml-c2pa": "^1.1.1"
   },
   "repository": {
     "type": "git",

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -232,7 +232,7 @@
             'pick the signing method (auto / §19.3 Manifest Box / §19.4 VSI), and load a signed ' +
             'stream to see a per-segment ✅ / ❌ / ⚠ indicator; click a segment for its manifest id, ' +
             'issuer and error codes. Enable/disable and method changes take effect at runtime. Requires a ' +
-            'C2PA-signed DASH stream (e.g. the c2pa-live-video-toolkit pipeline output).',
+            'C2PA-signed DASH stream (e.g. §19.3 segments signed with c2patool, or a custom §19.4 VSI signer).',
         category: 'C2PA',
         sidePanel: sidePanel,
         onInit: (video, container, wrapper) => initC2paSample(video, wrapper)

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -51,6 +51,7 @@
         .c2pa-chip.reordered,
         .c2pa-chip.missing { background: #ef6c00; }
         .c2pa-chip.continuityInvalid { background: #ad1457; }
+        .c2pa-chip.continuityUnsupported { background: #f9a825; color: #000; }
         .c2pa-chip.unverified { background: #757575; }
         .c2pa-details {
             margin-top: 12px;
@@ -76,8 +77,14 @@
         replayed: '♻',         // recycle
         reordered: '⇅',        // up-down arrows
         missing: '⁉',          // gap
-        continuityInvalid: '🔗', // broken/unrecognized continuity link, hash still valid
+        continuityInvalid: '🔗', // broken continuity link, hash still valid
+        continuityUnsupported: '⚠', // unrecognized continuity method, hash still valid
         unverified: '❔'        // question mark
+    };
+
+    var STATUS_MESSAGES = {
+        continuityUnsupported: 'Continuity method cannot be validated: only the spec-defined continuity ' +
+            'method (manifest ID chain, §19.7.2) is supported. The segment\'s content hash is valid.'
     };
 
     var player = null;
@@ -182,7 +189,9 @@
     }
 
     function showDetails(record) {
-        document.getElementById('c2pa-details').textContent = JSON.stringify(record, null, 2);
+        var message = STATUS_MESSAGES[record.status];
+        var json = JSON.stringify(record, null, 2);
+        document.getElementById('c2pa-details').textContent = message ? (message + '\n\n' + json) : json;
     }
 
     function setSummary(text) {
@@ -221,7 +230,7 @@
         title: 'C2PA provenance validation',
         description: 'Validates C2PA provenance of a live DASH stream per segment. Enable checking, ' +
             'pick the signing method (auto / §19.3 Manifest Box / §19.4 VSI), and load a signed ' +
-            'stream to see a per-segment ✅ / ❌ indicator; click a segment for its manifest id, ' +
+            'stream to see a per-segment ✅ / ❌ / ⚠ indicator; click a segment for its manifest id, ' +
             'issuer and error codes. Enable/disable and method changes take effect at runtime. Requires a ' +
             'C2PA-signed DASH stream (e.g. the c2pa-live-video-toolkit pipeline output).',
         category: 'C2PA',

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -50,6 +50,7 @@
         .c2pa-chip.replayed,
         .c2pa-chip.reordered,
         .c2pa-chip.missing { background: #ef6c00; }
+        .c2pa-chip.continuityInvalid { background: #ad1457; }
         .c2pa-chip.unverified { background: #757575; }
         .c2pa-details {
             margin-top: 12px;
@@ -70,12 +71,13 @@
     // enables the off-by-default `streaming.c2pa` capability, lets the operator pick the
     // signing method at runtime, and renders a per-segment provenance indicator.
     var STATUS_ICONS = {
-        valid: '✅',      // check mark
-        invalid: '❌',    // cross mark
-        replayed: '♻',   // recycle
-        reordered: '⇅',  // up-down arrows
-        missing: '⁉',    // gap
-        unverified: '❔'  // question mark
+        valid: '✅',            // check mark
+        invalid: '❌',          // cross mark
+        replayed: '♻',         // recycle
+        reordered: '⇅',        // up-down arrows
+        missing: '⁉',          // gap
+        continuityInvalid: '🔗', // broken/unrecognized continuity link, hash still valid
+        unverified: '❔'        // question mark
     };
 
     var player = null;

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -171,6 +171,8 @@
         );
     }
 
+    var MAX_VISIBLE_SEGMENT_CHIPS = 300;
+
     function onSegmentValidated(e) {
         var chip = document.createElement('div');
         chip.className = 'c2pa-chip ' + e.status;
@@ -179,7 +181,11 @@
         chip.addEventListener('click', function () {
             showDetails(e);
         });
-        document.getElementById('c2pa-grid').appendChild(chip);
+        var grid = document.getElementById('c2pa-grid');
+        grid.appendChild(chip);
+        while (grid.childElementCount > MAX_VISIBLE_SEGMENT_CHIPS) {
+            grid.removeChild(grid.firstElementChild);
+        }
     }
 
     function onC2paError(e) {

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -17,12 +17,20 @@
             margin-top: 12px;
             font-size: 0.9em;
         }
+        .c2pa-grid-row {
+            margin-top: 8px;
+        }
+        .c2pa-grid-label {
+            font-size: 0.75em;
+            font-weight: 600;
+            opacity: 0.7;
+        }
         .c2pa-grid {
             display: flex;
             flex-wrap: wrap;
             gap: 4px;
-            margin-top: 8px;
-            max-height: 220px;
+            margin-top: 2px;
+            max-height: 110px;
             overflow-y: auto;
         }
         .c2pa-chip {
@@ -181,7 +189,9 @@
         chip.addEventListener('click', function () {
             showDetails(e);
         });
-        var grid = document.getElementById('c2pa-grid');
+        // A separate row per media type, so a track validating both video and audio
+        // doesn't read as one jumbled interleaved sequence.
+        var grid = document.getElementById('c2pa-grid-' + e.mediaType) || document.getElementById('c2pa-grid-video');
         grid.appendChild(chip);
         while (grid.childElementCount > MAX_VISIBLE_SEGMENT_CHIPS) {
             grid.removeChild(grid.firstElementChild);
@@ -203,7 +213,8 @@
     }
 
     function resetPanel() {
-        document.getElementById('c2pa-grid').innerHTML = '';
+        document.getElementById('c2pa-grid-video').innerHTML = '';
+        document.getElementById('c2pa-grid-audio').innerHTML = '';
         document.getElementById('c2pa-details').textContent = '';
         setSummary('');
     }
@@ -234,7 +245,14 @@
         '    </select>' +
         '    <button type="button" id="c2pa-load" class="btn btn-primary btn-sm" style="margin-top:10px;">Load</button>' +
         '    <div class="c2pa-summary" id="c2pa-summary"></div>' +
-        '    <div class="c2pa-grid" id="c2pa-grid"></div>' +
+        '    <div class="c2pa-grid-row">' +
+        '      <div class="c2pa-grid-label">Video</div>' +
+        '      <div class="c2pa-grid" id="c2pa-grid-video"></div>' +
+        '    </div>' +
+        '    <div class="c2pa-grid-row">' +
+        '      <div class="c2pa-grid-label">Audio</div>' +
+        '      <div class="c2pa-grid" id="c2pa-grid-audio"></div>' +
+        '    </div>' +
         '    <div class="c2pa-details" id="c2pa-details"></div>' +
         '  </div>' +
         '</div>';

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>C2PA provenance validation</title>
+
+    <script src="../../dist/modern/umd/dash.all.debug.js"></script>
+
+    <link href="../lib/bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../lib/bootstrap-icons/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="../lib/sample.css" rel="stylesheet">
+    <link href="../../contrib/controlbar/controlbar.css" rel="stylesheet">
+
+    <style>
+        .c2pa-controls label {
+            display: block;
+            margin-top: 8px;
+            font-weight: 600;
+        }
+        .c2pa-controls input[type="text"],
+        .c2pa-controls select {
+            width: 100%;
+        }
+        .c2pa-summary {
+            margin-top: 12px;
+            font-size: 0.9em;
+        }
+        .c2pa-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-top: 8px;
+            max-height: 220px;
+            overflow-y: auto;
+        }
+        .c2pa-chip {
+            width: 28px;
+            height: 28px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 4px;
+            font-size: 0.75em;
+            cursor: pointer;
+            color: #fff;
+        }
+        .c2pa-chip.valid { background: #2e7d32; }
+        .c2pa-chip.invalid { background: #c62828; }
+        .c2pa-chip.replayed,
+        .c2pa-chip.reordered,
+        .c2pa-chip.missing { background: #ef6c00; }
+        .c2pa-chip.unverified { background: #757575; }
+        .c2pa-details {
+            margin-top: 12px;
+            padding: 8px;
+            border: 1px solid var(--bs-border-color, #ccc);
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 0.8em;
+            white-space: pre-wrap;
+            min-height: 60px;
+        }
+    </style>
+</head>
+<body>
+
+<script class="code">
+    // C2PA validation is delivered through the public dash.js event system. This sample
+    // enables the off-by-default `streaming.c2pa` capability, lets the operator pick the
+    // signing method at runtime, and renders a per-segment provenance indicator.
+    var STATUS_ICONS = {
+        valid: '✅',      // check mark
+        invalid: '❌',    // cross mark
+        replayed: '♻',   // recycle
+        reordered: '⇅',  // up-down arrows
+        missing: '⁉',    // gap
+        unverified: '❔'  // question mark
+    };
+
+    var player = null;
+    var videoElement = null;
+    var wrapperElement = null;
+
+    function initC2paSample(video, wrapper) {
+        videoElement = video;
+        wrapperElement = wrapper;
+
+        document.getElementById('c2pa-load').addEventListener('click', reload);
+        document.getElementById('c2pa-enabled').addEventListener('change', onEnabledChange);
+        document.getElementById('c2pa-method').addEventListener('change', onMethodChange);
+
+        reload();
+    }
+
+    function readOptions() {
+        return {
+            url: document.getElementById('c2pa-url').value.trim(),
+            enabled: document.getElementById('c2pa-enabled').checked,
+            method: document.getElementById('c2pa-method').value
+        };
+    }
+
+    // Full (re)load: the interceptor is registered during initialization, so a new source
+    // is attached with a fresh player. Toggling enable/method afterwards is handled live.
+    function reload() {
+        var options = readOptions();
+        if (player) {
+            player.destroy();
+            player = null;
+        }
+        resetPanel();
+        if (!options.url) {
+            setSummary('Enter a signed DASH stream URL and press Load.');
+            return;
+        }
+
+        player = dashjs.MediaPlayer().create();
+        player.updateSettings({
+            streaming: {
+                c2pa: {
+                    enabled: options.enabled,
+                    method: options.method
+                }
+            }
+        });
+        subscribeToC2paEvents(player);
+        player.initialize(videoElement, options.url, true);
+        window.createControlBar(player, videoElement, wrapperElement);
+    }
+
+    // Runtime toggle: the C2paController reacts to the enabled-setting change and
+    // registers / detaches the scanning interceptor without reloading.
+    function onEnabledChange() {
+        if (!player) {
+            return;
+        }
+        player.updateSettings({ streaming: { c2pa: { enabled: document.getElementById('c2pa-enabled').checked } } });
+    }
+
+    // The coordinator reads the method per segment, so a change takes effect live.
+    function onMethodChange() {
+        if (!player) {
+            return;
+        }
+        player.updateSettings({ streaming: { c2pa: { method: document.getElementById('c2pa-method').value } } });
+    }
+
+    function subscribeToC2paEvents(activePlayer) {
+        var events = dashjs.MediaPlayer.events;
+        activePlayer.on(events.C2PA_INIT_PROCESSED, onInitProcessed);
+        activePlayer.on(events.C2PA_SEGMENT_VALIDATED, onSegmentValidated);
+        activePlayer.on(events.C2PA_ERROR, onC2paError);
+    }
+
+    function onInitProcessed(e) {
+        var methodLabel = e.method ? ('§' + e.method) : 'no provenance';
+        setSummary(
+            'Track ' + e.trackKey + ' — ' + methodLabel +
+            ' | manifest: ' + (e.manifestId || '—') +
+            ' | issuer: ' + (e.issuer || '—') +
+            ' | session keys: ' + e.sessionKeyCount +
+            ' | valid: ' + e.isValid
+        );
+    }
+
+    function onSegmentValidated(e) {
+        var chip = document.createElement('div');
+        chip.className = 'c2pa-chip ' + e.status;
+        chip.textContent = STATUS_ICONS[e.status] || '?';
+        chip.title = 'segment ' + e.segmentNumber + ' (' + e.mediaType + ')';
+        chip.addEventListener('click', function () {
+            showDetails(e);
+        });
+        document.getElementById('c2pa-grid').appendChild(chip);
+    }
+
+    function onC2paError(e) {
+        showDetails(e);
+    }
+
+    function showDetails(record) {
+        document.getElementById('c2pa-details').textContent = JSON.stringify(record, null, 2);
+    }
+
+    function setSummary(text) {
+        document.getElementById('c2pa-summary').textContent = text;
+    }
+
+    function resetPanel() {
+        document.getElementById('c2pa-grid').innerHTML = '';
+        document.getElementById('c2pa-details').textContent = '';
+        setSummary('');
+    }
+</script>
+
+<script type="module">
+    import {initSamplePage} from '../lib/sample-template.js';
+
+    var sidePanel =
+        '<div class="c2pa-controls">' +
+        '  <h5>C2PA controls</h5>' +
+        '  <label for="c2pa-url">Signed DASH stream (MPD)</label>' +
+        '  <input type="text" id="c2pa-url" placeholder="https://.../manifest.mpd">' +
+        '  <label for="c2pa-enabled"><input type="checkbox" id="c2pa-enabled" checked> Enable C2PA checking</label>' +
+        '  <label for="c2pa-method">Method</label>' +
+        '  <select id="c2pa-method">' +
+        '    <option value="auto">auto (detect)</option>' +
+        '    <option value="19.3">19.3 (Manifest Box)</option>' +
+        '    <option value="19.4">19.4 (VSI)</option>' +
+        '  </select>' +
+        '  <button type="button" id="c2pa-load" class="btn btn-primary btn-sm" style="margin-top:10px;">Load</button>' +
+        '  <div class="c2pa-summary" id="c2pa-summary"></div>' +
+        '  <div class="c2pa-grid" id="c2pa-grid"></div>' +
+        '  <div class="c2pa-details" id="c2pa-details"></div>' +
+        '</div>';
+
+    initSamplePage({
+        title: 'C2PA provenance validation',
+        description: 'Validates C2PA provenance of a live DASH stream per segment. Enable checking, ' +
+            'pick the signing method (auto / §19.3 Manifest Box / §19.4 VSI), and load a signed ' +
+            'stream to see a per-segment ✅ / ❌ indicator; click a segment for its manifest id, ' +
+            'issuer and error codes. Enable/disable and method changes take effect at runtime. Requires a ' +
+            'C2PA-signed DASH stream (e.g. the c2pa-live-video-toolkit pipeline output).',
+        category: 'C2PA',
+        sidePanel: sidePanel,
+        onInit: (video, container, wrapper) => initC2paSample(video, wrapper)
+    });
+</script>
+</body>
+</html>

--- a/samples/c2pa/index.html
+++ b/samples/c2pa/index.html
@@ -13,15 +13,6 @@
     <link href="../../contrib/controlbar/controlbar.css" rel="stylesheet">
 
     <style>
-        .c2pa-controls label {
-            display: block;
-            margin-top: 8px;
-            font-weight: 600;
-        }
-        .c2pa-controls input[type="text"],
-        .c2pa-controls select {
-            width: 100%;
-        }
         .c2pa-summary {
             margin-top: 12px;
             font-size: 0.9em;
@@ -83,8 +74,9 @@
     };
 
     var STATUS_MESSAGES = {
-        continuityUnsupported: 'Continuity method cannot be validated: only the spec-defined continuity ' +
-            'method (manifest ID chain, §19.7.2) is supported. The segment\'s content hash is valid.'
+        continuityUnsupported: 'This segment\'s continuity method isn\'t recognized: this player only ' +
+            'implements the spec-default (manifest ID chain, §19.7.2). The content is still authentic ' +
+            '(its hash is valid), but continuity to the previous segment couldn\'t be confirmed.'
     };
 
     var player = null;
@@ -98,6 +90,12 @@
         document.getElementById('c2pa-load').addEventListener('click', reload);
         document.getElementById('c2pa-enabled').addEventListener('change', onEnabledChange);
         document.getElementById('c2pa-method').addEventListener('change', onMethodChange);
+        document.querySelectorAll('.c2pa-example').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                document.getElementById('c2pa-url').value = btn.dataset.url;
+                reload();
+            });
+        });
 
         reload();
     }
@@ -209,21 +207,30 @@
     import {initSamplePage} from '../lib/sample-template.js';
 
     var sidePanel =
-        '<div class="c2pa-controls">' +
-        '  <h5>C2PA controls</h5>' +
-        '  <label for="c2pa-url">Signed DASH stream (MPD)</label>' +
-        '  <input type="text" id="c2pa-url" placeholder="https://.../manifest.mpd">' +
-        '  <label for="c2pa-enabled"><input type="checkbox" id="c2pa-enabled" checked> Enable C2PA checking</label>' +
-        '  <label for="c2pa-method">Method</label>' +
-        '  <select id="c2pa-method">' +
-        '    <option value="auto">auto (detect)</option>' +
-        '    <option value="19.3">19.3 (Manifest Box)</option>' +
-        '    <option value="19.4">19.4 (VSI)</option>' +
-        '  </select>' +
-        '  <button type="button" id="c2pa-load" class="btn btn-primary btn-sm" style="margin-top:10px;">Load</button>' +
-        '  <div class="c2pa-summary" id="c2pa-summary"></div>' +
-        '  <div class="c2pa-grid" id="c2pa-grid"></div>' +
-        '  <div class="c2pa-details" id="c2pa-details"></div>' +
+        '<div class="sample-side-panel">' +
+        '  <div class="sample-side-panel-header">C2PA controls</div>' +
+        '  <div class="sample-side-panel-body">' +
+        '    <label for="c2pa-url">Signed DASH stream (MPD)</label>' +
+        '    <input type="text" id="c2pa-url" placeholder="https://.../manifest.mpd">' +
+        '    <div>' +
+        '      <button type="button" class="btn btn-link btn-sm p-0 c2pa-example" ' +
+        '        data-url="https://live.unified-streaming.com/trusted_media/wdr.ism/.mpd">§19.4 VSI example</button>' +
+        '      &nbsp;|&nbsp;' +
+        '      <button type="button" class="btn btn-link btn-sm p-0 c2pa-example" ' +
+        '        data-url="https://ezdrm-live-signer-dash-outputbucket-sykaqzo1yxog.s3.us-east-1.amazonaws.com/processed/stream.mpd">§19.3 Manifest Box example</button>' +
+        '    </div>' +
+        '    <label for="c2pa-enabled"><input type="checkbox" id="c2pa-enabled" checked> Enable C2PA checking</label>' +
+        '    <label for="c2pa-method">Method</label>' +
+        '    <select id="c2pa-method">' +
+        '      <option value="auto">auto (detect)</option>' +
+        '      <option value="19.3">19.3 (Manifest Box)</option>' +
+        '      <option value="19.4">19.4 (VSI)</option>' +
+        '    </select>' +
+        '    <button type="button" id="c2pa-load" class="btn btn-primary btn-sm" style="margin-top:10px;">Load</button>' +
+        '    <div class="c2pa-summary" id="c2pa-summary"></div>' +
+        '    <div class="c2pa-grid" id="c2pa-grid"></div>' +
+        '    <div class="c2pa-details" id="c2pa-details"></div>' +
+        '  </div>' +
         '</div>';
 
     initSamplePage({

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -1011,5 +1011,21 @@
                 ]
             }
         ]
+    },
+    {
+        "section": "C2PA",
+        "samples": [
+            {
+                "title": "C2PA provenance validation",
+                "description": "Validates C2PA provenance of a live DASH stream per segment (§19.3 Manifest Box and §19.4 VSI), with runtime enable/disable and method selection, rendering a per-segment provenance indicator.",
+                "href": "c2pa/index.html",
+                "image": "lib/img/bbb-1.jpg",
+                "labels": [
+                    "Live",
+                    "Video",
+                    "Audio"
+                ]
+            }
+        ]
     }
 ]

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1207,6 +1207,7 @@ function Settings() {
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
     const DISPATCH_KEY_MAP = {
+        'streaming.c2pa.enabled': Events.SETTING_UPDATED_C2PA_ENABLED,
         'streaming.delay.liveDelay': Events.SETTING_UPDATED_LIVE_DELAY,
         'streaming.delay.liveDelayFragmentCount': Events.SETTING_UPDATED_LIVE_DELAY_FRAGMENT_COUNT,
         'streaming.liveCatchup.enabled': Events.SETTING_UPDATED_CATCHUP_ENABLED,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -347,6 +347,11 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *                    etpWeightRatio: 0
  *                }
  *            },
+ *            c2pa: {
+ *                enabled: false,
+ *                method: 'auto',
+ *                mediaTypes: ['video', 'audio']
+ *            },
  *            enhancement: {
  *                enabled: false,
  *                codecs: ['lvc1']
@@ -1016,6 +1021,22 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  */
 
 /**
+ * @typedef {Object} module:Settings~C2paSettings
+ * @property {boolean} [enabled=false]
+ * Enable or disable per-segment C2PA provenance scanning and validation.
+ *
+ * Disabled by default: while disabled, no init or media segment is parsed and no C2PA event is emitted.
+ * @property {string} [method="auto"]
+ * Selects the C2PA signing method to validate against. Possible values:
+ *
+ * - "auto": determine C2PA presence and signing method through the detection strategy.
+ * - "19.3": force the per-segment Manifest Box method and skip detection.
+ * - "19.4": force the VSI (COSE_Sign1 in emsg) method and skip detection.
+ * @property {Array.<string>} [mediaTypes=['video', 'audio']]
+ * Restricts C2PA scanning to the listed media types.
+ */
+
+/**
  * @typedef {Object} module:Settings~DvbReportingSettings
  * @property {string} [reportingUrl]
  * Override DVB reporting url in manifest with a custom one
@@ -1165,6 +1186,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * Settings related to Common Media Client Data reporting.
  * @property {module:Settings~CmsdSettings} cmsd
  * Settings related to Common Media Server Data parsing.
+ * @property {module:Settings~C2paSettings} c2pa
+ * Settings related to per-segment C2PA provenance scanning and validation.
  * @property {module:Settings~EnhancementSettings} enhancement
  * Settings related to scalable enhancement playback (e.g. LCEVC).
  * @property {module:Settings~defaultSchemeIdUri} defaultSchemeIdUri
@@ -1525,6 +1548,11 @@ function Settings() {
                     applyMb: false,
                     etpWeightRatio: 0
                 }
+            },
+            c2pa: {
+                enabled: false,
+                method: 'auto',
+                mediaTypes: ['video', 'audio']
             },
             enhancement: {
                 enabled: false,

--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -72,6 +72,7 @@ class CoreEvents extends EventsBase {
         this.SERVICE_LOCATION_LOCATION_BLACKLIST_ADD = 'serviceLocationLocationBlacklistAdd';
         this.SERVICE_LOCATION_LOCATION_BLACKLIST_CHANGED = 'serviceLocationLocationBlacklistChanged';
         this.SETTING_UPDATED_ABR_ACTIVE_RULES = 'settingUpdatedAbrActiveRules';
+        this.SETTING_UPDATED_C2PA_ENABLED = 'settingUpdatedC2paEnabled';
         this.SETTING_UPDATED_CATCHUP_ENABLED = 'settingUpdatedCatchupEnabled';
         this.SETTING_UPDATED_LIVE_DELAY = 'settingUpdatedLiveDelay';
         this.SETTING_UPDATED_LIVE_DELAY_FRAGMENT_COUNT = 'settingUpdatedLiveDelayFragmentCount';

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -486,6 +486,7 @@ function MediaPlayer() {
         }
         if (c2paController) {
             c2paController.reset();
+            c2paController = null;
         }
         if (customParametersModel) {
             customParametersModel.reset();

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2579,6 +2579,9 @@ function MediaPlayer() {
         textController.reset();
         cmcdController.reset();
         cmsdModel.reset();
+        if (c2paController) {
+            c2paController.resetForNewSource();
+        }
     }
 
     function _resetPlaybackSessionSpecificSettings() {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -37,6 +37,7 @@ import CapabilitiesFilter from './utils/CapabilitiesFilter.js';
 import CmcdController from './controllers/CmcdController.js';
 import CatchupController from './controllers/CatchupController.js';
 import ClientDataReportingController from './controllers/ClientDataReportingController.js';
+import C2paController from './c2pa/C2paController.js';
 import CmsdModel from './models/CmsdModel.js';
 import Constants from './constants/Constants.js';
 import ContentSteeringController from '../dash/controllers/ContentSteeringController.js';
@@ -169,6 +170,7 @@ function MediaPlayer() {
         domStorage,
         segmentBaseController,
         clientDataReportingController,
+        c2paController,
         retrieveManifestRequest;
 
     /*
@@ -237,6 +239,9 @@ function MediaPlayer() {
         }
         if (config.clientDataReportingController) {
             clientDataReportingController = config.clientDataReportingController;
+        }
+        if (config.c2paController) {
+            c2paController = config.c2paController;
         }
         if (config.catchupController) {
             catchupController = config.catchupController;
@@ -361,6 +366,10 @@ function MediaPlayer() {
 
             clientDataReportingController = ClientDataReportingController(context).getInstance();
 
+            if (!c2paController) {
+                c2paController = C2paController(context).getInstance();
+            }
+
             dashMetrics = DashMetrics(context).getInstance({
                 settings: settings
             });
@@ -428,6 +437,13 @@ function MediaPlayer() {
                 eventBus
             })
 
+            c2paController.setConfig({
+                settings,
+                eventBus,
+                customParametersModel
+            });
+            c2paController.initialize();
+
             restoreDefaultUTCTimingSources();
             setAutoPlay(autoPlay !== undefined ? autoPlay : true);
 
@@ -467,6 +483,9 @@ function MediaPlayer() {
         if (metricsReportingController) {
             metricsReportingController.reset();
             metricsReportingController = null;
+        }
+        if (c2paController) {
+            c2paController.reset();
         }
         if (customParametersModel) {
             customParametersModel.reset();

--- a/src/streaming/MediaPlayerEvents.js
+++ b/src/streaming/MediaPlayerEvents.js
@@ -493,6 +493,24 @@ class MediaPlayerEvents extends EventsBase {
          * @type {string}
          */
         this.MANAGED_MEDIA_SOURCE_END_STREAMING = 'managedMediaSourceEndStreaming';
+
+        /**
+         * Triggered when C2PA scanning has processed an init segment.
+         * @event MediaPlayerEvents#C2PA_INIT_PROCESSED
+         */
+        this.C2PA_INIT_PROCESSED = 'c2paInitProcessed';
+
+        /**
+         * Triggered when C2PA scanning has validated a media segment.
+         * @event MediaPlayerEvents#C2PA_SEGMENT_VALIDATED
+         */
+        this.C2PA_SEGMENT_VALIDATED = 'c2paSegmentValidated';
+
+        /**
+         * Triggered when C2PA scanning could not validate a segment.
+         * @event MediaPlayerEvents#C2PA_ERROR
+         */
+        this.C2PA_ERROR = 'c2paError';
     }
 }
 

--- a/src/streaming/c2pa/C2paController.js
+++ b/src/streaming/c2pa/C2paController.js
@@ -31,10 +31,12 @@
 import FactoryMaker from '../../core/FactoryMaker.js';
 import EventBus from '../../core/EventBus.js';
 import Events from '../../core/events/Events.js';
+import MediaPlayerEvents from '../MediaPlayerEvents.js';
 import BoxParser from '../utils/BoxParser.js';
 import C2paScanner from './C2paScanner.js';
 import C2paValidationCoordinator from './C2paValidationCoordinator.js';
 import BoxParsingDetector from './detection/BoxParsingDetector.js';
+import { normalizeC2paOptions } from './C2paOptions.js';
 
 /**
  * @module C2paController
@@ -44,7 +46,6 @@ import BoxParsingDetector from './detection/BoxParsingDetector.js';
  * disabled it holds nothing heavy — no interceptor, no dynamic import of the validation
  * engine — which is the zero-cost path required when C2PA is off. It reacts to the
  * `SETTING_UPDATED_C2PA_ENABLED` event so the operator can enable/disable at runtime.
- * See ADR-0002.
  */
 function C2paController() {
     const context = this.context;
@@ -94,6 +95,8 @@ function C2paController() {
         }
         if (!subscribed) {
             eventBus.on(Events.SETTING_UPDATED_C2PA_ENABLED, _onEnabledChanged, instance);
+            eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKED, _onSeekOrPeriodSwitch, instance);
+            eventBus.on(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED, _onSeekOrPeriodSwitch, instance);
             subscribed = true;
         }
         _applyEnabledState();
@@ -101,6 +104,13 @@ function C2paController() {
 
     function _onEnabledChanged() {
         _applyEnabledState();
+    }
+
+    // A seek/period switch isn't a continuity break; reset so it doesn't read as one.
+    function _onSeekOrPeriodSwitch() {
+        if (coordinator) {
+            coordinator.resetActiveSequences();
+        }
     }
 
     function _applyEnabledState() {
@@ -112,8 +122,8 @@ function C2paController() {
     }
 
     function _isEnabled() {
-        const streaming = settings && typeof settings.get === 'function' ? settings.get().streaming : null;
-        return !!(streaming && streaming.c2pa && streaming.c2pa.enabled);
+        const streaming = settings ? settings.get().streaming : null;
+        return normalizeC2paOptions(streaming && streaming.c2pa).enabled;
     }
 
     function _attach() {
@@ -146,18 +156,27 @@ function C2paController() {
             eventBus,
             detector
         });
-        const c2pa = settings.get().streaming.c2pa;
+        const c2pa = normalizeC2paOptions(settings.get().streaming.c2pa);
         scanner = C2paScanner(context).create({
             customParametersModel,
             segmentHandler: coordinator.handleSegment,
-            mediaTypes: c2pa ? c2pa.mediaTypes : undefined
+            mediaTypes: c2pa.mediaTypes
         });
+    }
+
+    // Clears per-track state on source change, without detaching the interceptor.
+    function resetForNewSource() {
+        if (coordinator) {
+            coordinator.reset();
+        }
     }
 
     function reset() {
         _detach();
         if (eventBus && subscribed) {
             eventBus.off(Events.SETTING_UPDATED_C2PA_ENABLED, _onEnabledChanged, instance);
+            eventBus.off(MediaPlayerEvents.PLAYBACK_SEEKED, _onSeekOrPeriodSwitch, instance);
+            eventBus.off(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED, _onSeekOrPeriodSwitch, instance);
             subscribed = false;
         }
         scanner = null;
@@ -168,6 +187,7 @@ function C2paController() {
     instance = {
         setConfig,
         initialize,
+        resetForNewSource,
         reset
     };
 

--- a/src/streaming/c2pa/C2paController.js
+++ b/src/streaming/c2pa/C2paController.js
@@ -1,0 +1,180 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus.js';
+import Events from '../../core/events/Events.js';
+import BoxParser from '../utils/BoxParser.js';
+import C2paScanner from './C2paScanner.js';
+import C2paValidationCoordinator from './C2paValidationCoordinator.js';
+import BoxParsingDetector from './detection/BoxParsingDetector.js';
+
+/**
+ * @module C2paController
+ * @description Owns the C2PA scanning lifecycle inside the player. Created once during
+ * `MediaPlayer.initialize()`, it lazily builds the scanner + coordinator (+ detector) and
+ * registers the response interceptor **only while `streaming.c2pa.enabled` is true**. While
+ * disabled it holds nothing heavy — no interceptor, no dynamic import of the validation
+ * engine — which is the zero-cost path required when C2PA is off. It reacts to the
+ * `SETTING_UPDATED_C2PA_ENABLED` event so the operator can enable/disable at runtime.
+ * See ADR-0002.
+ */
+function C2paController() {
+    const context = this.context;
+
+    let instance,
+        settings,
+        eventBus,
+        customParametersModel,
+        scanner,
+        coordinator,
+        started,
+        subscribed;
+
+    function setup() {
+        started = false;
+        subscribed = false;
+    }
+
+    /**
+     * @param {Object} config
+     * @param {Object} config.settings dash.js Settings (read for `streaming.c2pa`).
+     * @param {Object} config.eventBus dash.js EventBus.
+     * @param {Object} config.customParametersModel Exposes add/removeResponseInterceptor.
+     */
+    function setConfig(config) {
+        if (!config) {
+            return;
+        }
+        if (config.settings) {
+            settings = config.settings;
+        }
+        if (config.eventBus) {
+            eventBus = config.eventBus;
+        }
+        if (config.customParametersModel) {
+            customParametersModel = config.customParametersModel;
+        }
+    }
+
+    /**
+     * Subscribes to runtime enable/disable and applies the current `enabled` state. Safe to
+     * call more than once.
+     */
+    function initialize() {
+        if (!eventBus) {
+            eventBus = EventBus(context).getInstance();
+        }
+        if (!subscribed) {
+            eventBus.on(Events.SETTING_UPDATED_C2PA_ENABLED, _onEnabledChanged, instance);
+            subscribed = true;
+        }
+        _applyEnabledState();
+    }
+
+    function _onEnabledChanged() {
+        _applyEnabledState();
+    }
+
+    function _applyEnabledState() {
+        if (_isEnabled()) {
+            _attach();
+        } else {
+            _detach();
+        }
+    }
+
+    function _isEnabled() {
+        const streaming = settings && typeof settings.get === 'function' ? settings.get().streaming : null;
+        return !!(streaming && streaming.c2pa && streaming.c2pa.enabled);
+    }
+
+    function _attach() {
+        if (started) {
+            return;
+        }
+        _ensureCreated();
+        scanner.registerInterceptor();
+        started = true;
+    }
+
+    function _detach() {
+        if (!started) {
+            return;
+        }
+        scanner.detach();
+        coordinator.reset();
+        started = false;
+    }
+
+    function _ensureCreated() {
+        if (scanner) {
+            return;
+        }
+        const detector = BoxParsingDetector(context).create({
+            boxParser: BoxParser(context).getInstance()
+        });
+        coordinator = C2paValidationCoordinator(context).create({
+            settings,
+            eventBus,
+            detector
+        });
+        const c2pa = settings.get().streaming.c2pa;
+        scanner = C2paScanner(context).create({
+            customParametersModel,
+            segmentHandler: coordinator.handleSegment,
+            mediaTypes: c2pa ? c2pa.mediaTypes : undefined
+        });
+    }
+
+    function reset() {
+        _detach();
+        if (eventBus && subscribed) {
+            eventBus.off(Events.SETTING_UPDATED_C2PA_ENABLED, _onEnabledChanged, instance);
+            subscribed = false;
+        }
+        scanner = null;
+        coordinator = null;
+        started = false;
+    }
+
+    instance = {
+        setConfig,
+        initialize,
+        reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+C2paController.__dashjs_factory_name = 'C2paController';
+export default FactoryMaker.getSingletonFactory(C2paController);

--- a/src/streaming/c2pa/C2paEvents.js
+++ b/src/streaming/c2pa/C2paEvents.js
@@ -1,0 +1,104 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import MediaPlayerEvents from '../MediaPlayerEvents.js';
+
+/**
+ * @module C2paEvents
+ * @description Event-name constants and payload typedefs for the C2PA scanning module.
+ *
+ * The event names are the same public identifiers declared on {@link MediaPlayerEvents}
+ * so that consumers subscribing through the player receive exactly these types; this
+ * module re-exposes them for internal use and documents the payload shapes dispatched
+ * alongside each event.
+ */
+
+/**
+ * The C2PA signing method a segment was validated against.
+ * @typedef {('19.3'|'19.4')} C2paMethod
+ */
+
+/**
+ * The provenance status assigned to a media segment.
+ * @typedef {('valid'|'invalid'|'replayed'|'reordered'|'missing'|'unverified')} C2paSegmentStatus
+ */
+
+/**
+ * Public payload of the {@link MediaPlayerEvents#event:C2PA_SEGMENT_VALIDATED} event.
+ * This is the record the reference-player UI renders per segment.
+ * @typedef {Object} SegmentRecord
+ * @property {number} segmentNumber Monotonic segment number derived from the segment URL.
+ * @property {('video'|'audio')} mediaType Media type of the validated segment.
+ * @property {?C2paMethod} method Signing method the segment was validated against, or null when unknown.
+ * @property {C2paSegmentStatus} status Provenance status assigned to the segment.
+ * @property {?string} keyId Identifier of the session key used for VSI validation, when applicable.
+ * @property {?string} hash Content hash reported by the validation engine, when applicable.
+ * @property {?string} manifestId Manifest id carried by the segment, when applicable.
+ * @property {?string} issuer Issuer of the signing certificate, when applicable.
+ * @property {?string} previousManifestId Manifest id of the previous segment in the continuity chain, when applicable.
+ * @property {Array.<string>} errorCodes Stable, narrowed error codes describing any validation failure.
+ * @property {number} timestamp Epoch milliseconds at which the record was produced.
+ */
+
+/**
+ * Public payload of the {@link MediaPlayerEvents#event:C2PA_INIT_PROCESSED} event.
+ * @typedef {Object} InitProcessedEvent
+ * @property {string} trackKey Stable per-representation key derived from the segment URL.
+ * @property {?C2paMethod} method Signing method classified from the init segment, or null when no provenance is present.
+ * @property {?string} manifestId Manifest id carried by the init segment, when applicable.
+ * @property {?string} issuer Issuer of the signing certificate, when applicable.
+ * @property {number} sessionKeyCount Number of VSI session keys found in the init segment.
+ * @property {boolean} isValid Whether the init segment carried verifiable C2PA provenance.
+ * @property {Array.<string>} errorCodes Stable, narrowed error codes describing any init validation failure.
+ */
+
+/**
+ * Public payload of the {@link MediaPlayerEvents#event:C2PA_ERROR} event.
+ * @typedef {Object} C2paErrorEvent
+ * @property {string} trackKey Stable per-representation key derived from the segment URL.
+ * @property {?number} segmentNumber Segment number the error relates to, when applicable.
+ * @property {?('video'|'audio')} mediaType Media type the error relates to, when applicable.
+ * @property {Array.<string>} errorCodes Stable, narrowed error codes describing the failure.
+ * @property {string} message Human-readable diagnostic message.
+ * @property {number} timestamp Epoch milliseconds at which the error was produced.
+ */
+
+/**
+ * Event-name constants dispatched by the C2PA scanning module. Values mirror the
+ * public identifiers on {@link MediaPlayerEvents}.
+ * @enum {string}
+ */
+const C2paEvents = {
+    C2PA_INIT_PROCESSED: MediaPlayerEvents.C2PA_INIT_PROCESSED,
+    C2PA_SEGMENT_VALIDATED: MediaPlayerEvents.C2PA_SEGMENT_VALIDATED,
+    C2PA_ERROR: MediaPlayerEvents.C2PA_ERROR
+};
+
+export default C2paEvents;

--- a/src/streaming/c2pa/C2paEvents.js
+++ b/src/streaming/c2pa/C2paEvents.js
@@ -28,16 +28,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-import MediaPlayerEvents from '../MediaPlayerEvents.js';
-
 /**
  * @module C2paEvents
- * @description Event-name constants and payload typedefs for the C2PA scanning module.
- *
- * The event names are the same public identifiers declared on {@link MediaPlayerEvents}
- * so that consumers subscribing through the player receive exactly these types; this
- * module re-exposes them for internal use and documents the payload shapes dispatched
- * alongside each event.
+ * @description Payload typedefs for the C2PA events declared on {@link MediaPlayerEvents}
+ * (`C2PA_INIT_PROCESSED`, `C2PA_SEGMENT_VALIDATED`, `C2PA_ERROR`).
  */
 
 /**
@@ -64,6 +58,7 @@ import MediaPlayerEvents from '../MediaPlayerEvents.js';
  * @property {?string} issuer Issuer of the signing certificate, when applicable.
  * @property {?string} previousManifestId Manifest id of the previous segment in the continuity chain, when applicable.
  * @property {Array.<string>} errorCodes Stable, narrowed error codes describing any validation failure.
+ * @property {?number} missingCount Gap size for a bounded `missing` record (`segmentNumber` is `NaN`).
  * @property {number} timestamp Epoch milliseconds at which the record was produced.
  */
 
@@ -90,15 +85,3 @@ import MediaPlayerEvents from '../MediaPlayerEvents.js';
  * @property {number} timestamp Epoch milliseconds at which the error was produced.
  */
 
-/**
- * Event-name constants dispatched by the C2PA scanning module. Values mirror the
- * public identifiers on {@link MediaPlayerEvents}.
- * @enum {string}
- */
-const C2paEvents = {
-    C2PA_INIT_PROCESSED: MediaPlayerEvents.C2PA_INIT_PROCESSED,
-    C2PA_SEGMENT_VALIDATED: MediaPlayerEvents.C2PA_SEGMENT_VALIDATED,
-    C2PA_ERROR: MediaPlayerEvents.C2PA_ERROR
-};
-
-export default C2paEvents;

--- a/src/streaming/c2pa/C2paEvents.js
+++ b/src/streaming/c2pa/C2paEvents.js
@@ -47,7 +47,7 @@ import MediaPlayerEvents from '../MediaPlayerEvents.js';
 
 /**
  * The provenance status assigned to a media segment.
- * @typedef {('valid'|'invalid'|'replayed'|'reordered'|'missing'|'unverified')} C2paSegmentStatus
+ * @typedef {('valid'|'invalid'|'replayed'|'reordered'|'missing'|'continuityInvalid'|'continuityUnsupported'|'unverified')} C2paSegmentStatus
  */
 
 /**

--- a/src/streaming/c2pa/C2paOptions.js
+++ b/src/streaming/c2pa/C2paOptions.js
@@ -29,6 +29,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+import Constants from '../constants/Constants.js';
+
 /**
  * @module C2paOptions
  * @description Defaults and validation for the C2PA scanning options exposed through
@@ -62,10 +64,24 @@ export const C2PA_METHOD_VSI = '19.4';
 export const C2PA_METHODS = [C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI];
 
 /**
+ * `SegmentInput.kind` for an initialization segment. The contract between
+ * {@link module:C2paScanner} (producer) and {@link module:C2paValidationCoordinator}
+ * (consumer).
+ * @constant {string}
+ */
+export const SEGMENT_KIND_INIT = 'init';
+
+/**
+ * `SegmentInput.kind` for a media segment.
+ * @constant {string}
+ */
+export const SEGMENT_KIND_MEDIA = 'media';
+
+/**
  * Media types scanned when the operator does not restrict them.
  * @constant {Array.<string>}
  */
-export const DEFAULT_C2PA_MEDIA_TYPES = ['video', 'audio'];
+export const DEFAULT_C2PA_MEDIA_TYPES = [Constants.VIDEO, Constants.AUDIO];
 
 /**
  * @typedef {Object} C2paOptions

--- a/src/streaming/c2pa/C2paOptions.js
+++ b/src/streaming/c2pa/C2paOptions.js
@@ -1,0 +1,119 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @module C2paOptions
+ * @description Defaults and validation for the C2PA scanning options exposed through
+ * the `streaming.c2pa` settings. Keeping the canonical defaults and the method
+ * validation here lets the scanner and coordinator normalize the operator-provided
+ * settings at a single point.
+ */
+
+/**
+ * Auto-detection: the detection strategy determines C2PA presence and signing method.
+ * @constant {string}
+ */
+export const C2PA_METHOD_AUTO = 'auto';
+
+/**
+ * Forced §19.3 per-segment Manifest Box method; detection is skipped.
+ * @constant {string}
+ */
+export const C2PA_METHOD_MANIFEST_BOX = '19.3';
+
+/**
+ * Forced §19.4 VSI (COSE_Sign1 in emsg) method; detection is skipped.
+ * @constant {string}
+ */
+export const C2PA_METHOD_VSI = '19.4';
+
+/**
+ * Every accepted value of the `method` setting.
+ * @constant {Array.<string>}
+ */
+export const C2PA_METHODS = [C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI];
+
+/**
+ * Media types scanned when the operator does not restrict them.
+ * @constant {Array.<string>}
+ */
+export const DEFAULT_C2PA_MEDIA_TYPES = ['video', 'audio'];
+
+/**
+ * @typedef {Object} C2paOptions
+ * @property {boolean} enabled Whether per-segment C2PA scanning is active. Off by default.
+ * @property {string} method Signing method setting: 'auto', '19.3' or '19.4'.
+ * @property {Array.<string>} mediaTypes Media types the scanner inspects.
+ */
+
+/**
+ * @param {*} method
+ * @returns {boolean} True when the value is one of the accepted `method` settings.
+ */
+export function isValidC2paMethod(method) {
+    return C2PA_METHODS.indexOf(method) !== -1;
+}
+
+/**
+ * @returns {C2paOptions} A fresh copy of the default C2PA options (scanning disabled).
+ */
+export function getDefaultC2paOptions() {
+    return {
+        enabled: false,
+        method: C2PA_METHOD_AUTO,
+        mediaTypes: DEFAULT_C2PA_MEDIA_TYPES.slice()
+    };
+}
+
+/**
+ * Merges operator-provided values over the defaults and sanitizes them, so downstream
+ * code always receives a well-formed {@link C2paOptions}. An unrecognized `method`
+ * falls back to 'auto' rather than throwing, keeping scanning non-interfering.
+ * @param {Object} [options] Partial options, typically the `streaming.c2pa` settings.
+ * @returns {C2paOptions} The normalized options.
+ */
+export function normalizeC2paOptions(options) {
+    const defaults = getDefaultC2paOptions();
+
+    if (!options) {
+        return defaults;
+    }
+
+    const enabled = typeof options.enabled === 'boolean' ? options.enabled : defaults.enabled;
+    const method = isValidC2paMethod(options.method) ? options.method : defaults.method;
+    const mediaTypes = Array.isArray(options.mediaTypes) ? options.mediaTypes.slice() : defaults.mediaTypes;
+
+    return {
+        enabled,
+        method,
+        mediaTypes
+    };
+}

--- a/src/streaming/c2pa/C2paScanner.js
+++ b/src/streaming/c2pa/C2paScanner.js
@@ -36,14 +36,18 @@ const SEGMENT_KIND_INIT = 'init';
 const SEGMENT_KIND_MEDIA = 'media';
 
 // dash.js 5.x does not reliably populate the representation id and req.index resets
-// per DASH period, so a stable per-representation trackKey and a globally-monotonic
-// segment number are derived from the segment URL filename instead.
-// The trailing segment number and the leading role prefix (init-/chunk-) are both
-// stripped so an init segment and its media segments map to the same trackKey:
-//   "init-stream3.m4s"        -> trackKey "stream3", segmentNumber NaN
-//   "chunk-stream3-00289.m4s" -> trackKey "stream3", segmentNumber 289
-const SEGMENT_EXTENSION_PATTERN = /\.m4s$/;
-const TRAILING_SEGMENT_NUMBER_PATTERN = /-(\d+)\.m4s$/;
+// per DASH period, so a stable per-representation trackKey is derived from the segment
+// URL filename instead. The file extension, the trailing segment number and the leading
+// role prefix (init-/chunk-) are stripped so an init segment and its media segments of
+// the same representation map to the same trackKey across common packager namings:
+//   "init-stream3.m4s"             -> trackKey "stream3",            segmentNumber NaN
+//   "chunk-stream3-00289.m4s"      -> trackKey "stream3",            segmentNumber 289
+//   "wdr-video=4045695.dash"       -> trackKey "wdr-video=4045695",  segmentNumber NaN
+//   "wdr-video=4045695-31200.dash" -> trackKey "wdr-video=4045695",  segmentNumber 31200
+// The URL-derived segment number is only per-representation metadata; the authoritative
+// sequence number used for provenance checks comes from the validated C2PA segment.
+const SEGMENT_EXTENSION_PATTERN = /\.(?:m4s|mp4|m4v|m4a|cmfv|cmfa|cmft|cmf|dash|fmp4|ts)$/i;
+const TRAILING_SEGMENT_NUMBER_PATTERN = /-(\d+)$/;
 const SEGMENT_ROLE_PREFIX_PATTERN = /^(?:init|chunk)-/;
 
 /**
@@ -192,15 +196,18 @@ function C2paScanner(config) {
         return withoutQuery.split('/').pop() || '';
     }
 
+    function _fileStem(url) {
+        return _fileNameFromUrl(url).replace(SEGMENT_EXTENSION_PATTERN, '');
+    }
+
     function _trackKeyFromUrl(url) {
-        return _fileNameFromUrl(url)
+        return _fileStem(url)
             .replace(TRAILING_SEGMENT_NUMBER_PATTERN, '')
-            .replace(SEGMENT_EXTENSION_PATTERN, '')
             .replace(SEGMENT_ROLE_PREFIX_PATTERN, '');
     }
 
     function _segmentNumberFromUrl(url) {
-        const match = _fileNameFromUrl(url).match(TRAILING_SEGMENT_NUMBER_PATTERN);
+        const match = _fileStem(url).match(TRAILING_SEGMENT_NUMBER_PATTERN);
         return match ? parseInt(match[1], 10) : NaN;
     }
 

--- a/src/streaming/c2pa/C2paScanner.js
+++ b/src/streaming/c2pa/C2paScanner.js
@@ -29,11 +29,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../../core/FactoryMaker.js';
+import Debug from '../../core/Debug.js';
 import { HTTPRequest } from '../vo/metrics/HTTPRequest.js';
-import { DEFAULT_C2PA_MEDIA_TYPES } from './C2paOptions.js';
-
-const SEGMENT_KIND_INIT = 'init';
-const SEGMENT_KIND_MEDIA = 'media';
+import { DEFAULT_C2PA_MEDIA_TYPES, SEGMENT_KIND_INIT, SEGMENT_KIND_MEDIA } from './C2paOptions.js';
 
 // dash.js 5.x does not reliably populate the representation id and req.index resets
 // per DASH period, so a stable per-representation trackKey is derived from the segment
@@ -74,15 +72,18 @@ const SEGMENT_ROLE_PREFIX_PATTERN = /^(?:init|chunk)-/;
  */
 function C2paScanner(config) {
     config = config || {};
+    const context = this.context;
     const customParametersModel = config.customParametersModel;
     const segmentHandler = config.segmentHandler;
     const mediaTypes = Array.isArray(config.mediaTypes) ? config.mediaTypes : DEFAULT_C2PA_MEDIA_TYPES.slice();
 
     let instance,
+        logger,
         interceptor,
         registered;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         registered = false;
         interceptor = _interceptResponse;
     }
@@ -125,7 +126,8 @@ function C2paScanner(config) {
                 _forwardWithoutBlocking(segmentInput);
             }
         } catch (e) {
-            // Scanning must never interfere with playback; swallow and deliver the response untouched.
+            // Scanning must never interfere with playback; swallow and log instead.
+            logger.warn('C2PA scanning failed for this response:', e);
         }
         return Promise.resolve(response);
     }
@@ -188,7 +190,10 @@ function C2paScanner(config) {
      * @returns {Uint8Array}
      */
     function _copySegmentBytes(data) {
-        return new Uint8Array(data).slice();
+        const view = data instanceof Uint8Array ? data : new Uint8Array(data);
+        const copy = new Uint8Array(view.byteLength);
+        copy.set(view);
+        return copy;
     }
 
     function _fileNameFromUrl(url) {

--- a/src/streaming/c2pa/C2paScanner.js
+++ b/src/streaming/c2pa/C2paScanner.js
@@ -1,0 +1,223 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker.js';
+import { HTTPRequest } from '../vo/metrics/HTTPRequest.js';
+import { DEFAULT_C2PA_MEDIA_TYPES } from './C2paOptions.js';
+
+const SEGMENT_KIND_INIT = 'init';
+const SEGMENT_KIND_MEDIA = 'media';
+
+// dash.js 5.x does not reliably populate the representation id and req.index resets
+// per DASH period, so a stable per-representation trackKey and a globally-monotonic
+// segment number are derived from the segment URL filename instead.
+// The trailing segment number and the leading role prefix (init-/chunk-) are both
+// stripped so an init segment and its media segments map to the same trackKey:
+//   "init-stream3.m4s"        -> trackKey "stream3", segmentNumber NaN
+//   "chunk-stream3-00289.m4s" -> trackKey "stream3", segmentNumber 289
+const SEGMENT_EXTENSION_PATTERN = /\.m4s$/;
+const TRAILING_SEGMENT_NUMBER_PATTERN = /-(\d+)\.m4s$/;
+const SEGMENT_ROLE_PREFIX_PATTERN = /^(?:init|chunk)-/;
+
+/**
+ * @typedef {Object} SegmentInput
+ * @property {('init'|'media')} kind Whether the chunk is an initialization or a media segment.
+ * @property {('video'|'audio')} mediaType Media type of the chunk.
+ * @property {Uint8Array} bytes A private copy of the segment bytes, safe to read asynchronously.
+ * @property {number} segmentNumber Globally-monotonic segment number from the URL, NaN when absent (init).
+ * @property {string} trackKey Stable per-representation key derived from the URL filename.
+ */
+
+/**
+ * @module C2paScanner
+ * @description Thin adapter over the dash.js 5.x public response pipeline. It registers a
+ * response interceptor that observes fetched init and media segments, copies their bytes
+ * (mandatory: dash.js transfers the original ArrayBuffer to MSE once the handler resolves),
+ * normalizes each chunk into a {@link SegmentInput} and forwards it to the injected segment
+ * handler. The response is always returned unmodified and the handler is never awaited, so
+ * scanning can never alter or block the fetch to MSE path.
+ * @param {Object} config
+ * @param {Object} config.customParametersModel Exposes addResponseInterceptor / removeResponseInterceptor.
+ * @param {function(SegmentInput):*} [config.segmentHandler] Consumer of the normalized chunk.
+ * @param {Array.<string>} [config.mediaTypes] Media types to scan; defaults to video and audio.
+ */
+function C2paScanner(config) {
+    config = config || {};
+    const customParametersModel = config.customParametersModel;
+    const segmentHandler = config.segmentHandler;
+    const mediaTypes = Array.isArray(config.mediaTypes) ? config.mediaTypes : DEFAULT_C2PA_MEDIA_TYPES.slice();
+
+    let instance,
+        interceptor,
+        registered;
+
+    function setup() {
+        registered = false;
+        interceptor = _interceptResponse;
+    }
+
+    /**
+     * Registers the response interceptor through the dash.js 5.x public API.
+     * Idempotent: a second call while already registered is a no-op.
+     */
+    function registerInterceptor() {
+        if (registered || !customParametersModel) {
+            return;
+        }
+        customParametersModel.addResponseInterceptor(interceptor);
+        registered = true;
+    }
+
+    /**
+     * Removes the response interceptor. Idempotent when not registered.
+     */
+    function deregisterInterceptor() {
+        if (!registered || !customParametersModel) {
+            return;
+        }
+        customParametersModel.removeResponseInterceptor(interceptor);
+        registered = false;
+    }
+
+    /**
+     * @returns {boolean} Whether the interceptor is currently registered.
+     */
+    function isRegistered() {
+        return registered;
+    }
+
+    function _interceptResponse(response) {
+        try {
+            const segmentInput = _toSegmentInput(response);
+            if (segmentInput && segmentHandler) {
+                _forwardWithoutBlocking(segmentInput);
+            }
+        } catch (e) {
+            // Scanning must never interfere with playback; swallow and deliver the response untouched.
+        }
+        return Promise.resolve(response);
+    }
+
+    function _forwardWithoutBlocking(segmentInput) {
+        const result = segmentHandler(segmentInput);
+        if (result && typeof result.then === 'function') {
+            result.catch(function () {
+                // Validation runs off the copied buffer and is never awaited here.
+            });
+        }
+    }
+
+    function _toSegmentInput(response) {
+        const request = response && response.request && response.request.customData && response.request.customData.request;
+        if (!request || !_hasSegmentBytes(response.data)) {
+            return null;
+        }
+
+        const kind = _resolveKind(request.type);
+        if (!kind) {
+            return null;
+        }
+
+        const mediaType = request.mediaType;
+        if (mediaTypes.indexOf(mediaType) === -1) {
+            return null;
+        }
+
+        const url = (response.request && response.request.url) || request.url || '';
+
+        return {
+            kind,
+            mediaType,
+            bytes: _copySegmentBytes(response.data),
+            segmentNumber: _segmentNumberFromUrl(url),
+            trackKey: _trackKeyFromUrl(url)
+        };
+    }
+
+    function _resolveKind(type) {
+        if (type === HTTPRequest.INIT_SEGMENT_TYPE) {
+            return SEGMENT_KIND_INIT;
+        }
+        if (type === HTTPRequest.MEDIA_SEGMENT_TYPE) {
+            return SEGMENT_KIND_MEDIA;
+        }
+        return null;
+    }
+
+    function _hasSegmentBytes(data) {
+        return !!data && typeof data.byteLength === 'number' && data.byteLength > 0;
+    }
+
+    /**
+     * Copies the segment bytes into a private buffer. This copy is mandatory: dash.js
+     * transfers the original ArrayBuffer to MSE after the response handler resolves, which
+     * detaches it, so any asynchronous validation must read from an independent copy.
+     * @param {ArrayBuffer|Uint8Array} data
+     * @returns {Uint8Array}
+     */
+    function _copySegmentBytes(data) {
+        return new Uint8Array(data).slice();
+    }
+
+    function _fileNameFromUrl(url) {
+        const withoutQuery = url.split('?')[0];
+        return withoutQuery.split('/').pop() || '';
+    }
+
+    function _trackKeyFromUrl(url) {
+        return _fileNameFromUrl(url)
+            .replace(TRAILING_SEGMENT_NUMBER_PATTERN, '')
+            .replace(SEGMENT_EXTENSION_PATTERN, '')
+            .replace(SEGMENT_ROLE_PREFIX_PATTERN, '');
+    }
+
+    function _segmentNumberFromUrl(url) {
+        const match = _fileNameFromUrl(url).match(TRAILING_SEGMENT_NUMBER_PATTERN);
+        return match ? parseInt(match[1], 10) : NaN;
+    }
+
+    function reset() {
+        deregisterInterceptor();
+    }
+
+    instance = {
+        registerInterceptor,
+        deregisterInterceptor,
+        isRegistered,
+        reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+C2paScanner.__dashjs_factory_name = 'C2paScanner';
+export default FactoryMaker.getClassFactory(C2paScanner);

--- a/src/streaming/c2pa/C2paScanner.js
+++ b/src/streaming/c2pa/C2paScanner.js
@@ -96,9 +96,10 @@ function C2paScanner(config) {
     }
 
     /**
-     * Removes the response interceptor. Idempotent when not registered.
+     * Teardown: removes the response interceptor through the public API so no scanning
+     * hook is left registered. Idempotent when not registered.
      */
-    function deregisterInterceptor() {
+    function detach() {
         if (!registered || !customParametersModel) {
             return;
         }
@@ -203,15 +204,10 @@ function C2paScanner(config) {
         return match ? parseInt(match[1], 10) : NaN;
     }
 
-    function reset() {
-        deregisterInterceptor();
-    }
-
     instance = {
         registerInterceptor,
-        deregisterInterceptor,
-        isRegistered,
-        reset
+        detach,
+        isRegistered
     };
 
     setup();

--- a/src/streaming/c2pa/C2paSequenceTracker.js
+++ b/src/streaming/c2pa/C2paSequenceTracker.js
@@ -1,0 +1,135 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker.js';
+
+/**
+ * Sequence-check result when a segment number is a fresh baseline or advances cleanly.
+ * @constant {string}
+ */
+export const SEQUENCE_OK = 'ok';
+
+/**
+ * Sequence-check result for a segment number equal to the last one seen.
+ * @constant {string}
+ */
+export const STATUS_REPLAYED = 'replayed';
+
+/**
+ * Sequence-check result for a segment number below the last one seen.
+ * @constant {string}
+ */
+export const STATUS_REORDERED = 'reordered';
+
+/**
+ * A gap larger than this is not enumerated (an unvalidated or forged sequence number
+ * must never drive an unbounded loop); its size is still reported via `missingCount`.
+ * @constant {number}
+ */
+export const MAX_REPORTED_MISSING_SEGMENTS = 100;
+
+/**
+ * @module C2paSequenceTracker
+ * @description Owns the lean per-track signed-sequence-number bookkeeping used to detect
+ * replays, reorders and gaps. Pure input/output: no event emission, no knowledge of
+ * records or tracks beyond the trackKey string.
+ */
+function C2paSequenceTracker() {
+    let instance, sequenceTracker;
+
+    function setup() {
+        sequenceTracker = {};
+    }
+
+    /**
+     * Checks a signed sequence number against the last one seen for this track. No
+     * cross-track correlation. A NaN segmentNumber is not sequence-checked.
+     * @param {string} trackKey
+     * @param {number} segmentNumber
+     * @returns {{status: string, missing: Array.<number>, missingCount: number}}
+     */
+    function check(trackKey, segmentNumber) {
+        if (isNaN(segmentNumber)) {
+            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
+        }
+
+        const lastSequenceNumber = sequenceTracker[trackKey];
+        if (lastSequenceNumber === undefined) {
+            sequenceTracker[trackKey] = segmentNumber;
+            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
+        }
+
+        if (segmentNumber === lastSequenceNumber) {
+            return { status: STATUS_REPLAYED, missing: [], missingCount: 0 };
+        }
+        if (segmentNumber < lastSequenceNumber) {
+            return { status: STATUS_REORDERED, missing: [], missingCount: 0 };
+        }
+
+        const missingCount = segmentNumber - lastSequenceNumber - 1;
+        const missing = [];
+        if (missingCount > 0 && missingCount <= MAX_REPORTED_MISSING_SEGMENTS) {
+            for (let skipped = lastSequenceNumber + 1; skipped < segmentNumber; skipped++) {
+                missing.push(skipped);
+            }
+        }
+        sequenceTracker[trackKey] = segmentNumber;
+        return { status: SEQUENCE_OK, missing, missingCount };
+    }
+
+    /**
+     * Clears one track's last-seen sequence number, so its next segment reads as a fresh
+     * baseline instead of a replay, reorder or gap.
+     * @param {string} trackKey
+     */
+    function resetForTrack(trackKey) {
+        delete sequenceTracker[trackKey];
+    }
+
+    /**
+     * Clears every track's sequence state.
+     */
+    function reset() {
+        sequenceTracker = {};
+    }
+
+    instance = {
+        check,
+        resetForTrack,
+        reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+C2paSequenceTracker.__dashjs_factory_name = 'C2paSequenceTracker';
+export default FactoryMaker.getClassFactory(C2paSequenceTracker);

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -41,11 +41,14 @@ const STATUS_REORDERED = 'reordered';
 const STATUS_MISSING = 'missing';
 const STATUS_UNVERIFIED = 'unverified';
 const STATUS_CONTINUITY_INVALID = 'continuityInvalid';
+const STATUS_CONTINUITY_UNSUPPORTED = 'continuityUnsupported';
 const SEQUENCE_OK = 'ok';
 
+const CONTINUITY_METHOD_INVALID_CODE = 'livevideo.continuityMethod.invalid';
+const CONTINUITY_METHOD_UNSUPPORTED_CODE = 'livevideo.continuityMethod.unsupported';
 const MANIFEST_BOX_CONTINUITY_CODES = [
-    'livevideo.continuityMethod.invalid',
-    'livevideo.continuityMethod.unsupported'
+    CONTINUITY_METHOD_INVALID_CODE,
+    CONTINUITY_METHOD_UNSUPPORTED_CODE
 ];
 
 // dash.js-side diagnostic codes (not CML codes).
@@ -429,7 +432,12 @@ function C2paValidationCoordinator(config) {
         }
         const isContinuityOnly = errorCodes.length > 0 &&
             errorCodes.every((code) => MANIFEST_BOX_CONTINUITY_CODES.indexOf(code) !== -1);
-        return isContinuityOnly ? STATUS_CONTINUITY_INVALID : STATUS_INVALID;
+        if (!isContinuityOnly) {
+            return STATUS_INVALID;
+        }
+        return errorCodes.indexOf(CONTINUITY_METHOD_UNSUPPORTED_CODE) !== -1
+            ? STATUS_CONTINUITY_UNSUPPORTED
+            : STATUS_CONTINUITY_INVALID;
     }
 
     function _toVsiSegmentRecord(input, result, state) {

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -171,18 +171,6 @@ function C2paValidationCoordinator(config) {
         const forced = _forcedMethod() !== null;
         const method = _resolveMediaMethod(input, state);
 
-        const sequence = _checkSequence(input.trackKey, input.segmentNumber);
-        sequence.missing.forEach((missingNumber) => {
-            // AC#8: report every skipped segment number in the track.
-            _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, method, missingNumber));
-        });
-        if (sequence.status !== SEQUENCE_OK) {
-            // AC#7: a replayed or reordered segment is surfaced with that status and not
-            // re-validated — the sequence anomaly is the finding.
-            _emitSegmentValidated(_sequenceRecord(input, sequence.status, method, input.segmentNumber));
-            return;
-        }
-
         if (method !== C2PA_METHOD_VSI && method !== C2PA_METHOD_MANIFEST_BOX) {
             return;
         }
@@ -201,7 +189,27 @@ function C2paValidationCoordinator(config) {
     }
 
     /**
-     * Lean per-track sequence check driven by the URL-derived segment number. Detects
+     * Emits a validated media record, applying the lean per-track sequence check on the
+     * authoritative signed sequence number (AC#7, AC#8): reports gaps as `missing` records
+     * and overrides the status to `replayed` / `reordered` on a duplicate / out-of-order
+     * sequence. Records without a sequence number are emitted unchanged.
+     */
+    function _emitValidatedWithSequence(input, record) {
+        const sequenceNumber = record.segmentNumber;
+        if (typeof sequenceNumber === 'number' && !isNaN(sequenceNumber)) {
+            const sequence = _checkSequence(input.trackKey, sequenceNumber);
+            sequence.missing.forEach((missingNumber) => {
+                _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, record.method, missingNumber));
+            });
+            if (sequence.status !== SEQUENCE_OK) {
+                record.status = sequence.status;
+            }
+        }
+        _emitSegmentValidated(record);
+    }
+
+    /**
+     * Lean per-track sequence check driven by the signed sequence number. Detects
      * replays (same as last), reorders (below last) and gaps (skipped numbers). No
      * cross-track correlation. Segments without a number (NaN) are not sequence-checked.
      * @returns {{status: string, missing: Array.<number>}}
@@ -295,7 +303,7 @@ function C2paValidationCoordinator(config) {
         if (state) {
             state.sequenceState = outcome.nextSequenceState;
         }
-        _emitSegmentValidated(_toVsiSegmentRecord(input, outcome.result, state));
+        _emitValidatedWithSequence(input, _toVsiSegmentRecord(input, outcome.result, state));
     }
 
     async function _validateManifestBoxSegment(input, state, forced) {
@@ -332,7 +340,7 @@ function C2paValidationCoordinator(config) {
             state.lastManifestId = outcome.nextManifestId;
             state.manifestBoxState = outcome.nextState;
         }
-        _emitSegmentValidated(_toManifestBoxSegmentRecord(input, outcome));
+        _emitValidatedWithSequence(input, _toManifestBoxSegmentRecord(input, outcome));
     }
 
     function _forcedMismatchRecord(input, method) {
@@ -354,7 +362,7 @@ function C2paValidationCoordinator(config) {
     function _toManifestBoxSegmentRecord(input, outcome) {
         const result = outcome.result;
         return {
-            segmentNumber: input.segmentNumber,
+            segmentNumber: _sequenceNumberOf(result, input),
             mediaType: input.mediaType,
             method: C2PA_METHOD_MANIFEST_BOX,
             status: result.isValid ? STATUS_VALID : STATUS_INVALID,
@@ -370,7 +378,7 @@ function C2paValidationCoordinator(config) {
 
     function _toVsiSegmentRecord(input, result, state) {
         return {
-            segmentNumber: input.segmentNumber,
+            segmentNumber: _sequenceNumberOf(result, input),
             mediaType: input.mediaType,
             method: C2PA_METHOD_VSI,
             status: result.isValid ? STATUS_VALID : STATUS_INVALID,
@@ -475,6 +483,12 @@ function C2paValidationCoordinator(config) {
     function _issuerOf(validation) {
         const manifest = validation ? validation.manifest : null;
         return manifest && manifest.signatureInfo ? manifest.signatureInfo.issuer : null;
+    }
+
+    // The authoritative sequence number is the one carried in the signed segment; the
+    // URL-derived number is only a fallback (it may be a time value for some packagers).
+    function _sequenceNumberOf(result, input) {
+        return result && typeof result.sequenceNumber === 'number' ? result.sequenceNumber : input.segmentNumber;
     }
 
     /**

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -106,7 +106,9 @@ function C2paValidationCoordinator(config) {
             issuer: _issuerOf(validation),
             hasC2pa: method !== null,
             skip: !_forcedMethod() && method === null,
-            sequenceState: undefined
+            sequenceState: undefined,
+            lastManifestId: validation ? validation.manifestId : null,
+            manifestBoxState: undefined
         };
 
         _emitInitProcessed(input, validation, method);
@@ -120,8 +122,10 @@ function C2paValidationCoordinator(config) {
         }
         if (state && state.method === C2PA_METHOD_VSI) {
             await _validateVsiSegment(input, state);
+        } else if (state && state.method === C2PA_METHOD_MANIFEST_BOX) {
+            await _validateManifestBoxSegment(input, state);
         }
-        // §19.3 ManifestBox and forced-method routing are implemented by later slices.
+        // Forced-method routing is implemented by a later slice.
     }
 
     async function _validateVsiSegment(input, state) {
@@ -145,6 +149,46 @@ function C2paValidationCoordinator(config) {
 
         state.sequenceState = outcome.nextSequenceState;
         _emitSegmentValidated(_toVsiSegmentRecord(input, outcome.result, state));
+    }
+
+    async function _validateManifestBoxSegment(input, state) {
+        const engine = await _getEngine();
+        if (!engine || typeof engine.validateC2paManifestBoxSegment !== 'function') {
+            return;
+        }
+
+        let outcome;
+        try {
+            outcome = await engine.validateC2paManifestBoxSegment(input.bytes, state.lastManifestId, state.manifestBoxState);
+        } catch (e) {
+            // Degradation to `unverified` / C2PA_ERROR is added by the error-handling slice.
+            return;
+        }
+
+        if (!outcome) {
+            return;
+        }
+
+        state.lastManifestId = outcome.nextManifestId;
+        state.manifestBoxState = outcome.nextState;
+        _emitSegmentValidated(_toManifestBoxSegmentRecord(input, outcome));
+    }
+
+    function _toManifestBoxSegmentRecord(input, outcome) {
+        const result = outcome.result;
+        return {
+            segmentNumber: input.segmentNumber,
+            mediaType: input.mediaType,
+            method: C2PA_METHOD_MANIFEST_BOX,
+            status: result.isValid ? STATUS_VALID : STATUS_INVALID,
+            keyId: null,
+            hash: result.bmffHashHex,
+            manifestId: outcome.nextManifestId,
+            issuer: result.issuer,
+            previousManifestId: result.previousManifestId,
+            errorCodes: _mapErrorCodes(result.errorCodes),
+            timestamp: Date.now()
+        };
     }
 
     function _toVsiSegmentRecord(input, result, state) {

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -1,0 +1,206 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../core/FactoryMaker.js';
+import EventBus from '../../core/EventBus.js';
+import MediaPlayerEvents from '../MediaPlayerEvents.js';
+import { C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from './C2paOptions.js';
+
+const SEGMENT_KIND_INIT = 'init';
+
+/**
+ * Guarded dynamic import of the validation engine. Keeps `@svta/cml-c2pa` out of both
+ * default bundles (code-split, loaded only when C2PA is enabled). A missing package
+ * rejects and is caught by the caller, degrading to no validation rather than breaking.
+ * @returns {Promise<Object>}
+ */
+function loadC2paEngine() {
+    return import('@svta/cml-c2pa');
+}
+
+/**
+ * @module C2paValidationCoordinator
+ * @description Owns per-track C2PA state and orchestrates validation. This first slice
+ * handles init segments: it validates the init through the CML engine, extracts VSI
+ * session keys, classifies the track (§19.4 VSI when session keys are present, §19.3
+ * ManifestBox when only a manifest is present, non-C2PA otherwise) and emits
+ * {@link MediaPlayerEvents#event:C2PA_INIT_PROCESSED}. In `auto` mode a track whose init
+ * carries no C2PA information is marked so its media segments are never parsed or
+ * validated (the zero-cost path on plain streams). Media-segment validation is added by
+ * later slices.
+ * @param {Object} config
+ * @param {Object} [config.eventBus] dash.js EventBus; defaults to the per-context singleton.
+ * @param {Object} [config.settings] dash.js Settings, read for `streaming.c2pa.method`.
+ * @param {function(): Promise<Object>} [config.loadEngine] Loads the CML engine; defaults to
+ * the guarded dynamic import. Injectable for testing.
+ */
+function C2paValidationCoordinator(config) {
+    config = config || {};
+    const context = this.context;
+    const eventBus = config.eventBus || EventBus(context).getInstance();
+    const settings = config.settings;
+    const loadEngine = config.loadEngine || loadC2paEngine;
+
+    let instance,
+        trackStates,
+        enginePromise;
+
+    function setup() {
+        trackStates = {};
+        enginePromise = null;
+    }
+
+    /**
+     * Entry point invoked by the scanner for every normalized segment.
+     * @param {import('./C2paScanner.js').SegmentInput} segmentInput
+     * @returns {Promise<void>}
+     */
+    function handleSegment(segmentInput) {
+        if (!segmentInput) {
+            return Promise.resolve();
+        }
+        if (segmentInput.kind === SEGMENT_KIND_INIT) {
+            return _handleInitSegment(segmentInput);
+        }
+        return _handleMediaSegment(segmentInput);
+    }
+
+    async function _handleInitSegment(input) {
+        const engine = await _getEngine();
+        const validation = await _validateInit(engine, input.bytes);
+        const method = _classify(validation);
+
+        trackStates[input.trackKey] = {
+            method,
+            sessionKeys: validation ? validation.sessionKeys : [],
+            manifestId: validation ? validation.manifestId : null,
+            hasC2pa: method !== null,
+            skip: !_forcedMethod() && method === null
+        };
+
+        _emitInitProcessed(input, validation, method);
+    }
+
+    async function _handleMediaSegment(input) {
+        const state = trackStates[input.trackKey];
+        if (state && state.skip) {
+            // AC#16: a non-C2PA track in auto mode is never parsed or validated again.
+            return;
+        }
+        // Media-segment validation (§19.3 / §19.4 / forced) is implemented by later slices.
+    }
+
+    async function _validateInit(engine, bytes) {
+        if (!engine || typeof engine.validateC2paInitSegment !== 'function') {
+            return null;
+        }
+        try {
+            return await engine.validateC2paInitSegment(bytes);
+        } catch (e) {
+            // The init segment carries no C2PA information (or could not be parsed).
+            return null;
+        }
+    }
+
+    function _classify(validation) {
+        if (!validation) {
+            return null;
+        }
+        if (validation.sessionKeys && validation.sessionKeys.length > 0) {
+            return C2PA_METHOD_VSI;
+        }
+        if (validation.manifest) {
+            return C2PA_METHOD_MANIFEST_BOX;
+        }
+        return null;
+    }
+
+    function _forcedMethod() {
+        const method = _methodSetting();
+        return method === C2PA_METHOD_MANIFEST_BOX || method === C2PA_METHOD_VSI ? method : null;
+    }
+
+    function _methodSetting() {
+        if (!settings || typeof settings.get !== 'function') {
+            return C2PA_METHOD_AUTO;
+        }
+        const streaming = settings.get().streaming;
+        const c2pa = streaming && streaming.c2pa;
+        return c2pa && c2pa.method ? c2pa.method : C2PA_METHOD_AUTO;
+    }
+
+    function _emitInitProcessed(input, validation, method) {
+        const manifest = validation ? validation.manifest : null;
+        const payload = {
+            trackKey: input.trackKey,
+            method,
+            manifestId: validation ? validation.manifestId : null,
+            issuer: manifest && manifest.signatureInfo ? manifest.signatureInfo.issuer : null,
+            sessionKeyCount: validation && validation.sessionKeys ? validation.sessionKeys.length : 0,
+            isValid: validation ? validation.isValid : false,
+            errorCodes: _mapErrorCodes(validation ? validation.errorCodes : [])
+        };
+        eventBus.trigger(MediaPlayerEvents.C2PA_INIT_PROCESSED, payload, { mediaType: input.mediaType });
+    }
+
+    /**
+     * Narrows CML's LiveVideoStatusCode / C2paStatusCode enums to a stable string union at
+     * this single mapping point, so dash.js exposes stable codes regardless of CML's enums.
+     * @param {Array} codes
+     * @returns {Array.<string>}
+     */
+    function _mapErrorCodes(codes) {
+        return (codes || []).map((code) => String(code));
+    }
+
+    function _getEngine() {
+        if (!enginePromise) {
+            enginePromise = Promise.resolve().then(() => loadEngine()).catch(() => null);
+        }
+        return enginePromise;
+    }
+
+    function reset() {
+        trackStates = {};
+        enginePromise = null;
+    }
+
+    instance = {
+        handleSegment,
+        reset
+    };
+
+    setup();
+
+    return instance;
+}
+
+C2paValidationCoordinator.__dashjs_factory_name = 'C2paValidationCoordinator';
+export default FactoryMaker.getClassFactory(C2paValidationCoordinator);

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -102,12 +102,14 @@ function C2paValidationCoordinator(config) {
         trackStates,
         sequenceTracker,
         activeTrackKeyByMediaType,
+        initPromises,
         enginePromise;
 
     function setup() {
         trackStates = {};
         sequenceTracker = {};
         activeTrackKeyByMediaType = {};
+        initPromises = {};
         enginePromise = null;
     }
 
@@ -122,9 +124,26 @@ function C2paValidationCoordinator(config) {
         }
         _resetAbandonedTrackOnSwitch(segmentInput);
         if (segmentInput.kind === SEGMENT_KIND_INIT) {
-            return _handleInitSegment(segmentInput);
+            const promise = _handleInitSegment(segmentInput);
+            initPromises[segmentInput.trackKey] = promise;
+            return promise;
         }
-        return _handleMediaSegment(segmentInput);
+        return _handleMediaSegmentAfterInit(segmentInput);
+    }
+
+    /**
+     * The scanner forwards each segment without awaiting the previous one, so a track's
+     * first media segment can arrive and be handled while that track's own init segment is
+     * still being classified (dynamic import + crypto work). Awaiting the init's own promise
+     * here — if one was seen for this track — guarantees `trackStates[trackKey]` is populated
+     * (session keys, method, etc.) before a media segment reads it, closing that race.
+     */
+    async function _handleMediaSegmentAfterInit(input) {
+        const pendingInit = initPromises[input.trackKey];
+        if (pendingInit) {
+            await pendingInit;
+        }
+        return _handleMediaSegment(input);
     }
 
     /**

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -36,6 +36,10 @@ import { C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from './C
 const SEGMENT_KIND_INIT = 'init';
 const STATUS_VALID = 'valid';
 const STATUS_INVALID = 'invalid';
+const STATUS_REPLAYED = 'replayed';
+const STATUS_REORDERED = 'reordered';
+const STATUS_MISSING = 'missing';
+const SEQUENCE_OK = 'ok';
 
 // Diagnostic emitted when a forced method does not match a segment's actual structure
 // (AC#12) — e.g. method '19.4' forced on a §19.3 segment. Not a CML code.
@@ -79,10 +83,12 @@ function C2paValidationCoordinator(config) {
 
     let instance,
         trackStates,
+        sequenceTracker,
         enginePromise;
 
     function setup() {
         trackStates = {};
+        sequenceTracker = {};
         enginePromise = null;
     }
 
@@ -129,11 +135,72 @@ function C2paValidationCoordinator(config) {
         }
         const forced = _forcedMethod() !== null;
         const method = _resolveMediaMethod(input, state);
+
+        const sequence = _checkSequence(input.trackKey, input.segmentNumber);
+        sequence.missing.forEach((missingNumber) => {
+            // AC#8: report every skipped segment number in the track.
+            _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, method, missingNumber));
+        });
+        if (sequence.status !== SEQUENCE_OK) {
+            // AC#7: a replayed or reordered segment is surfaced with that status and not
+            // re-validated — the sequence anomaly is the finding.
+            _emitSegmentValidated(_sequenceRecord(input, sequence.status, method, input.segmentNumber));
+            return;
+        }
+
         if (method === C2PA_METHOD_VSI) {
             await _validateVsiSegment(input, state, forced);
         } else if (method === C2PA_METHOD_MANIFEST_BOX) {
             await _validateManifestBoxSegment(input, state, forced);
         }
+    }
+
+    /**
+     * Lean per-track sequence check driven by the URL-derived segment number. Detects
+     * replays (same as last), reorders (below last) and gaps (skipped numbers). No
+     * cross-track correlation. Segments without a number (NaN) are not sequence-checked.
+     * @returns {{status: string, missing: Array.<number>}}
+     */
+    function _checkSequence(trackKey, segmentNumber) {
+        if (isNaN(segmentNumber)) {
+            return { status: SEQUENCE_OK, missing: [] };
+        }
+
+        const lastSequenceNumber = sequenceTracker[trackKey];
+        if (lastSequenceNumber === undefined) {
+            sequenceTracker[trackKey] = segmentNumber;
+            return { status: SEQUENCE_OK, missing: [] };
+        }
+
+        if (segmentNumber === lastSequenceNumber) {
+            return { status: STATUS_REPLAYED, missing: [] };
+        }
+        if (segmentNumber < lastSequenceNumber) {
+            return { status: STATUS_REORDERED, missing: [] };
+        }
+
+        const missing = [];
+        for (let skipped = lastSequenceNumber + 1; skipped < segmentNumber; skipped++) {
+            missing.push(skipped);
+        }
+        sequenceTracker[trackKey] = segmentNumber;
+        return { status: SEQUENCE_OK, missing };
+    }
+
+    function _sequenceRecord(input, status, method, segmentNumber) {
+        return {
+            segmentNumber,
+            mediaType: input.mediaType,
+            method: method || null,
+            status,
+            keyId: null,
+            hash: null,
+            manifestId: null,
+            issuer: null,
+            previousManifestId: null,
+            errorCodes: [],
+            timestamp: Date.now()
+        };
     }
 
     /**
@@ -349,6 +416,7 @@ function C2paValidationCoordinator(config) {
 
     function reset() {
         trackStates = {};
+        sequenceTracker = {};
         enginePromise = null;
     }
 

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -37,6 +37,10 @@ const SEGMENT_KIND_INIT = 'init';
 const STATUS_VALID = 'valid';
 const STATUS_INVALID = 'invalid';
 
+// Diagnostic emitted when a forced method does not match a segment's actual structure
+// (AC#12) — e.g. method '19.4' forced on a §19.3 segment. Not a CML code.
+const FORCED_METHOD_MISMATCH_CODE = 'c2pa.forcedMethodMismatch';
+
 /**
  * Guarded dynamic import of the validation engine. Keeps `@svta/cml-c2pa` out of both
  * default bundles (code-split, loaded only when C2PA is enabled). A missing package
@@ -62,6 +66,8 @@ function loadC2paEngine() {
  * @param {Object} [config.settings] dash.js Settings, read for `streaming.c2pa.method`.
  * @param {function(): Promise<Object>} [config.loadEngine] Loads the CML engine; defaults to
  * the guarded dynamic import. Injectable for testing.
+ * @param {Object} [config.detector] A {@link module:C2paDetector} used in `auto` mode to
+ * classify each media segment. When the method is forced the detector is skipped.
  */
 function C2paValidationCoordinator(config) {
     config = config || {};
@@ -69,6 +75,7 @@ function C2paValidationCoordinator(config) {
     const eventBus = config.eventBus || EventBus(context).getInstance();
     const settings = config.settings;
     const loadEngine = config.loadEngine || loadC2paEngine;
+    const detector = config.detector;
 
     let instance,
         trackStates,
@@ -120,58 +127,113 @@ function C2paValidationCoordinator(config) {
             // AC#16: a non-C2PA track in auto mode is never parsed or validated again.
             return;
         }
-        if (state && state.method === C2PA_METHOD_VSI) {
-            await _validateVsiSegment(input, state);
-        } else if (state && state.method === C2PA_METHOD_MANIFEST_BOX) {
-            await _validateManifestBoxSegment(input, state);
+        const forced = _forcedMethod() !== null;
+        const method = _resolveMediaMethod(input, state);
+        if (method === C2PA_METHOD_VSI) {
+            await _validateVsiSegment(input, state, forced);
+        } else if (method === C2PA_METHOD_MANIFEST_BOX) {
+            await _validateManifestBoxSegment(input, state, forced);
         }
-        // Forced-method routing is implemented by a later slice.
     }
 
-    async function _validateVsiSegment(input, state) {
+    /**
+     * Resolves which method validates a media segment. A forced method (AC#11) is used
+     * directly and the detector is skipped; in `auto` mode the injected detector classifies
+     * the segment, falling back to the track's init classification when no detector is set.
+     * @returns {?string}
+     */
+    function _resolveMediaMethod(input, state) {
+        const forced = _forcedMethod();
+        if (forced) {
+            return forced;
+        }
+        if (detector && typeof detector.detect === 'function') {
+            return detector.detect(input).method;
+        }
+        return state ? state.method : null;
+    }
+
+    async function _validateVsiSegment(input, state, forced) {
         const engine = await _getEngine();
         if (!engine || typeof engine.validateC2paSegment !== 'function') {
             return;
         }
 
+        const sessionKeys = state ? state.sessionKeys : [];
+        const sequenceState = state ? state.sequenceState : undefined;
+
         let outcome;
         try {
-            outcome = await engine.validateC2paSegment(input.bytes, state.sessionKeys, state.sequenceState);
+            outcome = await engine.validateC2paSegment(input.bytes, sessionKeys, sequenceState);
         } catch (e) {
             // Degradation to `unverified` / C2PA_ERROR is added by the error-handling slice.
             return;
         }
 
         if (!outcome) {
-            // No C2PA emsg box in this segment; forced-method mismatch is handled later.
+            // No C2PA emsg box. Under a forced method this is a mismatch (AC#12); in auto
+            // mode the segment simply carries no VSI provenance.
+            if (forced) {
+                _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_VSI));
+            }
             return;
         }
 
-        state.sequenceState = outcome.nextSequenceState;
+        if (state) {
+            state.sequenceState = outcome.nextSequenceState;
+        }
         _emitSegmentValidated(_toVsiSegmentRecord(input, outcome.result, state));
     }
 
-    async function _validateManifestBoxSegment(input, state) {
+    async function _validateManifestBoxSegment(input, state, forced) {
         const engine = await _getEngine();
         if (!engine || typeof engine.validateC2paManifestBoxSegment !== 'function') {
             return;
         }
 
+        const lastManifestId = state ? state.lastManifestId : null;
+        const manifestBoxState = state ? state.manifestBoxState : undefined;
+
         let outcome;
         try {
-            outcome = await engine.validateC2paManifestBoxSegment(input.bytes, state.lastManifestId, state.manifestBoxState);
+            outcome = await engine.validateC2paManifestBoxSegment(input.bytes, lastManifestId, manifestBoxState);
         } catch (e) {
-            // Degradation to `unverified` / C2PA_ERROR is added by the error-handling slice.
+            // A throw means no C2PA manifest box. Under a forced method this is a mismatch
+            // (AC#12); richer error degradation is added by the error-handling slice.
+            if (forced) {
+                _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_MANIFEST_BOX));
+            }
             return;
         }
 
         if (!outcome) {
+            if (forced) {
+                _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_MANIFEST_BOX));
+            }
             return;
         }
 
-        state.lastManifestId = outcome.nextManifestId;
-        state.manifestBoxState = outcome.nextState;
+        if (state) {
+            state.lastManifestId = outcome.nextManifestId;
+            state.manifestBoxState = outcome.nextState;
+        }
         _emitSegmentValidated(_toManifestBoxSegmentRecord(input, outcome));
+    }
+
+    function _forcedMismatchRecord(input, method) {
+        return {
+            segmentNumber: input.segmentNumber,
+            mediaType: input.mediaType,
+            method,
+            status: STATUS_INVALID,
+            keyId: null,
+            hash: null,
+            manifestId: null,
+            issuer: null,
+            previousManifestId: null,
+            errorCodes: [FORCED_METHOD_MISMATCH_CODE],
+            timestamp: Date.now()
+        };
     }
 
     function _toManifestBoxSegmentRecord(input, outcome) {
@@ -200,7 +262,7 @@ function C2paValidationCoordinator(config) {
             keyId: result.kidHex,
             hash: result.bmffHashHex,
             manifestId: result.manifestId,
-            issuer: state.issuer,
+            issuer: state ? state.issuer : null,
             previousManifestId: null,
             errorCodes: _mapErrorCodes(result.errorCodes),
             timestamp: Date.now()

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -494,15 +494,36 @@ function C2paValidationCoordinator(config) {
         return enginePromise;
     }
 
+    /**
+     * Clears all per-track state. Called on teardown / source change so nothing leaks
+     * across sources.
+     */
     function reset() {
         trackStates = {};
         sequenceTracker = {};
         enginePromise = null;
     }
 
+    /**
+     * Clears the sequence and continuity state of a single track. Called on seek / period
+     * change so the jump does not read as a replay, reorder, gap or continuity break; the
+     * track's classification and session keys are kept.
+     * @param {string} trackKey
+     */
+    function resetSequenceForTrack(trackKey) {
+        delete sequenceTracker[trackKey];
+        const state = trackStates[trackKey];
+        if (state) {
+            state.sequenceState = undefined;
+            state.manifestBoxState = undefined;
+            state.lastManifestId = null;
+        }
+    }
+
     instance = {
         handleSegment,
-        reset
+        reset,
+        resetSequenceForTrack
     };
 
     setup();

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -30,10 +30,11 @@
  */
 import FactoryMaker from '../../core/FactoryMaker.js';
 import EventBus from '../../core/EventBus.js';
+import Debug from '../../core/Debug.js';
 import MediaPlayerEvents from '../MediaPlayerEvents.js';
-import { C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from './C2paOptions.js';
-
-const SEGMENT_KIND_INIT = 'init';
+import {
+    C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI, normalizeC2paOptions, SEGMENT_KIND_INIT
+} from './C2paOptions.js';
 const STATUS_VALID = 'valid';
 const STATUS_INVALID = 'invalid';
 const STATUS_REPLAYED = 'replayed';
@@ -43,6 +44,7 @@ const STATUS_UNVERIFIED = 'unverified';
 const STATUS_CONTINUITY_INVALID = 'continuityInvalid';
 const STATUS_CONTINUITY_UNSUPPORTED = 'continuityUnsupported';
 const SEQUENCE_OK = 'ok';
+const MAX_REPORTED_MISSING_SEGMENTS = 100;
 
 const CONTINUITY_METHOD_INVALID_CODE = 'livevideo.continuityMethod.invalid';
 const CONTINUITY_METHOD_UNSUPPORTED_CODE = 'livevideo.continuityMethod.unsupported';
@@ -52,17 +54,19 @@ const MANIFEST_BOX_CONTINUITY_CODES = [
 ];
 
 // dash.js-side diagnostic codes (not CML codes).
-// Emitted when a forced method does not match a segment's actual structure (AC#12).
+// Emitted when a forced method does not match a segment's actual structure.
 const FORCED_METHOD_MISMATCH_CODE = 'c2pa.forcedMethodMismatch';
-// Emitted when the runtime lacks a secure context / Web Crypto (AC#15).
+// Emitted when the runtime lacks a secure context / Web Crypto.
 const CRYPTO_UNAVAILABLE_CODE = 'c2pa.cryptoUnavailable';
 // Emitted when the validation engine throws unexpectedly.
 const VALIDATION_ERROR_CODE = 'c2pa.validationError';
+// Emitted once per session when the validation engine fails to load.
+const ENGINE_UNAVAILABLE_CODE = 'c2pa.engineUnavailable';
 
 /**
  * Guarded dynamic import of the validation engine. Keeps `@svta/cml-c2pa` out of both
- * default bundles (code-split, loaded only when C2PA is enabled). A missing package
- * rejects and is caught by the caller, degrading to no validation rather than breaking.
+ * default bundles; a rejection is caught by the caller and reported once via
+ * {@link ENGINE_UNAVAILABLE_CODE}.
  * @returns {Promise<Object>}
  */
 function loadC2paEngine() {
@@ -71,7 +75,7 @@ function loadC2paEngine() {
 
 /**
  * Whether Web Crypto is usable. Browsers only expose `crypto.subtle` in secure contexts,
- * so its presence covers both the "no secure context" and "no Web Crypto" cases (AC#15).
+ * so its presence covers both the "no secure context" and "no Web Crypto" cases.
  * @returns {boolean}
  */
 function _defaultCryptoAvailable() {
@@ -108,18 +112,22 @@ function C2paValidationCoordinator(config) {
     const isCryptoAvailable = config.isCryptoAvailable || _defaultCryptoAvailable;
 
     let instance,
+        logger,
         trackStates,
         sequenceTracker,
         activeTrackKeyByMediaType,
         initPromises,
-        enginePromise;
+        enginePromise,
+        engineErrorReported;
 
     function setup() {
+        logger = Debug(context).getInstance().getLogger(instance);
         trackStates = {};
         sequenceTracker = {};
         activeTrackKeyByMediaType = {};
         initPromises = {};
         enginePromise = null;
+        engineErrorReported = false;
     }
 
     /**
@@ -172,7 +180,7 @@ function C2paValidationCoordinator(config) {
 
     async function _handleInitSegment(input) {
         if (!isCryptoAvailable()) {
-            // AC#15: without Web Crypto we cannot validate; keep the track active (skip:false)
+            // Without Web Crypto we cannot validate; keep the track active (skip:false)
             // so its media segments surface as `unverified` rather than being dropped.
             trackStates[input.trackKey] = {
                 method: null,
@@ -190,6 +198,12 @@ function C2paValidationCoordinator(config) {
         }
 
         const engine = await _getEngine();
+        if (!engine && !engineErrorReported) {
+            // Once per session, not once per segment.
+            engineErrorReported = true;
+            _emitError(input, input.segmentNumber, ENGINE_UNAVAILABLE_CODE,
+                'The C2PA validation engine failed to load; validation is disabled for this session.');
+        }
         const validation = await _validateInit(engine, input.bytes);
         const method = _classify(validation);
 
@@ -214,7 +228,7 @@ function C2paValidationCoordinator(config) {
     async function _handleMediaSegment(input) {
         const state = trackStates[input.trackKey];
         if (state && state.skip) {
-            // AC#16: a non-C2PA track in auto mode is never parsed or validated again.
+            // A non-C2PA track in auto mode is never parsed or validated again.
             return;
         }
         const forced = _forcedMethod() !== null;
@@ -225,7 +239,7 @@ function C2paValidationCoordinator(config) {
         }
 
         if (!isCryptoAvailable()) {
-            // AC#15: emit `unverified` rather than calling the engine (which would throw).
+            // Emit `unverified` rather than calling the engine (which would throw).
             _emitUnverified(input, method, CRYPTO_UNAVAILABLE_CODE, 'Web Crypto is unavailable in this context');
             return;
         }
@@ -238,20 +252,22 @@ function C2paValidationCoordinator(config) {
     }
 
     /**
-     * Emits a validated media record, applying the lean per-track sequence check on the
-     * authoritative signed sequence number (AC#7, AC#8): reports gaps as `missing` records
-     * and overrides the status to `replayed` / `reordered` on a duplicate / out-of-order
-     * sequence. Records without a sequence number are emitted unchanged.
+     * Emits a validated media record, sequence-checking the signed number on a `valid`
+     * record only: a forged number on a failed one must never drive the gap loop below.
      */
     function _emitValidatedWithSequence(input, record) {
         const sequenceNumber = record.segmentNumber;
-        if (typeof sequenceNumber === 'number' && !isNaN(sequenceNumber)) {
+        if (record.status === STATUS_VALID && typeof sequenceNumber === 'number' && !isNaN(sequenceNumber)) {
             const sequence = _checkSequence(input.trackKey, sequenceNumber);
-            sequence.missing.forEach((missingNumber) => {
-                _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, record.method, missingNumber));
-            });
+            if (sequence.missingCount > MAX_REPORTED_MISSING_SEGMENTS) {
+                _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, record.method, NaN, sequence.missingCount));
+            } else {
+                sequence.missing.forEach((missingNumber) => {
+                    _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, record.method, missingNumber));
+                });
+            }
             if (sequence.status !== SEQUENCE_OK) {
-                record.status = sequence.status;
+                record = Object.assign({}, record, { status: sequence.status });
             }
         }
         _emitSegmentValidated(record);
@@ -261,35 +277,39 @@ function C2paValidationCoordinator(config) {
      * Lean per-track sequence check driven by the signed sequence number. Detects
      * replays (same as last), reorders (below last) and gaps (skipped numbers). No
      * cross-track correlation. Segments without a number (NaN) are not sequence-checked.
-     * @returns {{status: string, missing: Array.<number>}}
+     * A gap over {@link MAX_REPORTED_MISSING_SEGMENTS} isn't enumerated, only counted.
+     * @returns {{status: string, missing: Array.<number>, missingCount: number}}
      */
     function _checkSequence(trackKey, segmentNumber) {
         if (isNaN(segmentNumber)) {
-            return { status: SEQUENCE_OK, missing: [] };
+            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
         }
 
         const lastSequenceNumber = sequenceTracker[trackKey];
         if (lastSequenceNumber === undefined) {
             sequenceTracker[trackKey] = segmentNumber;
-            return { status: SEQUENCE_OK, missing: [] };
+            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
         }
 
         if (segmentNumber === lastSequenceNumber) {
-            return { status: STATUS_REPLAYED, missing: [] };
+            return { status: STATUS_REPLAYED, missing: [], missingCount: 0 };
         }
         if (segmentNumber < lastSequenceNumber) {
-            return { status: STATUS_REORDERED, missing: [] };
+            return { status: STATUS_REORDERED, missing: [], missingCount: 0 };
         }
 
+        const missingCount = segmentNumber - lastSequenceNumber - 1;
         const missing = [];
-        for (let skipped = lastSequenceNumber + 1; skipped < segmentNumber; skipped++) {
-            missing.push(skipped);
+        if (missingCount > 0 && missingCount <= MAX_REPORTED_MISSING_SEGMENTS) {
+            for (let skipped = lastSequenceNumber + 1; skipped < segmentNumber; skipped++) {
+                missing.push(skipped);
+            }
         }
         sequenceTracker[trackKey] = segmentNumber;
-        return { status: SEQUENCE_OK, missing };
+        return { status: SEQUENCE_OK, missing, missingCount };
     }
 
-    function _sequenceRecord(input, status, method, segmentNumber) {
+    function _sequenceRecord(input, status, method, segmentNumber, missingCount) {
         return {
             segmentNumber,
             mediaType: input.mediaType,
@@ -301,14 +321,15 @@ function C2paValidationCoordinator(config) {
             issuer: null,
             previousManifestId: null,
             errorCodes: [],
+            missingCount: missingCount || null,
             timestamp: Date.now()
         };
     }
 
     /**
-     * Resolves which method validates a media segment. A forced method (AC#11) is used
-     * directly and the detector is skipped; in `auto` mode the injected detector classifies
-     * the segment, falling back to the track's init classification when no detector is set.
+     * Resolves which method validates a media segment. A forced method skips the detector;
+     * in `auto` mode, a track already classified from its init trusts that classification,
+     * and the detector only runs when there's none to trust.
      * @returns {?string}
      */
     function _resolveMediaMethod(input, state) {
@@ -316,10 +337,13 @@ function C2paValidationCoordinator(config) {
         if (forced) {
             return forced;
         }
+        if (state && state.method) {
+            return state.method;
+        }
         if (detector && typeof detector.detect === 'function') {
             return detector.detect(input).method;
         }
-        return state ? state.method : null;
+        return null;
     }
 
     async function _validateVsiSegment(input, state, forced) {
@@ -335,14 +359,14 @@ function C2paValidationCoordinator(config) {
         try {
             outcome = await engine.validateC2paSegment(input.bytes, sessionKeys, sequenceState);
         } catch (e) {
-            // AC#6: never propagate a validation failure to the pipeline; surface it instead.
+            // Never propagate a validation failure to the pipeline; surface it instead.
             _emitUnverified(input, C2PA_METHOD_VSI, VALIDATION_ERROR_CODE, _errorMessage(e));
             return;
         }
 
         if (!outcome) {
-            // No C2PA emsg box. Under a forced method this is a mismatch (AC#12); in auto
-            // mode the segment simply carries no VSI provenance.
+            // No C2PA emsg box. Under a forced method this is a mismatch; in auto mode the
+            // segment simply carries no VSI provenance.
             if (forced) {
                 _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_VSI));
             }
@@ -368,8 +392,8 @@ function C2paValidationCoordinator(config) {
         try {
             outcome = await engine.validateC2paManifestBoxSegment(input.bytes, lastManifestId, manifestBoxState);
         } catch (e) {
-            // Under a forced method a throw means the forced structure is absent (AC#12);
-            // in auto mode it is an unexpected engine failure surfaced as `unverified` (AC#6).
+            // Under a forced method a throw means the forced structure is absent; in auto
+            // mode it is an unexpected engine failure surfaced as `unverified`.
             if (forced) {
                 _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_MANIFEST_BOX));
             } else {
@@ -404,6 +428,7 @@ function C2paValidationCoordinator(config) {
             issuer: null,
             previousManifestId: null,
             errorCodes: [FORCED_METHOD_MISMATCH_CODE],
+            missingCount: null,
             timestamp: Date.now()
         };
     }
@@ -422,6 +447,7 @@ function C2paValidationCoordinator(config) {
             issuer: result.issuer,
             previousManifestId: result.previousManifestId,
             errorCodes,
+            missingCount: null,
             timestamp: Date.now()
         };
     }
@@ -452,6 +478,7 @@ function C2paValidationCoordinator(config) {
             issuer: state ? state.issuer : null,
             previousManifestId: null,
             errorCodes: _mapErrorCodes(result.errorCodes),
+            missingCount: null,
             timestamp: Date.now()
         };
     }
@@ -463,7 +490,8 @@ function C2paValidationCoordinator(config) {
         try {
             return await engine.validateC2paInitSegment(bytes);
         } catch (e) {
-            // The init segment carries no C2PA information (or could not be parsed).
+            // The common case (a plain, never-signed stream); debug level, see README.md.
+            logger.debug('No usable C2PA data in this init segment:', _errorMessage(e));
             return null;
         }
     }
@@ -487,12 +515,11 @@ function C2paValidationCoordinator(config) {
     }
 
     function _methodSetting() {
-        if (!settings || typeof settings.get !== 'function') {
+        if (!settings) {
             return C2PA_METHOD_AUTO;
         }
         const streaming = settings.get().streaming;
-        const c2pa = streaming && streaming.c2pa;
-        return c2pa && c2pa.method ? c2pa.method : C2PA_METHOD_AUTO;
+        return normalizeC2paOptions(streaming && streaming.c2pa).method;
     }
 
     function _emitInitProcessed(input, validation, method, errorCodes) {
@@ -524,6 +551,7 @@ function C2paValidationCoordinator(config) {
             issuer: null,
             previousManifestId: null,
             errorCodes: [errorCode],
+            missingCount: null,
             timestamp: Date.now()
         });
         _emitError(input, input.segmentNumber, errorCode, message);
@@ -567,26 +595,40 @@ function C2paValidationCoordinator(config) {
 
     function _getEngine() {
         if (!enginePromise) {
-            enginePromise = Promise.resolve().then(() => loadEngine()).catch(() => null);
+            enginePromise = Promise.resolve().then(() => loadEngine()).catch((e) => {
+                logger.error('Failed to load the C2PA validation engine (@svta/cml-c2pa):', e);
+                return null;
+            });
         }
         return enginePromise;
     }
 
     /**
-     * Clears all per-track state. Called on teardown / source change so nothing leaks
-     * across sources.
+     * Clears all per-track state. Called on teardown / source change so a new stream
+     * never inherits a previous one's state (they can share a filename-derived trackKey).
      */
     function reset() {
         trackStates = {};
         sequenceTracker = {};
         activeTrackKeyByMediaType = {};
+        initPromises = {};
         enginePromise = null;
+        engineErrorReported = false;
     }
 
     /**
-     * Clears the sequence and continuity state of a single track. Called on seek / period
-     * change so the jump does not read as a replay, reorder, gap or continuity break; the
-     * track's classification and session keys are kept.
+     * Resets every currently active track's sequence state (one per media type). Called
+     * on seek / period change so the jump doesn't read as a replay, reorder or gap.
+     */
+    function resetActiveSequences() {
+        Object.keys(activeTrackKeyByMediaType).forEach((mediaType) => {
+            resetSequenceForTrack(activeTrackKeyByMediaType[mediaType]);
+        });
+    }
+
+    /**
+     * Clears the sequence and continuity state of a single track; the track's
+     * classification and session keys are kept.
      * @param {string} trackKey
      */
     function resetSequenceForTrack(trackKey) {
@@ -602,6 +644,7 @@ function C2paValidationCoordinator(config) {
     instance = {
         handleSegment,
         reset,
+        resetActiveSequences,
         resetSequenceForTrack
     };
 

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -39,11 +39,16 @@ const STATUS_INVALID = 'invalid';
 const STATUS_REPLAYED = 'replayed';
 const STATUS_REORDERED = 'reordered';
 const STATUS_MISSING = 'missing';
+const STATUS_UNVERIFIED = 'unverified';
 const SEQUENCE_OK = 'ok';
 
-// Diagnostic emitted when a forced method does not match a segment's actual structure
-// (AC#12) — e.g. method '19.4' forced on a §19.3 segment. Not a CML code.
+// dash.js-side diagnostic codes (not CML codes).
+// Emitted when a forced method does not match a segment's actual structure (AC#12).
 const FORCED_METHOD_MISMATCH_CODE = 'c2pa.forcedMethodMismatch';
+// Emitted when the runtime lacks a secure context / Web Crypto (AC#15).
+const CRYPTO_UNAVAILABLE_CODE = 'c2pa.cryptoUnavailable';
+// Emitted when the validation engine throws unexpectedly.
+const VALIDATION_ERROR_CODE = 'c2pa.validationError';
 
 /**
  * Guarded dynamic import of the validation engine. Keeps `@svta/cml-c2pa` out of both
@@ -53,6 +58,15 @@ const FORCED_METHOD_MISMATCH_CODE = 'c2pa.forcedMethodMismatch';
  */
 function loadC2paEngine() {
     return import('@svta/cml-c2pa');
+}
+
+/**
+ * Whether Web Crypto is usable. Browsers only expose `crypto.subtle` in secure contexts,
+ * so its presence covers both the "no secure context" and "no Web Crypto" cases (AC#15).
+ * @returns {boolean}
+ */
+function _defaultCryptoAvailable() {
+    return typeof globalThis !== 'undefined' && !!(globalThis.crypto && globalThis.crypto.subtle);
 }
 
 /**
@@ -72,6 +86,8 @@ function loadC2paEngine() {
  * the guarded dynamic import. Injectable for testing.
  * @param {Object} [config.detector] A {@link module:C2paDetector} used in `auto` mode to
  * classify each media segment. When the method is forced the detector is skipped.
+ * @param {function(): boolean} [config.isCryptoAvailable] Reports whether Web Crypto is
+ * usable; defaults to a real secure-context check. Injectable for testing.
  */
 function C2paValidationCoordinator(config) {
     config = config || {};
@@ -80,6 +96,7 @@ function C2paValidationCoordinator(config) {
     const settings = config.settings;
     const loadEngine = config.loadEngine || loadC2paEngine;
     const detector = config.detector;
+    const isCryptoAvailable = config.isCryptoAvailable || _defaultCryptoAvailable;
 
     let instance,
         trackStates,
@@ -108,6 +125,24 @@ function C2paValidationCoordinator(config) {
     }
 
     async function _handleInitSegment(input) {
+        if (!isCryptoAvailable()) {
+            // AC#15: without Web Crypto we cannot validate; keep the track active (skip:false)
+            // so its media segments surface as `unverified` rather than being dropped.
+            trackStates[input.trackKey] = {
+                method: null,
+                sessionKeys: [],
+                manifestId: null,
+                issuer: null,
+                hasC2pa: false,
+                skip: false,
+                sequenceState: undefined,
+                lastManifestId: null,
+                manifestBoxState: undefined
+            };
+            _emitInitProcessed(input, null, null, [CRYPTO_UNAVAILABLE_CODE]);
+            return;
+        }
+
         const engine = await _getEngine();
         const validation = await _validateInit(engine, input.bytes);
         const method = _classify(validation);
@@ -148,9 +183,19 @@ function C2paValidationCoordinator(config) {
             return;
         }
 
+        if (method !== C2PA_METHOD_VSI && method !== C2PA_METHOD_MANIFEST_BOX) {
+            return;
+        }
+
+        if (!isCryptoAvailable()) {
+            // AC#15: emit `unverified` rather than calling the engine (which would throw).
+            _emitUnverified(input, method, CRYPTO_UNAVAILABLE_CODE, 'Web Crypto is unavailable in this context');
+            return;
+        }
+
         if (method === C2PA_METHOD_VSI) {
             await _validateVsiSegment(input, state, forced);
-        } else if (method === C2PA_METHOD_MANIFEST_BOX) {
+        } else {
             await _validateManifestBoxSegment(input, state, forced);
         }
     }
@@ -233,7 +278,8 @@ function C2paValidationCoordinator(config) {
         try {
             outcome = await engine.validateC2paSegment(input.bytes, sessionKeys, sequenceState);
         } catch (e) {
-            // Degradation to `unverified` / C2PA_ERROR is added by the error-handling slice.
+            // AC#6: never propagate a validation failure to the pipeline; surface it instead.
+            _emitUnverified(input, C2PA_METHOD_VSI, VALIDATION_ERROR_CODE, _errorMessage(e));
             return;
         }
 
@@ -265,10 +311,12 @@ function C2paValidationCoordinator(config) {
         try {
             outcome = await engine.validateC2paManifestBoxSegment(input.bytes, lastManifestId, manifestBoxState);
         } catch (e) {
-            // A throw means no C2PA manifest box. Under a forced method this is a mismatch
-            // (AC#12); richer error degradation is added by the error-handling slice.
+            // Under a forced method a throw means the forced structure is absent (AC#12);
+            // in auto mode it is an unexpected engine failure surfaced as `unverified` (AC#6).
             if (forced) {
                 _emitSegmentValidated(_forcedMismatchRecord(input, C2PA_METHOD_MANIFEST_BOX));
+            } else {
+                _emitUnverified(input, C2PA_METHOD_MANIFEST_BOX, VALIDATION_ERROR_CODE, _errorMessage(e));
             }
             return;
         }
@@ -375,7 +423,7 @@ function C2paValidationCoordinator(config) {
         return c2pa && c2pa.method ? c2pa.method : C2PA_METHOD_AUTO;
     }
 
-    function _emitInitProcessed(input, validation, method) {
+    function _emitInitProcessed(input, validation, method, errorCodes) {
         const payload = {
             trackKey: input.trackKey,
             method,
@@ -383,13 +431,45 @@ function C2paValidationCoordinator(config) {
             issuer: _issuerOf(validation),
             sessionKeyCount: validation && validation.sessionKeys ? validation.sessionKeys.length : 0,
             isValid: validation ? validation.isValid : false,
-            errorCodes: _mapErrorCodes(validation ? validation.errorCodes : [])
+            errorCodes: errorCodes || _mapErrorCodes(validation ? validation.errorCodes : [])
         };
         eventBus.trigger(MediaPlayerEvents.C2PA_INIT_PROCESSED, payload, { mediaType: input.mediaType });
     }
 
     function _emitSegmentValidated(record) {
         eventBus.trigger(MediaPlayerEvents.C2PA_SEGMENT_VALIDATED, record, { mediaType: record.mediaType });
+    }
+
+    function _emitUnverified(input, method, errorCode, message) {
+        _emitSegmentValidated({
+            segmentNumber: input.segmentNumber,
+            mediaType: input.mediaType,
+            method: method || null,
+            status: STATUS_UNVERIFIED,
+            keyId: null,
+            hash: null,
+            manifestId: null,
+            issuer: null,
+            previousManifestId: null,
+            errorCodes: [errorCode],
+            timestamp: Date.now()
+        });
+        _emitError(input, input.segmentNumber, errorCode, message);
+    }
+
+    function _emitError(input, segmentNumber, errorCode, message) {
+        eventBus.trigger(MediaPlayerEvents.C2PA_ERROR, {
+            trackKey: input.trackKey,
+            segmentNumber,
+            mediaType: input.mediaType,
+            errorCodes: [errorCode],
+            message,
+            timestamp: Date.now()
+        }, { mediaType: input.mediaType });
+    }
+
+    function _errorMessage(error) {
+        return error && error.message ? error.message : String(error);
     }
 
     function _issuerOf(validation) {

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -34,6 +34,8 @@ import MediaPlayerEvents from '../MediaPlayerEvents.js';
 import { C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from './C2paOptions.js';
 
 const SEGMENT_KIND_INIT = 'init';
+const STATUS_VALID = 'valid';
+const STATUS_INVALID = 'invalid';
 
 /**
  * Guarded dynamic import of the validation engine. Keeps `@svta/cml-c2pa` out of both
@@ -101,8 +103,10 @@ function C2paValidationCoordinator(config) {
             method,
             sessionKeys: validation ? validation.sessionKeys : [],
             manifestId: validation ? validation.manifestId : null,
+            issuer: _issuerOf(validation),
             hasC2pa: method !== null,
-            skip: !_forcedMethod() && method === null
+            skip: !_forcedMethod() && method === null,
+            sequenceState: undefined
         };
 
         _emitInitProcessed(input, validation, method);
@@ -114,7 +118,49 @@ function C2paValidationCoordinator(config) {
             // AC#16: a non-C2PA track in auto mode is never parsed or validated again.
             return;
         }
-        // Media-segment validation (§19.3 / §19.4 / forced) is implemented by later slices.
+        if (state && state.method === C2PA_METHOD_VSI) {
+            await _validateVsiSegment(input, state);
+        }
+        // §19.3 ManifestBox and forced-method routing are implemented by later slices.
+    }
+
+    async function _validateVsiSegment(input, state) {
+        const engine = await _getEngine();
+        if (!engine || typeof engine.validateC2paSegment !== 'function') {
+            return;
+        }
+
+        let outcome;
+        try {
+            outcome = await engine.validateC2paSegment(input.bytes, state.sessionKeys, state.sequenceState);
+        } catch (e) {
+            // Degradation to `unverified` / C2PA_ERROR is added by the error-handling slice.
+            return;
+        }
+
+        if (!outcome) {
+            // No C2PA emsg box in this segment; forced-method mismatch is handled later.
+            return;
+        }
+
+        state.sequenceState = outcome.nextSequenceState;
+        _emitSegmentValidated(_toVsiSegmentRecord(input, outcome.result, state));
+    }
+
+    function _toVsiSegmentRecord(input, result, state) {
+        return {
+            segmentNumber: input.segmentNumber,
+            mediaType: input.mediaType,
+            method: C2PA_METHOD_VSI,
+            status: result.isValid ? STATUS_VALID : STATUS_INVALID,
+            keyId: result.kidHex,
+            hash: result.bmffHashHex,
+            manifestId: result.manifestId,
+            issuer: state.issuer,
+            previousManifestId: null,
+            errorCodes: _mapErrorCodes(result.errorCodes),
+            timestamp: Date.now()
+        };
     }
 
     async function _validateInit(engine, bytes) {
@@ -157,17 +203,25 @@ function C2paValidationCoordinator(config) {
     }
 
     function _emitInitProcessed(input, validation, method) {
-        const manifest = validation ? validation.manifest : null;
         const payload = {
             trackKey: input.trackKey,
             method,
             manifestId: validation ? validation.manifestId : null,
-            issuer: manifest && manifest.signatureInfo ? manifest.signatureInfo.issuer : null,
+            issuer: _issuerOf(validation),
             sessionKeyCount: validation && validation.sessionKeys ? validation.sessionKeys.length : 0,
             isValid: validation ? validation.isValid : false,
             errorCodes: _mapErrorCodes(validation ? validation.errorCodes : [])
         };
         eventBus.trigger(MediaPlayerEvents.C2PA_INIT_PROCESSED, payload, { mediaType: input.mediaType });
+    }
+
+    function _emitSegmentValidated(record) {
+        eventBus.trigger(MediaPlayerEvents.C2PA_SEGMENT_VALIDATED, record, { mediaType: record.mediaType });
+    }
+
+    function _issuerOf(validation) {
+        const manifest = validation ? validation.manifest : null;
+        return manifest && manifest.signatureInfo ? manifest.signatureInfo.issuer : null;
     }
 
     /**

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -40,7 +40,13 @@ const STATUS_REPLAYED = 'replayed';
 const STATUS_REORDERED = 'reordered';
 const STATUS_MISSING = 'missing';
 const STATUS_UNVERIFIED = 'unverified';
+const STATUS_CONTINUITY_INVALID = 'continuityInvalid';
 const SEQUENCE_OK = 'ok';
+
+const MANIFEST_BOX_CONTINUITY_CODES = [
+    'livevideo.continuityMethod.invalid',
+    'livevideo.continuityMethod.unsupported'
+];
 
 // dash.js-side diagnostic codes (not CML codes).
 // Emitted when a forced method does not match a segment's actual structure (AC#12).
@@ -401,19 +407,29 @@ function C2paValidationCoordinator(config) {
 
     function _toManifestBoxSegmentRecord(input, outcome) {
         const result = outcome.result;
+        const errorCodes = _mapErrorCodes(result.errorCodes);
         return {
             segmentNumber: _sequenceNumberOf(result, input),
             mediaType: input.mediaType,
             method: C2PA_METHOD_MANIFEST_BOX,
-            status: result.isValid ? STATUS_VALID : STATUS_INVALID,
+            status: _manifestBoxStatus(result.isValid, errorCodes),
             keyId: null,
             hash: result.bmffHashHex,
             manifestId: outcome.nextManifestId,
             issuer: result.issuer,
             previousManifestId: result.previousManifestId,
-            errorCodes: _mapErrorCodes(result.errorCodes),
+            errorCodes,
             timestamp: Date.now()
         };
+    }
+
+    function _manifestBoxStatus(isValid, errorCodes) {
+        if (isValid) {
+            return STATUS_VALID;
+        }
+        const isContinuityOnly = errorCodes.length > 0 &&
+            errorCodes.every((code) => MANIFEST_BOX_CONTINUITY_CODES.indexOf(code) !== -1);
+        return isContinuityOnly ? STATUS_CONTINUITY_INVALID : STATUS_INVALID;
     }
 
     function _toVsiSegmentRecord(input, result, state) {

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -101,11 +101,13 @@ function C2paValidationCoordinator(config) {
     let instance,
         trackStates,
         sequenceTracker,
+        activeTrackKeyByMediaType,
         enginePromise;
 
     function setup() {
         trackStates = {};
         sequenceTracker = {};
+        activeTrackKeyByMediaType = {};
         enginePromise = null;
     }
 
@@ -118,10 +120,26 @@ function C2paValidationCoordinator(config) {
         if (!segmentInput) {
             return Promise.resolve();
         }
+        _resetAbandonedTrackOnSwitch(segmentInput);
         if (segmentInput.kind === SEGMENT_KIND_INIT) {
             return _handleInitSegment(segmentInput);
         }
         return _handleMediaSegment(segmentInput);
+    }
+
+    /**
+     * ABR can switch the active representation of a media type at any time; each
+     * representation has its own independent sequence/manifest-id chain, so a track that
+     * goes idle while a sibling representation is playing is not a continuity break — it's
+     * simply not being observed. Reset the abandoned track's continuity state on switch so
+     * resuming it later starts a fresh baseline instead of reporting a false gap.
+     */
+    function _resetAbandonedTrackOnSwitch(input) {
+        const previousTrackKey = activeTrackKeyByMediaType[input.mediaType];
+        if (previousTrackKey && previousTrackKey !== input.trackKey) {
+            resetSequenceForTrack(previousTrackKey);
+        }
+        activeTrackKeyByMediaType[input.mediaType] = input.trackKey;
     }
 
     async function _handleInitSegment(input) {
@@ -155,7 +173,10 @@ function C2paValidationCoordinator(config) {
             hasC2pa: method !== null,
             skip: !_forcedMethod() && method === null,
             sequenceState: undefined,
-            lastManifestId: validation ? validation.manifestId : null,
+            // The init segment's own manifest is not part of the media-segment
+            // previousManifestId chain, so the continuity baseline starts unknown; the
+            // first media segment establishes it for the one after it.
+            lastManifestId: null,
             manifestBoxState: undefined
         };
 
@@ -515,6 +536,7 @@ function C2paValidationCoordinator(config) {
     function reset() {
         trackStates = {};
         sequenceTracker = {};
+        activeTrackKeyByMediaType = {};
         enginePromise = null;
     }
 

--- a/src/streaming/c2pa/C2paValidationCoordinator.js
+++ b/src/streaming/c2pa/C2paValidationCoordinator.js
@@ -35,16 +35,13 @@ import MediaPlayerEvents from '../MediaPlayerEvents.js';
 import {
     C2PA_METHOD_AUTO, C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI, normalizeC2paOptions, SEGMENT_KIND_INIT
 } from './C2paOptions.js';
+import C2paSequenceTracker, { MAX_REPORTED_MISSING_SEGMENTS, SEQUENCE_OK } from './C2paSequenceTracker.js';
 const STATUS_VALID = 'valid';
 const STATUS_INVALID = 'invalid';
-const STATUS_REPLAYED = 'replayed';
-const STATUS_REORDERED = 'reordered';
 const STATUS_MISSING = 'missing';
 const STATUS_UNVERIFIED = 'unverified';
 const STATUS_CONTINUITY_INVALID = 'continuityInvalid';
 const STATUS_CONTINUITY_UNSUPPORTED = 'continuityUnsupported';
-const SEQUENCE_OK = 'ok';
-const MAX_REPORTED_MISSING_SEGMENTS = 100;
 
 const CONTINUITY_METHOD_INVALID_CODE = 'livevideo.continuityMethod.invalid';
 const CONTINUITY_METHOD_UNSUPPORTED_CODE = 'livevideo.continuityMethod.unsupported';
@@ -101,6 +98,8 @@ function _defaultCryptoAvailable() {
  * classify each media segment. When the method is forced the detector is skipped.
  * @param {function(): boolean} [config.isCryptoAvailable] Reports whether Web Crypto is
  * usable; defaults to a real secure-context check. Injectable for testing.
+ * @param {function(): number} [config.now] Clock used for `SegmentRecord.timestamp`;
+ * defaults to `Date.now`. Injectable for testing.
  */
 function C2paValidationCoordinator(config) {
     config = config || {};
@@ -110,6 +109,7 @@ function C2paValidationCoordinator(config) {
     const loadEngine = config.loadEngine || loadC2paEngine;
     const detector = config.detector;
     const isCryptoAvailable = config.isCryptoAvailable || _defaultCryptoAvailable;
+    const now = config.now || Date.now;
 
     let instance,
         logger,
@@ -123,7 +123,7 @@ function C2paValidationCoordinator(config) {
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
         trackStates = {};
-        sequenceTracker = {};
+        sequenceTracker = C2paSequenceTracker(context).create();
         activeTrackKeyByMediaType = {};
         initPromises = {};
         enginePromise = null;
@@ -258,7 +258,7 @@ function C2paValidationCoordinator(config) {
     function _emitValidatedWithSequence(input, record) {
         const sequenceNumber = record.segmentNumber;
         if (record.status === STATUS_VALID && typeof sequenceNumber === 'number' && !isNaN(sequenceNumber)) {
-            const sequence = _checkSequence(input.trackKey, sequenceNumber);
+            const sequence = sequenceTracker.check(input.trackKey, sequenceNumber);
             if (sequence.missingCount > MAX_REPORTED_MISSING_SEGMENTS) {
                 _emitSegmentValidated(_sequenceRecord(input, STATUS_MISSING, record.method, NaN, sequence.missingCount));
             } else {
@@ -273,57 +273,35 @@ function C2paValidationCoordinator(config) {
         _emitSegmentValidated(record);
     }
 
-    /**
-     * Lean per-track sequence check driven by the signed sequence number. Detects
-     * replays (same as last), reorders (below last) and gaps (skipped numbers). No
-     * cross-track correlation. Segments without a number (NaN) are not sequence-checked.
-     * A gap over {@link MAX_REPORTED_MISSING_SEGMENTS} isn't enumerated, only counted.
-     * @returns {{status: string, missing: Array.<number>, missingCount: number}}
-     */
-    function _checkSequence(trackKey, segmentNumber) {
-        if (isNaN(segmentNumber)) {
-            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
-        }
-
-        const lastSequenceNumber = sequenceTracker[trackKey];
-        if (lastSequenceNumber === undefined) {
-            sequenceTracker[trackKey] = segmentNumber;
-            return { status: SEQUENCE_OK, missing: [], missingCount: 0 };
-        }
-
-        if (segmentNumber === lastSequenceNumber) {
-            return { status: STATUS_REPLAYED, missing: [], missingCount: 0 };
-        }
-        if (segmentNumber < lastSequenceNumber) {
-            return { status: STATUS_REORDERED, missing: [], missingCount: 0 };
-        }
-
-        const missingCount = segmentNumber - lastSequenceNumber - 1;
-        const missing = [];
-        if (missingCount > 0 && missingCount <= MAX_REPORTED_MISSING_SEGMENTS) {
-            for (let skipped = lastSequenceNumber + 1; skipped < segmentNumber; skipped++) {
-                missing.push(skipped);
-            }
-        }
-        sequenceTracker[trackKey] = segmentNumber;
-        return { status: SEQUENCE_OK, missing, missingCount };
-    }
-
     function _sequenceRecord(input, status, method, segmentNumber, missingCount) {
-        return {
+        return _createSegmentRecord({
             segmentNumber,
             mediaType: input.mediaType,
             method: method || null,
             status,
+            missingCount: missingCount || null
+        });
+    }
+
+    /**
+     * The default {@link module:C2paEvents.SegmentRecord} shape; each builder below only
+     * overrides the fields it actually has.
+     */
+    function _createSegmentRecord(overrides) {
+        return Object.assign({
+            segmentNumber: NaN,
+            mediaType: null,
+            method: null,
+            status: null,
             keyId: null,
             hash: null,
             manifestId: null,
             issuer: null,
             previousManifestId: null,
             errorCodes: [],
-            missingCount: missingCount || null,
-            timestamp: Date.now()
-        };
+            missingCount: null,
+            timestamp: now()
+        }, overrides);
     }
 
     /**
@@ -417,39 +395,29 @@ function C2paValidationCoordinator(config) {
     }
 
     function _forcedMismatchRecord(input, method) {
-        return {
+        return _createSegmentRecord({
             segmentNumber: input.segmentNumber,
             mediaType: input.mediaType,
             method,
             status: STATUS_INVALID,
-            keyId: null,
-            hash: null,
-            manifestId: null,
-            issuer: null,
-            previousManifestId: null,
-            errorCodes: [FORCED_METHOD_MISMATCH_CODE],
-            missingCount: null,
-            timestamp: Date.now()
-        };
+            errorCodes: [FORCED_METHOD_MISMATCH_CODE]
+        });
     }
 
     function _toManifestBoxSegmentRecord(input, outcome) {
         const result = outcome.result;
         const errorCodes = _mapErrorCodes(result.errorCodes);
-        return {
+        return _createSegmentRecord({
             segmentNumber: _sequenceNumberOf(result, input),
             mediaType: input.mediaType,
             method: C2PA_METHOD_MANIFEST_BOX,
             status: _manifestBoxStatus(result.isValid, errorCodes),
-            keyId: null,
             hash: result.bmffHashHex,
             manifestId: outcome.nextManifestId,
             issuer: result.issuer,
             previousManifestId: result.previousManifestId,
-            errorCodes,
-            missingCount: null,
-            timestamp: Date.now()
-        };
+            errorCodes
+        });
     }
 
     function _manifestBoxStatus(isValid, errorCodes) {
@@ -467,7 +435,7 @@ function C2paValidationCoordinator(config) {
     }
 
     function _toVsiSegmentRecord(input, result, state) {
-        return {
+        return _createSegmentRecord({
             segmentNumber: _sequenceNumberOf(result, input),
             mediaType: input.mediaType,
             method: C2PA_METHOD_VSI,
@@ -476,11 +444,8 @@ function C2paValidationCoordinator(config) {
             hash: result.bmffHashHex,
             manifestId: result.manifestId,
             issuer: state ? state.issuer : null,
-            previousManifestId: null,
-            errorCodes: _mapErrorCodes(result.errorCodes),
-            missingCount: null,
-            timestamp: Date.now()
-        };
+            errorCodes: _mapErrorCodes(result.errorCodes)
+        });
     }
 
     async function _validateInit(engine, bytes) {
@@ -540,20 +505,13 @@ function C2paValidationCoordinator(config) {
     }
 
     function _emitUnverified(input, method, errorCode, message) {
-        _emitSegmentValidated({
+        _emitSegmentValidated(_createSegmentRecord({
             segmentNumber: input.segmentNumber,
             mediaType: input.mediaType,
             method: method || null,
             status: STATUS_UNVERIFIED,
-            keyId: null,
-            hash: null,
-            manifestId: null,
-            issuer: null,
-            previousManifestId: null,
-            errorCodes: [errorCode],
-            missingCount: null,
-            timestamp: Date.now()
-        });
+            errorCodes: [errorCode]
+        }));
         _emitError(input, input.segmentNumber, errorCode, message);
     }
 
@@ -609,7 +567,7 @@ function C2paValidationCoordinator(config) {
      */
     function reset() {
         trackStates = {};
-        sequenceTracker = {};
+        sequenceTracker.reset();
         activeTrackKeyByMediaType = {};
         initPromises = {};
         enginePromise = null;
@@ -632,7 +590,7 @@ function C2paValidationCoordinator(config) {
      * @param {string} trackKey
      */
     function resetSequenceForTrack(trackKey) {
-        delete sequenceTracker[trackKey];
+        sequenceTracker.resetForTrack(trackKey);
         const state = trackStates[trackKey];
         if (state) {
             state.sequenceState = undefined;

--- a/src/streaming/c2pa/README.md
+++ b/src/streaming/c2pa/README.md
@@ -60,7 +60,12 @@ player.updateSettings({
 - **`C2PA_SEGMENT_VALIDATED`** — once per media segment (plus synthetic records for any
   gap detected in the signed sequence). Payload: `{ segmentNumber, mediaType, method,
   status, keyId, hash, manifestId, issuer, previousManifestId, errorCodes, timestamp }`.
-  `status` is one of `valid`, `invalid`, `replayed`, `reordered`, `missing`, `unverified`.
+  `status` is one of `valid`, `invalid`, `replayed`, `reordered`, `missing`,
+  `continuityInvalid`, `unverified`. `continuityInvalid` is ManifestBox-only (§19.3): the
+  segment's own content hash matched (it's authentic, not tampered) but its continuity
+  link to the previous segment is broken or uses a `continuityMethod` this build doesn't
+  recognize (see `livevideo.continuityMethod.unsupported`) — distinct from a generic
+  `invalid`, which always includes a content-hash or other structural failure.
 - **`C2PA_ERROR`** — emitted alongside an `unverified` segment record when the engine
   throws unexpectedly or Web Crypto is unavailable. Payload: `{ trackKey, segmentNumber,
   mediaType, errorCodes, message, timestamp }`.

--- a/src/streaming/c2pa/README.md
+++ b/src/streaming/c2pa/README.md
@@ -1,0 +1,95 @@
+# C2PA provenance validation
+
+Native, opt-in per-segment C2PA provenance scanning and validation for live CMAF/DASH
+streams, built directly into dash.js (not an external plugin). Validates C2PA §19.3
+(Manifest Box) and §19.4 (VSI) live signing methods per segment as they're fetched, and
+surfaces the result through the public dash.js event system.
+
+Off by default: while disabled, no init or media segment is parsed, no C2PA event is
+emitted, and the validation engine (`@svta/cml-c2pa`) is never imported.
+
+## Architecture
+
+- **`C2paController`** — owns the scanning lifecycle. Created once during
+  `MediaPlayer.initialize()`. Lazily creates the scanner/coordinator/detector and
+  registers the response interceptor only while `streaming.c2pa.enabled` is true; reacts
+  to `SETTING_UPDATED_C2PA_ENABLED` so the operator can toggle at runtime without
+  reloading the source. See ADR-0002 for the zero-cost-when-disabled design.
+- **`C2paScanner`** — a thin adapter over dash.js's public response interceptor API
+  (`customParametersModel.addResponseInterceptor`). Observes every fetched init/media
+  segment, copies its bytes (mandatory: dash.js transfers the original `ArrayBuffer` to
+  MSE once the response handler resolves, detaching it), normalizes it into a
+  `SegmentInput`, and forwards it to the coordinator without ever blocking or altering
+  the fetch-to-MSE path.
+- **`C2paValidationCoordinator`** — owns per-track state and orchestrates validation.
+  Classifies each track from its init segment (§19.4 when session keys are present,
+  §19.3 when only a manifest is present, non-C2PA otherwise), then validates each media
+  segment through `@svta/cml-c2pa` (dynamically imported, code-split out of both default
+  bundles) and emits a result record per segment.
+- **`C2paDetector`** (`detection/BoxParsingDetector.js`) — in `auto` mode, classifies each
+  *media* segment independently by inspecting its ISO-BMFF boxes, so a track can be
+  correctly identified even if its init segment was missed or ambiguous. This is a
+  swappable strategy: once DASH-IF/MPEG define how to signal C2PA in the MPD itself, an
+  `MpdSignalingDetector` can implement the same `C2paDetector` contract and replace
+  box-parsing without touching the validation path (see `detection/C2paDetector.js`).
+
+## Settings
+
+```js
+player.updateSettings({
+    streaming: {
+        c2pa: {
+            enabled: true,       // off by default
+            method: 'auto',      // 'auto' | '19.3' | '19.4'
+            mediaTypes: ['video', 'audio']  // optional, defaults to video+audio
+        }
+    }
+});
+```
+
+- `method: 'auto'` uses the detector per segment. A forced method (`'19.3'` or `'19.4'`)
+  skips detection entirely; a segment that doesn't match the forced structure is reported
+  `invalid` with a `c2pa.forcedMethodMismatch` code rather than silently ignored.
+- `enabled` and `method` both take effect at runtime via `updateSettings` — no need to
+  reattach the source.
+
+## Events
+
+- **`C2PA_INIT_PROCESSED`** — once per track, after its init segment is classified.
+  Payload: `{ trackKey, method, manifestId, issuer, sessionKeyCount, isValid, errorCodes }`.
+- **`C2PA_SEGMENT_VALIDATED`** — once per media segment (plus synthetic records for any
+  gap detected in the signed sequence). Payload: `{ segmentNumber, mediaType, method,
+  status, keyId, hash, manifestId, issuer, previousManifestId, errorCodes, timestamp }`.
+  `status` is one of `valid`, `invalid`, `replayed`, `reordered`, `missing`, `unverified`.
+- **`C2PA_ERROR`** — emitted alongside an `unverified` segment record when the engine
+  throws unexpectedly or Web Crypto is unavailable. Payload: `{ trackKey, segmentNumber,
+  mediaType, errorCodes, message, timestamp }`.
+
+See `samples/c2pa/index.html` for a working example that renders a per-segment ✅/❌ grid.
+
+## Continuity semantics
+
+Each representation (not each media type) has its own independent signed chain
+(`previousManifestId` for §19.3, a monotonic sequence number for §19.4), tracked under a
+stable per-representation `trackKey` derived from the segment URL. Two things follow
+from that:
+
+- **Joining a live stream mid-broadcast**: a track's first observed segment has no known
+  predecessor, so its continuity baseline starts unknown (`null`) rather than being
+  seeded from the init segment's own manifest — the chain only self-anchors from that
+  first segment onward.
+- **ABR switches**: when the active representation of a media type changes, the
+  abandoned representation's continuity state is reset. Resuming it later starts a fresh
+  baseline instead of reporting a false gap for segments that were never fetched because
+  a sibling representation was playing instead.
+
+## Gotchas
+
+- **Browser only**: `@svta/cml-c2pa` needs a real Web Crypto implementation and correctly
+  validates certificate/signature data only in a browser context; it should always be
+  tested in an actual browser, not assumed correct from a Node script.
+- **A track's init is async**: classifying it (dynamic import + crypto work) takes real
+  time, and the scanner never blocks later segments waiting for it. The coordinator
+  awaits a track's own init promise before validating that track's first media segment,
+  so this doesn't race — but any change to `handleSegment`'s dispatch order should keep
+  that invariant.

--- a/src/streaming/c2pa/README.md
+++ b/src/streaming/c2pa/README.md
@@ -14,7 +14,7 @@ emitted, and the validation engine (`@svta/cml-c2pa`) is never imported.
   `MediaPlayer.initialize()`. Lazily creates the scanner/coordinator/detector and
   registers the response interceptor only while `streaming.c2pa.enabled` is true; reacts
   to `SETTING_UPDATED_C2PA_ENABLED` so the operator can toggle at runtime without
-  reloading the source. See ADR-0002 for the zero-cost-when-disabled design.
+  reloading the source.
 - **`C2paScanner`** — a thin adapter over dash.js's public response interceptor API
   (`customParametersModel.addResponseInterceptor`). Observes every fetched init/media
   segment, copies its bytes (mandatory: dash.js transfers the original `ArrayBuffer` to
@@ -59,7 +59,11 @@ player.updateSettings({
   Payload: `{ trackKey, method, manifestId, issuer, sessionKeyCount, isValid, errorCodes }`.
 - **`C2PA_SEGMENT_VALIDATED`** — once per media segment (plus synthetic records for any
   gap detected in the signed sequence). Payload: `{ segmentNumber, mediaType, method,
-  status, keyId, hash, manifestId, issuer, previousManifestId, errorCodes, timestamp }`.
+  status, keyId, hash, manifestId, issuer, previousManifestId, errorCodes, missingCount,
+  timestamp }`. The sequence number only drives the gap check on a `valid` record, so a
+  segment that failed validation can never claim a forged number and trigger it. A gap
+  larger than 100 is not enumerated segment by segment; instead a single `missing` record
+  is emitted with `missingCount` set to the gap size and `segmentNumber: NaN`.
   `status` is one of `valid`, `invalid`, `replayed`, `reordered`, `missing`,
   `continuityInvalid`, `continuityUnsupported`, `unverified`. Both are ManifestBox-only
   (§19.3): in each case the segment's own content hash matched (it's authentic, not
@@ -101,3 +105,10 @@ from that:
   awaits a track's own init promise before validating that track's first media segment,
   so this doesn't race — but any change to `handleSegment`'s dispatch order should keep
   that invariant.
+- **A stripped or corrupted C2PA box reads as "never signed"**: `@svta/cml-c2pa` throws
+  for both a plain init segment with no C2PA data and one whose C2PA box is present but
+  malformed, with no stable, documented way to tell them apart (only the exception's free
+  text message differs, which is not a contract we build behavior on). An attacker who
+  strips or corrupts the init segment's C2PA box therefore downgrades that track to
+  "non-C2PA" rather than surfacing as tampered. This is a known limitation of the current
+  threat model, not something dash.js can currently close on its own.

--- a/src/streaming/c2pa/README.md
+++ b/src/streaming/c2pa/README.md
@@ -61,11 +61,14 @@ player.updateSettings({
   gap detected in the signed sequence). Payload: `{ segmentNumber, mediaType, method,
   status, keyId, hash, manifestId, issuer, previousManifestId, errorCodes, timestamp }`.
   `status` is one of `valid`, `invalid`, `replayed`, `reordered`, `missing`,
-  `continuityInvalid`, `unverified`. `continuityInvalid` is ManifestBox-only (§19.3): the
-  segment's own content hash matched (it's authentic, not tampered) but its continuity
-  link to the previous segment is broken or uses a `continuityMethod` this build doesn't
-  recognize (see `livevideo.continuityMethod.unsupported`) — distinct from a generic
-  `invalid`, which always includes a content-hash or other structural failure.
+  `continuityInvalid`, `continuityUnsupported`, `unverified`. Both are ManifestBox-only
+  (§19.3): in each case the segment's own content hash matched (it's authentic, not
+  tampered), but its continuity link to the previous segment could not be confirmed,
+  distinct from a generic `invalid`, which always includes a content-hash or other
+  structural failure. `continuityInvalid` means the link itself is broken
+  (`livevideo.continuityMethod.invalid`); `continuityUnsupported` means the segment uses a
+  `continuityMethod` this build doesn't recognize (`livevideo.continuityMethod.unsupported`),
+  so continuity simply couldn't be evaluated either way.
 - **`C2PA_ERROR`** — emitted alongside an `unverified` segment record when the engine
   throws unexpectedly or Web Crypto is unavailable. Payload: `{ trackKey, segmentNumber,
   mediaType, errorCodes, message, timestamp }`.

--- a/src/streaming/c2pa/detection/BoxParsingDetector.js
+++ b/src/streaming/c2pa/detection/BoxParsingDetector.js
@@ -1,0 +1,135 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+import FactoryMaker from '../../../core/FactoryMaker.js';
+import { C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from '../C2paOptions.js';
+import { NON_C2PA_DETECTION_RESULT } from './C2paDetector.js';
+
+// §19.4 VSI: the COSE_Sign1 travels in an emsg box carrying this scheme URI.
+const VSI_EMSG_SCHEME_URI = 'urn:c2pa:verifiable-segment-info';
+
+// §19.3 ManifestBox: the C2PA manifest is stored in a uuid box. Signers use one of two
+// UUIDs, so both are recognized (matching the CML validation engine): the C2PA manifest
+// store UUID and the ISO 19566-5 JUMBF UUID used by c2pa-rs.
+const C2PA_MANIFEST_STORE_UUID = [
+    0xd8, 0xfe, 0xc3, 0xd6, 0x1a, 0x96, 0x4f, 0x32,
+    0xa0, 0xf6, 0xf3, 0xec, 0xf9, 0x6c, 0x10, 0xea
+];
+const JUMBF_UUID = [
+    0xd8, 0xfe, 0xc3, 0xd6, 0x1b, 0x0e, 0x48, 0x3c,
+    0x92, 0x97, 0x58, 0x28, 0x87, 0x7e, 0xc4, 0x81
+];
+
+/**
+ * @module BoxParsingDetector
+ * @implements module:C2paDetector
+ * @description The box-parsing {@link module:C2paDetector} strategy. It reuses dash.js's own
+ * ISO-BMFF parser (`BoxParser` over codem-isoboxer) to classify a segment: an emsg box with
+ * the VSI scheme URI marks §19.4, a C2PA uuid box marks §19.3, and neither marks non-C2PA.
+ * No new parser or dependency is introduced. This strategy can be swapped for an
+ * `MpdSignalingDetector` once C2PA is signalled in the MPD, without touching the validation
+ * path (see {@link module:C2paDetector}).
+ * @param {Object} config
+ * @param {Object} config.boxParser The dash.js BoxParser singleton (parse(buffer) -> IsoFile).
+ */
+function BoxParsingDetector(config) {
+    config = config || {};
+    const boxParser = config.boxParser;
+
+    let instance;
+
+    /**
+     * @param {import('../C2paScanner.js').SegmentInput} segmentInput
+     * @returns {import('./C2paDetector.js').C2paDetectionResult}
+     */
+    function detect(segmentInput) {
+        if (!segmentInput || !segmentInput.bytes || !boxParser) {
+            return NON_C2PA_DETECTION_RESULT;
+        }
+
+        const isoFile = _parse(segmentInput.bytes);
+        if (!isoFile) {
+            return NON_C2PA_DETECTION_RESULT;
+        }
+
+        if (_hasVsiEmsg(isoFile)) {
+            return { hasC2pa: true, method: C2PA_METHOD_VSI };
+        }
+        if (_hasC2paManifestBox(isoFile)) {
+            return { hasC2pa: true, method: C2PA_METHOD_MANIFEST_BOX };
+        }
+        return NON_C2PA_DETECTION_RESULT;
+    }
+
+    function _parse(bytes) {
+        try {
+            return boxParser.parse(_toArrayBuffer(bytes));
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function _toArrayBuffer(bytes) {
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    }
+
+    function _hasVsiEmsg(isoFile) {
+        return isoFile.getBoxes('emsg').some((box) => box.scheme_id_uri === VSI_EMSG_SCHEME_URI);
+    }
+
+    function _hasC2paManifestBox(isoFile) {
+        return isoFile.getBoxes('uuid').some((box) => _isC2paUuid(box.usertype));
+    }
+
+    function _isC2paUuid(usertype) {
+        return _matchesUuid(usertype, C2PA_MANIFEST_STORE_UUID) || _matchesUuid(usertype, JUMBF_UUID);
+    }
+
+    function _matchesUuid(usertype, expected) {
+        if (!usertype || usertype.length !== expected.length) {
+            return false;
+        }
+        for (let i = 0; i < expected.length; i++) {
+            if (usertype[i] !== expected[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    instance = {
+        detect
+    };
+
+    return instance;
+}
+
+BoxParsingDetector.__dashjs_factory_name = 'BoxParsingDetector';
+export default FactoryMaker.getClassFactory(BoxParsingDetector);

--- a/src/streaming/c2pa/detection/BoxParsingDetector.js
+++ b/src/streaming/c2pa/detection/BoxParsingDetector.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../../../core/FactoryMaker.js';
+import Debug from '../../../core/Debug.js';
 import { C2PA_METHOD_MANIFEST_BOX, C2PA_METHOD_VSI } from '../C2paOptions.js';
 import { NON_C2PA_DETECTION_RESULT } from './C2paDetector.js';
 
@@ -61,9 +62,10 @@ const JUMBF_UUID = [
  */
 function BoxParsingDetector(config) {
     config = config || {};
+    const context = this.context;
     const boxParser = config.boxParser;
 
-    let instance;
+    let instance, logger;
 
     /**
      * @param {import('../C2paScanner.js').SegmentInput} segmentInput
@@ -92,12 +94,16 @@ function BoxParsingDetector(config) {
         try {
             return boxParser.parse(_toArrayBuffer(bytes));
         } catch (e) {
+            logger.warn('Failed to parse a media segment while detecting its C2PA method:', e);
             return null;
         }
     }
 
+    // The scanner's copy already starts at byte 0, so this is usually a no-op copy.
     function _toArrayBuffer(bytes) {
-        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+            ? bytes.buffer
+            : bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
     }
 
     function _hasVsiEmsg(isoFile) {
@@ -127,6 +133,8 @@ function BoxParsingDetector(config) {
     instance = {
         detect
     };
+
+    logger = Debug(context).getInstance().getLogger(instance);
 
     return instance;
 }

--- a/src/streaming/c2pa/detection/C2paDetector.js
+++ b/src/streaming/c2pa/detection/C2paDetector.js
@@ -1,0 +1,66 @@
+/**
+ * The copyright in this software is being made available under the BSD License,
+ * included below. This software may be subject to other third party and contributor
+ * rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Dash Industry Forum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation and/or
+ *  other materials provided with the distribution.
+ *  * Neither the name of Dash Industry Forum nor the names of its
+ *  contributors may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @module C2paDetector
+ * @description Strategy contract that answers "does this segment carry C2PA provenance,
+ * and by which signing method?". It decouples detection from validation so the detection
+ * mechanism can evolve independently.
+ *
+ * The only implementation today is {@link module:BoxParsingDetector}, which inspects the
+ * ISO-BMFF boxes of the segment. Once DASH-IF/MPEG define how to signal C2PA in the MPD,
+ * an `MpdSignalingDetector` can implement this same contract and replace the box-parsing
+ * strategy without touching the validation path — the coordinator depends on this contract,
+ * not on any concrete detector.
+ *
+ * A detector is invoked only when the operator leaves `streaming.c2pa.method` as `'auto'`;
+ * a forced method (`'19.3'`/`'19.4'`) bypasses detection entirely.
+ */
+
+/**
+ * The outcome of inspecting a segment for C2PA provenance.
+ * @typedef {Object} C2paDetectionResult
+ * @property {boolean} hasC2pa Whether any C2PA provenance was found in the segment.
+ * @property {?('19.3'|'19.4')} method The detected signing method, or null when none was found.
+ */
+
+/**
+ * The detection strategy contract.
+ * @typedef {Object} C2paDetector
+ * @property {function(import('../C2paScanner.js').SegmentInput): C2paDetectionResult} detect
+ * Classifies a normalized segment as §19.3 ManifestBox, §19.4 VSI or non-C2PA.
+ */
+
+/**
+ * The result returned when a segment carries no C2PA provenance.
+ * @type {C2paDetectionResult}
+ */
+export const NON_C2PA_DETECTION_RESULT = Object.freeze({ hasC2pa: false, method: null });

--- a/src/streaming/vo/IsoBox.js
+++ b/src/streaming/vo/IsoBox.js
@@ -122,6 +122,11 @@ class IsoBox {
                 this.media_time = boxData.media_time;
                 this.flags = boxData.flags;
                 break;
+            case 'uuid':
+                // codem-isoboxer parses the 16-byte usertype for uuid boxes; expose it
+                // so callers (e.g. C2PA detection) can identify the box by its UUID.
+                this.usertype = boxData.usertype;
+                break;
         }
     }
 

--- a/test/unit/test/streaming/streaming.c2pa.C2paController.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paController.js
@@ -2,6 +2,7 @@ import C2paController from '../../../../src/streaming/c2pa/C2paController.js';
 import Settings from '../../../../src/core/Settings.js';
 import EventBus from '../../../../src/core/EventBus.js';
 import FactoryMaker from '../../../../src/core/FactoryMaker.js';
+import MediaPlayerEvents from '../../../../src/streaming/MediaPlayerEvents.js';
 import {expect} from 'chai';
 
 function createCustomParametersModelMock() {
@@ -99,5 +100,44 @@ describe('C2paController', function () {
         enableC2pa();
 
         expect(customParametersModel.interceptors.length).to.equal(0);
+    });
+
+    it('should clear source state on resetForNewSource without detaching the interceptor', () => {
+        enableC2pa();
+        controller.initialize();
+        expect(customParametersModel.interceptors.length).to.equal(1);
+
+        controller.resetForNewSource();
+
+        expect(customParametersModel.interceptors.length).to.equal(1);
+    });
+
+    it('should allow resetForNewSource before C2PA was ever enabled', () => {
+        controller.initialize();
+
+        expect(() => controller.resetForNewSource()).to.not.throw();
+    });
+
+    it('should not throw on a seek or period switch whether or not C2PA is enabled', () => {
+        controller.initialize();
+        eventBus.trigger(MediaPlayerEvents.PLAYBACK_SEEKED);
+        eventBus.trigger(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED);
+
+        enableC2pa();
+        eventBus.trigger(MediaPlayerEvents.PLAYBACK_SEEKED);
+        eventBus.trigger(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED);
+
+        expect(customParametersModel.interceptors.length).to.equal(1);
+    });
+
+    it('should stop reacting to seek/period events after reset', () => {
+        enableC2pa();
+        controller.initialize();
+        controller.reset();
+
+        expect(() => {
+            eventBus.trigger(MediaPlayerEvents.PLAYBACK_SEEKED);
+            eventBus.trigger(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED);
+        }).to.not.throw();
     });
 });

--- a/test/unit/test/streaming/streaming.c2pa.C2paController.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paController.js
@@ -1,0 +1,103 @@
+import C2paController from '../../../../src/streaming/c2pa/C2paController.js';
+import Settings from '../../../../src/core/Settings.js';
+import EventBus from '../../../../src/core/EventBus.js';
+import FactoryMaker from '../../../../src/core/FactoryMaker.js';
+import {expect} from 'chai';
+
+function createCustomParametersModelMock() {
+    const interceptors = [];
+    return {
+        interceptors,
+        addResponseInterceptor(interceptor) {
+            interceptors.push(interceptor);
+        },
+        removeResponseInterceptor(interceptor) {
+            const index = interceptors.indexOf(interceptor);
+            if (index !== -1) {
+                interceptors.splice(index, 1);
+            }
+        }
+    };
+}
+
+describe('C2paController', function () {
+
+    let context;
+    let settings;
+    let eventBus;
+    let customParametersModel;
+    let controller;
+
+    beforeEach(() => {
+        context = {};
+        settings = Settings(context).getInstance();
+        eventBus = EventBus(context).getInstance();
+        customParametersModel = createCustomParametersModelMock();
+        controller = C2paController(context).getInstance();
+        controller.setConfig({settings, eventBus, customParametersModel});
+    });
+
+    afterEach(() => {
+        controller.reset();
+        FactoryMaker.deleteSingletonInstances(context);
+    });
+
+    function enableC2pa() {
+        settings.update({streaming: {c2pa: {enabled: true}}});
+    }
+
+    function disableC2pa() {
+        settings.update({streaming: {c2pa: {enabled: false}}});
+    }
+
+    it('should not register any interceptor while disabled (the default)', () => {
+        controller.initialize();
+
+        expect(customParametersModel.interceptors.length).to.equal(0);
+    });
+
+    it('should register the interceptor when initialized already enabled', () => {
+        enableC2pa();
+        controller.initialize();
+
+        expect(customParametersModel.interceptors.length).to.equal(1);
+    });
+
+    it('should register and detach the interceptor when the flag is toggled at runtime', () => {
+        controller.initialize();
+        expect(customParametersModel.interceptors.length).to.equal(0);
+
+        enableC2pa();
+        expect(customParametersModel.interceptors.length).to.equal(1);
+
+        disableC2pa();
+        expect(customParametersModel.interceptors.length).to.equal(0);
+    });
+
+    it('should not register twice when enabled is set repeatedly', () => {
+        controller.initialize();
+        enableC2pa();
+        enableC2pa();
+
+        expect(customParametersModel.interceptors.length).to.equal(1);
+    });
+
+    it('should leave no interceptor registered after reset', () => {
+        enableC2pa();
+        controller.initialize();
+        expect(customParametersModel.interceptors.length).to.equal(1);
+
+        controller.reset();
+
+        expect(customParametersModel.interceptors.length).to.equal(0);
+    });
+
+    it('should stop reacting to the flag after reset', () => {
+        controller.initialize();
+        controller.reset();
+
+        enableC2pa();
+
+        expect(customParametersModel.interceptors.length).to.equal(0);
+    });
+});

--- a/test/unit/test/streaming/streaming.c2pa.C2paOptions.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paOptions.js
@@ -1,0 +1,98 @@
+import {
+    C2PA_METHOD_AUTO,
+    C2PA_METHOD_MANIFEST_BOX,
+    C2PA_METHOD_VSI,
+    C2PA_METHODS,
+    DEFAULT_C2PA_MEDIA_TYPES,
+    isValidC2paMethod,
+    getDefaultC2paOptions,
+    normalizeC2paOptions
+} from '../../../../src/streaming/c2pa/C2paOptions.js';
+import {expect} from 'chai';
+
+describe('C2paOptions', function () {
+
+    describe('constants', function () {
+        it('should expose the C2PA method identifiers', () => {
+            expect(C2PA_METHOD_AUTO).to.equal('auto');
+            expect(C2PA_METHOD_MANIFEST_BOX).to.equal('19.3');
+            expect(C2PA_METHOD_VSI).to.equal('19.4');
+        });
+
+        it('should list every accepted method', () => {
+            expect(C2PA_METHODS).to.deep.equal(['auto', '19.3', '19.4']);
+        });
+
+        it('should default media types to video and audio', () => {
+            expect(DEFAULT_C2PA_MEDIA_TYPES).to.deep.equal(['video', 'audio']);
+        });
+    });
+
+    describe('getDefaultC2paOptions', function () {
+        it('should default to scanning disabled with auto detection', () => {
+            const defaults = getDefaultC2paOptions();
+
+            expect(defaults.enabled).to.equal(false);
+            expect(defaults.method).to.equal('auto');
+            expect(defaults.mediaTypes).to.deep.equal(['video', 'audio']);
+        });
+
+        it('should return a fresh mediaTypes array on each call', () => {
+            const first = getDefaultC2paOptions();
+            const second = getDefaultC2paOptions();
+
+            expect(first.mediaTypes).to.not.equal(second.mediaTypes);
+            expect(first.mediaTypes).to.not.equal(DEFAULT_C2PA_MEDIA_TYPES);
+        });
+    });
+
+    describe('isValidC2paMethod', function () {
+        it('should accept the three known methods', () => {
+            expect(isValidC2paMethod('auto')).to.equal(true);
+            expect(isValidC2paMethod('19.3')).to.equal(true);
+            expect(isValidC2paMethod('19.4')).to.equal(true);
+        });
+
+        it('should reject unknown or malformed values', () => {
+            expect(isValidC2paMethod('20.0')).to.equal(false);
+            expect(isValidC2paMethod('')).to.equal(false);
+            expect(isValidC2paMethod(undefined)).to.equal(false);
+            expect(isValidC2paMethod(null)).to.equal(false);
+        });
+    });
+
+    describe('normalizeC2paOptions', function () {
+        it('should return the defaults when no options are provided', () => {
+            expect(normalizeC2paOptions()).to.deep.equal(getDefaultC2paOptions());
+            expect(normalizeC2paOptions(null)).to.deep.equal(getDefaultC2paOptions());
+        });
+
+        it('should preserve a valid forced method', () => {
+            const normalized = normalizeC2paOptions({enabled: true, method: '19.4'});
+
+            expect(normalized.enabled).to.equal(true);
+            expect(normalized.method).to.equal('19.4');
+        });
+
+        it('should fall back to auto for an unrecognized method', () => {
+            const normalized = normalizeC2paOptions({method: 'invalid'});
+
+            expect(normalized.method).to.equal('auto');
+        });
+
+        it('should ignore a non-boolean enabled flag', () => {
+            const normalized = normalizeC2paOptions({enabled: 'yes'});
+
+            expect(normalized.enabled).to.equal(false);
+        });
+
+        it('should copy a provided mediaTypes array and fall back when it is not an array', () => {
+            const provided = ['video'];
+            const normalized = normalizeC2paOptions({mediaTypes: provided});
+
+            expect(normalized.mediaTypes).to.deep.equal(['video']);
+            expect(normalized.mediaTypes).to.not.equal(provided);
+            expect(normalizeC2paOptions({mediaTypes: 'video'}).mediaTypes).to.deep.equal(['video', 'audio']);
+        });
+    });
+});

--- a/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
@@ -159,6 +159,26 @@ describe('C2paScanner', function () {
             expect(handledSegments[0].trackKey).to.equal('stream3');
         });
 
+        it('should derive a matching trackKey for Unified Streaming .dash naming', async () => {
+            await intercept(createResponse({
+                type: HTTPRequest.INIT_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://live.example/wdr.ism/dash/wdr-video=4045695.dash',
+                data: bufferFrom([1])
+            }));
+            await intercept(createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://live.example/wdr.ism/dash/wdr-video=4045695-31200.dash',
+                data: bufferFrom([2])
+            }));
+
+            expect(handledSegments[0].trackKey).to.equal('wdr-video=4045695');
+            expect(handledSegments[0].segmentNumber).to.be.NaN;
+            expect(handledSegments[1].trackKey).to.equal('wdr-video=4045695');
+            expect(handledSegments[1].segmentNumber).to.equal(31200);
+        });
+
         it('should hand the segment a private copy of the bytes', async () => {
             const values = [5, 6, 7];
             const response = createResponse({

--- a/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
@@ -1,4 +1,5 @@
 import C2paScanner from '../../../../src/streaming/c2pa/C2paScanner.js';
+import C2paValidationCoordinator from '../../../../src/streaming/c2pa/C2paValidationCoordinator.js';
 import {HTTPRequest} from '../../../../src/streaming/vo/metrics/HTTPRequest.js';
 import {expect} from 'chai';
 
@@ -226,6 +227,43 @@ describe('C2paScanner', function () {
             const returned = await intercept(response);
 
             expect(returned).to.equal(response);
+        });
+    });
+
+    describe('non-interference when validation degrades', function () {
+
+        it('should pass the response through untouched while C2PA degrades to unverified without Web Crypto', async () => {
+            const events = [];
+            const coordinator = C2paValidationCoordinator(context).create({
+                eventBus: {trigger: (type, payload) => events.push({type, payload})},
+                settings: {get: () => ({streaming: {c2pa: {method: '19.4'}}})},
+                isCryptoAvailable: () => false,
+                loadEngine: () => Promise.resolve({
+                    validateC2paSegment: async () => {
+                        throw new Error('engine must not be called without Web Crypto');
+                    }
+                })
+            });
+            scanner = C2paScanner(context).create({
+                customParametersModel,
+                segmentHandler: coordinator.handleSegment
+            });
+            const values = [9, 8, 7, 6];
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00289.m4s',
+                data: bufferFrom(values)
+            });
+
+            scanner.registerInterceptor();
+            const returned = await customParametersModel.interceptors[0](response);
+            await Promise.resolve();
+
+            expect(returned).to.equal(response);
+            expect(Array.from(new Uint8Array(returned.data))).to.deep.equal(values);
+            const record = events.find((event) => event.type === 'c2paSegmentValidated');
+            expect(record.payload.status).to.equal('unverified');
         });
     });
 });

--- a/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
@@ -63,17 +63,16 @@ describe('C2paScanner', function () {
             expect(scanner.isRegistered()).to.equal(true);
         });
 
-        it('should deregister the interceptor', () => {
+        it('should detach the interceptor, leaving none registered', () => {
             scanner.registerInterceptor();
-            scanner.deregisterInterceptor();
+            scanner.detach();
 
             expect(customParametersModel.interceptors.length).to.equal(0);
             expect(scanner.isRegistered()).to.equal(false);
         });
 
-        it('should remove the interceptor on reset', () => {
-            scanner.registerInterceptor();
-            scanner.reset();
+        it('should be idempotent when detaching without a prior registration', () => {
+            scanner.detach();
 
             expect(customParametersModel.interceptors.length).to.equal(0);
             expect(scanner.isRegistered()).to.equal(false);

--- a/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paScanner.js
@@ -1,0 +1,231 @@
+import C2paScanner from '../../../../src/streaming/c2pa/C2paScanner.js';
+import {HTTPRequest} from '../../../../src/streaming/vo/metrics/HTTPRequest.js';
+import {expect} from 'chai';
+
+const context = {};
+
+function createCustomParametersModelMock() {
+    const interceptors = [];
+    return {
+        interceptors,
+        addResponseInterceptor(interceptor) {
+            interceptors.push(interceptor);
+        },
+        removeResponseInterceptor(interceptor) {
+            const index = interceptors.indexOf(interceptor);
+            if (index !== -1) {
+                interceptors.splice(index, 1);
+            }
+        }
+    };
+}
+
+function createResponse({type, mediaType, url, data}) {
+    return {
+        request: {
+            url,
+            customData: {
+                request: {type, mediaType, url}
+            }
+        },
+        data
+    };
+}
+
+function bufferFrom(values) {
+    return new Uint8Array(values).buffer;
+}
+
+describe('C2paScanner', function () {
+
+    let customParametersModel;
+    let handledSegments;
+    let scanner;
+
+    beforeEach(() => {
+        customParametersModel = createCustomParametersModelMock();
+        handledSegments = [];
+        scanner = C2paScanner(context).create({
+            customParametersModel,
+            segmentHandler: (segmentInput) => {
+                handledSegments.push(segmentInput);
+            }
+        });
+    });
+
+    describe('interceptor registration', function () {
+        it('should register through the public API exactly once', () => {
+            scanner.registerInterceptor();
+            scanner.registerInterceptor();
+
+            expect(customParametersModel.interceptors.length).to.equal(1);
+            expect(scanner.isRegistered()).to.equal(true);
+        });
+
+        it('should deregister the interceptor', () => {
+            scanner.registerInterceptor();
+            scanner.deregisterInterceptor();
+
+            expect(customParametersModel.interceptors.length).to.equal(0);
+            expect(scanner.isRegistered()).to.equal(false);
+        });
+
+        it('should remove the interceptor on reset', () => {
+            scanner.registerInterceptor();
+            scanner.reset();
+
+            expect(customParametersModel.interceptors.length).to.equal(0);
+            expect(scanner.isRegistered()).to.equal(false);
+        });
+    });
+
+    describe('response interception', function () {
+
+        function intercept(response) {
+            scanner.registerInterceptor();
+            return customParametersModel.interceptors[0](response);
+        }
+
+        it('should return the same response with byte-identical data', async () => {
+            const values = [0, 1, 2, 3, 250, 255];
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00289.m4s',
+                data: bufferFrom(values)
+            });
+
+            const returned = await intercept(response);
+
+            expect(returned).to.equal(response);
+            expect(returned.data).to.equal(response.data);
+            expect(Array.from(new Uint8Array(returned.data))).to.deep.equal(values);
+        });
+
+        it('should normalize a media chunk into a SegmentInput', async () => {
+            const values = [10, 20, 30];
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00289.m4s',
+                data: bufferFrom(values)
+            });
+
+            await intercept(response);
+
+            expect(handledSegments.length).to.equal(1);
+            const segmentInput = handledSegments[0];
+            expect(segmentInput.kind).to.equal('media');
+            expect(segmentInput.mediaType).to.equal('video');
+            expect(segmentInput.trackKey).to.equal('stream3');
+            expect(segmentInput.segmentNumber).to.equal(289);
+            expect(segmentInput.bytes).to.be.instanceOf(Uint8Array);
+            expect(Array.from(segmentInput.bytes)).to.deep.equal(values);
+        });
+
+        it('should normalize an init chunk into a SegmentInput without a segment number', async () => {
+            const response = createResponse({
+                type: HTTPRequest.INIT_SEGMENT_TYPE,
+                mediaType: 'audio',
+                url: 'https://cdn.example/live/init-stream3.m4s',
+                data: bufferFrom([1, 2])
+            });
+
+            await intercept(response);
+
+            expect(handledSegments.length).to.equal(1);
+            const segmentInput = handledSegments[0];
+            expect(segmentInput.kind).to.equal('init');
+            expect(segmentInput.mediaType).to.equal('audio');
+            expect(segmentInput.trackKey).to.equal('stream3');
+            expect(segmentInput.segmentNumber).to.be.NaN;
+        });
+
+        it('should derive the same trackKey for an init and its media segments', async () => {
+            await intercept(createResponse({
+                type: HTTPRequest.INIT_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/init-stream3.m4s',
+                data: bufferFrom([1])
+            }));
+            await intercept(createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00289.m4s',
+                data: bufferFrom([2])
+            }));
+
+            expect(handledSegments[0].trackKey).to.equal(handledSegments[1].trackKey);
+            expect(handledSegments[0].trackKey).to.equal('stream3');
+        });
+
+        it('should hand the segment a private copy of the bytes', async () => {
+            const values = [5, 6, 7];
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00042.m4s',
+                data: bufferFrom(values)
+            });
+
+            await intercept(response);
+
+            const segmentInput = handledSegments[0];
+            expect(segmentInput.bytes.buffer).to.not.equal(response.data);
+
+            segmentInput.bytes[0] = 99;
+            expect(Array.from(new Uint8Array(response.data))).to.deep.equal(values);
+        });
+
+        it('should ignore non-segment responses and pass them through', async () => {
+            const response = createResponse({
+                type: HTTPRequest.MPD_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/manifest.mpd',
+                data: bufferFrom([1, 2, 3])
+            });
+
+            const returned = await intercept(response);
+
+            expect(returned).to.equal(response);
+            expect(handledSegments.length).to.equal(0);
+        });
+
+        it('should ignore media types outside the configured set', async () => {
+            scanner = C2paScanner(context).create({
+                customParametersModel,
+                segmentHandler: (segmentInput) => handledSegments.push(segmentInput),
+                mediaTypes: ['video']
+            });
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'audio',
+                url: 'https://cdn.example/live/chunk-stream4-00001.m4s',
+                data: bufferFrom([1])
+            });
+
+            await intercept(response);
+
+            expect(handledSegments.length).to.equal(0);
+        });
+
+        it('should never propagate a handler failure to the pipeline', async () => {
+            scanner = C2paScanner(context).create({
+                customParametersModel,
+                segmentHandler: () => {
+                    throw new Error('handler blew up');
+                }
+            });
+            const response = createResponse({
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                url: 'https://cdn.example/live/chunk-stream3-00007.m4s',
+                data: bufferFrom([1, 2])
+            });
+
+            const returned = await intercept(response);
+
+            expect(returned).to.equal(response);
+        });
+    });
+});

--- a/test/unit/test/streaming/streaming.c2pa.C2paSequenceTracker.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paSequenceTracker.js
@@ -1,0 +1,79 @@
+import C2paSequenceTracker, { MAX_REPORTED_MISSING_SEGMENTS } from '../../../../src/streaming/c2pa/C2paSequenceTracker.js';
+import {expect} from 'chai';
+
+const context = {};
+
+describe('C2paSequenceTracker', function () {
+
+    let tracker;
+
+    beforeEach(() => {
+        tracker = C2paSequenceTracker(context).create();
+    });
+
+    it('should treat the first observed sequence number as a fresh baseline', () => {
+        const result = tracker.check('stream3', 10);
+
+        expect(result).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+    });
+
+    it('should detect a replay', () => {
+        tracker.check('stream3', 10);
+
+        expect(tracker.check('stream3', 10)).to.deep.equal({status: 'replayed', missing: [], missingCount: 0});
+    });
+
+    it('should detect a reorder', () => {
+        tracker.check('stream3', 10);
+
+        expect(tracker.check('stream3', 9)).to.deep.equal({status: 'reordered', missing: [], missingCount: 0});
+    });
+
+    it('should enumerate a small gap', () => {
+        tracker.check('stream3', 10);
+
+        expect(tracker.check('stream3', 13)).to.deep.equal({status: 'ok', missing: [11, 12], missingCount: 2});
+    });
+
+    it('should not enumerate a gap larger than the reported limit, but still report its size', () => {
+        tracker.check('stream3', 10);
+
+        const result = tracker.check('stream3', 10 + MAX_REPORTED_MISSING_SEGMENTS + 2);
+
+        expect(result.status).to.equal('ok');
+        expect(result.missing).to.deep.equal([]);
+        expect(result.missingCount).to.equal(MAX_REPORTED_MISSING_SEGMENTS + 1);
+    });
+
+    it('should keep state independent per track', () => {
+        tracker.check('stream3', 10);
+        tracker.check('stream4', 500);
+
+        expect(tracker.check('stream3', 10)).to.deep.equal({status: 'replayed', missing: [], missingCount: 0});
+        expect(tracker.check('stream4', 500)).to.deep.equal({status: 'replayed', missing: [], missingCount: 0});
+    });
+
+    it('should not sequence-check a NaN segment number', () => {
+        expect(tracker.check('stream3', NaN)).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+        // A real number afterwards still reads as a fresh baseline, since NaN was never recorded.
+        expect(tracker.check('stream3', 10)).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+    });
+
+    it('should read as a fresh baseline after resetForTrack', () => {
+        tracker.check('stream3', 10);
+
+        tracker.resetForTrack('stream3');
+
+        expect(tracker.check('stream3', 10)).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+    });
+
+    it('should clear every track after reset', () => {
+        tracker.check('stream3', 10);
+        tracker.check('stream4', 500);
+
+        tracker.reset();
+
+        expect(tracker.check('stream3', 10)).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+        expect(tracker.check('stream4', 500)).to.deep.equal({status: 'ok', missing: [], missingCount: 0});
+    });
+});

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -79,7 +79,7 @@ function vsiSegmentOutcome({isValid, errorCodes}) {
     };
 }
 
-function createCoordinator({engine, method = 'auto'}) {
+function createCoordinator({engine, method = 'auto', detector}) {
     const events = [];
     const eventBus = {
         trigger: (type, payload, filters) => events.push({type, payload, filters})
@@ -90,9 +90,21 @@ function createCoordinator({engine, method = 'auto'}) {
     const coordinator = C2paValidationCoordinator(context).create({
         eventBus,
         settings,
+        detector,
         loadEngine: () => Promise.resolve(engine)
     });
     return {coordinator, events};
+}
+
+function countingDetector(method) {
+    const calls = {count: 0};
+    const detector = {
+        detect: () => {
+            calls.count++;
+            return {hasC2pa: method !== null, method};
+        }
+    };
+    return {detector, calls};
 }
 
 function initInput(trackKey, mediaType) {
@@ -321,6 +333,73 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(mediaInput('stream3', 290));
 
             expect(seenLastManifestIds).to.deep.equal(['urn:c2pa:manifest-0', 'urn:c2pa:manifest-1']);
+        });
+    });
+
+    describe('forced-method routing', function () {
+
+        it('should emit a mismatch diagnostic when forcing §19.4 on a §19.3 segment', async () => {
+            const {engine, calls} = createEngine({
+                initValidation: manifestBoxInitValidation(),
+                segmentOutcome: null
+            });
+            const {detector, calls: detectorCalls} = countingDetector('19.3');
+            const {coordinator, events} = createCoordinator({engine, method: '19.4', detector});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(detectorCalls.count).to.equal(0);
+            expect(calls.vsi).to.equal(1);
+            expect(events[1].payload.status).to.equal('invalid');
+            expect(events[1].payload.method).to.equal('19.4');
+            expect(events[1].payload.errorCodes).to.deep.equal(['c2pa.forcedMethodMismatch']);
+        });
+
+        it('should emit a mismatch diagnostic when forcing §19.3 on a §19.4 segment', async () => {
+            const {engine} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            engine.validateC2paManifestBoxSegment = async () => {
+                throw new Error('No C2PA UUID box found in the provided bytes');
+            };
+            const {detector, calls: detectorCalls} = countingDetector('19.4');
+            const {coordinator, events} = createCoordinator({engine, method: '19.3', detector});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(detectorCalls.count).to.equal(0);
+            expect(events[1].payload.status).to.equal('invalid');
+            expect(events[1].payload.method).to.equal('19.3');
+            expect(events[1].payload.errorCodes).to.deep.equal(['c2pa.forcedMethodMismatch']);
+        });
+
+        it('should validate against the forced method even without prior init state', async () => {
+            const {engine} = createEngine({
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            const {coordinator, events} = createCoordinator({engine, method: '19.4'});
+
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(events.length).to.equal(1);
+            expect(events[0].payload.status).to.equal('valid');
+            expect(events[0].payload.method).to.equal('19.4');
+        });
+
+        it('should use the detector to classify media segments in auto mode', async () => {
+            const {engine} = createEngine({
+                initValidation: vsiInitValidation([{kid: 'key-1'}]),
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            const {detector, calls: detectorCalls} = countingDetector('19.4');
+            const {coordinator, events} = createCoordinator({engine, method: 'auto', detector});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(detectorCalls.count).to.equal(1);
+            expect(events[1].payload.status).to.equal('valid');
+            expect(events[1].payload.method).to.equal('19.4');
         });
     });
 });

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -329,7 +329,7 @@ describe('C2paValidationCoordinator', function () {
             expect(events[1].payload.errorCodes).to.deep.equal(['livevideo.continuityMethod.invalid']);
         });
 
-        it('should thread lastManifestId from the init anchor through the chain', async () => {
+        it('should thread lastManifestId across the chain starting from an unknown baseline', async () => {
             const seenLastManifestIds = [];
             const {engine} = createEngine({initValidation: manifestBoxInitValidation()});
             engine.validateC2paManifestBoxSegment = async (bytes, lastManifestId) => {
@@ -347,7 +347,10 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(mediaInput('stream3', 289));
             await coordinator.handleSegment(mediaInput('stream3', 290));
 
-            expect(seenLastManifestIds).to.deep.equal(['urn:c2pa:manifest-0', 'urn:c2pa:manifest-1']);
+            // The init segment's own manifest is not part of the media-segment chain, so the
+            // first media segment a track sees has no baseline to check against (null); the
+            // chain only self-anchors from that segment's own manifest id onward.
+            expect(seenLastManifestIds).to.deep.equal([null, 'urn:c2pa:manifest-1']);
         });
     });
 
@@ -407,6 +410,25 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(mediaInput('stream4', 1000));
 
             expect(segmentStatuses(events)).to.deep.equal([[10, 'valid'], [10, 'valid']]);
+        });
+
+        it('should not report a gap when a track resumes after an ABR switch to a sibling representation', async () => {
+            const {engine} = vsiEngineReturningSequences([10, 999, 50]);
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(initInput('stream4'));
+            await coordinator.handleSegment(mediaInput('stream4', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
+
+            // stream3 resumes at 50 (far past its last-seen 10) after the ABR switch to
+            // stream4 and back; it must read as a fresh baseline, not a 39-segment gap.
+            expect(segmentStatuses(events)).to.deep.equal([
+                [10, 'valid'],
+                [999, 'valid'],
+                [50, 'valid']
+            ]);
         });
     });
 

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -79,7 +79,7 @@ function vsiSegmentOutcome({isValid, errorCodes}) {
     };
 }
 
-function createCoordinator({engine, method = 'auto', detector}) {
+function createCoordinator({engine, method = 'auto', detector, isCryptoAvailable}) {
     const events = [];
     const eventBus = {
         trigger: (type, payload, filters) => events.push({type, payload, filters})
@@ -91,9 +91,14 @@ function createCoordinator({engine, method = 'auto', detector}) {
         eventBus,
         settings,
         detector,
+        isCryptoAvailable: isCryptoAvailable || (() => true),
         loadEngine: () => Promise.resolve(engine)
     });
     return {coordinator, events};
+}
+
+function eventsOfType(events, type) {
+    return events.filter((event) => event.type === type).map((event) => event.payload);
 }
 
 function countingDetector(method) {
@@ -397,6 +402,62 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(mediaInput('stream4', 5));
 
             expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [5, 'valid']]);
+        });
+    });
+
+    describe('error handling and unverified degradation', function () {
+
+        it('should emit unverified without calling the engine when Web Crypto is unavailable', async () => {
+            const {engine, calls} = createEngine({
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            const {detector} = countingDetector('19.4');
+            const {coordinator, events} = createCoordinator({
+                engine,
+                detector,
+                isCryptoAvailable: () => false
+            });
+
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            const records = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED);
+            expect(records.length).to.equal(1);
+            expect(records[0].status).to.equal('unverified');
+            expect(records[0].errorCodes).to.deep.equal(['c2pa.cryptoUnavailable']);
+            expect(calls.vsi).to.equal(0);
+
+            const errors = eventsOfType(events, MediaPlayerEvents.C2PA_ERROR);
+            expect(errors.length).to.equal(1);
+            expect(errors[0].errorCodes).to.deep.equal(['c2pa.cryptoUnavailable']);
+        });
+
+        it('should report crypto unavailability on the init event without calling the engine', async () => {
+            const {engine, calls} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            const {coordinator, events} = createCoordinator({engine, isCryptoAvailable: () => false});
+
+            await coordinator.handleSegment(initInput('stream3'));
+
+            expect(calls.init).to.equal(0);
+            const initEvents = eventsOfType(events, MediaPlayerEvents.C2PA_INIT_PROCESSED);
+            expect(initEvents[0].method).to.be.null;
+            expect(initEvents[0].errorCodes).to.deep.equal(['c2pa.cryptoUnavailable']);
+        });
+
+        it('should surface an engine throw as unverified and a C2PA_ERROR, never throwing', async () => {
+            const {engine} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            engine.validateC2paSegment = async () => {
+                throw new Error('engine exploded');
+            };
+            const {coordinator, events} = createCoordinator({engine, isCryptoAvailable: () => true});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            const records = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED);
+            expect(records[0].status).to.equal('unverified');
+            expect(records[0].errorCodes).to.deep.equal(['c2pa.validationError']);
+            const errors = eventsOfType(events, MediaPlayerEvents.C2PA_ERROR);
+            expect(errors[0].message).to.equal('engine exploded');
         });
     });
 

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -4,7 +4,7 @@ import {expect} from 'chai';
 
 const context = {};
 
-function createEngine({initValidation, throwOnInit, segmentOutcome}) {
+function createEngine({initValidation, throwOnInit, segmentOutcome, manifestBoxOutcome}) {
     const calls = {init: 0, vsi: 0, manifestBox: 0};
     const engine = {
         validateC2paInitSegment: async () => {
@@ -20,10 +20,38 @@ function createEngine({initValidation, throwOnInit, segmentOutcome}) {
         },
         validateC2paManifestBoxSegment: async () => {
             calls.manifestBox++;
-            return {};
+            return manifestBoxOutcome !== undefined ? manifestBoxOutcome : null;
         }
     };
     return {engine, calls};
+}
+
+function manifestBoxInitValidation() {
+    return {
+        manifest: {signatureInfo: {issuer: 'CN=Test Issuer'}, assertions: []},
+        manifestId: 'urn:c2pa:manifest-0',
+        sessionKeys: [],
+        isValid: true,
+        errorCodes: []
+    };
+}
+
+function manifestBoxOutcomeFor({isValid, errorCodes, previousManifestId, nextManifestId}) {
+    return {
+        result: {
+            manifest: {signatureInfo: {issuer: 'CN=Test Issuer'}, assertions: []},
+            issuer: 'CN=Test Issuer',
+            sequenceNumber: 289,
+            previousManifestId,
+            streamId: 'stream3',
+            continuityMethod: 'manifest-id',
+            bmffHashHex: 'beef',
+            isValid,
+            errorCodes
+        },
+        nextManifestId,
+        nextState: {lastStreamId: 'stream3', lastSequenceNumber: 289}
+    };
 }
 
 function vsiInitValidation(sessionKeys) {
@@ -223,6 +251,76 @@ describe('C2paValidationCoordinator', function () {
 
             await coordinator.handleSegment(mediaInput('stream3', 290));
             expect(seenSequenceState).to.deep.equal({lastSequenceNumber: 289, seenSequences: new Set([289])});
+        });
+    });
+
+    describe('ManifestBox (§19.3) media-segment validation', function () {
+
+        it('should emit a valid SegmentRecord for a valid ManifestBox segment', async () => {
+            const {engine, calls} = createEngine({
+                initValidation: manifestBoxInitValidation(),
+                manifestBoxOutcome: manifestBoxOutcomeFor({
+                    isValid: true,
+                    errorCodes: [],
+                    previousManifestId: 'urn:c2pa:manifest-0',
+                    nextManifestId: 'urn:c2pa:manifest-1'
+                })
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(calls.manifestBox).to.equal(1);
+            const record = events[1];
+            expect(record.type).to.equal(MediaPlayerEvents.C2PA_SEGMENT_VALIDATED);
+            expect(record.payload.status).to.equal('valid');
+            expect(record.payload.method).to.equal('19.3');
+            expect(record.payload.manifestId).to.equal('urn:c2pa:manifest-1');
+            expect(record.payload.previousManifestId).to.equal('urn:c2pa:manifest-0');
+            expect(record.payload.issuer).to.equal('CN=Test Issuer');
+            expect(record.payload.hash).to.equal('beef');
+            expect(record.payload.keyId).to.be.null;
+        });
+
+        it('should emit invalid with the CML error code for a broken manifest-id chain', async () => {
+            const {engine} = createEngine({
+                initValidation: manifestBoxInitValidation(),
+                manifestBoxOutcome: manifestBoxOutcomeFor({
+                    isValid: false,
+                    errorCodes: ['livevideo.continuityMethod.invalid'],
+                    previousManifestId: 'urn:c2pa:unexpected',
+                    nextManifestId: 'urn:c2pa:manifest-1'
+                })
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(events[1].payload.status).to.equal('invalid');
+            expect(events[1].payload.errorCodes).to.deep.equal(['livevideo.continuityMethod.invalid']);
+        });
+
+        it('should thread lastManifestId from the init anchor through the chain', async () => {
+            const seenLastManifestIds = [];
+            const {engine} = createEngine({initValidation: manifestBoxInitValidation()});
+            engine.validateC2paManifestBoxSegment = async (bytes, lastManifestId) => {
+                seenLastManifestIds.push(lastManifestId);
+                return manifestBoxOutcomeFor({
+                    isValid: true,
+                    errorCodes: [],
+                    previousManifestId: lastManifestId,
+                    nextManifestId: 'urn:c2pa:manifest-' + seenLastManifestIds.length
+                });
+            };
+            const {coordinator} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 290));
+
+            expect(seenLastManifestIds).to.deep.equal(['urn:c2pa:manifest-0', 'urn:c2pa:manifest-1']);
         });
     });
 });

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -337,7 +337,7 @@ describe('C2paValidationCoordinator', function () {
             expect(record.payload.keyId).to.be.null;
         });
 
-        it('should emit invalid with the CML error code for a broken manifest-id chain', async () => {
+        it('should report a distinct continuityInvalid status for a broken manifest-id chain', async () => {
             const {engine} = createEngine({
                 initValidation: manifestBoxInitValidation(),
                 manifestBoxOutcome: manifestBoxOutcomeFor({
@@ -352,8 +352,49 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(initInput('stream3'));
             await coordinator.handleSegment(mediaInput('stream3', 289));
 
-            expect(events[1].payload.status).to.equal('invalid');
+            // The content hash itself matched — a broken/unsupported continuity method
+            // doesn't mean the segment's bytes were tampered with, so it gets its own
+            // status instead of the generic 'invalid'.
+            expect(events[1].payload.status).to.equal('continuityInvalid');
             expect(events[1].payload.errorCodes).to.deep.equal(['livevideo.continuityMethod.invalid']);
+        });
+
+        it('should report the same continuityInvalid status for an unsupported custom continuity method', async () => {
+            const {engine} = createEngine({
+                initValidation: manifestBoxInitValidation(),
+                manifestBoxOutcome: manifestBoxOutcomeFor({
+                    isValid: false,
+                    errorCodes: ['livevideo.continuityMethod.invalid', 'livevideo.continuityMethod.unsupported'],
+                    previousManifestId: null,
+                    nextManifestId: 'urn:c2pa:manifest-1'
+                })
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(events[1].payload.status).to.equal('continuityInvalid');
+        });
+
+        it('should keep the generic invalid status when a content-hash failure is also present', async () => {
+            const {engine} = createEngine({
+                initValidation: manifestBoxInitValidation(),
+                manifestBoxOutcome: manifestBoxOutcomeFor({
+                    isValid: false,
+                    errorCodes: ['livevideo.continuityMethod.invalid', 'livevideo.segment.invalid'],
+                    previousManifestId: 'urn:c2pa:unexpected',
+                    nextManifestId: 'urn:c2pa:manifest-1'
+                })
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            // A genuine content-hash failure is present too, so this is not purely a
+            // continuity problem — it stays 'invalid', not 'continuityInvalid'.
+            expect(events[1].payload.status).to.equal('invalid');
         });
 
         it('should thread lastManifestId across the chain starting from an unknown baseline', async () => {

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -279,6 +279,33 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(mediaInput('stream3', 290));
             expect(seenSequenceState).to.deep.equal({lastSequenceNumber: 289, seenSequences: new Set([289])});
         });
+
+        it('should not validate a track\'s first media segment before its own init has finished classifying', async () => {
+            let resolveInit;
+            const initGate = new Promise((resolve) => { resolveInit = resolve; });
+            const {engine} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            engine.validateC2paInitSegment = async () => {
+                await initGate;
+                return vsiInitValidation([{kid: 'key-1'}]);
+            };
+            let seenSessionKeys = 'unset';
+            engine.validateC2paSegment = async (bytes, sessionKeys) => {
+                seenSessionKeys = sessionKeys;
+                return vsiSegmentOutcome({isValid: true, errorCodes: []});
+            };
+            const {coordinator} = createCoordinator({engine});
+
+            // The scanner never awaits a segment's own handler before forwarding the next
+            // one (AC — never block the fetch-to-MSE path), so a track's first media
+            // segment can genuinely arrive while its init classification is still pending.
+            const initHandled = coordinator.handleSegment(initInput('stream3'));
+            const mediaHandled = coordinator.handleSegment(mediaInput('stream3', 289));
+
+            resolveInit();
+            await Promise.all([initHandled, mediaHandled]);
+
+            expect(seenSessionKeys).to.deep.equal([{kid: 'key-1'}]);
+        });
     });
 
     describe('ManifestBox (§19.3) media-segment validation', function () {

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -89,7 +89,7 @@ function vsiEngineReturningSequences(seqs) {
     return {engine, calls};
 }
 
-function createCoordinator({engine, method = 'auto', detector, isCryptoAvailable}) {
+function createCoordinator({engine, method = 'auto', detector, isCryptoAvailable, loadEngine}) {
     const events = [];
     const eventBus = {
         trigger: (type, payload, filters) => events.push({type, payload, filters})
@@ -102,7 +102,7 @@ function createCoordinator({engine, method = 'auto', detector, isCryptoAvailable
         settings,
         detector,
         isCryptoAvailable: isCryptoAvailable || (() => true),
-        loadEngine: () => Promise.resolve(engine)
+        loadEngine: loadEngine || (() => Promise.resolve(engine))
     });
     return {coordinator, events};
 }
@@ -481,6 +481,42 @@ describe('C2paValidationCoordinator', function () {
             expect(segmentStatuses(events)).to.deep.equal([[10, 'valid'], [10, 'valid']]);
         });
 
+        it('should not enumerate a gap from an invalid segment claiming a forged sequence number', async () => {
+            const {engine} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            const outcomes = [
+                vsiSegmentOutcome({isValid: true, errorCodes: [], seq: 10}),
+                vsiSegmentOutcome({isValid: false, errorCodes: ['livevideo.segment.invalid'], seq: 1000000000})
+            ];
+            let index = 0;
+            engine.validateC2paSegment = async () => outcomes[index++];
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
+
+            expect(segmentStatuses(events)).to.deep.equal([
+                [10, 'valid'],
+                [1000000000, 'invalid']
+            ]);
+        });
+
+        it('should emit a single bounded record instead of enumerating a gap larger than the limit', async () => {
+            const {engine} = vsiEngineReturningSequences([10, 500]);
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
+
+            const validated = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED);
+            expect(validated.map((record) => [record.segmentNumber, record.status, record.missingCount])).to.deep.equal([
+                [10, 'valid', null],
+                [NaN, 'missing', 489],
+                [500, 'valid', null]
+            ]);
+        });
+
         it('should not report a gap when a track resumes after an ABR switch to a sibling representation', async () => {
             const {engine} = vsiEngineReturningSequences([10, 999, 50]);
             const {coordinator, events} = createCoordinator({engine});
@@ -539,9 +575,46 @@ describe('C2paValidationCoordinator', function () {
             const statuses = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED).map((record) => record.status);
             expect(statuses).to.deep.equal(['valid', 'valid']);
         });
+
+        it('should reset every currently active track on a seek without losing classification', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+            const audioMediaInput = (trackKey, segmentNumber) =>
+                Object.assign({}, mediaInput(trackKey, segmentNumber), {mediaType: 'audio'});
+
+            await coordinator.handleSegment(initInput('stream3', 'video'));
+            await coordinator.handleSegment(initInput('stream-audio', 'audio'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(audioMediaInput('stream-audio', 500));
+
+            coordinator.resetActiveSequences();
+
+            // Re-observing the same sequence numbers reads as fresh baselines (valid), not
+            // as replays, because the seek reset both active tracks' sequence state.
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(audioMediaInput('stream-audio', 500));
+
+            const statuses = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED).map((record) => record.status);
+            expect(statuses).to.deep.equal(['valid', 'valid', 'valid', 'valid']);
+        });
     });
 
     describe('error handling and unverified degradation', function () {
+
+        it('should emit a single c2pa.engineUnavailable error when the engine fails to load, not once per track', async () => {
+            const {coordinator, events} = createCoordinator({
+                loadEngine: () => Promise.reject(new Error('network error'))
+            });
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(initInput('stream4'));
+
+            const errors = eventsOfType(events, MediaPlayerEvents.C2PA_ERROR);
+            expect(errors.length).to.equal(1);
+            expect(errors[0].errorCodes).to.deep.equal(['c2pa.engineUnavailable']);
+
+            const initEvents = eventsOfType(events, MediaPlayerEvents.C2PA_INIT_PROCESSED);
+            expect(initEvents.map((e) => e.method)).to.deep.equal([null, null]);
+        });
 
         it('should emit unverified without calling the engine when Web Crypto is unavailable', async () => {
             const {engine, calls} = createEngine({
@@ -647,18 +720,33 @@ describe('C2paValidationCoordinator', function () {
             expect(events[0].payload.method).to.equal('19.4');
         });
 
-        it('should use the detector to classify media segments in auto mode', async () => {
+        it('should use the detector to classify a media segment when its track has no init classification', async () => {
+            const {detector, calls: detectorCalls} = countingDetector('19.4');
+            const {engine} = createEngine({segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})});
+            const {coordinator, events} = createCoordinator({engine, method: 'auto', detector});
+
+            // No init segment was ever seen for this track (e.g. joined the stream mid-broadcast).
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(detectorCalls.count).to.equal(1);
+            expect(events[0].payload.status).to.equal('valid');
+            expect(events[0].payload.method).to.equal('19.4');
+        });
+
+        it('should trust the track\'s init classification over the detector for its media segments', async () => {
             const {engine} = createEngine({
                 initValidation: vsiInitValidation([{kid: 'key-1'}]),
                 segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
             });
-            const {detector, calls: detectorCalls} = countingDetector('19.4');
+            // Deliberately returns a different method: if the detector were still consulted
+            // despite a known init classification, this segment would validate as §19.3 instead.
+            const {detector, calls: detectorCalls} = countingDetector('19.3');
             const {coordinator, events} = createCoordinator({engine, method: 'auto', detector});
 
             await coordinator.handleSegment(initInput('stream3'));
             await coordinator.handleSegment(mediaInput('stream3', 289));
 
-            expect(detectorCalls.count).to.equal(1);
+            expect(detectorCalls.count).to.equal(0);
             expect(events[1].payload.status).to.equal('valid');
             expect(events[1].payload.method).to.equal('19.4');
         });

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -64,10 +64,10 @@ function vsiInitValidation(sessionKeys) {
     };
 }
 
-function vsiSegmentOutcome({isValid, errorCodes}) {
+function vsiSegmentOutcome({isValid, errorCodes, seq = 289}) {
     return {
         result: {
-            sequenceNumber: 289,
+            sequenceNumber: seq,
             manifestId: 'urn:c2pa:manifest-1',
             bmffHashHex: 'abcd',
             kidHex: 'key-1',
@@ -75,8 +75,18 @@ function vsiSegmentOutcome({isValid, errorCodes}) {
             isValid,
             errorCodes
         },
-        nextSequenceState: {lastSequenceNumber: 289, seenSequences: new Set([289])}
+        nextSequenceState: {lastSequenceNumber: seq, seenSequences: new Set([seq])}
     };
+}
+
+function vsiEngineReturningSequences(seqs) {
+    const {engine, calls} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+    let index = 0;
+    engine.validateC2paSegment = async () => {
+        calls.vsi++;
+        return vsiSegmentOutcome({isValid: true, errorCodes: [], seq: seqs[index++]});
+    };
+    return {engine, calls};
 }
 
 function createCoordinator({engine, method = 'auto', detector, isCryptoAvailable}) {
@@ -349,59 +359,54 @@ describe('C2paValidationCoordinator', function () {
                 .map((event) => [event.payload.segmentNumber, event.payload.status]);
         }
 
-        function createValidVsiCoordinator() {
-            const {engine, calls} = createEngine({
-                initValidation: vsiInitValidation([{kid: 'key-1'}]),
-                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
-            });
-            return {calls, ...createCoordinator({engine})};
-        }
-
-        it('should mark a duplicate sequence number as replayed and not re-validate it', async () => {
-            const {coordinator, events, calls} = createValidVsiCoordinator();
+        it('should mark a duplicate signed sequence number as replayed', async () => {
+            const {engine} = vsiEngineReturningSequences([10, 10]);
+            const {coordinator, events} = createCoordinator({engine});
 
             await coordinator.handleSegment(initInput('stream3'));
-            await coordinator.handleSegment(mediaInput('stream3', 289));
-            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
 
-            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [289, 'replayed']]);
-            expect(calls.vsi).to.equal(1);
+            expect(segmentStatuses(events)).to.deep.equal([[10, 'valid'], [10, 'replayed']]);
         });
 
-        it('should mark a lower sequence number as reordered', async () => {
-            const {coordinator, events} = createValidVsiCoordinator();
+        it('should mark a lower signed sequence number as reordered', async () => {
+            const {engine} = vsiEngineReturningSequences([10, 9]);
+            const {coordinator, events} = createCoordinator({engine});
 
             await coordinator.handleSegment(initInput('stream3'));
-            await coordinator.handleSegment(mediaInput('stream3', 289));
-            await coordinator.handleSegment(mediaInput('stream3', 288));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
 
-            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [288, 'reordered']]);
+            expect(segmentStatuses(events)).to.deep.equal([[10, 'valid'], [9, 'reordered']]);
         });
 
         it('should emit missing records for a gap and then validate the current segment', async () => {
-            const {coordinator, events} = createValidVsiCoordinator();
+            const {engine} = vsiEngineReturningSequences([10, 13]);
+            const {coordinator, events} = createCoordinator({engine});
 
             await coordinator.handleSegment(initInput('stream3'));
-            await coordinator.handleSegment(mediaInput('stream3', 289));
-            await coordinator.handleSegment(mediaInput('stream3', 292));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream3', 2000));
 
             expect(segmentStatuses(events)).to.deep.equal([
-                [289, 'valid'],
-                [290, 'missing'],
-                [291, 'missing'],
-                [292, 'valid']
+                [10, 'valid'],
+                [11, 'missing'],
+                [12, 'missing'],
+                [13, 'valid']
             ]);
         });
 
         it('should keep sequence state independent per track', async () => {
-            const {coordinator, events} = createValidVsiCoordinator();
+            const {engine} = vsiEngineReturningSequences([10, 10]);
+            const {coordinator, events} = createCoordinator({engine});
 
             await coordinator.handleSegment(initInput('stream3'));
             await coordinator.handleSegment(initInput('stream4'));
-            await coordinator.handleSegment(mediaInput('stream3', 289));
-            await coordinator.handleSegment(mediaInput('stream4', 5));
+            await coordinator.handleSegment(mediaInput('stream3', 1000));
+            await coordinator.handleSegment(mediaInput('stream4', 1000));
 
-            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [5, 'valid']]);
+            expect(segmentStatuses(events)).to.deep.equal([[10, 'valid'], [10, 'valid']]);
         });
     });
 

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -336,6 +336,70 @@ describe('C2paValidationCoordinator', function () {
         });
     });
 
+    describe('lean per-track sequence checks', function () {
+
+        function segmentStatuses(events) {
+            return events
+                .filter((event) => event.type === MediaPlayerEvents.C2PA_SEGMENT_VALIDATED)
+                .map((event) => [event.payload.segmentNumber, event.payload.status]);
+        }
+
+        function createValidVsiCoordinator() {
+            const {engine, calls} = createEngine({
+                initValidation: vsiInitValidation([{kid: 'key-1'}]),
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            return {calls, ...createCoordinator({engine})};
+        }
+
+        it('should mark a duplicate sequence number as replayed and not re-validate it', async () => {
+            const {coordinator, events, calls} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [289, 'replayed']]);
+            expect(calls.vsi).to.equal(1);
+        });
+
+        it('should mark a lower sequence number as reordered', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 288));
+
+            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [288, 'reordered']]);
+        });
+
+        it('should emit missing records for a gap and then validate the current segment', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 292));
+
+            expect(segmentStatuses(events)).to.deep.equal([
+                [289, 'valid'],
+                [290, 'missing'],
+                [291, 'missing'],
+                [292, 'valid']
+            ]);
+        });
+
+        it('should keep sequence state independent per track', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(initInput('stream4'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream4', 5));
+
+            expect(segmentStatuses(events)).to.deep.equal([[289, 'valid'], [5, 'valid']]);
+        });
+    });
+
     describe('forced-method routing', function () {
 
         it('should emit a mismatch diagnostic when forcing §19.4 on a §19.3 segment', async () => {

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -1,0 +1,143 @@
+import C2paValidationCoordinator from '../../../../src/streaming/c2pa/C2paValidationCoordinator.js';
+import MediaPlayerEvents from '../../../../src/streaming/MediaPlayerEvents.js';
+import {expect} from 'chai';
+
+const context = {};
+
+function createEngine({initValidation, throwOnInit}) {
+    const calls = {init: 0, vsi: 0, manifestBox: 0};
+    const engine = {
+        validateC2paInitSegment: async () => {
+            calls.init++;
+            if (throwOnInit) {
+                throw new Error('No C2PA UUID box found in the provided bytes');
+            }
+            return initValidation;
+        },
+        validateC2paSegment: async () => {
+            calls.vsi++;
+            return {};
+        },
+        validateC2paManifestBoxSegment: async () => {
+            calls.manifestBox++;
+            return {};
+        }
+    };
+    return {engine, calls};
+}
+
+function createCoordinator({engine, method = 'auto'}) {
+    const events = [];
+    const eventBus = {
+        trigger: (type, payload, filters) => events.push({type, payload, filters})
+    };
+    const settings = {
+        get: () => ({streaming: {c2pa: {method}}})
+    };
+    const coordinator = C2paValidationCoordinator(context).create({
+        eventBus,
+        settings,
+        loadEngine: () => Promise.resolve(engine)
+    });
+    return {coordinator, events};
+}
+
+function initInput(trackKey, mediaType) {
+    return {kind: 'init', mediaType: mediaType || 'video', trackKey, bytes: new Uint8Array([1, 2, 3]), segmentNumber: NaN};
+}
+
+function mediaInput(trackKey, segmentNumber) {
+    return {kind: 'media', mediaType: 'video', trackKey, bytes: new Uint8Array([4, 5, 6]), segmentNumber};
+}
+
+describe('C2paValidationCoordinator', function () {
+
+    describe('init-segment classification', function () {
+
+        it('should classify a §19.4 init with session keys as VSI', async () => {
+            const {engine} = createEngine({
+                initValidation: {
+                    manifest: {signatureInfo: {issuer: 'CN=Test Issuer'}, assertions: []},
+                    manifestId: 'urn:c2pa:manifest-1',
+                    sessionKeys: [{kid: 'key-1'}, {kid: 'key-2'}],
+                    isValid: true,
+                    errorCodes: []
+                }
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+
+            expect(events.length).to.equal(1);
+            expect(events[0].type).to.equal(MediaPlayerEvents.C2PA_INIT_PROCESSED);
+            expect(events[0].payload.trackKey).to.equal('stream3');
+            expect(events[0].payload.method).to.equal('19.4');
+            expect(events[0].payload.manifestId).to.equal('urn:c2pa:manifest-1');
+            expect(events[0].payload.issuer).to.equal('CN=Test Issuer');
+            expect(events[0].payload.sessionKeyCount).to.equal(2);
+            expect(events[0].payload.isValid).to.equal(true);
+        });
+
+        it('should classify a §19.3 init without session keys as ManifestBox', async () => {
+            const {engine} = createEngine({
+                initValidation: {
+                    manifest: {signatureInfo: {issuer: 'CN=Test Issuer'}, assertions: []},
+                    manifestId: 'urn:c2pa:manifest-2',
+                    sessionKeys: [],
+                    isValid: true,
+                    errorCodes: []
+                }
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+
+            expect(events.length).to.equal(1);
+            expect(events[0].payload.method).to.equal('19.3');
+            expect(events[0].payload.sessionKeyCount).to.equal(0);
+            expect(events[0].payload.manifestId).to.equal('urn:c2pa:manifest-2');
+        });
+
+        it('should map CML error codes to strings', async () => {
+            const {engine} = createEngine({
+                initValidation: {
+                    manifest: {signatureInfo: {issuer: null}, assertions: []},
+                    manifestId: 'urn:c2pa:manifest-3',
+                    sessionKeys: [],
+                    isValid: false,
+                    errorCodes: ['livevideo.init.invalid']
+                }
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+
+            expect(events[0].payload.errorCodes).to.deep.equal(['livevideo.init.invalid']);
+            expect(events[0].payload.isValid).to.equal(false);
+        });
+    });
+
+    describe('non-C2PA init in auto mode', function () {
+
+        it('should emit a no-provenance event and skip the track\'s media segments', async () => {
+            const {engine, calls} = createEngine({throwOnInit: true});
+            const {coordinator, events} = createCoordinator({engine, method: 'auto'});
+
+            await coordinator.handleSegment(initInput('stream3'));
+
+            expect(events.length).to.equal(1);
+            expect(events[0].type).to.equal(MediaPlayerEvents.C2PA_INIT_PROCESSED);
+            expect(events[0].payload.method).to.be.null;
+            expect(events[0].payload.sessionKeyCount).to.equal(0);
+            expect(events[0].payload.isValid).to.equal(false);
+
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            await coordinator.handleSegment(mediaInput('stream3', 290));
+
+            expect(events.length).to.equal(1);
+            expect(calls.init).to.equal(1);
+            expect(calls.vsi).to.equal(0);
+            expect(calls.manifestBox).to.equal(0);
+        });
+    });
+});

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -4,7 +4,7 @@ import {expect} from 'chai';
 
 const context = {};
 
-function createEngine({initValidation, throwOnInit}) {
+function createEngine({initValidation, throwOnInit, segmentOutcome}) {
     const calls = {init: 0, vsi: 0, manifestBox: 0};
     const engine = {
         validateC2paInitSegment: async () => {
@@ -16,7 +16,7 @@ function createEngine({initValidation, throwOnInit}) {
         },
         validateC2paSegment: async () => {
             calls.vsi++;
-            return {};
+            return segmentOutcome !== undefined ? segmentOutcome : null;
         },
         validateC2paManifestBoxSegment: async () => {
             calls.manifestBox++;
@@ -24,6 +24,31 @@ function createEngine({initValidation, throwOnInit}) {
         }
     };
     return {engine, calls};
+}
+
+function vsiInitValidation(sessionKeys) {
+    return {
+        manifest: {signatureInfo: {issuer: 'CN=Test Issuer'}, assertions: []},
+        manifestId: 'urn:c2pa:manifest-1',
+        sessionKeys,
+        isValid: true,
+        errorCodes: []
+    };
+}
+
+function vsiSegmentOutcome({isValid, errorCodes}) {
+    return {
+        result: {
+            sequenceNumber: 289,
+            manifestId: 'urn:c2pa:manifest-1',
+            bmffHashHex: 'abcd',
+            kidHex: 'key-1',
+            sequenceResult: {isValid: true, reason: 'valid'},
+            isValid,
+            errorCodes
+        },
+        nextSequenceState: {lastSequenceNumber: 289, seenSequences: new Set([289])}
+    };
 }
 
 function createCoordinator({engine, method = 'auto'}) {
@@ -138,6 +163,66 @@ describe('C2paValidationCoordinator', function () {
             expect(calls.init).to.equal(1);
             expect(calls.vsi).to.equal(0);
             expect(calls.manifestBox).to.equal(0);
+        });
+    });
+
+    describe('VSI (§19.4) media-segment validation', function () {
+
+        it('should emit a valid SegmentRecord for a valid VSI segment', async () => {
+            const {engine, calls} = createEngine({
+                initValidation: vsiInitValidation([{kid: 'key-1'}]),
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            expect(calls.vsi).to.equal(1);
+            expect(events.length).to.equal(2);
+            const record = events[1];
+            expect(record.type).to.equal(MediaPlayerEvents.C2PA_SEGMENT_VALIDATED);
+            expect(record.payload.status).to.equal('valid');
+            expect(record.payload.method).to.equal('19.4');
+            expect(record.payload.segmentNumber).to.equal(289);
+            expect(record.payload.keyId).to.equal('key-1');
+            expect(record.payload.hash).to.equal('abcd');
+            expect(record.payload.manifestId).to.equal('urn:c2pa:manifest-1');
+            expect(record.payload.issuer).to.equal('CN=Test Issuer');
+            expect(record.payload.errorCodes).to.deep.equal([]);
+            expect(record.payload.timestamp).to.be.a('number');
+        });
+
+        it('should emit an invalid SegmentRecord with the CML error code for a tampered segment', async () => {
+            const {engine} = createEngine({
+                initValidation: vsiInitValidation([{kid: 'key-1'}]),
+                segmentOutcome: vsiSegmentOutcome({isValid: false, errorCodes: ['livevideo.segment.invalid']})
+            });
+            const {coordinator, events} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            const record = events[1];
+            expect(record.payload.status).to.equal('invalid');
+            expect(record.payload.errorCodes).to.deep.equal(['livevideo.segment.invalid']);
+        });
+
+        it('should thread the sequence state returned by the engine into the next call', async () => {
+            let seenSequenceState = 'unset';
+            const {engine} = createEngine({initValidation: vsiInitValidation([{kid: 'key-1'}])});
+            engine.validateC2paSegment = async (bytes, sessionKeys, sequenceState) => {
+                seenSequenceState = sequenceState;
+                return vsiSegmentOutcome({isValid: true, errorCodes: []});
+            };
+            const {coordinator} = createCoordinator({engine});
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+            expect(seenSequenceState).to.equal(undefined);
+
+            await coordinator.handleSegment(mediaInput('stream3', 290));
+            expect(seenSequenceState).to.deep.equal({lastSequenceNumber: 289, seenSequences: new Set([289])});
         });
     });
 });

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -359,7 +359,7 @@ describe('C2paValidationCoordinator', function () {
             expect(events[1].payload.errorCodes).to.deep.equal(['livevideo.continuityMethod.invalid']);
         });
 
-        it('should report the same continuityInvalid status for an unsupported custom continuity method', async () => {
+        it('should report a distinct continuityUnsupported status for an unsupported custom continuity method', async () => {
             const {engine} = createEngine({
                 initValidation: manifestBoxInitValidation(),
                 manifestBoxOutcome: manifestBoxOutcomeFor({
@@ -374,7 +374,8 @@ describe('C2paValidationCoordinator', function () {
             await coordinator.handleSegment(initInput('stream3'));
             await coordinator.handleSegment(mediaInput('stream3', 289));
 
-            expect(events[1].payload.status).to.equal('continuityInvalid');
+            expect(events[1].payload.status).to.equal('continuityUnsupported');
+            expect(events[1].payload.errorCodes).to.deep.equal(['livevideo.continuityMethod.invalid', 'livevideo.continuityMethod.unsupported']);
         });
 
         it('should keep the generic invalid status when a content-hash failure is also present', async () => {

--- a/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
+++ b/test/unit/test/streaming/streaming.c2pa.C2paValidationCoordinator.js
@@ -405,6 +405,46 @@ describe('C2paValidationCoordinator', function () {
         });
     });
 
+    describe('lifecycle', function () {
+
+        function createValidVsiCoordinator() {
+            const {engine} = createEngine({
+                initValidation: vsiInitValidation([{kid: 'key-1'}]),
+                segmentOutcome: vsiSegmentOutcome({isValid: true, errorCodes: []})
+            });
+            return createCoordinator({engine});
+        }
+
+        it('should not leak sequence state across sources after reset', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            coordinator.reset();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            const statuses = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED).map((record) => record.status);
+            expect(statuses).to.deep.equal(['valid', 'valid']);
+        });
+
+        it('should reset one track\'s sequence while keeping its classification', async () => {
+            const {coordinator, events} = createValidVsiCoordinator();
+
+            await coordinator.handleSegment(initInput('stream3'));
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            coordinator.resetSequenceForTrack('stream3');
+
+            await coordinator.handleSegment(mediaInput('stream3', 289));
+
+            const statuses = eventsOfType(events, MediaPlayerEvents.C2PA_SEGMENT_VALIDATED).map((record) => record.status);
+            expect(statuses).to.deep.equal(['valid', 'valid']);
+        });
+    });
+
     describe('error handling and unverified degradation', function () {
 
         it('should emit unverified without calling the engine when Web Crypto is unavailable', async () => {

--- a/test/unit/test/streaming/streaming.c2pa.detection.BoxParsingDetector.js
+++ b/test/unit/test/streaming/streaming.c2pa.detection.BoxParsingDetector.js
@@ -1,0 +1,114 @@
+import BoxParsingDetector from '../../../../src/streaming/c2pa/detection/BoxParsingDetector.js';
+import BoxParser from '../../../../src/streaming/utils/BoxParser.js';
+import {expect} from 'chai';
+
+const context = {};
+
+const VSI_EMSG_SCHEME_URI = 'urn:c2pa:verifiable-segment-info';
+const C2PA_MANIFEST_STORE_UUID = [
+    0xd8, 0xfe, 0xc3, 0xd6, 0x1a, 0x96, 0x4f, 0x32,
+    0xa0, 0xf6, 0xf3, 0xec, 0xf9, 0x6c, 0x10, 0xea
+];
+const JUMBF_UUID = [
+    0xd8, 0xfe, 0xc3, 0xd6, 0x1b, 0x0e, 0x48, 0x3c,
+    0x92, 0x97, 0x58, 0x28, 0x87, 0x7e, 0xc4, 0x81
+];
+
+function stringBytes(value) {
+    return Array.from(value).map((character) => character.charCodeAt(0));
+}
+
+function box(type, payload) {
+    const size = 8 + payload.length;
+    const header = [
+        (size >>> 24) & 0xff, (size >>> 16) & 0xff, (size >>> 8) & 0xff, size & 0xff,
+        type.charCodeAt(0), type.charCodeAt(1), type.charCodeAt(2), type.charCodeAt(3)
+    ];
+    return header.concat(payload);
+}
+
+function uuidBox(uuid) {
+    return box('uuid', uuid.slice());
+}
+
+function emsgV0Box(schemeIdUri) {
+    const payload = [0, 0, 0, 0] // version 0 + flags
+        .concat(stringBytes(schemeIdUri), [0]) // scheme_id_uri (null-terminated)
+        .concat([0]) // value (empty, null-terminated)
+        .concat([0, 0, 0, 1]) // timescale
+        .concat([0, 0, 0, 0]) // presentation_time_delta
+        .concat([0, 0, 0, 0]) // event_duration
+        .concat([0, 0, 0, 1]); // id
+    return box('emsg', payload);
+}
+
+function segmentInputFrom(byteArray) {
+    return { bytes: new Uint8Array(byteArray) };
+}
+
+describe('BoxParsingDetector', function () {
+
+    let detector;
+
+    beforeEach(() => {
+        detector = BoxParsingDetector(context).create({
+            boxParser: BoxParser(context).getInstance()
+        });
+    });
+
+    it('should classify a segment with a VSI emsg box as §19.4', () => {
+        const result = detector.detect(segmentInputFrom(emsgV0Box(VSI_EMSG_SCHEME_URI)));
+
+        expect(result.hasC2pa).to.equal(true);
+        expect(result.method).to.equal('19.4');
+    });
+
+    it('should classify a segment with a C2PA manifest-store uuid box as §19.3', () => {
+        const result = detector.detect(segmentInputFrom(uuidBox(C2PA_MANIFEST_STORE_UUID)));
+
+        expect(result.hasC2pa).to.equal(true);
+        expect(result.method).to.equal('19.3');
+    });
+
+    it('should classify a segment with a JUMBF uuid box as §19.3', () => {
+        const result = detector.detect(segmentInputFrom(uuidBox(JUMBF_UUID)));
+
+        expect(result.hasC2pa).to.equal(true);
+        expect(result.method).to.equal('19.3');
+    });
+
+    it('should classify a segment without any C2PA box as non-C2PA', () => {
+        const result = detector.detect(segmentInputFrom(box('free', [1, 2, 3, 4])));
+
+        expect(result.hasC2pa).to.equal(false);
+        expect(result.method).to.be.null;
+    });
+
+    it('should ignore an emsg box whose scheme is not the VSI scheme', () => {
+        const result = detector.detect(segmentInputFrom(emsgV0Box('urn:mpeg:dash:event:2012')));
+
+        expect(result.hasC2pa).to.equal(false);
+        expect(result.method).to.be.null;
+    });
+
+    it('should ignore a uuid box whose usertype is not a C2PA UUID', () => {
+        const foreignUuid = new Array(16).fill(0x11);
+        const result = detector.detect(segmentInputFrom(uuidBox(foreignUuid)));
+
+        expect(result.hasC2pa).to.equal(false);
+        expect(result.method).to.be.null;
+    });
+
+    it('should return non-C2PA when no boxParser is available', () => {
+        const detectorWithoutParser = BoxParsingDetector(context).create({});
+        const result = detectorWithoutParser.detect(segmentInputFrom(uuidBox(JUMBF_UUID)));
+
+        expect(result.hasC2pa).to.equal(false);
+        expect(result.method).to.be.null;
+    });
+
+    it('should return non-C2PA for missing input', () => {
+        expect(detector.detect(null).hasC2pa).to.equal(false);
+        expect(detector.detect({}).hasC2pa).to.equal(false);
+    });
+});


### PR DESCRIPTION
## Summary

Adds native, opt-in C2PA provenance validation for live CMAF/DASH streams, per C2PA 2.4 [§19, "Live Video"](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#live-video). A live stream isn't one complete file you can hash and sign upfront: segments go out continuously as the broadcast happens. §19 solves this by making each segment provable on its own, and gives two ways to do it. We support both, plus auto-detection between them.

- **[§19.3, Manifest Box method](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#using_c2pa_manifest_box)**: every media segment carries a full C2PA manifest in a `uuid` box, hashed with `c2pa.hash.bmff.v3` and chained to the previous segment (`previousManifestId`, `continuityMethod`).
- **[§19.4, Verifiable Segment Info method](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#verifiable_segment_info)**: session keys are set up once in the init segment, then each media segment just needs a lightweight COSE_Sign1 payload against those keys, carried in an `emsg` box.

Both bind the init segment to its media segments (hash covers the `moov` box) to stop replay/substitution attacks, so our per-track state (session keys, sequence/continuity baseline) is scoped to that binding and gets reset on source change.

Off by default behind `streaming.c2pa.enabled`, it's brand new. While disabled nothing gets parsed and `@svta/cml-c2pa` (the actual validation engine) is never imported: it's a dynamic `import()`, code-split out of both bundles.

```js
player.updateSettings({
    streaming: {
        c2pa: { enabled: true, method: 'auto' }  // 'auto' | '19.3' | '19.4'
    }
});
```

`auto` mode classifies each track from its init segment, falling back to per-segment ISO-BMFF box inspection if the init was missed or ambiguous. Results come through three new events: `C2PA_INIT_PROCESSED`, `C2PA_SEGMENT_VALIDATED`, `C2PA_ERROR`.

Each `C2PA_SEGMENT_VALIDATED` carries a status: `valid`/`invalid` for the manifest/hash check, `replayed`/`reordered`/`missing` from cross-checking the manifest's signed sequence number (independent per representation, so an ABR switch or a seek doesn't read as an attack), plus two §19.3-only continuity statuses for a broken link vs. a `continuityMethod` we just don't recognize. Anything we can't evaluate degrades to `unverified` instead of being dropped or treated as valid. Full docs in `src/streaming/c2pa/README.md`; `samples/c2pa/index.html` has a working ✅ / ❌ / ⚠ grid to try against a real stream.

## Testing

Tested against real signed streams for both methods, plus the full unit suite (~1950 tests). All cert/signature validation is delegated to `@svta/cml-c2pa`, we don't reimplement any C2PA crypto here.