### PR TITLE
fix(cmcd): make ec handling spec-conformant (inner list of strings, buffered per reporting channel)

### DIFF
--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -250,11 +250,13 @@ function CmcdController() {
         if (errorData.error?.data?.request?.type === HTTPRequest.CMCD_EVENT) {
             return;
         }
-        // Update CmcdReporter with the error code
+        // Update CmcdReporter with the error code.
+        // Per the CMCD v2 specification, ec is an inner list of strings and the list
+        // notation must be used even for a single error code, e.g. ec=("16")
         if (cmcdReporter) {
             const errorCode = errorData.error?.code || errorData.error?.data?.code;
             if (errorCode) {
-                cmcdReporter.update({ ec: errorCode });
+                cmcdReporter.update({ ec: [String(errorCode)] });
             }
         }
 

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -58,7 +58,8 @@ function CmcdController() {
         logger,
         mediaPlayerModel,
         reporterNeedsRebuild,
-        urlLoader;
+        urlLoader,
+        _pendingErrorCodes;
 
 
     let context = this.context;
@@ -134,6 +135,12 @@ function CmcdController() {
 
     function _resetInitialSettings() {
         reporterNeedsRebuild = false;
+        // Error codes buffered per reporting channel until the next report of that channel flushes them
+        _pendingErrorCodes = {
+            request: [],
+            response: [],
+            event: []
+        };
     }
 
     function _initializeEventBus(autoPlay) {
@@ -250,17 +257,49 @@ function CmcdController() {
         if (errorData.error?.data?.request?.type === HTTPRequest.CMCD_EVENT) {
             return;
         }
-        // Update CmcdReporter with the error code.
-        // Per the CMCD v2 specification, ec is an inner list of strings and the list
-        // notation must be used even for a single error code, e.g. ec=("16")
-        if (cmcdReporter) {
-            const errorCode = errorData.error?.code || errorData.error?.data?.code;
-            if (errorCode) {
-                cmcdReporter.update({ ec: [String(errorCode)] });
-            }
+        // Per the CMCD v2 specification, error codes are buffered per report destination
+        // as they occur and reported as an inner list of strings, e.g. ec=("16" "27"),
+        // along with the next CMCD report. The buffers are flushed by the next report
+        // of each reporting channel (request, response, event).
+        const errorCode = errorData.error?.code || errorData.error?.data?.code;
+        if (errorCode) {
+            const code = String(errorCode);
+            _pendingErrorCodes.request.push(code);
+            _pendingErrorCodes.response.push(code);
+            _pendingErrorCodes.event.push(code);
         }
 
         triggerCmcdEventMode(Constants.CMCD_REPORTING_EVENTS.ERROR);
+    }
+
+    /**
+     * Returns the buffered error codes for the given reporting channel and clears its buffer.
+     * @param {string} channel - 'request', 'response' or 'event'
+     * @returns {Array.<string>} the buffered error codes
+     * @private
+     */
+    function _takeErrorCodes(channel) {
+        const codes = _pendingErrorCodes[channel];
+        _pendingErrorCodes[channel] = [];
+        return codes;
+    }
+
+    /**
+     * Checks whether at least one enabled event target is subscribed to the given event type,
+     * i.e. whether CmcdReporter.recordEvent() will actually record a report for it.
+     * @param {string} event
+     * @returns {boolean}
+     * @private
+     */
+    function _willAnyTargetRecordEvent(event) {
+        const targets = cmcdConfigAccessor.getEventTargets();
+        return targets.some((_target, index) => {
+            if (!isCmcdEnabled(index)) {
+                return false;
+            }
+            const events = cmcdConfigAccessor.getEventTarget(index).get('targetEvents');
+            return Array.isArray(events) && events.includes(event);
+        });
     }
 
     function _rebuildReporterIfNeeded() {
@@ -306,6 +345,12 @@ function CmcdController() {
             cmcdReporter.update(msdData);
         }
 
+        // Attach buffered error codes to the next event report and clear the buffer.
+        // Only flush when a target will actually record this event, so codes are not discarded unseen.
+        if (_pendingErrorCodes.event.length > 0 && _willAnyTargetRecordEvent(event)) {
+            cmcdData.ec = _takeErrorCodes('event');
+        }
+
         // Pass event-mode data as transient per-event data (not persisted)
         cmcdReporter.recordEvent(event, cmcdData);
     }
@@ -332,6 +377,11 @@ function CmcdController() {
             const msdData = cmcdModel.calculateMsd();
             if (msdData.msd !== undefined) {
                 cmcdReporter.update(msdData);
+            }
+
+            // Attach buffered error codes to this request report only, then clear the buffer
+            if (_pendingErrorCodes.request.length > 0) {
+                cmcdData.ec = _takeErrorCodes('request');
             }
 
             const decorated = cmcdReporter.createRequestReport(request, cmcdData);
@@ -561,6 +611,11 @@ function CmcdController() {
         // Collect dash.js-specific additional data
         const additionalData = {};
 
+        // Attach buffered error codes to this response report only, then clear the buffer
+        if (_pendingErrorCodes.response.length > 0) {
+            additionalData.ec = _takeErrorCodes('response');
+        }
+
         if (response.headers) {
             try {
                 const cmsdStaticHeader = response.headers['cmsd-static'];
@@ -614,6 +669,7 @@ function CmcdController() {
             cmcdReporter = null;
         }
 
+        _resetInitialSettings();
         cmcdModel.resetInitialSettings();
     }
 

--- a/test/unit/test/streaming/streaming.controllers.CmcdController.js
+++ b/test/unit/test/streaming/streaming.controllers.CmcdController.js
@@ -195,6 +195,44 @@ describe('CmcdController', function () {
             expect(metrics).to.have.property('e', 'e');
         });
 
+        it('should send the error code (ec) as an inner list of strings', () => {
+            settings.update({
+                streaming: {
+                    cmcd: {
+                        version: 2,
+                        eventTargets: [{
+                            url: 'https://cmcd.event.collector/api',
+                            enabled: true,
+                            enabledKeys: ['e', 'ec'],
+                            events: ['e'],
+                            interval: 0
+                        }]
+                    }
+                }
+            });
+            cmcdController.initialize();
+
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: {
+                    code: 123,
+                    message: 'Test Error Message',
+                    data: {
+                        request: {
+                            type: 'someOtherRequestType'
+                        }
+                    }
+                }
+            });
+
+            expect(urlLoaderMock.load.calledOnce).to.be.true;
+            const requestSent = urlLoaderMock.load.firstCall.args[0].request;
+
+            // ec must use list notation with string entries even for a single code: ec=("123")
+            expect(decodeURIComponent(requestSent.body)).to.include('ec=("123")');
+            const metrics = decodeCmcd(decodeURIComponent(requestSent.body));
+            expect(metrics.ec).to.deep.equal(['123']);
+        });
+
         it('should not send a report when the ERROR event is triggered by a CMCD_EVENT', () => {
             settings.update({
                 streaming: {

--- a/test/unit/test/streaming/streaming.controllers.CmcdController.js
+++ b/test/unit/test/streaming/streaming.controllers.CmcdController.js
@@ -233,6 +233,40 @@ describe('CmcdController', function () {
             expect(metrics.ec).to.deep.equal(['123']);
         });
 
+        it('should not repeat ec on subsequent event reports', () => {
+            settings.update({
+                streaming: {
+                    cmcd: {
+                        version: 2,
+                        eventTargets: [{
+                            url: 'https://cmcd.event.collector/api',
+                            enabled: true,
+                            enabledKeys: ['e', 'ec', 'sta'],
+                            events: ['e', 'ps'],
+                            interval: 0
+                        }]
+                    }
+                }
+            });
+            cmcdController.initialize();
+
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: { code: 123, data: { request: { type: 'someOtherRequestType' } } }
+            });
+            eventBus.trigger(MediaPlayerEvents.PLAYBACK_PLAYING);
+
+            expect(urlLoaderMock.load.calledTwice).to.be.true;
+
+            const firstReport = decodeCmcd(decodeURIComponent(urlLoaderMock.load.firstCall.args[0].request.body));
+            expect(firstReport).to.have.property('e', 'e');
+            expect(firstReport.ec).to.deep.equal(['123']);
+
+            // The error event flushed the buffer; the following play state report must not carry ec
+            const secondReport = decodeCmcd(decodeURIComponent(urlLoaderMock.load.secondCall.args[0].request.body));
+            expect(secondReport).to.have.property('e', 'ps');
+            expect(secondReport).to.not.have.property('ec');
+        });
+
         it('should not send a report when the ERROR event is triggered by a CMCD_EVENT', () => {
             settings.update({
                 streaming: {
@@ -728,6 +762,64 @@ describe('CmcdController', function () {
             expect(metrics).to.have.property('ttlb');
         });
 
+        it('should attach buffered error codes (ec) to the next response report only', () => {
+            settings.update({
+                streaming: {
+                    cmcd: {
+                        version: 2,
+                        eventTargets: [{
+                            url: 'https://cmcd.response.collector/api',
+                            enabled: true,
+                            includeInRequests: ['segment'],
+                            enabledKeys: ['rc', 'ec'],
+                            events: ['rr']
+                        }]
+                    }
+                }
+            });
+            cmcdController.initialize();
+
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: { code: 123, data: { request: { type: 'someOtherRequestType' } } }
+            });
+
+            let currentTime = new Date(Date.now());
+            const mockResponse = {
+                status: 200,
+                request: {
+                    url: 'http://test.url/video.m4s',
+                    customData: {
+                        request: {
+                            type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                            url: 'http://test.url/video.m4s',
+                            startDate: currentTime - 1000,
+                            firstByteDate: currentTime - 500,
+                            endDate: new Date()
+                        }
+                    },
+                    cmcd: {},
+                },
+                resourceTiming: {
+                    startTime: currentTime - 1000,
+                    responseStart: currentTime - 500,
+                    duration: 1000
+                }
+            };
+
+            const interceptor = cmcdController.getCmcdResponseReceivedInterceptors()[0];
+            interceptor(mockResponse);
+            interceptor(mockResponse);
+
+            expect(urlLoaderMock.load.calledTwice).to.be.true;
+
+            const firstReport = decodeCmcd(decodeURIComponent(urlLoaderMock.load.firstCall.args[0].request.body));
+            expect(firstReport.ec).to.deep.equal(['123']);
+
+            // The buffer is flushed by the first response report; later reports must not repeat the code
+            const secondReport = decodeCmcd(decodeURIComponent(urlLoaderMock.load.secondCall.args[0].request.body));
+            expect(secondReport).to.not.have.property('ec');
+        });
+
         it('should send a response report with cmsdd and cmsds keys when CMSD headers are present', () => {
             settings.update({
                 streaming: {
@@ -1033,6 +1125,72 @@ describe('CmcdController', function () {
             const metrics = getCmcdFromUrl(result.url);
             expect(metrics).to.have.property('ot', 'v');
             expect(metrics).to.have.property('v', 2);
+        });
+
+        it('should attach buffered error codes (ec) to the next request only', function () {
+            settings.update({ streaming: { cmcd: { enabled: true, version: 2 } } });
+            cmcdController.reset();
+            cmcdController.initialize();
+            cmcdController.setConfig({
+                abrController: abrControllerMock,
+                dashMetrics: dashMetricsMock,
+                playbackController: playbackControllerMock,
+                throughputController: throughputControllerMock,
+                serviceDescriptionController: serviceDescriptionControllerMock
+            });
+
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: { code: 123, data: { request: { type: 'someOtherRequestType' } } }
+            });
+
+            const interceptor = cmcdController.getCmcdRequestInterceptors()[0];
+            const requestConfig = {
+                url: 'http://example.com/segment.m4s',
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                quality: 0,
+                representation: { mediaInfo: { bitrateList: [{ bandwidth: 10000 }] } },
+                duration: 4
+            };
+
+            const first = interceptor(createCommonMediaRequest(requestConfig));
+            expect(getCmcdFromUrl(first.url).ec).to.deep.equal(['123']);
+
+            // The buffer is flushed by the first report; later requests must not repeat the code
+            const second = interceptor(createCommonMediaRequest(requestConfig));
+            expect(getCmcdFromUrl(second.url)).to.not.have.property('ec');
+        });
+
+        it('should accumulate multiple error codes into a single ec list', function () {
+            settings.update({ streaming: { cmcd: { enabled: true, version: 2 } } });
+            cmcdController.reset();
+            cmcdController.initialize();
+            cmcdController.setConfig({
+                abrController: abrControllerMock,
+                dashMetrics: dashMetricsMock,
+                playbackController: playbackControllerMock,
+                throughputController: throughputControllerMock,
+                serviceDescriptionController: serviceDescriptionControllerMock
+            });
+
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: { code: 123, data: { request: { type: 'someOtherRequestType' } } }
+            });
+            eventBus.trigger(MediaPlayerEvents.ERROR, {
+                error: { code: 456, data: { request: { type: 'someOtherRequestType' } } }
+            });
+
+            const interceptor = cmcdController.getCmcdRequestInterceptors()[0];
+            const result = interceptor(createCommonMediaRequest({
+                url: 'http://example.com/segment.m4s',
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                quality: 0,
+                representation: { mediaInfo: { bitrateList: [{ bandwidth: 10000 }] } },
+                duration: 4
+            }));
+
+            expect(getCmcdFromUrl(result.url).ec).to.deep.equal(['123', '456']);
         });
 
         it('should decorate a v1 request with CMCD headers when mode is headers', function () {


### PR DESCRIPTION
Fixes #5111

Per the CMCD v2 specification, `ec` (Player Error Code) is an inner list of strings — list notation is required even for a single code — and errors "should be buffered per report destination as they occur and reported along with the next CMCD report."

Previously the error code was sent as a bare integer (e.g. `ec=27`) and stored in the reporter's persistent session data, so the last error code was attached to every subsequent report for the remainder of the session, and consecutive errors overwrote each other.

### Changes (two commits)
1. **Send `ec` as an inner list of strings** — the code is passed as `[String(code)]` so it serializes as `ec=("27")`.
2. **Buffer error codes and report them once per reporting channel** — codes are buffered per reporting channel (request / response / event) and delivered as transient per-report data with the next report of each channel, then cleared. Multiple errors between two reports accumulate in occurrence order, e.g. `ec=("16" "27")`. The immediate error event report (`e="e"`) carries the codes explicitly, as required by the spec. The event buffer is only flushed when a target actually records the event, so codes are never discarded unseen.

### Known limitation
Flushing is per reporting channel, not per individual target — all targets of a channel are served by the same library call, so behavior matches in practice. Fully per-target buffering could later be built on the CmcdReporter report transforms added upstream (streaming-video-technology-alliance/common-media-library#390 RFC, implemented in #399) once dash.js upgrades `@svta/cml-cmcd` beyond the currently pinned 2.3.2.

### Verification
- `npm run ci:verify` passes (tsc, full unit suite, lint)
- Unit tests cover: wire format `ec=("123")`, flush-once semantics per request/response/event channel, multi-error accumulation, and the CMCD-event feedback-loop guard
- Verified on the wire against a live stream: after a forced segment download error, `ec=("27")` appears on exactly one request and is absent afterwards (previously it repeated on every request through the end of the session)
