### PR TITLE
harden: the application fetches and parses mpd manifest... in...

### DIFF
--- a/src/streaming/net/FetchLoader.js
+++ b/src/streaming/net/FetchLoader.js
@@ -60,6 +60,14 @@ function FetchLoader() {
      * @param {CommonMediaResponse} commonMediaResponse
      */
     function load(commonMediaRequest, commonMediaResponse) {
+        // Reject protocol downgrades (e.g. a manifest/segment URL rewritten to plain HTTP by a
+        // man-in-the-middle or DNS hijacker) so that requests originating from a secure page can
+        // never be silently redirected to an unauthenticated, tamperable transport.
+        if (_isInsecureRequestUrl(commonMediaRequest.url)) {
+            _handleFetchError(commonMediaRequest);
+            return;
+        }
+
         const headers = _getHeaders(commonMediaRequest);
         const abortController = _setupAbortMechanism(commonMediaRequest);
         const fetchResourceRequestObject = _getFetchResourceRequestObject(commonMediaRequest, headers, abortController);
@@ -71,6 +79,15 @@ function FetchLoader() {
             .catch(() => {
                 _handleFetchError(commonMediaRequest);
             })
+    }
+
+    function _isInsecureRequestUrl(url) {
+        try {
+            return typeof window !== 'undefined' && window.isSecureContext &&
+                new URL(url, window.location.href).protocol === 'http:';
+        } catch (e) {
+            return false;
+        }
     }
 
     function _handleFetchResponse(fetchResponse, commonMediaRequest, commonMediaResponse) {


### PR DESCRIPTION
## Summary
Harden input handling in `src/streaming/net/FetchLoader.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/streaming/net/FetchLoader.js:67` |
| **Assessment** | Defensive hardening |

**Description**: The application fetches and parses MPD manifest files without cryptographic integrity verification. An attacker who can compromise the manifest server or perform DNS hijacking can inject malicious segment URLs pointing to attacker-controlled servers, potentially delivering malicious content to users.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/streaming/net/FetchLoader.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
