### PR TITLE
fix(streaming): settle selectMediaInfo without representation controller

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -701,11 +701,11 @@ function StreamProcessor(config) {
      * @param {MediaInfoSelectionInput} mediaInfoSelectionInput
      */
     function selectMediaInfo(mediaInfoSelectionInput) {
-        return new Promise((resolve) => {
-            if (!representationController) {
-                return Promise.resolve();
-            }
+        if (!representationController) {
+            return Promise.resolve();
+        }
 
+        return new Promise((resolve) => {
             let selectedValues = null;
 
             // Switching to a new AdaptationSet as part of a quality switch

--- a/test/unit/test/streaming/streaming.StreamProcessor.js
+++ b/test/unit/test/streaming/streaming.StreamProcessor.js
@@ -34,6 +34,11 @@ describe('StreamProcessor', function () {
             expect(streamProcessor.setEnhancementStreamProcessor.bind(streamProcessor, {})).to.not.throw();
         });
 
+        it('selectMediaInfo should resolve when the representation controller is not initialized', async function () {
+            const result = await streamProcessor.selectMediaInfo({});
+            expect(result).to.be.undefined;
+        });
+
     });
 
 });


### PR DESCRIPTION
## What does this PR change?

- Resolve `StreamProcessor.selectMediaInfo()` immediately when no `representationController` is available.
- Add a regression test for the uninitialized `StreamProcessor` path.

## Why is this needed?

The existing guard is inside the Promise executor and returns `Promise.resolve()`:

```js
return new Promise((resolve) => {
    if (!representationController) {
        return Promise.resolve();
    }
});
```

A Promise executor's return value is ignored. The outer Promise therefore never settles when this guard is reached.

Moving the guard before the Promise constructor makes the existing early-exit behavior work as intended. The initialized path is unchanged.

## Scope

No production path triggering this state has been identified on the current `development` branch. The normal `Stream` lifecycle initializes the representation controller before calling `selectMediaInfo()`.

This PR is intentionally limited to a defensive correctness fix with a unit-level regression test. It prevents direct or future callers from waiting indefinitely, but does not claim to fix a currently reproduced playback failure.

This issue was found while investigating #5046 and is unrelated to the startup-time regression reported there.

## Verification

- `npm run ci:verify`
  - TypeScript validation
  - 3,796 unit tests
  - ESLint

Fixes #5124
