### PR TITLE
fix(streaming): check all Preselection representations for capability support

### DIFF
--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -146,12 +146,8 @@ function CapabilitiesFilter() {
         period.Preselection = period.Preselection.filter((prsl) => {
             if (adapter.getPreselectionIsTypeOf(prsl, period.AdaptationSet, type)) {
                 const prslCodec = adapter.getCodecForPreselection(prsl, period.AdaptationSet);
-                let isPrslCodecSupported = true;
-                if (prslCodec) {
-                    let commonRepresentation = adapter.getCommonRepresentationForPreselection(prsl, period.AdaptationSet);
-
-                    isPrslCodecSupported = _isCodecSupported(type, prsl, prslCodec, commonRepresentation);
-                }
+                const isPrslCodecSupported = !prslCodec || _getRepresentationsForPreselection(prsl, period.AdaptationSet)
+                    .every((representation) => _isCodecSupported(type, prsl, prslCodec, representation));
 
                 if (!isPrslCodecSupported) {
                     logger.warn(`[CapabilitiesFilter] Preselection@codecs ${prslCodec} not supported. Removing Preselection with ID ${prsl.id}`);
@@ -162,6 +158,11 @@ function CapabilitiesFilter() {
                 return true;
             }
         })
+    }
+
+    function _getRepresentationsForPreselection(preselection, adaptations) {
+        const mainAdaptationSet = adapter.getMainAdaptationSetForPreselection(preselection, adaptations);
+        return mainAdaptationSet && mainAdaptationSet.Representation ? mainAdaptationSet.Representation : [];
     }
 
     function _filterUnsupportedRepresentationsOfAdaptation(as, type) {
@@ -234,9 +235,11 @@ function CapabilitiesFilter() {
                 period.Preselection.forEach((prsl) => {
                     if (adapter.getPreselectionIsTypeOf(prsl, period.AdaptationSet, type)) {
                         const prslCodec = adapter.getCodecForPreselection(prsl, period.AdaptationSet);
-                        const prslCommonRepresentation = adapter.getCommonRepresentationForPreselection(prsl, period.AdaptationSet);
+                        const representations = _getRepresentationsForPreselection(prsl, period.AdaptationSet);
 
-                        _processCodecToCheck(type, prsl, prslCodec, configurationsSet, configurations, prslCommonRepresentation);
+                        representations.forEach((representation) => {
+                            _processCodecToCheck(type, prsl, prslCodec, configurationsSet, configurations, representation);
+                        });
                     }
                 });
             }

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -249,10 +249,14 @@ function AdapterMock() {
         return 'audio/mp4;codecs="' + adaptations[0].Representation[0].codecs + '"'
     }
 
-    this.getCommonRepresentationForPreselection = function (preselection, adaptations) {
+    this.getMainAdaptationSetForPreselection = function (preselection, adaptations) {
         const id = preselection.preselectionComponents.split(' ')[0];
-        const as = adaptations.find((as) => as.id == id);
-        return (as ? as.Representation[0] : undefined);
+        return adaptations.find((adaptation) => adaptation.id === id);
+    }
+
+    this.getCommonRepresentationForPreselection = function (preselection, adaptations) {
+        const adaptation = this.getMainAdaptationSetForPreselection(preselection, adaptations);
+        return adaptation ? adaptation.Representation[0] : undefined;
     }
 
 }

--- a/test/unit/test/streaming/streaming.utils.CapabilitiesFilter.js
+++ b/test/unit/test/streaming/streaming.utils.CapabilitiesFilter.js
@@ -436,6 +436,67 @@ describe('CapabilitiesFilter', function () {
 
             });
 
+            it('should check all Representations of the main AdaptationSet for a Preselection codec override', function (done) {
+                const preselectionCodec = 'audio/mp4;codecs="iamf.000.000.mp4a.40.2"';
+                const checkedPreselectionBitrates = [];
+                const manifest = {
+                    Period: [{
+                        Preselection: [{
+                            id: '10',
+                            codecs: 'iamf.000.000.mp4a.40.2',
+                            preselectionComponents: '1',
+                            tagName: 'Preselection'
+                        }],
+                        AdaptationSet: [{
+                            id: '1',
+                            mimeType: 'audio/mp4',
+                            Representation: [
+                                {
+                                    id: '1-low',
+                                    mimeType: 'audio/mp4',
+                                    codecs: 'mp4a.40.2',
+                                    audioSamplingRate: '48000',
+                                    bandwidth: 64000
+                                },
+                                {
+                                    id: '1-high',
+                                    mimeType: 'audio/mp4',
+                                    codecs: 'mp4a.40.2',
+                                    audioSamplingRate: '48000',
+                                    bandwidth: 128000
+                                }
+                            ]
+                        }]
+                    }]
+                };
+
+                prepareCapabilitiesMock({
+                    name: 'runCodecSupportCheck', definition: function (config) {
+                        if (config.codec === preselectionCodec) {
+                            checkedPreselectionBitrates.push(config.bitrate);
+                        }
+                        return Promise.resolve();
+                    }
+                });
+                prepareCapabilitiesMock({
+                    name: 'isCodecSupportedBasedOnTestedConfigurations', definition: function (config) {
+                        return config.codec !== preselectionCodec || config.bitrate === 64000;
+                    }
+                });
+
+                capabilitiesFilter.filterUnsupportedFeatures(manifest)
+                    .then(() => {
+                        expect(checkedPreselectionBitrates).to.have.members([64000, 128000]);
+                        expect(manifest.Period[0].Preselection).to.be.empty;
+                        expect(manifest.Period[0].AdaptationSet).to.have.lengthOf(1);
+                        expect(manifest.Period[0].AdaptationSet[0].Representation).to.have.lengthOf(2);
+                        done();
+                    })
+                    .catch((e) => {
+                        done(e);
+                    });
+            });
+
         });
 
         describe('filter codecs using codec properties', function () {


### PR DESCRIPTION
## Description

Capability checks for a Preselection currently use only the first Representation of its Main Adaptation Set.

When `Preselection@codecs` overrides the codec of the Main Adaptation Set, support can also depend on Representation-level properties such as bitrate, sampling rate, resolution, frame rate, HDR properties, or content protection.

This change:

- schedules capability checks for every Representation of the Main Adaptation Set;
- keeps a Preselection only when all of those configurations are supported;
- leaves the shared Adaptation Set and its Representations unchanged;
- keeps the existing public adapter API intact.

The all-or-nothing behavior is intentional: dash.js does not maintain a separate Representation subset per Preselection, and pruning the shared Adaptation Set would also affect the regular track.

## Tests

- `npx --no-install karma start test/unit/config/karma.unit.conf.cjs --grep="CapabilitiesFilter"` (62 tests)
- `npx --no-install eslint src/streaming/utils/CapabilitiesFilter.js test/unit/mocks/AdapterMock.js test/unit/test/streaming/streaming.utils.CapabilitiesFilter.js`

Closes #4807
