### PR TITLE
fix(StreamController): recover when the media element is emptied and the MediaSource is detached from outside

### DIFF
--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -225,9 +225,9 @@ function Stream(config) {
             // short-circuit on isActive with no processors behind it.
             const epoch = activationEpoch;
             _initializeMedia(mediaSource, previousSourceBufferSinks, representationsFromPreviousPeriod)
-                .then(() => {
-                    if (epoch !== activationEpoch) {
-                        resolve();
+                .then((result) => {
+                    if ((result && result.cancelled) || epoch !== activationEpoch) {
+                        resolve({ cancelled: true });
                         return;
                     }
                     isActive = true;
@@ -257,7 +257,12 @@ function Stream(config) {
             _setPreloaded(true);
 
             _commonMediaInitialization(mediaSource, previousBuffers, representationsFromPreviousPeriod)
-                .then(() => {
+                .then((result) => {
+                    if (result && result.cancelled) {
+                        _setPreloaded(false);
+                        resolve({ cancelled: true });
+                        return;
+                    }
                     for (let i = 0; i < streamProcessors.length && streamProcessors[i]; i++) {
                         streamProcessors[i].setExplicitBufferingTime(getStartTime());
                         streamProcessors[i].getScheduleController().startScheduleTimer();
@@ -292,6 +297,11 @@ function Stream(config) {
      */
     function _commonMediaInitialization(mediaSource, previousSourceBufferSinks, representationsFromPreviousPeriod) {
         return new Promise((resolve, reject) => {
+            // deactivate() bumps the epoch; an initialization overtaken by a
+            // deactivation must stop before its side effects (buffer sinks,
+            // error signalling, text tracks) and report itself cancelled, so
+            // no caller mistakes it for a successful initialization.
+            const epoch = activationEpoch;
             checkConfig();
 
             _addInlineEvents();
@@ -311,9 +321,16 @@ function Stream(config) {
 
             Promise.all(promises)
                 .then(() => {
+                    if (epoch !== activationEpoch) {
+                        return null;
+                    }
                     return _createBufferSinks(previousSourceBufferSinks, representationsFromPreviousPeriod)
                 })
                 .then((bufferSinks) => {
+                    if (epoch !== activationEpoch) {
+                        resolve({ cancelled: true });
+                        return;
+                    }
                     if (streamProcessors.length === 0) {
                         const msg = 'No streams to play.';
                         errHandler.error(new DashJSError(Errors.MANIFEST_ERROR_ID_NOSTREAMS_CODE, msg, manifestModel.getValue()));

--- a/src/streaming/Stream.js
+++ b/src/streaming/Stream.js
@@ -77,7 +77,8 @@ function Stream(config) {
     const settings = config.settings;
 
 
-    let boxParser,
+    let activationEpoch,
+        boxParser,
         debug,
         fragmentController,
         hasAudioTrack,
@@ -99,6 +100,7 @@ function Stream(config) {
      * Setup the stream
      */
     function setup() {
+        activationEpoch = 0;
         try {
             debug = Debug(context).getInstance();
             logger = debug.getLogger(instance);
@@ -217,8 +219,17 @@ function Stream(config) {
             }
 
 
+            // deactivate() bumps the epoch: an activation that was started
+            // before a deactivation must not mark the stream active when its
+            // initialization settles late, or the next activate() would
+            // short-circuit on isActive with no processors behind it.
+            const epoch = activationEpoch;
             _initializeMedia(mediaSource, previousSourceBufferSinks, representationsFromPreviousPeriod)
                 .then(() => {
+                    if (epoch !== activationEpoch) {
+                        resolve();
+                        return;
+                    }
                     isActive = true;
                     if (representationsFromPreviousPeriod && representationsFromPreviousPeriod.length > 0) {
                         startScheduleControllers();
@@ -589,6 +600,7 @@ function Stream(config) {
         }
         streamProcessors = [];
         isActive = false;
+        activationEpoch++;
         hasFinishedBuffering = false;
         _setPreloaded(false);
         setIsEndedEventSignaled(false);

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -89,17 +89,19 @@ function MediaSourceController() {
 
             managedMediaSourceEventHandlers = {
                 // A ManagedMediaSource that is being detached emits streaming events
-                // while it closes. Forwarding those latches ScheduleController on
-                // behalf of a source that no longer exists, so only pass events from
-                // the source that is still current and still open.
-                start: (e) => {
-                    if (e.target !== attachedMediaSource || attachedMediaSource.readyState !== 'open') {
+                // while it closes, and a replaced source's listeners survive its
+                // replacement. Forwarding those latches ScheduleController on
+                // behalf of a source that no longer exists, so only pass events
+                // when the source these handlers were attached for is still the
+                // controller's current one and still open.
+                start: () => {
+                    if (attachedMediaSource !== mediaSource || attachedMediaSource.readyState !== 'open') {
                         return;
                     }
                     eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_START_STREAMING)
                 },
-                end: (e) => {
-                    if (e.target !== attachedMediaSource || attachedMediaSource.readyState !== 'open') {
+                end: () => {
+                    if (attachedMediaSource !== mediaSource || attachedMediaSource.readyState !== 'open') {
                         return;
                     }
                     eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_END_STREAMING)

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -39,7 +39,8 @@ function MediaSourceController() {
         mediaSource,
         settings,
         mediaSourceType,
-        logger;
+        logger,
+        managedMediaSourceEventHandlers;
 
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
@@ -78,12 +79,34 @@ function MediaSourceController() {
 
         if (mediaSourceType === 'managedMediaSource') {
             videoModel.setDisableRemotePlayback(true);
-            mediaSource.addEventListener('startstreaming', () => {
-                eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_START_STREAMING)
-            })
-            mediaSource.addEventListener('endstreaming', () => {
-                eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_END_STREAMING)
-            })
+            // Re-attaching the same source must not stack a second pair of
+            // forwarding listeners, so drop the previous pair first.
+            if (managedMediaSourceEventHandlers) {
+                mediaSource.removeEventListener('startstreaming', managedMediaSourceEventHandlers.start);
+                mediaSource.removeEventListener('endstreaming', managedMediaSourceEventHandlers.end);
+            }
+            const attachedMediaSource = mediaSource;
+
+            managedMediaSourceEventHandlers = {
+                // A ManagedMediaSource that is being detached emits streaming events
+                // while it closes. Forwarding those latches ScheduleController on
+                // behalf of a source that no longer exists, so only pass events from
+                // the source that is still current and still open.
+                start: (e) => {
+                    if (e.target !== attachedMediaSource || attachedMediaSource.readyState !== 'open') {
+                        return;
+                    }
+                    eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_START_STREAMING)
+                },
+                end: (e) => {
+                    if (e.target !== attachedMediaSource || attachedMediaSource.readyState !== 'open') {
+                        return;
+                    }
+                    eventBus.trigger(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_END_STREAMING)
+                }
+            };
+            mediaSource.addEventListener('startstreaming', managedMediaSourceEventHandlers.start)
+            mediaSource.addEventListener('endstreaming', managedMediaSourceEventHandlers.end)
         }
 
         return objectURL;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -67,7 +67,7 @@ function StreamController() {
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
         firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
         pendingDynamicToStaticUpdate, expectedSourceDetach, lastKnownPlaybackTime,
-        boundVideoElement;
+        boundVideoElement, pendingSourceOpenHandler;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -545,8 +545,7 @@ function StreamController() {
 
             logger.debug('MediaSource is open!');
             window.URL.revokeObjectURL(sourceUrl);
-            mediaSource.removeEventListener('sourceopen', _onMediaSourceOpen);
-            mediaSource.removeEventListener('webkitsourceopen', _onMediaSourceOpen);
+            _removePendingSourceOpenHandler();
 
             _setMediaDuration();
             const dvrInfo = dashMetrics.getCurrentDVRInfo();
@@ -567,6 +566,13 @@ function StreamController() {
         }
 
         function _open() {
+            // A cold attachment that never reached sourceopen leaves its own
+            // callback registered: the early return above does not remove it,
+            // and the recovery path re-attaches the SAME MediaSource object, so
+            // without this the next sourceopen would run both callbacks and
+            // initialize the stream twice.
+            _removePendingSourceOpenHandler();
+            pendingSourceOpenHandler = { callback: _onMediaSourceOpen, source: mediaSource };
             mediaSource.addEventListener('sourceopen', _onMediaSourceOpen, false);
             mediaSource.addEventListener('webkitsourceopen', _onMediaSourceOpen, false);
             sourceUrl = mediaSourceController.attachMediaSource(videoModel);
@@ -641,18 +647,20 @@ function StreamController() {
      * @private
      */
     function _onPlaybackSeeking(e) {
-        const newTime = e.seekTime;
-        if (!isNaN(newTime)) {
-            // An explicit seek target is a valid resume position for
-            // _onVideoElementEmptied(), zero included; only the load
-            // algorithm's reset-to-zero must not overwrite the cache, and
-            // that never arrives through a seeking event.
-            lastKnownPlaybackTime = newTime;
-        }
-        let seekToStream = getStreamForTime(newTime);
+        let seekToStream = getStreamForTime(e.seekTime);
 
         if (!seekToStream) {
             seekToStream = _handleSeekBeyondEndOfContent(e);
+        }
+
+        // An explicit seek target is a valid resume position for
+        // _onVideoElementEmptied(), zero included; only the load algorithm's
+        // reset-to-zero must not overwrite the cache, and that never arrives
+        // through a seeking event. Read AFTER _handleSeekBeyondEndOfContent(),
+        // which adjusts e.seekTime in place, so an overshooting static seek
+        // caches the clamped target rather than a position past the end.
+        if (!isNaN(e.seekTime)) {
+            lastKnownPlaybackTime = e.seekTime;
         }
 
         if (!seekToStream || seekToStream === activeStream) {
@@ -1654,6 +1662,15 @@ function StreamController() {
      * initialize() rebinds later in that flow.
      * @private
      */
+    function _removePendingSourceOpenHandler() {
+        if (!pendingSourceOpenHandler) {
+            return;
+        }
+        pendingSourceOpenHandler.source.removeEventListener('sourceopen', pendingSourceOpenHandler.callback);
+        pendingSourceOpenHandler.source.removeEventListener('webkitsourceopen', pendingSourceOpenHandler.callback);
+        pendingSourceOpenHandler = null;
+    }
+
     function _bindVideoElementEmptied() {
         if (!videoModel) {
             return;
@@ -1711,6 +1728,14 @@ function StreamController() {
                 const streamInfo = activeStream.getStreamInfo();
                 seekTime = streamInfo && !isNaN(streamInfo.start) ? streamInfo.start : 0;
             }
+        }
+        if (isNaN(seekTime)) {
+            // A detach before playback established leaves no cached position
+            // and no DVR metrics either. Fall back to the same computation a
+            // cold start uses; a non-NaN seekTime here also makes
+            // _activateStream() start the schedule controllers, which nothing
+            // else does on this path.
+            seekTime = _getInitialStartTime();
         }
         activeStream.deactivate(false);
         logger.info(`MediaSource has been reset. Resuming playback from time ${seekTime}`);
@@ -1851,6 +1876,7 @@ function StreamController() {
         expectedSourceDetach = false;
         lastKnownPlaybackTime = NaN;
         boundVideoElement = null;
+        pendingSourceOpenHandler = null;
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;
@@ -1886,6 +1912,7 @@ function StreamController() {
 
         if (mediaSource) {
             expectedSourceDetach = true;
+            _removePendingSourceOpenHandler();
             mediaSourceController.detachMediaSource(videoModel);
             mediaSource = null;
         }

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -576,6 +576,16 @@ function StreamController() {
             pendingSourceOpenHandler = { callback: _onMediaSourceOpen, source: mediaSource };
             mediaSource.addEventListener('sourceopen', _onMediaSourceOpen, false);
             mediaSource.addEventListener('webkitsourceopen', _onMediaSourceOpen, false);
+            // Attaching over an element that already holds a resource makes
+            // the load algorithm fire abort/emptied for dash.js's OWN source
+            // assignment; arm the suppression so that is not misread as an
+            // external detach. A fresh NETWORK_EMPTY element fires no emptied
+            // for this assignment, so do not arm there, where it would
+            // swallow the next real external detach instead.
+            const element = videoModel.getElement();
+            if (element && element.networkState !== 0) {
+                expectedSourceDetach = true;
+            }
             sourceUrl = mediaSourceController.attachMediaSource(videoModel);
             pendingSourceOpenHandler.url = sourceUrl;
             logger.debug('MediaSource attached to element.  Waiting on open...');
@@ -1716,6 +1726,12 @@ function StreamController() {
         // completes (_onMediaSourceOpen returns early on a non-open source), so
         // the flag would stay true forever and block the only way out.
         logger.error('The media element was emptied outside of dash.js and the MediaSource is detached: Resetting the MediaSource');
+        // Preloaded periods were initialized against the detached source, and
+        // Stream.activate() would reuse their processors and buffer sinks
+        // through the preloaded short-circuit; drop them (an in-flight preload
+        // aborts its requests through the same call) so the next period
+        // initializes against the recovered source.
+        _deactivateAllPreloadingStreams();
         // The element's currentTime is already 0 here, so getTime() is useless;
         // resume from the last position a timeupdate reported. If playback never
         // established one, fall back to the live edge for dynamic streams, the

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1721,6 +1721,18 @@ function StreamController() {
         // established one, fall back to the live edge for dynamic streams, the
         // way seekToCurrentLive() computes it, and to the start for static ones.
         let seekTime = lastKnownPlaybackTime;
+        if (!isNaN(seekTime)) {
+            // A detach during a non-seamless period transition: _switchStream()
+            // makes the target period active before its MediaSource opens, so
+            // the cache can still hold a position from the previous period.
+            // Discard a position outside the active stream and let the
+            // fallbacks resume at the target period instead.
+            const activeStreamInfo = activeStream.getStreamInfo();
+            const activeStreamEnd = activeStreamInfo.start + activeStreamInfo.duration;
+            if (seekTime < activeStreamInfo.start || (!isNaN(activeStreamEnd) && seekTime > activeStreamEnd)) {
+                seekTime = NaN;
+            }
+        }
         const isDynamic = playbackController.getIsDynamic();
         const dvrInfo = isDynamic ? dashMetrics.getCurrentDVRInfo(hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO) : null;
         if (isDynamic && !isNaN(seekTime) && (!dvrInfo || !dvrInfo.range || seekTime < dvrInfo.range.start || seekTime > dvrInfo.range.end)) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -66,7 +66,7 @@ function StreamController() {
         playbackController, serviceDescriptionController, mediaPlayerModel, customParametersModel, isPaused,
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
         firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
-        pendingDynamicToStaticUpdate;
+        pendingDynamicToStaticUpdate, expectedSourceDetach, lastKnownPlaybackTime;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -119,6 +119,8 @@ function StreamController() {
                 protectionController.setProtectionData(protectionData);
             }
         }
+
+        videoModel.addEventListener('emptied', _onVideoElementEmptied);
 
         registerEvents();
     }
@@ -577,6 +579,7 @@ function StreamController() {
             if (inputParameters.keepBuffers) {
                 _activateStream(inputParameters);
             } else {
+                expectedSourceDetach = true;
                 mediaSourceController.detachMediaSource(videoModel);
                 _open();
             }
@@ -947,6 +950,13 @@ function StreamController() {
      * @private
      */
     function _onPlaybackTimeUpdated(/*e*/) {
+        // Remember where playback was: when the element is reset from outside,
+        // its currentTime is already back at 0 by the time 'emptied' fires, so
+        // this is the only usable resume position for _onVideoElementEmptied().
+        const time = playbackController.getTime();
+        if (time !== null && !isNaN(time) && time > 0) {
+            lastKnownPlaybackTime = time;
+        }
         if (hasVideoTrack()) {
             const playbackQuality = videoModel.getPlaybackQuality();
             if (playbackQuality) {
@@ -1612,6 +1622,49 @@ function StreamController() {
         _openMediaSource({ seekTime, keepBuffers: false, streamActivated: false });
     }
 
+    /**
+     * Fired by the media element whenever the resource selection algorithm empties it.
+     * When that was not caused by dash.js itself, the MediaSource has been detached
+     * from outside (an external element.load(), a src write, or a UA-driven reload).
+     * A detached ManagedMediaSource is permanently closed and emits a final
+     * endstreaming, so without intervention the player silently never requests
+     * another byte. Recover the same way _handleMediaErrorDecode() does.
+     * @private
+     */
+    function _onVideoElementEmptied() {
+        if (expectedSourceDetach) {
+            expectedSourceDetach = false;
+            return;
+        }
+        if (!activeStream || !mediaSource) {
+            return;
+        }
+        if (mediaSource.readyState === 'open') {
+            return;
+        }
+        // Deliberately no isStreamSwitchingInProgress bail-out: a switch that is
+        // waiting on sourceopen of a source that just got detached never
+        // completes (_onMediaSourceOpen returns early on a non-open source), so
+        // the flag would stay true forever and block the only way out.
+        logger.error('The media element was emptied outside of dash.js and the MediaSource is detached: Resetting the MediaSource');
+        // The element's currentTime is already 0 here, so getTime() is useless;
+        // resume from the last position a timeupdate reported. If playback never
+        // established one, fall back to the live edge for dynamic streams, the
+        // way seekToCurrentLive() computes it, and to the start for static ones.
+        let seekTime = lastKnownPlaybackTime;
+        if (isNaN(seekTime)) {
+            if (playbackController.getIsDynamic()) {
+                const dvrInfo = dashMetrics.getCurrentDVRInfo(hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO);
+                seekTime = dvrInfo && dvrInfo.range ? dvrInfo.range.end - playbackController.getLiveDelay() : NaN;
+            } else {
+                seekTime = 0;
+            }
+        }
+        activeStream.deactivate(false);
+        logger.info(`MediaSource has been resetted. Resuming playback from time ${seekTime}`);
+        _openMediaSource({ seekTime, keepBuffers: false, streamActivated: false });
+    }
+
     function getActiveStreamInfo() {
         return activeStream ? activeStream.getStreamInfo() : null;
     }
@@ -1743,6 +1796,8 @@ function StreamController() {
         autoPlay = true;
         playbackEndedTimerInterval = null;
         pendingDynamicToStaticUpdate = false;
+        expectedSourceDetach = false;
+        lastKnownPlaybackTime = NaN;
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;
@@ -1777,8 +1832,12 @@ function StreamController() {
         initCache.reset();
 
         if (mediaSource) {
+            expectedSourceDetach = true;
             mediaSourceController.detachMediaSource(videoModel);
             mediaSource = null;
+        }
+        if (videoModel) {
+            videoModel.removeEventListener('emptied', _onVideoElementEmptied);
         }
         videoModel = null;
         if (protectionController) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -544,7 +544,8 @@ function StreamController() {
             }
 
             logger.debug('MediaSource is open!');
-            window.URL.revokeObjectURL(sourceUrl);
+            // _removePendingSourceOpenHandler() also revokes this attachment's
+            // object URL, the single revocation site for both outcomes.
             _removePendingSourceOpenHandler();
 
             _setMediaDuration();
@@ -576,6 +577,7 @@ function StreamController() {
             mediaSource.addEventListener('sourceopen', _onMediaSourceOpen, false);
             mediaSource.addEventListener('webkitsourceopen', _onMediaSourceOpen, false);
             sourceUrl = mediaSourceController.attachMediaSource(videoModel);
+            pendingSourceOpenHandler.url = sourceUrl;
             logger.debug('MediaSource attached to element.  Waiting on open...');
         }
 
@@ -1643,14 +1645,24 @@ function StreamController() {
     }
 
     /**
-     * Fired by the media element whenever the resource selection algorithm empties it.
-     * When that was not caused by dash.js itself, the MediaSource has been detached
-     * from outside (an external element.load(), a src write, or a UA-driven reload).
-     * A detached ManagedMediaSource is permanently closed and emits a final
-     * endstreaming, so without intervention the player silently never requests
-     * another byte. Recover the same way _handleMediaErrorDecode() does.
+     * Cancels the source-open callback of an attachment that has not opened,
+     * and revokes that attachment's object URL, so a cancelled attachment
+     * neither initializes the stream a second time nor leaks its URL. Also
+     * the revocation site for the successful-open path.
      * @private
      */
+    function _removePendingSourceOpenHandler() {
+        if (!pendingSourceOpenHandler) {
+            return;
+        }
+        pendingSourceOpenHandler.source.removeEventListener('sourceopen', pendingSourceOpenHandler.callback);
+        pendingSourceOpenHandler.source.removeEventListener('webkitsourceopen', pendingSourceOpenHandler.callback);
+        if (pendingSourceOpenHandler.url) {
+            window.URL.revokeObjectURL(pendingSourceOpenHandler.url);
+        }
+        pendingSourceOpenHandler = null;
+    }
+
     /**
      * (Re)binds the emptied listener to the current view. VideoModel's
      * add/removeEventListener are no-ops without an element, so a view
@@ -1662,15 +1674,6 @@ function StreamController() {
      * initialize() rebinds later in that flow.
      * @private
      */
-    function _removePendingSourceOpenHandler() {
-        if (!pendingSourceOpenHandler) {
-            return;
-        }
-        pendingSourceOpenHandler.source.removeEventListener('sourceopen', pendingSourceOpenHandler.callback);
-        pendingSourceOpenHandler.source.removeEventListener('webkitsourceopen', pendingSourceOpenHandler.callback);
-        pendingSourceOpenHandler = null;
-    }
-
     function _bindVideoElementEmptied() {
         if (!videoModel) {
             return;
@@ -1688,6 +1691,15 @@ function StreamController() {
         boundVideoElement = element || null;
     }
 
+    /**
+     * Fired by the media element whenever the resource selection algorithm empties it.
+     * When that was not caused by dash.js itself, the MediaSource has been detached
+     * from outside (an external element.load(), a src write, or a UA-driven reload).
+     * A detached ManagedMediaSource is permanently closed and emits a final
+     * endstreaming, so without intervention the player silently never requests
+     * another byte. Recover the same way _handleMediaErrorDecode() does.
+     * @private
+     */
     function _onVideoElementEmptied() {
         if (expectedSourceDetach) {
             expectedSourceDetach = false;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -67,7 +67,7 @@ function StreamController() {
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
         firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
         pendingDynamicToStaticUpdate, expectedSourceDetach, lastKnownPlaybackTime,
-        boundVideoElement, pendingSourceOpenHandler;
+        boundVideoElement, pendingSourceOpenHandler, pendingPreloadStream;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -612,7 +612,10 @@ function StreamController() {
     function _activateStream(inputParameters) {
         const representationsFromPreviousPeriod = inputParameters.representationsFromPreviousPeriod || [];
         activeStream.activate(mediaSource, inputParameters.sourceBufferSinksFromPreviousPeriod, representationsFromPreviousPeriod)
-            .then(() => {
+            .then((result) => {
+                if (result && result.cancelled) {
+                    return;
+                }
 
                 // Set the initial time for this stream in the StreamProcessor
                 if (!isNaN(inputParameters.seekTime)) {
@@ -748,6 +751,13 @@ function StreamController() {
      * @private
      */
     function _deactivateAllPreloadingStreams() {
+        // A preload still in flight is not in preloadingStreams yet (it is
+        // pushed on resolve); deactivating it bumps its activation epoch, so
+        // its initialization cancels itself and never reports preloaded.
+        if (pendingPreloadStream) {
+            pendingPreloadStream.deactivate(true);
+            pendingPreloadStream = null;
+        }
         if (preloadingStreams && preloadingStreams.length > 0) {
             preloadingStreams.forEach((s) => {
                 s.deactivate(true);
@@ -861,8 +871,15 @@ function StreamController() {
 
         const representationsFromPreviousPeriod = _getRepresentationsFromPreviousPeriod(previousStream);
         const previousSourceBufferSinks = _getSourceBufferSinksFromPreviousPeriod(previousStream);
+        pendingPreloadStream = nextStream;
         nextStream.startPreloading(mediaSource, previousSourceBufferSinks, representationsFromPreviousPeriod)
-            .then(() => {
+            .then((result) => {
+                if (pendingPreloadStream === nextStream) {
+                    pendingPreloadStream = null;
+                }
+                if (result && result.cancelled) {
+                    return;
+                }
                 preloadingStreams.push(nextStream);
             });
     }
@@ -1917,6 +1934,7 @@ function StreamController() {
         lastKnownPlaybackTime = NaN;
         boundVideoElement = null;
         pendingSourceOpenHandler = null;
+        pendingPreloadStream = null;
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1618,7 +1618,7 @@ function StreamController() {
         activeStream.deactivate(false);
 
         // Reset MSE
-        logger.info(`MediaSource has been resetted. Resuming playback from time ${seekTime}`);
+        logger.info(`MediaSource has been reset. Resuming playback from time ${seekTime}`);
         _openMediaSource({ seekTime, keepBuffers: false, streamActivated: false });
     }
 
@@ -1661,7 +1661,7 @@ function StreamController() {
             }
         }
         activeStream.deactivate(false);
-        logger.info(`MediaSource has been resetted. Resuming playback from time ${seekTime}`);
+        logger.info(`MediaSource has been reset. Resuming playback from time ${seekTime}`);
         _openMediaSource({ seekTime, keepBuffers: false, streamActivated: false });
     }
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -120,7 +120,7 @@ function StreamController() {
             }
         }
 
-        videoModel.addEventListener('emptied', _onVideoElementEmptied);
+        _bindVideoElementEmptied();
 
         registerEvents();
     }
@@ -641,6 +641,13 @@ function StreamController() {
      */
     function _onPlaybackSeeking(e) {
         const newTime = e.seekTime;
+        if (!isNaN(newTime)) {
+            // An explicit seek target is a valid resume position for
+            // _onVideoElementEmptied(), zero included; only the load
+            // algorithm's reset-to-zero must not overwrite the cache, and
+            // that never arrives through a seeking event.
+            lastKnownPlaybackTime = newTime;
+        }
         let seekToStream = getStreamForTime(newTime);
 
         if (!seekToStream) {
@@ -951,8 +958,11 @@ function StreamController() {
      */
     function _onPlaybackTimeUpdated(/*e*/) {
         // Remember where playback was: when the element is reset from outside,
-        // its currentTime is already back at 0 by the time 'emptied' fires, so
-        // this is the only usable resume position for _onVideoElementEmptied().
+        // its currentTime is already back at 0 by the time 'emptied' fires.
+        // Together with explicit seek targets recorded in _onPlaybackSeeking()
+        // this is the resume position for _onVideoElementEmptied(); zero is
+        // excluded HERE because the load algorithm fires a timeupdate while
+        // zeroing the clock, which is not playback progress.
         const time = playbackController.getTime();
         if (time !== null && !isNaN(time) && time > 0) {
             lastKnownPlaybackTime = time;
@@ -1460,6 +1470,7 @@ function StreamController() {
 
 
     function switchToVideoElement(seekTime) {
+        _bindVideoElementEmptied();
         if (activeStream) {
             playbackController.initialize(getActiveStreamInfo());
             _openMediaSource({ seekTime, keepBuffers: false, streamActivated: true });
@@ -1631,6 +1642,25 @@ function StreamController() {
      * another byte. Recover the same way _handleMediaErrorDecode() does.
      * @private
      */
+    /**
+     * (Re)binds the emptied listener to the current view. VideoModel's
+     * add/removeEventListener are no-ops without an element, so a view
+     * attached after initialize(), or replacing an earlier one, would
+     * otherwise never get the listener; called from initialize() and from
+     * switchToVideoElement(), and remove-before-add keeps it idempotent.
+     * MediaPlayer.initialize() reaches switchToVideoElement() via attachView()
+     * before setConfig() has run, so bail out until videoModel is wired;
+     * initialize() rebinds later in that flow.
+     * @private
+     */
+    function _bindVideoElementEmptied() {
+        if (!videoModel) {
+            return;
+        }
+        videoModel.removeEventListener('emptied', _onVideoElementEmptied);
+        videoModel.addEventListener('emptied', _onVideoElementEmptied);
+    }
+
     function _onVideoElementEmptied() {
         if (expectedSourceDetach) {
             expectedSourceDetach = false;

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -66,7 +66,8 @@ function StreamController() {
         playbackController, serviceDescriptionController, mediaPlayerModel, customParametersModel, isPaused,
         initialPlayback, initialSteeringRequest, playbackEndedTimerInterval, preloadingStreams, settings,
         firstLicenseIsFetched, waitForPlaybackStartTimeout, providedStartTime, errorInformation,
-        pendingDynamicToStaticUpdate, expectedSourceDetach, lastKnownPlaybackTime;
+        pendingDynamicToStaticUpdate, expectedSourceDetach, lastKnownPlaybackTime,
+        boundVideoElement;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -1657,8 +1658,17 @@ function StreamController() {
         if (!videoModel) {
             return;
         }
+        // MediaPlayer.attachView() has already pointed videoModel at the NEW
+        // element by the time switchToVideoElement() runs, so going through
+        // videoModel alone can never unhook the previous element; track what
+        // was actually bound and remove from it directly.
+        const element = videoModel.getElement();
+        if (boundVideoElement && boundVideoElement !== element) {
+            boundVideoElement.removeEventListener('emptied', _onVideoElementEmptied);
+        }
         videoModel.removeEventListener('emptied', _onVideoElementEmptied);
         videoModel.addEventListener('emptied', _onVideoElementEmptied);
+        boundVideoElement = element || null;
     }
 
     function _onVideoElementEmptied() {
@@ -1682,12 +1692,24 @@ function StreamController() {
         // established one, fall back to the live edge for dynamic streams, the
         // way seekToCurrentLive() computes it, and to the start for static ones.
         let seekTime = lastKnownPlaybackTime;
+        const isDynamic = playbackController.getIsDynamic();
+        const dvrInfo = isDynamic ? dashMetrics.getCurrentDVRInfo(hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO) : null;
+        if (isDynamic && !isNaN(seekTime) && (!dvrInfo || !dvrInfo.range || seekTime < dvrInfo.range.start || seekTime > dvrInfo.range.end)) {
+            // The cached position can slide out of the DVR window while the
+            // element sits emptied (a long pause on live); an expired position
+            // would seek outside the seekable range, so resume from the live
+            // edge instead.
+            seekTime = NaN;
+        }
         if (isNaN(seekTime)) {
-            if (playbackController.getIsDynamic()) {
-                const dvrInfo = dashMetrics.getCurrentDVRInfo(hasVideoTrack() ? Constants.VIDEO : Constants.AUDIO);
+            if (isDynamic) {
                 seekTime = dvrInfo && dvrInfo.range ? dvrInfo.range.end - playbackController.getLiveDelay() : NaN;
             } else {
-                seekTime = 0;
+                // Match _getInitialStartTimeForStaticStream(): the first period
+                // can start above zero and playback never starts earlier than
+                // that, so neither should the recovery.
+                const streamInfo = activeStream.getStreamInfo();
+                seekTime = streamInfo && !isNaN(streamInfo.start) ? streamInfo.start : 0;
             }
         }
         activeStream.deactivate(false);
@@ -1828,6 +1850,7 @@ function StreamController() {
         pendingDynamicToStaticUpdate = false;
         expectedSourceDetach = false;
         lastKnownPlaybackTime = NaN;
+        boundVideoElement = null;
         firstLicenseIsFetched = false;
         preloadingStreams = [];
         waitForPlaybackStartTimeout = null;
@@ -1865,6 +1888,10 @@ function StreamController() {
             expectedSourceDetach = true;
             mediaSourceController.detachMediaSource(videoModel);
             mediaSource = null;
+        }
+        if (boundVideoElement) {
+            boundVideoElement.removeEventListener('emptied', _onVideoElementEmptied);
+            boundVideoElement = null;
         }
         if (videoModel) {
             videoModel.removeEventListener('emptied', _onVideoElementEmptied);

--- a/test/unit/test/streaming/streaming.Stream.js
+++ b/test/unit/test/streaming/streaming.Stream.js
@@ -83,6 +83,28 @@ describe('Stream', function () {
             expect(isActive).to.be.false; // jshint ignore:line
         });
 
+        it('does not mark the stream active when an activation settles after deactivate()', async () => {
+            // No media types, so initialization resolves without touching the
+            // media pipeline and the activation completes on mocks alone.
+            const originalGetAllMediaInfoForType = adapterMock.getAllMediaInfoForType;
+            adapterMock.getAllMediaInfoForType = function () {
+                return [];
+            };
+            try {
+                stream.initialize();
+                // Start an activation, deactivate before its asynchronous
+                // initialization settles: the stale activation must not set
+                // isActive afterwards, or the next activate() short-circuits on
+                // a stream with no processors behind it.
+                const pendingActivation = stream.activate(null, new Map(), []);
+                stream.deactivate(false);
+                await pendingActivation;
+                expect(stream.getIsActive()).to.be.false; // jshint ignore:line
+            } finally {
+                adapterMock.getAllMediaInfoForType = originalGetAllMediaInfoForType;
+            }
+        });
+
         it('should return an empty array when getStreamProcessors is called but streamProcessors attribute is an empty array', () => {
             const processors = stream.getStreamProcessors();
 

--- a/test/unit/test/streaming/streaming.Stream.js
+++ b/test/unit/test/streaming/streaming.Stream.js
@@ -98,7 +98,8 @@ describe('Stream', function () {
                 // a stream with no processors behind it.
                 const pendingActivation = stream.activate(null, new Map(), []);
                 stream.deactivate(false);
-                await pendingActivation;
+                const result = await pendingActivation;
+                expect(result).to.have.property('cancelled', true);
                 expect(stream.getIsActive()).to.be.false; // jshint ignore:line
             } finally {
                 adapterMock.getAllMediaInfoForType = originalGetAllMediaInfoForType;

--- a/test/unit/test/streaming/streaming.controllers.MediaSourceController.js
+++ b/test/unit/test/streaming/streaming.controllers.MediaSourceController.js
@@ -2,6 +2,9 @@ import MediaSourceController from '../../../../src/streaming/controllers/MediaSo
 import VideoModelMock from '../../mocks/VideoModelMock.js';
 
 import {expect} from 'chai';
+import EventBus from '../../../../src/core/EventBus.js';
+import MediaPlayerEvents from '../../../../src/streaming/MediaPlayerEvents.js';
+import sinon from 'sinon';
 const context = {};
 
 describe('MediaSourceController', function () {
@@ -14,6 +17,106 @@ describe('MediaSourceController', function () {
 
     afterEach(function () {
         mediaSourceController = null;
+    });
+
+    describe('ManagedMediaSource streaming event forwarding', function () {
+        let localContext;
+        let localController;
+        let localEventBus;
+        let videoModel;
+        let realManagedMediaSource;
+        let createObjectURLStub;
+        let startCount;
+        let endCount;
+        let onStart;
+        let onEnd;
+
+        // A real EventTarget, so listener add/remove/dispatch behaves like the
+        // engine's and duplicate registration is observable.
+        class FakeManagedMediaSource extends EventTarget {
+            constructor() {
+                super();
+                this.readyState = 'closed';
+            }
+        }
+
+        beforeEach(function () {
+            localContext = {};
+            localController = MediaSourceController(localContext).getInstance();
+            localEventBus = EventBus(localContext).getInstance();
+            videoModel = new VideoModelMock();
+            videoModel.setDisableRemotePlayback = function () {};
+            realManagedMediaSource = window.ManagedMediaSource;
+            window.ManagedMediaSource = FakeManagedMediaSource;
+            createObjectURLStub = sinon.stub(window.URL, 'createObjectURL').returns('blob:fake-mms');
+            startCount = 0;
+            endCount = 0;
+            onStart = function () {
+                startCount++;
+            };
+            onEnd = function () {
+                endCount++;
+            };
+            localEventBus.on(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_START_STREAMING, onStart, this);
+            localEventBus.on(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_END_STREAMING, onEnd, this);
+        });
+
+        afterEach(function () {
+            localEventBus.off(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_START_STREAMING, onStart, this);
+            localEventBus.off(MediaPlayerEvents.MANAGED_MEDIA_SOURCE_END_STREAMING, onEnd, this);
+            createObjectURLStub.restore();
+            if (realManagedMediaSource !== undefined) {
+                window.ManagedMediaSource = realManagedMediaSource;
+            } else {
+                delete window.ManagedMediaSource;
+            }
+        });
+
+        it('forwards streaming events from the current open source', function () {
+            const source = localController.createMediaSource();
+            localController.attachMediaSource(videoModel);
+            source.readyState = 'open';
+            source.dispatchEvent(new Event('startstreaming'));
+            source.dispatchEvent(new Event('endstreaming'));
+            expect(startCount).to.equal(1);
+            expect(endCount).to.equal(1);
+        });
+
+        it('does not forward streaming events while the source is not open', function () {
+            const source = localController.createMediaSource();
+            localController.attachMediaSource(videoModel);
+            source.readyState = 'closed';
+            source.dispatchEvent(new Event('startstreaming'));
+            source.dispatchEvent(new Event('endstreaming'));
+            expect(startCount).to.equal(0);
+            expect(endCount).to.equal(0);
+        });
+
+        it('does not forward streaming events from a replaced source', function () {
+            const firstSource = localController.createMediaSource();
+            localController.attachMediaSource(videoModel);
+            firstSource.readyState = 'open';
+            const secondSource = localController.createMediaSource();
+            localController.attachMediaSource(videoModel);
+            secondSource.readyState = 'open';
+            firstSource.dispatchEvent(new Event('startstreaming'));
+            firstSource.dispatchEvent(new Event('endstreaming'));
+            expect(startCount).to.equal(0);
+            expect(endCount).to.equal(0);
+            secondSource.dispatchEvent(new Event('startstreaming'));
+            expect(startCount).to.equal(1);
+        });
+
+        it('does not duplicate forwarding when the same source is re-attached', function () {
+            const source = localController.createMediaSource();
+            localController.attachMediaSource(videoModel);
+            localController.attachMediaSource(videoModel);
+            source.readyState = 'open';
+            source.dispatchEvent(new Event('startstreaming'));
+            source.dispatchEvent(new Event('endstreaming'));
+            expect(startCount).to.equal(1);
+            expect(endCount).to.equal(1);
+        });
     });
 
     describe('Method createMediaSource', function () {

--- a/test/unit/test/streaming/streaming.controllers.StreamController.js
+++ b/test/unit/test/streaming/streaming.controllers.StreamController.js
@@ -19,6 +19,7 @@ import CapabilitiesFilterMock from '../../mocks/CapabilitiesFilterMock.js';
 import ContentSteeringControllerMock from '../../mocks/ContentSteeringControllerMock.js';
 import TextControllerMock from '../../mocks/TextControllerMock.js';
 import ManifestUpdaterMock from '../../mocks/ManifestUpdaterMock.js';
+import MediaSourceMock from '../../mocks/MediaSourceMock.js';
 import ServiceDescriptionController from '../../../../src/dash/controllers/ServiceDescriptionController.js';
 
 import chai from 'chai';
@@ -581,8 +582,30 @@ describe('StreamController', function () {
 
     describe('external detach recovery', function () {
         let setSourceSpy;
+        let createObjectURLStub;
+        let revokeObjectURLStub;
+        let realMediaSource;
+        let realManagedMediaSource;
+        let lastCreatedMediaSource;
+
+        // A controllable stand-in so the test transitions the source to
+        // 'closed' explicitly instead of racing the browser's sourceopen.
+        class ControllableMediaSource extends MediaSourceMock {
+            constructor() {
+                super();
+                lastCreatedMediaSource = this;
+            }
+            addEventListener() {}
+            removeEventListener() {}
+        }
 
         beforeEach(function (done) {
+            realMediaSource = window.MediaSource;
+            realManagedMediaSource = window.ManagedMediaSource;
+            window.MediaSource = ControllableMediaSource;
+            delete window.ManagedMediaSource;
+            createObjectURLStub = sinon.stub(window.URL, 'createObjectURL').returns('blob:controllable');
+            revokeObjectURLStub = sinon.stub(window.URL, 'revokeObjectURL');
             playbackControllerMock.setTime(0);
             playbackControllerMock.setIsDynamic(false);
             const serviceDescriptionController = ServiceDescriptionController(context).getInstance();
@@ -622,11 +645,15 @@ describe('StreamController', function () {
         afterEach(function () {
             if (setSourceSpy) { setSourceSpy.restore(); }
             streamController.reset();
+            createObjectURLStub.restore();
+            revokeObjectURLStub.restore();
+            window.MediaSource = realMediaSource;
+            if (realManagedMediaSource !== undefined) { window.ManagedMediaSource = realManagedMediaSource; }
         });
 
         it('recovers by detaching and re-attaching the source when the element is emptied from outside', function (done) {
-            // The media element's own load algorithm ran outside dash.js (the
-            // detach this PR handles), so the source is closed, not open.
+            // the external load algorithm has run: the source is detached and closed
+            lastCreatedMediaSource.readyState = 'closed';
             videoModelMock.fireEvent('emptied', []);
             setTimeout(function () {
                 try {
@@ -635,6 +662,17 @@ describe('StreamController', function () {
                     // followed by a fresh object-URL attach
                     expect(args).to.include(null);
                     expect(args.some(function (v) { return typeof v === 'string'; })).to.be.true; // jshint ignore:line
+                    done();
+                } catch (e) { done(e); }
+            }, 0);
+        });
+
+        it('does not recover while the source is still open', function (done) {
+            lastCreatedMediaSource.readyState = 'open';
+            videoModelMock.fireEvent('emptied', []);
+            setTimeout(function () {
+                try {
+                    expect(setSourceSpy.called).to.be.false; // jshint ignore:line
                     done();
                 } catch (e) { done(e); }
             }, 0);

--- a/test/unit/test/streaming/streaming.controllers.StreamController.js
+++ b/test/unit/test/streaming/streaming.controllers.StreamController.js
@@ -578,4 +578,66 @@ describe('StreamController', function () {
             expect(manifestUpdaterMock.refreshManifest.notCalled).to.be.true;
         })
     });
+
+    describe('external detach recovery', function () {
+        let setSourceSpy;
+
+        beforeEach(function (done) {
+            playbackControllerMock.setTime(0);
+            playbackControllerMock.setIsDynamic(false);
+            const serviceDescriptionController = ServiceDescriptionController(context).getInstance();
+            streamController.setConfig({
+                adapter: adapterMock,
+                manifestLoader: manifestLoaderMock,
+                timelineConverter: timelineConverterMock,
+                manifestModel: manifestModelMock,
+                errHandler: errHandlerMock,
+                dashMetrics: dashMetricsMock,
+                protectionController: protectionControllerMock,
+                videoModel: videoModelMock,
+                playbackController: playbackControllerMock,
+                baseURLController: baseUrlControllerMock,
+                settings: settings,
+                uriFragmentModel: uriFragmentModelMock,
+                serviceDescriptionController
+            });
+            streamController.initialize(false);
+            const getStreamsInfoStub = sinon.stub(adapterMock, 'getStreamsInfo');
+            getStreamsInfoStub.returns([{
+                id: 'detachStream', index: 0, start: 0, duration: 100,
+                manifestInfo: { isDynamic: false }
+            }]);
+            const onSwitch = function () {
+                eventBus.off(Events.INITIAL_STREAM_SWITCH, onSwitch);
+                getStreamsInfoStub.restore();
+                setTimeout(function () {
+                    setSourceSpy = sinon.spy(videoModelMock, 'setSource');
+                    done();
+                }, 0);
+            };
+            eventBus.on(Events.INITIAL_STREAM_SWITCH, onSwitch, this);
+            eventBus.trigger(Events.TIME_SYNCHRONIZATION_COMPLETED);
+        });
+
+        afterEach(function () {
+            if (setSourceSpy) { setSourceSpy.restore(); }
+            streamController.reset();
+        });
+
+        it('recovers by detaching and re-attaching the source when the element is emptied from outside', function (done) {
+            // The media element's own load algorithm ran outside dash.js (the
+            // detach this PR handles), so the source is closed, not open.
+            videoModelMock.fireEvent('emptied', []);
+            setTimeout(function () {
+                try {
+                    const args = setSourceSpy.getCalls().map(function (c) { return c.args[0]; });
+                    // recovery re-opens the MediaSource: a detach (setSource(null))
+                    // followed by a fresh object-URL attach
+                    expect(args).to.include(null);
+                    expect(args.some(function (v) { return typeof v === 'string'; })).to.be.true; // jshint ignore:line
+                    done();
+                } catch (e) { done(e); }
+            }, 0);
+        });
+    });
 });

--- a/test/unit/test/streaming/streaming.controllers.StreamController.js
+++ b/test/unit/test/streaming/streaming.controllers.StreamController.js
@@ -678,4 +678,104 @@ describe('StreamController', function () {
             }, 0);
         });
     });
+    describe('initial attach over an element with an existing source', function () {
+        let setSourceSpy;
+        let createObjectURLStub;
+        let revokeObjectURLStub;
+        let realMediaSource;
+        let realManagedMediaSource;
+        let lastCreatedMediaSource;
+
+        class ControllableMediaSource extends MediaSourceMock {
+            constructor() {
+                super();
+                lastCreatedMediaSource = this;
+            }
+            addEventListener() {}
+            removeEventListener() {}
+        }
+
+        beforeEach(function (done) {
+            realMediaSource = window.MediaSource;
+            realManagedMediaSource = window.ManagedMediaSource;
+            window.MediaSource = ControllableMediaSource;
+            delete window.ManagedMediaSource;
+            createObjectURLStub = sinon.stub(window.URL, 'createObjectURL').returns('blob:controllable');
+            revokeObjectURLStub = sinon.stub(window.URL, 'revokeObjectURL');
+            // The element the app hands over already carries a resource, so
+            // dash.js's own source assignment will run the load algorithm.
+            Object.defineProperty(videoModelMock.getElement(), 'networkState', { value: 2, configurable: true });
+            playbackControllerMock.setTime(0);
+            playbackControllerMock.setIsDynamic(false);
+            const serviceDescriptionController = ServiceDescriptionController(context).getInstance();
+            streamController.setConfig({
+                adapter: adapterMock,
+                manifestLoader: manifestLoaderMock,
+                timelineConverter: timelineConverterMock,
+                manifestModel: manifestModelMock,
+                errHandler: errHandlerMock,
+                dashMetrics: dashMetricsMock,
+                protectionController: protectionControllerMock,
+                videoModel: videoModelMock,
+                playbackController: playbackControllerMock,
+                baseURLController: baseUrlControllerMock,
+                settings: settings,
+                uriFragmentModel: uriFragmentModelMock,
+                serviceDescriptionController
+            });
+            streamController.initialize(false);
+            const getStreamsInfoStub = sinon.stub(adapterMock, 'getStreamsInfo');
+            getStreamsInfoStub.returns([{
+                id: 'dirtyElementStream', index: 0, start: 0, duration: 100,
+                manifestInfo: { isDynamic: false }
+            }]);
+            const onSwitch = function () {
+                eventBus.off(Events.INITIAL_STREAM_SWITCH, onSwitch);
+                getStreamsInfoStub.restore();
+                setTimeout(function () {
+                    setSourceSpy = sinon.spy(videoModelMock, 'setSource');
+                    done();
+                }, 0);
+            };
+            eventBus.on(Events.INITIAL_STREAM_SWITCH, onSwitch, this);
+            eventBus.trigger(Events.TIME_SYNCHRONIZATION_COMPLETED);
+        });
+
+        afterEach(function () {
+            if (setSourceSpy) { setSourceSpy.restore(); }
+            streamController.reset();
+            createObjectURLStub.restore();
+            revokeObjectURLStub.restore();
+            delete videoModelMock.getElement().networkState;
+            window.MediaSource = realMediaSource;
+            if (realManagedMediaSource !== undefined) { window.ManagedMediaSource = realManagedMediaSource; }
+        });
+
+        it('does not treat the emptied fired by its own initial attachment as an external detach', function (done) {
+            lastCreatedMediaSource.readyState = 'closed';
+            // the emptied the load algorithm queues for dash.js's own assignment
+            videoModelMock.fireEvent('emptied', []);
+            setTimeout(function () {
+                try {
+                    expect(setSourceSpy.called).to.be.false; // jshint ignore:line
+                    done();
+                } catch (e) { done(e); }
+            }, 0);
+        });
+
+        it('still recovers from a real external detach once the suppression is consumed', function (done) {
+            lastCreatedMediaSource.readyState = 'closed';
+            videoModelMock.fireEvent('emptied', []); // own assignment, consumed
+            videoModelMock.fireEvent('emptied', []); // the real external detach
+            setTimeout(function () {
+                try {
+                    const args = setSourceSpy.getCalls().map(function (c) { return c.args[0]; });
+                    expect(args).to.include(null);
+                    expect(args.some(function (v) { return typeof v === 'string'; })).to.be.true; // jshint ignore:line
+                    done();
+                } catch (e) { done(e); }
+            }, 0);
+        });
+    });
+
 });


### PR DESCRIPTION
When the media element's load algorithm runs outside dash.js's control (an external `element.load()`, any `src` write, or a UA-driven reload), WebKit detaches the attached MediaSource. For a `ManagedMediaSource` the consequences are fatal today: the source closes permanently, it emits `startstreaming` and `endstreaming` while closing (measured, both delivered with `readyState === 'closed'`), the `endstreaming` latches `ScheduleController`'s `managedMediaSourceAllowsRequest` with `startstreaming` as the only way back, and no `startstreaming` can ever come from a closed source. The player then sits at `readyState` 0 with zero requests, no error on the element or the bus, and nothing logged above `warn`. Details and reproduction in #5127.

This PR fixes it in two places:

`MediaSourceController`: the `startstreaming`/`endstreaming` forwards now ignore events from a source that is not the currently attached one or is no longer open, so a dying source cannot latch the scheduler on its way out. Re-attaching also no longer stacks a second pair of forwarding listeners on the same source.

`StreamController`: a new `emptied` listener on the media element detects the external detach (own detaches are flagged and skipped) and recovers the way `_handleMediaErrorDecode()` already does: deactivate the active stream and re-open the MediaSource. The resume position is the last time a `timeupdate` reported, because the element's `currentTime` is already 0 by the time `emptied` fires; if playback never established one, a dynamic stream resumes from the live edge (computed as in `seekToCurrentLive()`) and a static one from the start. There is deliberately no `isStreamSwitchingInProgress` bail-out: a switch waiting on `sourceopen` of a detached source never completes, so that flag would stay true forever and block the only way out.

Measured on Safari 27 (macOS, real Safari via safaridriver, ManagedMediaSource path): an external `removeAttribute('src'); load()` at first `sourceopen` or 5 s into live playback leaves stock v5.2.2 permanently dead at 0 requests; with this change both recover, resuming with a full buffer within tens of milliseconds of `emptied`, and behaviour without a detach is unchanged. Holding the scheduler gate open instead was measured as insufficient: requests resume but nothing can be appended to a closed source, which is why the recovery lives here and not in `ScheduleController`.

Fixes #5127.