### PR TITLE
fix: restore two reported BCP-47 track language values

### DIFF
--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -443,10 +443,16 @@ function MediaController() {
             return !settings.lang ||
             (settings.lang instanceof RegExp) ?
                 (track.lang.match(settings.lang)) : track.lang !== '' ?
-                    (extendedFilter(track.lang, normalizeBcp47(settings.lang)).length > 0) : false;
+                    _matchesLanguage(track.lang, settings.lang) : false;
         } catch (e) {
             return false
         }
+    }
+
+    function _matchesLanguage(trackLang, requestedLang) {
+        const normalizedRequestedLang = normalizeBcp47(requestedLang);
+        return extendedFilter(trackLang, normalizedRequestedLang).length > 0 ||
+            extendedFilter(normalizedRequestedLang, trackLang).length > 0;
     }
 
     function matchSettingsIndex(settings, track) {
@@ -517,10 +523,7 @@ function MediaController() {
 
             // If the track has a language and we can normalize the target language check if we got a match
             else if (track.lang !== '') {
-                const normalizedSettingsLang = normalizeBcp47(settings.lang);
-                if (normalizedSettingsLang) {
-                    matchLang = extendedFilter(track.lang, normalizedSettingsLang).length > 0
-                }
+                matchLang = _matchesLanguage(track.lang, settings.lang)
             }
 
             const matchIndex = (settings.index === undefined) || (settings.index === null) || (track.index === settings.index);

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -443,16 +443,10 @@ function MediaController() {
             return !settings.lang ||
             (settings.lang instanceof RegExp) ?
                 (track.lang.match(settings.lang)) : track.lang !== '' ?
-                    _matchesLanguage(track.lang, settings.lang) : false;
+                    (extendedFilter(track.lang, normalizeBcp47(settings.lang)).length > 0) : false;
         } catch (e) {
             return false
         }
-    }
-
-    function _matchesLanguage(trackLang, requestedLang) {
-        const normalizedRequestedLang = normalizeBcp47(requestedLang);
-        return extendedFilter(trackLang, normalizedRequestedLang).length > 0 ||
-            extendedFilter(normalizedRequestedLang, trackLang).length > 0;
     }
 
     function matchSettingsIndex(settings, track) {
@@ -523,7 +517,10 @@ function MediaController() {
 
             // If the track has a language and we can normalize the target language check if we got a match
             else if (track.lang !== '') {
-                matchLang = _matchesLanguage(track.lang, settings.lang)
+                const normalizedSettingsLang = normalizeBcp47(settings.lang);
+                if (normalizedSettingsLang) {
+                    matchLang = extendedFilter(track.lang, normalizedSettingsLang).length > 0
+                }
             }
 
             const matchIndex = (settings.index === undefined) || (settings.index === null) || (track.index === settings.index);

--- a/src/streaming/utils/BCP47Utils.js
+++ b/src/streaming/utils/BCP47Utils.js
@@ -82,6 +82,17 @@ export const ISO_639_2_TO_1 = Object.create(null, Object.getOwnPropertyDescripto
     yor: 'yo', zha: 'za', zho: 'zh', zul: 'zu'
 }));
 
+/**
+ * CLDR normalizations applied by bcp-47-normalize before it was removed.
+ *
+ * Keep the mappings used by the DASH-IF complex multi-period test vector so
+ * MediaInfo.lang remains compatible with dash.js versions prior to 5.2.0.
+ */
+const COMPATIBILITY_TAG_MAPPINGS = Object.create(null, Object.getOwnPropertyDescriptors({
+    'zh-cmn': 'zh',
+    'nl-NL': 'nl'
+}));
+
 export function normalizeBcp47(tag) {
     if (!tag || typeof tag !== 'string') {
         return tag;
@@ -99,8 +110,12 @@ export function normalizeBcp47(tag) {
         } else if (parts[i].length === 2 && /^[a-zA-Z]+$/.test(parts[i])) {
             // Region (2 alpha): uppercase (e.g. us -> US)
             parts[i] = parts[i].toUpperCase();
+        } else {
+            // Extlang, variant, extension, and private-use subtags are lowercase
+            parts[i] = parts[i].toLowerCase();
         }
     }
 
-    return parts.join('-');
+    const normalizedTag = parts.join('-');
+    return COMPATIBILITY_TAG_MAPPINGS[normalizedTag] || normalizedTag;
 }

--- a/src/streaming/utils/BCP47Utils.js
+++ b/src/streaming/utils/BCP47Utils.js
@@ -90,7 +90,7 @@ export const ISO_639_2_TO_1 = Object.create(null, Object.getOwnPropertyDescripto
  */
 const COMPATIBILITY_TAG_MAPPINGS = Object.create(null, Object.getOwnPropertyDescriptors({
     'zh-cmn': 'zh',
-    'nl-NL': 'nl'
+    'nl-nl': 'nl'
 }));
 
 export function normalizeBcp47(tag) {
@@ -110,12 +110,9 @@ export function normalizeBcp47(tag) {
         } else if (parts[i].length === 2 && /^[a-zA-Z]+$/.test(parts[i])) {
             // Region (2 alpha): uppercase (e.g. us -> US)
             parts[i] = parts[i].toUpperCase();
-        } else {
-            // Extlang, variant, extension, and private-use subtags are lowercase
-            parts[i] = parts[i].toLowerCase();
         }
     }
 
     const normalizedTag = parts.join('-');
-    return COMPATIBILITY_TAG_MAPPINGS[normalizedTag] || normalizedTag;
+    return COMPATIBILITY_TAG_MAPPINGS[normalizedTag.toLowerCase()] || normalizedTag;
 }

--- a/test/unit/test/streaming/streaming.controllers.MediaController.js
+++ b/test/unit/test/streaming/streaming.controllers.MediaController.js
@@ -70,6 +70,17 @@ describe('MediaController', function () {
         });
     });
 
+    describe('Language Matching', function () {
+        it('should match generic track languages against more specific preferences', function () {
+            expect(mediaController.matchSettingsLang({ lang: 'en-US' }, { lang: 'en' })).to.be.true;
+            expect(mediaController.matchSettingsLang({ lang: 'zh-Hans-CN' }, { lang: 'zh' })).to.be.true;
+        });
+
+        it('should not match different regional variants', function () {
+            expect(mediaController.matchSettingsLang({ lang: 'en-US' }, { lang: 'en-GB' })).to.be.false;
+        });
+    });
+
     describe('Track Equality', function () {
         it('should return false if track are not equals', function () {
 

--- a/test/unit/test/streaming/streaming.controllers.MediaController.js
+++ b/test/unit/test/streaming/streaming.controllers.MediaController.js
@@ -71,13 +71,10 @@ describe('MediaController', function () {
     });
 
     describe('Language Matching', function () {
-        it('should match generic track languages against more specific preferences', function () {
-            expect(mediaController.matchSettingsLang({ lang: 'en-US' }, { lang: 'en' })).to.be.true;
-            expect(mediaController.matchSettingsLang({ lang: 'zh-Hans-CN' }, { lang: 'zh' })).to.be.true;
-        });
-
-        it('should not match different regional variants', function () {
+        it('should keep language range matching directional', function () {
+            expect(mediaController.matchSettingsLang({ lang: 'en-GB' }, { lang: 'en' })).to.be.false;
             expect(mediaController.matchSettingsLang({ lang: 'en-US' }, { lang: 'en-GB' })).to.be.false;
+            expect(mediaController.matchSettingsLang({ lang: 'en-GB' }, { lang: 'en-GB' })).to.be.true;
         });
     });
 

--- a/test/unit/test/streaming/streaming.utils.BCP47Utils.js
+++ b/test/unit/test/streaming/streaming.utils.BCP47Utils.js
@@ -19,7 +19,6 @@ describe('BCP47Utils', function () {
             expect(normalizeBcp47('zh-hans')).to.equal('zh-Hans');
             expect(normalizeBcp47('en-us')).to.equal('en-US');
             expect(normalizeBcp47('ZH-hANS-cn')).to.equal('zh-Hans-CN');
-            expect(normalizeBcp47('de-DE-1996-A-EXTENSION-X-PRIVATE')).to.equal('de-DE-1996-a-extension-x-private');
         });
 
         it('should preserve the language normalization used before dash.js 5.2.0', () => {

--- a/test/unit/test/streaming/streaming.utils.BCP47Utils.js
+++ b/test/unit/test/streaming/streaming.utils.BCP47Utils.js
@@ -19,6 +19,14 @@ describe('BCP47Utils', function () {
             expect(normalizeBcp47('zh-hans')).to.equal('zh-Hans');
             expect(normalizeBcp47('en-us')).to.equal('en-US');
             expect(normalizeBcp47('ZH-hANS-cn')).to.equal('zh-Hans-CN');
+            expect(normalizeBcp47('de-DE-1996-A-EXTENSION-X-PRIVATE')).to.equal('de-DE-1996-a-extension-x-private');
+        });
+
+        it('should preserve the language normalization used before dash.js 5.2.0', () => {
+            expect(normalizeBcp47('zh-cmn')).to.equal('zh');
+            expect(normalizeBcp47('ZH-CMN')).to.equal('zh');
+            expect(normalizeBcp47('nl-NL')).to.equal('nl');
+            expect(normalizeBcp47('NLD-nl')).to.equal('nl');
         });
 
         // Numeric regions (UN M.49) and variant subtags must not be altered


### PR DESCRIPTION
## Summary

After #4970 replaced `bcp-47-normalize`, the DASH-IF complex multi-period vector reported `MediaInfo.lang` as `zh-cmn` and `nl-NL` instead of the previous `zh` and `nl`.

This patch restores those two reported values through exact-tag compatibility mappings applied after ISO-code and case normalization. It adds regression coverage for those values and directional language matching.

## Scope and language matching

The RFC 4647 directional filtering algorithm is unchanged, but normalization changes its inputs and therefore some matches. For example, preference `nl-NL` matches a `nl-BE` track with the old library, does not match in 5.2.0, and matches again with this patch because the preference becomes `nl`.

The two mappings do not restore general compatibility with the old library. Compound forms such as `zh-cmn-Hans-CN` and `nl-NL-x-audit` remain different, along with other aliases, CLDR minimization and formatting behavior. This patch does not implement ranking across tracks.

## Compatibility audit and decisions requested

The [reproducible audit](https://github.com/PascalThuet/dash.js/tree/17c91e8f0f2376db54ae74953ccbb1d98f7295c9) compares the exact `bcp-47-normalize@2.3.0` dependencies locked in dash.js 5.0.0 against 5.2.0 and this patch at `87670d1`. It includes every historical table entry and 32,390 distinct generated inputs, with a [detailed mapping inventory](https://github.com/PascalThuet/dash.js/blob/17c91e8f0f2376db54ae74953ccbb1d98f7295c9/missing-mappings.md). The corpus measures differences in synthetic cases, not production impact.

Before extending the patch, maintainer confirmation is requested on the compatibility contract:

1. Exact compatibility with the previous 2.3.0 outputs, including CLDR minimization and historical behavior such as `und → en`.
2. A deliberately narrower normalization contract with supported aliases and intentional differences documented and tested.

The proposed separate follow-up would specify track-selection priorities: exact match, generic-language fallback, other-region fallback, script handling and interactions with other preferences. Restoring the old normalizer alone would not implement this ranking: it already collapsed `en-US` and `en` to the same value.

The compatibility target and the proposed split remain open for maintainer feedback.

## Validation

Previously completed for the code at `87670d1`:

- Targeted Karma tests: 164 passed.
- Full unit test suite: 3,798 passed.
- `npm run lint` and `npx tsc` passed.

Audit validation:

- All six upstream tests passed, including the 89-fixture test.
- 45 source-extracted language-predicate checks and 18 parser-converter checks passed.
- Six historical dependency versions/integrity hashes and the upstream source snapshots were verified.
- Full-player playback and bundle-size validation were not performed for the audit.

Related to #5090.
