### PR TITLE
(fix/text): CEA-608 captions with presentationTimeOffset on embedding video AdaptationSet

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2583,6 +2583,7 @@ function MediaPlayer() {
                 mediaController,
                 settings,
                 videoModel,
+                timelineConverter
             });
         }
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -54,6 +54,7 @@ function TextController(config) {
     const baseURLController = config.baseURLController;
     const videoModel = config.videoModel;
     const settings = config.settings;
+    const timelineConverter = config.timelineConverter;
 
     let instance,
         streamData,
@@ -122,7 +123,8 @@ function TextController(config) {
             vttCustomRenderingParser,
             ttmlParser,
             streamInfo,
-            settings
+            settings,
+            timelineConverter
         });
         textSourceBuffer.initialize();
         textSourceBuffers[streamId] = textSourceBuffer;

--- a/src/streaming/text/TextSourceBuffer.js
+++ b/src/streaming/text/TextSourceBuffer.js
@@ -55,6 +55,7 @@ function TextSourceBuffer(config) {
     const ttmlParser = config.ttmlParser;
     const streamInfo = config.streamInfo;
     const settings = config.settings;
+    const timelineConverter = config.timelineConverter;
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
@@ -473,7 +474,8 @@ function TextSourceBuffer(config) {
                     const fieldParser = embeddedCea608FieldParsers[fieldNr];
                     if (fieldParser) {
                         for (i = 0; i < ccData.length; i++) {
-                            fieldParser.addData(ccData[i][0] / embeddedTimescale, ccData[i][1]);
+                            const time = timelineConverter.calcPresentationTimeFromMediaTime(ccData[i][0] / embeddedTimescale, chunk.representation);
+                            fieldParser.addData(time, ccData[i][1]);
                         }
                     }
                 }


### PR DESCRIPTION
This PR is fixing display of CEA-608 captions embedded in a video `AdaptationSet` that has a `presentationTimeOffset`. 
The `presentationTimeOffset` was not considered when computing cues start time, which cues were consequently not rendered.

An issue was already opened a long time ago... https://github.com/Dash-Industry-Forum/dash.js/issues/4517