### PR TITLE
feat(cmcd): add support for custom keys via streaming.cmcd.customKeys

### DIFF
--- a/docs/site/pages/usage/cmcd.md
+++ b/docs/site/pages/usage/cmcd.md
@@ -28,6 +28,7 @@ dash.js offers various configuration options related to CMCD. The following sett
 | enabledKeys            | This value is used to specify the desired CMCD parameters. Parameters not included in this list are not reported.                                                                                                     | 
 | includeInRequests      | Specifies which HTTP GET requests shall carry parameters. If not specified this value defaults to ['segment', 'mpd].                                                                                                  | 
 | version                | The version of the CMCD to use. If not specified this value defaults to 1.                                                                                                                                            | 
+| customKeys             | Custom CMCD keys to include in reports as a list of key/value entries, e.g. `[{ key: 'org.svta-p-n', value: 'dash.js' }]`. See [Custom keys](#custom-keys).                                                            | 
 
 For a full documentation of all CMCD related options please refer to
 our [API documentation](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html#~CmcdSettings).
@@ -52,6 +53,35 @@ player.updateSettings({
     },
 })
 ````
+
+## Custom keys
+
+Next to the standard keys, CMCD allows application-defined custom keys. Per the CMCD specification, custom keys must
+carry a hyphenated prefix to avoid namespace collisions with future revisions, and a reverse-DNS syntax is recommended
+for the prefix, e.g. `com.example-mykey`. The
+[SVTA CMCD custom keys registry](https://github.com/streaming-video-technology-alliance/common-media-client-data-custom-keys)
+lists well-known custom keys, such as the player name (`org.svta-p-n`) and player version (`org.svta-p-v`).
+
+dash.js supports custom keys via the `customKeys` setting. Each entry defines a key and a value; the values are included
+in all CMCD reports as persistent session data. Entries whose key does not carry a valid hyphenated prefix are ignored
+with a console warning. The setting applies identically to CMCD version 1 and version 2.
+
+````js
+player.updateSettings({
+    streaming: {
+        cmcd: {
+            enabled: true,
+            customKeys: [
+                { key: 'org.svta-p-n', value: 'dash.js' },
+                { key: 'org.svta-p-v', value: player.getVersion() }
+            ]
+        }
+    },
+})
+````
+
+Note: event and response reporting targets (see below) filter keys by their own `enabledKeys` list. To include custom
+keys in reports sent to a target, add the custom key names to that target's `enabledKeys`.
 
 ## CMCD Version 2
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1974,6 +1974,10 @@ export class MediaPlayerSettingClass {
                 enabledKeys?: Array<string>,
                 includeInRequests?: Array<string>,
                 batchSize?: number
+            }>,
+            customKeys?: Array<{
+                key: string,
+                value: string | number | boolean
             }>
         },
         cmsd?: {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -339,7 +339,8 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  *                enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v']
  *                includeInRequests: ['segment', 'mpd'],
  *                version: 1,
- *                eventTargets: []
+ *                eventTargets: [],
+ *                customKeys: []
  *            },
  *            cmsd: {
  *                enabled: false,
@@ -984,6 +985,16 @@ import SwitchRequest from '../streaming/rules/SwitchRequest.js';
  * If not specified this value defaults to 1.
  * @property {Array.<CmcdEventTarget>} [eventTargets]
  * List of CMCD reporting targets.
+ * @property {Array.<object>} [customKeys=[]]
+ * Custom CMCD keys to include in reports as persistent session data. Each entry is an object with a
+ * "key" and a "value" property, e.g. [{ key: 'org.svta-p-n', value: 'dash.js' }].
+ *
+ * Per the CMCD specification, custom keys must carry a hyphenated prefix (reverse-DNS syntax recommended)
+ * to avoid namespace collisions, e.g. 'com.example-mykey'. Keys without a valid prefix are ignored.
+ * See the SVTA CMCD custom keys registry for registered keys.
+ *
+ * Note: event/response targets filter keys by their own enabledKeys; add custom keys there to include
+ * them in target reports.
  */
 
 /**
@@ -1528,7 +1539,8 @@ function Settings() {
                 enabledKeys: Constants.CMCD_KEYS,
                 includeInRequests: ['segment', 'mpd'],
                 version: 1,
-                eventTargets: []
+                eventTargets: [],
+                customKeys: []
             },
             cmsd: {
                 enabled: false,

--- a/src/streaming/cmcd/config/CmcdPropertyMap.js
+++ b/src/streaming/cmcd/config/CmcdPropertyMap.js
@@ -228,6 +228,23 @@ const CmcdPropertyMap = {
     },
 
     /**
+     * Custom CMCD keys as a list of { key, value } entries
+     * (hyphenated key prefix required, e.g. 'org.svta-p-n').
+     * Settings only; not configurable via manifest.
+     */
+    customKeys: {
+        version: [1, 2],
+        sources: [
+            {
+                path: 'settings.streaming.cmcd.customKeys',
+                priority: 1,
+                type: 'array',
+                default: []
+            }
+        ]
+    },
+
+    /**
      * Request types to include CMCD data in
      * Priority: manifest > settings > default (['segment', 'mpd'])
      */

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -39,6 +39,7 @@ import {
     CmcdReporter,
     CMCD_QUERY,
     CMCD_HEADERS,
+    isCmcdCustomKey,
 } from '@svta/cml-cmcd';
 import Debug from '../../core/Debug.js';
 
@@ -174,10 +175,12 @@ function CmcdController() {
     }
 
     function _createCmcdReporter() {
+        const customKeys = _getValidatedCustomKeys();
         const cmcdConfig = {
             version: cmcdConfigAccessor.getVersion(),
             transmissionMode: cmcdConfigAccessor.get('mode') === Constants.CMCD_MODE_HEADERS ? CMCD_HEADERS : CMCD_QUERY,
-            enabledKeys: cmcdConfigAccessor.get('keys'),
+            // Configured custom keys are enabled implicitly, otherwise the reporter's key filter would drop them
+            enabledKeys: [...cmcdConfigAccessor.get('keys'), ...Object.keys(customKeys)],
             eventTargets: _buildReporterTargets(),
         };
 
@@ -192,7 +195,33 @@ function CmcdController() {
             cmcdConfig.cid = cid;
         }
 
-        return new CmcdReporter(cmcdConfig, _customRequester);
+        const reporter = new CmcdReporter(cmcdConfig, _customRequester);
+
+        // Custom keys are persistent session data and included in all reports
+        if (Object.keys(customKeys).length > 0) {
+            reporter.update(customKeys);
+        }
+
+        return reporter;
+    }
+
+    /**
+     * Returns the configured custom CMCD keys as a data object, dropping entries whose key
+     * lacks the hyphenated prefix required by the CMCD specification (e.g. 'com.example-mykey').
+     * @returns {object}
+     * @private
+     */
+    function _getValidatedCustomKeys() {
+        const customKeys = cmcdConfigAccessor.get('customKeys') || [];
+
+        return customKeys.reduce((result, entry) => {
+            if (entry && typeof entry.key === 'string' && isCmcdCustomKey(entry.key) && entry.value !== undefined) {
+                result[entry.key] = entry.value;
+            } else {
+                logger.warn(`Ignoring CMCD custom key entry "${entry ? entry.key : entry}": entries require a value and a key with a hyphenated prefix, e.g. "com.example-mykey"`);
+            }
+            return result;
+        }, {});
     }
 
     function _buildReporterTargets() {

--- a/test/unit/test/streaming/streaming.controllers.CmcdController.js
+++ b/test/unit/test/streaming/streaming.controllers.CmcdController.js
@@ -1049,6 +1049,84 @@ describe('CmcdController', function () {
             expect(result.headers).to.have.property('CMCD-Object');
         });
 
+        it('should include configured custom keys and ignore keys without a valid prefix', function () {
+            settings.update({
+                streaming: {
+                    cmcd: {
+                        enabled: true,
+                        version: 2,
+                        customKeys: [
+                            { key: 'org.svta-p-n', value: 'dash.js' },
+                            { key: 'org.svta-p-v', value: '5.2.2' },
+                            { key: 'invalidkey', value: 'should-be-ignored' }
+                        ]
+                    }
+                }
+            });
+            cmcdController.reset();
+            cmcdController.initialize();
+            cmcdController.setConfig({
+                abrController: abrControllerMock,
+                dashMetrics: dashMetricsMock,
+                playbackController: playbackControllerMock,
+                throughputController: throughputControllerMock,
+                serviceDescriptionController: serviceDescriptionControllerMock
+            });
+
+            const interceptor = cmcdController.getCmcdRequestInterceptors()[0];
+            const result = interceptor(createCommonMediaRequest({
+                url: 'http://example.com/segment.m4s',
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                quality: 0,
+                representation: { mediaInfo: { bitrateList: [{ bandwidth: 10000 }] } },
+                duration: 4
+            }));
+
+            const metrics = getCmcdFromUrl(result.url);
+            expect(metrics).to.have.property('org.svta-p-n', 'dash.js');
+            expect(metrics).to.have.property('org.svta-p-v', '5.2.2');
+            expect(metrics).to.not.have.property('invalidkey');
+        });
+
+        it('should include configured custom keys in v1 requests using the same definition', function () {
+            settings.update({
+                streaming: {
+                    cmcd: {
+                        enabled: true,
+                        version: 1,
+                        customKeys: [
+                            { key: 'org.svta-p-n', value: 'dash.js' },
+                            { key: 'org.svta-p-v', value: '5.2.2' }
+                        ]
+                    }
+                }
+            });
+            cmcdController.reset();
+            cmcdController.initialize();
+            cmcdController.setConfig({
+                abrController: abrControllerMock,
+                dashMetrics: dashMetricsMock,
+                playbackController: playbackControllerMock,
+                throughputController: throughputControllerMock,
+                serviceDescriptionController: serviceDescriptionControllerMock
+            });
+
+            const interceptor = cmcdController.getCmcdRequestInterceptors()[0];
+            const result = interceptor(createCommonMediaRequest({
+                url: 'http://example.com/segment.m4s',
+                type: HTTPRequest.MEDIA_SEGMENT_TYPE,
+                mediaType: 'video',
+                quality: 0,
+                representation: { mediaInfo: { bitrateList: [{ bandwidth: 10000 }] } },
+                duration: 4
+            }));
+
+            const metrics = getCmcdFromUrl(result.url);
+            expect(metrics).to.have.property('org.svta-p-n', 'dash.js');
+            expect(metrics).to.have.property('org.svta-p-v', '5.2.2');
+        });
+
         it('should filter keys based on enabledKeys configuration', function () {
             settings.update({ streaming: { cmcd: { enabled: true, version: 2, enabledKeys: ['ot', 'br'] } } });
             cmcdController.reset();


### PR DESCRIPTION
Implements #5113

Adds a new setting to include CMCD custom keys in all reports as persistent session data, e.g. the SVTA-registered player name and player version keys from the [CMCD custom keys registry](https://github.com/streaming-video-technology-alliance/common-media-client-data-custom-keys):

    customKeys: [
        { key: 'org.svta-p-n', value: 'dash.js' },
        { key: 'org.svta-p-v', value: player.getVersion() }
    ]

Resulting wire output on decorated requests: `org.svta-p-n="dash.js",org.svta-p-v="5.2.2"`.

### Design
- Array of `{ key, value }` entries — a plain object map is rejected by `Settings.update()`'s schema validation of nested keys; arrays follow the `eventTargets` precedent for open collections, and the entry shape allows adding optional fields later (e.g. a `header` field or a value provider) without breaking changes
- Keys are validated with the library's own `isCmcdCustomKey` (hyphenated prefix required per the CMCD specification); invalid entries are ignored with a console warning, so standard keys cannot be overridden through this setting
- Configured custom keys are implicitly appended to the reporter's enabled keys — no additional configuration needed
- Applies identically to CMCD v1 and v2: one definition, unit-tested for both versions
- Event/response targets select custom keys via their own `enabledKeys`, implementing the spec's recommendation of selective per-target custom key sets
- Scope: all custom keys are persistent session data included in every report (like `sid`/`cid`). Per-request values are a future extension of the entry shape; event-scoped custom data belongs to the spec's custom event mechanism (`e="ce"`); header-category assignment in header mode requires the library to expose its `customHeaderMap` through the reporter configuration (until then, custom keys default to the CMCD-Request header)

### Includes
- New setting incl. JSDoc (`Settings.js`), TypeScript typings (`index.d.ts`), config mapping (`CmcdPropertyMap.js`), and controller wiring (`CmcdController.js`)
- Unit tests: v2 request decoration, v1 parity with the same definition, invalid-prefix rejection
- Documentation: new "Custom keys" section and settings-table entry in `docs/site/pages/usage/cmcd.md`

### Verification
- `npm run ci:verify` passes (tsc, full unit suite, lint)
- Verified on the wire against a live stream in both query mode and with the full v2 key set enabled
