### PR TITLE
Link audio/video scheduling together and check ahead for video buffer gaps

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -300,6 +300,11 @@ function Stream(config) {
 
             Promise.all(promises)
                 .then(() => {
+                    const audioProcessor = _getStreamProcessorForType(Constants.AUDIO);
+                    const videoProcessor = _getStreamProcessorForType(Constants.VIDEO);
+                    if (audioProcessor && videoProcessor) {
+                        audioProcessor.setBufferTargetLink(videoProcessor);
+                    }
                     return _createBufferSinks(previousSourceBufferSinks, representationsFromPreviousPeriod)
                 })
                 .then((bufferSinks) => {

--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -1235,6 +1235,12 @@ function StreamProcessor(config) {
         return scheduleController;
     }
 
+    function setBufferTargetLink(sourceProcessor) {
+        if (type === Constants.AUDIO && sourceProcessor && sourceProcessor.getType() === Constants.VIDEO) {
+            scheduleController.setBufferTargetLink(sourceProcessor.getBufferController());
+        }
+    }
+
     function clearScheduleTimer() {
         if (scheduleController) {
             scheduleController.clearScheduleTimer();
@@ -1645,6 +1651,7 @@ function StreamProcessor(config) {
         probeNextRequest,
         reset,
         selectMediaInfo,
+        setBufferTargetLink,
         setEnhancementStreamProcessor,
         setExplicitBufferingTime,
         setMediaInfoArray,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -42,6 +42,7 @@ function ScheduleController(config) {
     config = config || {};
     const abrController = config.abrController;
     const bufferController = config.bufferController;
+    let bufferTargetLink = null;
     const context = this.context;
     const dashMetrics = config.dashMetrics;
     const eventBus = EventBus(context).getInstance();
@@ -305,15 +306,45 @@ function ScheduleController(config) {
         try {
             const videoBufferLevel = dashMetrics.getCurrentBufferLevel(Constants.VIDEO);
             const currentRepresentation = representationController.getCurrentRepresentation();
+
+            // If there's a gap in the video buffer, the audio will not stream over it. Check video buffer ranges
+            // past a gap and use that as a buffer target if bigger.
+            const gappedBufferTarget = _getGappedBufferTargetFromLink();
             // For multiperiod we need to consider that audio and video segments might have different durations.
             // This can lead to scenarios in which we completely buffered the video segments and the video buffer level for the current period is not changing anymore. However we might still need a small audio segment to finish buffering audio as well.
             // If we set the buffer time of audio equal to the video buffer time scheduling for the remaining audio segment will only be triggered when audio fragmentDuration > videoBufferLevel. That will delay preloading of the upcoming period.
             // Should find a better solution than just adding 1
             if (isNaN(currentRepresentation.fragmentDuration)) {
-                return videoBufferLevel + 1;
+                return Math.max(videoBufferLevel + 1, gappedBufferTarget);
             } else {
-                return Math.max(videoBufferLevel + 1, currentRepresentation.fragmentDuration);
+                return Math.max(videoBufferLevel + 1, currentRepresentation.fragmentDuration, gappedBufferTarget);
             }
+        } catch (e) {
+            return 0;
+        }
+    }
+
+    function _getGappedBufferTargetFromLink() {
+        try {
+            const gaps = settings.get().streaming.gaps;
+            if (!bufferTargetLink || !gaps.jumpGaps || !gaps.jumpLargeGaps) {
+                return 0;
+            }
+
+            const ranges = bufferTargetLink.getBuffer().getAllBufferRanges();
+            const currentTime = playbackController.getTime();
+            const bufferTarget = _getGenericBufferTarget();
+            if (!ranges || ranges.length === 0 || isNaN(currentTime) || isNaN(bufferTarget)) {
+                return 0;
+            }
+
+            for (let index = 0; index < ranges.length; index++) {
+                if (ranges.start(index) > currentTime && ranges.start(index) - currentTime <= bufferTarget) {
+                    return Math.min(Math.max(ranges.end(index) - currentTime, 0), bufferTarget);
+                }
+            }
+
+            return 0;
         } catch (e) {
             return 0;
         }
@@ -420,6 +451,10 @@ function ScheduleController(config) {
         shouldCheckPlaybackQuality = value;
     }
 
+    function setBufferTargetLink(value) {
+        bufferTargetLink = value;
+    }
+
     function setInitSegmentRequired(value) {
         initSegmentRequired = value;
     }
@@ -468,6 +503,7 @@ function ScheduleController(config) {
         getType,
         initialize,
         reset,
+        setBufferTargetLink,
         setShouldCheckPlaybackQuality,
         setInitSegmentRequired,
         setLastInitializedRepresentationId,

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -464,6 +464,7 @@ function ScheduleController(config) {
     }
 
     function resetInitialSettings() {
+        bufferTargetLink = null;
         shouldCheckPlaybackQuality = true;
         timeToLoadDelay = 0;
         lastInitializedRepresentationId = null;

--- a/test/unit/test/streaming/streaming.Stream.js
+++ b/test/unit/test/streaming/streaming.Stream.js
@@ -1,4 +1,5 @@
 import Stream from '../../../../src/streaming/Stream.js';
+import FactoryMaker from '../../../../src/core/FactoryMaker.js';
 import Events from '../../../../src/core/events/Events.js';
 import ProtectionEvents from '../../../../src/streaming/protection/ProtectionEvents.js';
 import EventBus from '../../../../src/core/EventBus.js';
@@ -20,6 +21,7 @@ import VideoModelMock from '../../mocks/VideoModelMock.js';
 import ProtectionControllerMock from '../../mocks/ProtectionControllerMock.js';
 import ObjectsHelper from '../../helpers/ObjectsHelper.js';
 
+import sinon from 'sinon';
 import {expect} from 'chai';
 
 const context = {};
@@ -186,5 +188,57 @@ describe('Stream', function () {
 
             expect(thumbnailController).to.be.undefined; // jshint ignore:line
         });
+
+        it('should link the audio processor to the video processor after media initialization', (done) => {
+            const audioProcessor = createStreamProcessorMock('audio');
+            const videoProcessor = createStreamProcessorMock('video');
+            const originalGetAllMediaInfoForType = adapterMock.getAllMediaInfoForType;
+            const originalSetInitialMediaSettingsForType = mediaControllerMock.setInitialMediaSettingsForType;
+            const createProcessor = sinon.spy((config) => {
+                return config.type === 'audio' ? audioProcessor : videoProcessor;
+            });
+            FactoryMaker.extend('StreamProcessor', createProcessor, false, context);
+
+            adapterMock.getAllMediaInfoForType = (streamInfo, type) => {
+                return type === 'audio' || type === 'video' ? [{type, isEmbedded: false}] : [];
+            };
+            mediaControllerMock.setInitialMediaSettingsForType = () => {};
+            const cleanup = () => {
+                delete context.StreamProcessor;
+                adapterMock.getAllMediaInfoForType = originalGetAllMediaInfoForType;
+                mediaControllerMock.setInitialMediaSettingsForType = originalSetInitialMediaSettingsForType;
+            };
+
+            stream.initialize();
+            stream.startPreloading()
+                .then(() => {
+                    expect(createProcessor.callCount).to.equal(2);
+                    expect(stream.getStreamProcessors()).to.deep.equal([videoProcessor, audioProcessor]);
+                    expect(audioProcessor.setBufferTargetLink.calledOnceWithExactly(videoProcessor)).to.be.true; // jshint ignore:line
+                    cleanup();
+                    done();
+                })
+                .catch((error) => {
+                    cleanup();
+                    done(error);
+                });
+        });
     });
 });
+
+function createStreamProcessorMock(type) {
+    return {
+        createBufferSinks: () => Promise.resolve(null),
+        getFragmentModel: () => ({
+            abortRequests: () => {},
+            resetInitialSettings: () => {}
+        }),
+        getRepresentation: () => ({mediaInfo: {type}}),
+        getType: () => type,
+        initialize: () => {},
+        reset: () => {},
+        selectMediaInfo: () => Promise.resolve(),
+        setBufferTargetLink: sinon.spy(),
+        setMediaInfoArray: () => {}
+    };
+}

--- a/test/unit/test/streaming/streaming.StreamProcessor.js
+++ b/test/unit/test/streaming/streaming.StreamProcessor.js
@@ -34,6 +34,10 @@ describe('StreamProcessor', function () {
             expect(streamProcessor.setEnhancementStreamProcessor.bind(streamProcessor, {})).to.not.throw();
         });
 
+        it('setBufferTargetLink should exist', function () {
+            expect(streamProcessor.setBufferTargetLink).to.be.a('function');
+        });
+
     });
 
 });

--- a/test/unit/test/streaming/streaming.controllers.ScheduleController.js
+++ b/test/unit/test/streaming/streaming.controllers.ScheduleController.js
@@ -6,6 +6,7 @@ import AdapterMock from '../../mocks/AdapterMock.js';
 import DashMetricsMock from '../../mocks/DashMetricsMock.js';
 import AbrControllerMock from '../../mocks/AbrControllerMock.js';
 import MediaPlayerModelMock from '../../mocks/MediaPlayerModelMock.js';
+import PlaybackControllerMock from '../../mocks/PlaybackControllerMock.js';
 import TextControllerMock from '../../mocks/TextControllerMock.js';
 import RepresentationControllerMock from '../../mocks/RepresentationControllerMock.js';
 
@@ -13,6 +14,14 @@ const voHelper = new VoHelper();
 import {expect} from 'chai';
 const context = {};
 const settings = Settings(context).getInstance();
+
+function createBufferedRanges(ranges) {
+    return {
+        length: ranges.length,
+        start: (index) => ranges[index].start,
+        end: (index) => ranges[index].end
+    };
+}
 
 let scheduleController;
 let streamInfo, adapter, dashMetrics, abrController, mediaPlayerModel, textController, representationController;
@@ -127,6 +136,91 @@ describe('ScheduleController', function () {
                 }
                 const result = scheduleController.getBufferTarget();
                 expect(result).to.be.equal(settings.get().streaming.buffer.bufferTimeAtTopQualityLongForm);
+            });
+
+            it('should use the generic buffer target as the linked video range search window and cap', () => {
+                const playbackController = new PlaybackControllerMock();
+                playbackController.setTime(7);
+                const sourceBuffer = {
+                    getAllBufferRanges: () => createBufferedRanges([{start: 0, end: 10}, {start: 14, end: 130}])
+                };
+                dashMetrics.getCurrentBufferLevel = () => 5;
+                settings.update({streaming: {gaps: {jumpGaps: true, jumpLargeGaps: true}}});
+                scheduleController.reset();
+                scheduleController = ScheduleController(context).create({
+                    streamInfo,
+                    adapter,
+                    type: Constants.AUDIO,
+                    dashMetrics,
+                    abrController,
+                    mediaPlayerModel,
+                    playbackController,
+                    representationController,
+                    settings
+                });
+                scheduleController.setBufferTargetLink({
+                    getBuffer: () => sourceBuffer
+                });
+                scheduleController.initialize(true);
+                representationController.getCurrentRepresentation = () => ({fragmentDuration: 6});
+
+                expect(scheduleController.getBufferTarget()).to.equal(12);
+            });
+
+            it('should ignore a linked video range that starts beyond the generic buffer target', () => {
+                const playbackController = new PlaybackControllerMock();
+                playbackController.setTime(5);
+                const sourceBuffer = {
+                    getAllBufferRanges: () => createBufferedRanges([{start: 0, end: 10}, {start: 500, end: 520}])
+                };
+                settings.update({streaming: {gaps: {jumpGaps: true, jumpLargeGaps: true}}});
+                scheduleController.reset();
+                scheduleController = ScheduleController(context).create({
+                    streamInfo,
+                    adapter,
+                    type: Constants.AUDIO,
+                    dashMetrics,
+                    abrController,
+                    mediaPlayerModel,
+                    playbackController,
+                    representationController,
+                    settings
+                });
+                scheduleController.setBufferTargetLink({
+                    getBuffer: () => sourceBuffer
+                });
+                scheduleController.initialize(true);
+                representationController.getCurrentRepresentation = () => ({fragmentDuration: 6});
+
+                expect(scheduleController.getBufferTarget()).to.equal(16);
+            });
+
+            it('should ignore the linked video buffer horizon when large gap jumping is disabled', () => {
+                const playbackController = new PlaybackControllerMock();
+                playbackController.setTime(7);
+                const sourceBuffer = {
+                    getAllBufferRanges: () => createBufferedRanges([{start: 0, end: 10}, {start: 14, end: 130}])
+                };
+                settings.update({streaming: {gaps: {jumpGaps: false, jumpLargeGaps: false}}});
+                scheduleController.reset();
+                scheduleController = ScheduleController(context).create({
+                    streamInfo,
+                    adapter,
+                    type: Constants.AUDIO,
+                    dashMetrics,
+                    abrController,
+                    mediaPlayerModel,
+                    playbackController,
+                    representationController,
+                    settings
+                });
+                scheduleController.setBufferTargetLink({
+                    getBuffer: () => sourceBuffer
+                });
+                scheduleController.initialize(true);
+                representationController.getCurrentRepresentation = () => ({fragmentDuration: 6});
+
+                expect(scheduleController.getBufferTarget()).to.equal(16);
             });
         })
 

--- a/test/unit/test/streaming/streaming.controllers.ScheduleController.js
+++ b/test/unit/test/streaming/streaming.controllers.ScheduleController.js
@@ -165,6 +165,12 @@ describe('ScheduleController', function () {
                 representationController.getCurrentRepresentation = () => ({fragmentDuration: 6});
 
                 expect(scheduleController.getBufferTarget()).to.equal(12);
+
+                scheduleController.reset();
+                scheduleController.setup();
+                scheduleController.initialize(true);
+
+                expect(scheduleController.getBufferTarget()).to.equal(6);
             });
 
             it('should ignore a linked video range that starts beyond the generic buffer target', () => {


### PR DESCRIPTION
Fixes #5115 .

This commit changes ScheduleController's audio buffer target to look into the video source buffer and try and find a buffer range ahead of a gap and use that as the buffer target. This allows audio to stream through gaps just like video.

This fixes the issue in a rather blunt way that I'm not sure that I like, and maybe we should be working out audio buffer target in a different way completely. It seems kind of complicated now, and the +1 hack still remains. If you wanted something else I'd be happy to reject this and try implementing some other behaviour.