### PR TITLE
fix(cmcd): compute msd as time between starting and playing states

### DIFF
--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -67,6 +67,7 @@ function CmcdModel() {
         _bufferLevelStarved,
         _initialMediaRequestsDone,
         _playbackStartedTime,
+        _msd,
         _isSeeking,
         streamProcessors,
         _rebufferingStartTime = {},
@@ -531,12 +532,17 @@ function CmcdModel() {
     }
 
     function onPlaybackStarted() {
-        if (!_playbackStartedTime) {
+        if (_playbackStartedTime === undefined) {
             _playbackStartedTime = Date.now();
         }
     }
 
     function onPlaybackPlaying() {
+        // MSD is the wall-clock time between the player being instructed to play (play event,
+        // or start of manifest loading for autoplay) and the first transition to the playing state.
+        if (_msd === undefined && _playbackStartedTime !== undefined) {
+            _msd = Date.now() - _playbackStartedTime;
+        }
         for (const mediaType in _rebufferingStartTime) {
             if (_rebufferingStartTime.hasOwnProperty(mediaType)) {
                 onRebufferingCompleted(mediaType);
@@ -558,10 +564,7 @@ function CmcdModel() {
     }
 
     function _calculateMsd() {
-        if (!_playbackStartedTime) {
-            return null;
-        }
-        return Date.now() - _playbackStartedTime;
+        return _msd !== undefined ? _msd : null;
     }
 
     function getGenericCmcdData(mediaType) {
@@ -619,6 +622,7 @@ function CmcdModel() {
         _isSeeking = false;
         _lastMediaTypeRequest = undefined;
         _playbackStartedTime = undefined;
+        _msd = undefined;
         _rebufferingStartTime = {};
         _rebufferingDuration = {};
         _streamType = undefined;

--- a/test/unit/test/streaming/streaming.models.CmcdModel.js
+++ b/test/unit/test/streaming/streaming.models.CmcdModel.js
@@ -213,12 +213,42 @@ describe('CmcdModel', function () {
     });
 
     describe('calculateMsd', function () {
-        it('should return MSD data when playback has started', function () {
+        let clock;
+
+        beforeEach(function () {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(function () {
+            clock.restore();
+        });
+
+        it('should return the time between playback start and the playing state', function () {
             cmcdModel.onPlaybackStarted();
+            clock.tick(500);
             cmcdModel.onPlaybackPlaying();
 
             const msdData = cmcdModel.calculateMsd();
-            expect(msdData).to.have.property('msd').that.is.a('number');
+            expect(msdData.msd).to.equal(500);
+        });
+
+        it('should freeze MSD at the first playing transition', function () {
+            cmcdModel.onPlaybackStarted();
+            clock.tick(500);
+            cmcdModel.onPlaybackPlaying();
+
+            // Later reports and playing transitions must not change the value
+            clock.tick(1000);
+            cmcdModel.onPlaybackPlaying();
+            const msdData = cmcdModel.calculateMsd();
+            expect(msdData.msd).to.equal(500);
+        });
+
+        it('should return empty object before the playing state is reached', function () {
+            cmcdModel.onPlaybackStarted();
+
+            const msdData = cmcdModel.calculateMsd();
+            expect(Object.keys(msdData)).to.have.length(0);
         });
 
         it('should return empty object when playback has not started', function () {


### PR DESCRIPTION
Fixes #5109

The msd (Media Start Delay) value was calculated lazily at report time as the difference between now and the playback start timestamp. Its value therefore depended on when the first CMCD report happened to be sent, not on the actual startup delay.

Per the CMCD v2 specification, msd should be the wall-clock time between the "starting" and "playing" states. The value is now frozen once at the first transition to the playing state (play event, or start of manifest loading for autoplay) and is not reported before startup has completed.