### PR TITLE
fix(test): select functional vectors that only define exclusions

### DIFF
--- a/test/functional/config/test-configurations/streams/all.json
+++ b/test/functional/config/test-configurations/streams/all.json
@@ -363,7 +363,7 @@
       "url": "/base/test/functional/content/gap/video_negative_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
@@ -372,25 +372,25 @@
       "url": "/base/test/functional/content/gap/audio_negative_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
       "name": "Segment Timeline with positive video EPT Delta",
       "type": "vod",
-      "url": "/base/test/functional/content/gap/video_negative_ept_delta.mpd",
+      "url": "/base/test/functional/content/gap/video_positive_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
       "name": "Segment Timeline with positive audio EPT Delta",
       "type": "vod",
-      "url": "/base/test/functional/content/gap/audio_negative_ept_delta.mpd",
+      "url": "/base/test/functional/content/gap/audio_positive_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {

--- a/test/functional/config/test-configurations/streams/drm_emsg_eptdelta_gaps.json
+++ b/test/functional/config/test-configurations/streams/drm_emsg_eptdelta_gaps.json
@@ -78,7 +78,7 @@
       "url": "/base/test/functional/content/gap/video_negative_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
@@ -87,25 +87,25 @@
       "url": "/base/test/functional/content/gap/audio_negative_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
       "name": "Segment Timeline with positive video EPT Delta",
       "type": "vod",
-      "url": "/base/test/functional/content/gap/video_negative_ept_delta.mpd",
+      "url": "/base/test/functional/content/gap/video_positive_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {
       "name": "Segment Timeline with positive audio EPT Delta",
       "type": "vod",
-      "url": "/base/test/functional/content/gap/audio_negative_ept_delta.mpd",
+      "url": "/base/test/functional/content/gap/audio_positive_ept_delta.mpd",
       "excludedTestfiles": [
         "playback/seek",
-        "payback-advanced/attach-at-non-zero"
+        "playback-advanced/attach-at-non-zero"
       ]
     },
     {

--- a/test/functional/src/Utils.js
+++ b/test/functional/src/Utils.js
@@ -10,6 +10,9 @@ class Utils {
         }
 
         const targetTestvectors = [];
+        const lastIndex = testcase.lastIndexOf('/')
+        const category = lastIndex >= 0 ? testcase.substring(0, lastIndex) + '/*' : ''
+
         testvectors.forEach((rawTestvector) => {
 
             if (Utils._shouldPlatformBeExcluded(rawTestvector.excludedPlatforms)) {
@@ -17,37 +20,16 @@ class Utils {
             }
 
             const testvector = Utils._applyPlatformOverrides(rawTestvector)
+            const includedTestfiles = testvector.includedTestfiles || []
+            const excludedTestfiles = testvector.excludedTestfiles || []
 
-            // Nothing to be filtered
-            if ((!testvector.includedTestfiles || testvector.includedTestfiles.length === 0) && (!testvector.excludedTestfiles || testvector.excludedTestfiles.length === 0)) {
-                targetTestvectors.push(testvector)
-            }
+            const isIncluded = includedTestfiles.length === 0 ||
+                includedTestfiles.indexOf('all') >= 0 ||
+                includedTestfiles.indexOf(testcase) >= 0 ||
+                includedTestfiles.indexOf(category) >= 0
+            const isExcluded = excludedTestfiles.indexOf(testcase) >= 0
 
-            // Testvector explicitly included either concretely or per category
-            else if (testvector.includedTestfiles && testvector.includedTestfiles.length > 0) {
-                if (testvector.includedTestfiles.indexOf(testcase) >= 0) {
-                    targetTestvectors.push(testvector);
-                } else {
-                    const lastIndex = testcase.lastIndexOf('/');
-                    const category = testcase.substring(0, lastIndex) + '/*';
-                    if (testvector.includedTestfiles.indexOf(category) >= 0) {
-                        targetTestvectors.push(testvector);
-                    }
-                }
-            }
-
-            // All testfiles included and the current testcase not explicitly excluded
-            else if (
-                (testvector.includedTestfiles
-                    && testvector.includedTestfiles.length > 0
-                    && testvector.includedTestfiles.indexOf('all') >= 0
-                )
-                &&
-                (!testvector.excludedTestfiles
-                    || testvector.excludedTestfiles.length === 0
-                    || testvector.excludedTestfiles.indexOf(testcase) === -1
-                )
-            ) {
+            if (isIncluded && !isExcluded) {
                 targetTestvectors.push(testvector)
             }
         })

--- a/test/unit/test/functional/functional.Utils.js
+++ b/test/unit/test/functional/functional.Utils.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai';
+import Utils from '../../../functional/src/Utils.js';
+
+describe('Functional Utils', () => {
+    const testcase = 'playback/play';
+    let originalTestvectors;
+
+    before(() => {
+        originalTestvectors = window.__karma__.config.testvectors;
+    });
+
+    afterEach(() => {
+        window.__karma__.config.testvectors = originalTestvectors;
+    });
+
+    function getSelectedTestvectors(testvector) {
+        window.__karma__.config.testvectors = [testvector];
+        return Utils.getTestvectorsForTestcase(testcase);
+    }
+
+    it('should select a testvector without testfile filters', () => {
+        const testvector = {name: 'unfiltered'};
+
+        expect(getSelectedTestvectors(testvector)).to.deep.equal([testvector]);
+    });
+
+    it('should select exact, category and all inclusions', () => {
+        expect(getSelectedTestvectors({includedTestfiles: [testcase]})).to.have.lengthOf(1);
+        expect(getSelectedTestvectors({includedTestfiles: ['playback/*']})).to.have.lengthOf(1);
+        expect(getSelectedTestvectors({includedTestfiles: ['all']})).to.have.lengthOf(1);
+    });
+
+    it('should reject an unrelated inclusion', () => {
+        expect(getSelectedTestvectors({includedTestfiles: ['text/*']})).to.be.empty;
+    });
+
+    it('should treat a missing or empty inclusion list as all tests before applying exclusions', () => {
+        expect(getSelectedTestvectors({excludedTestfiles: ['playback/seek']})).to.have.lengthOf(1);
+        expect(getSelectedTestvectors({includedTestfiles: [], excludedTestfiles: ['playback/seek']})).to.have.lengthOf(1);
+        expect(getSelectedTestvectors({excludedTestfiles: [testcase]})).to.be.empty;
+    });
+
+    it('should give an exact exclusion priority over an inclusion', () => {
+        const testvector = {
+            includedTestfiles: ['all', testcase, 'playback/*'],
+            excludedTestfiles: [testcase]
+        };
+
+        expect(getSelectedTestvectors(testvector)).to.be.empty;
+    });
+});


### PR DESCRIPTION
## Summary

- Treat missing or empty `includedTestfiles` as applying to every testcase.
- Preserve exact, category and `all` inclusions while giving explicit exclusions precedence.
- Add unit coverage and correct the EPT vector definitions exposed by the fix.

## Validation

- `npm run ci:verify` — 3,818 unit tests passed; TypeScript and lint passed.
- `npm run webpack-build-modern`
- Functional `single` profile on Chrome — 60 tests passed.
- Targeted utility tests on Chrome and Firefox — 10 tests passed.

## CI impact

The existing pull-request functional profile remains unchanged. Full and manual profiles now execute the previously skipped vectors and may expose failures requiring separate triage before extending CI coverage.

Closes #5131
