### PR TITLE
fix(dash): index SegmentURL by segment in SegmentList with SegmentTimeline

### DIFF
--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -89,8 +89,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
                 segmentBase,
                 segmentURL,
                 currentSElement,
-                sElementCounterIncludingRepeats,
-                sElementCounter
+                sElementCounterIncludingRepeats
             } = data
             const targetDurationInTimescale = currentSElement.d;
             const fTimescale = representation.timescale;
@@ -101,7 +100,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
                 _onSegmentFound({
                     segmentBase,
                     segmentURL,
-                    sElementCounter,
                     currentSElement,
                     mediaTime: mediaStartTime,
                     durationInTimescale: targetDurationInTimescale,
@@ -119,7 +117,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
             const {
                 segmentBase,
                 segmentURL,
-                sElementCounter,
                 currentSElement,
                 mediaTime,
                 durationInTimescale,
@@ -127,8 +124,8 @@ function TimelineSegmentsGetter(config, isDynamic) {
                 requiredMediaTimeInTimescaleUnits,
                 sElementCounterIncludingRepeats
             } = data
-            let mediaUrl = _getMediaUrl(segmentBase, segmentURL, sElementCounter);
-            let mediaRange = _getMediaRange(currentSElement, segmentURL, sElementCounter);
+            let mediaUrl = _getMediaUrl(segmentBase, segmentURL, sElementCounterIncludingRepeats);
+            let mediaRange = _getMediaRange(currentSElement, segmentURL, sElementCounterIncludingRepeats);
             const totalNumberOfPartialSegments = getTotalNumberOfPartialSegments(currentSElement);
             const subNumberOfPartialSegmentToRequest = _getSubNumberOfPartialSegmentToRequestByTime({
                 durationInTimescale,

--- a/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
+++ b/test/unit/test/dash/dash.utils.TimelineSegmentsGetter.js
@@ -61,6 +61,64 @@ describe('TimelineSegmentsGetter', () => {
         });
     });
 
+    describe('SegmentList with SegmentTimeline', () => {
+
+        function createSegmentListRepresentationMock() {
+            const voHelper = new VoHelper();
+            const representation = voHelper.getDummyRepresentation(Constants.VIDEO);
+            representation.timescale = 90000;
+            representation.SegmentList = {
+                'timescale': 90000,
+                'SegmentTimeline': {
+                    'S': [{ 't': 0, 'd': 90000, 'r': 2 }, { 'd': 90000 }]
+                },
+                'SegmentURL': [
+                    { 'media': 'seg1.m4s', 'mediaRange': '0-999' },
+                    { 'media': 'seg2.m4s', 'mediaRange': '1000-1999' },
+                    { 'media': 'seg3.m4s', 'mediaRange': '2000-2999' },
+                    { 'media': 'seg4.m4s', 'mediaRange': '3000-3999' }
+                ]
+            };
+            representation.adaptation.period.mpd.manifest.Period[0].AdaptationSet[0].Representation[0] = representation;
+            representation.adaptation.period.mpd.maxSegmentDuration = 5;
+            representation.adaptation.period.duration = 4;
+            representation.presentationTimeOffset = 0;
+
+            return representation;
+        }
+
+        it('should use a separate SegmentURL for each repeated segment', () => {
+            const representation = createSegmentListRepresentationMock();
+            const media = [0, 1, 2, 3].map((time) => {
+                return timelineSegmentsGetter.getSegmentByTime(representation, time).media;
+            });
+
+            expect(media).to.deep.equal(['seg1.m4s', 'seg2.m4s', 'seg3.m4s', 'seg4.m4s']);
+        });
+
+        it('should use the mediaRange of the matching SegmentURL', () => {
+            const representation = createSegmentListRepresentationMock();
+            const ranges = [0, 1, 2, 3].map((time) => {
+                return timelineSegmentsGetter.getSegmentByTime(representation, time).mediaRange;
+            });
+
+            expect(ranges).to.deep.equal(['0-999', '1000-1999', '2000-2999', '3000-3999']);
+        });
+
+        it('should walk the SegmentURL list when requesting consecutive segments', () => {
+            const representation = createSegmentListRepresentationMock();
+            const media = [];
+            let segment = null;
+
+            for (let i = 0; i < 4; i++) {
+                segment = timelineSegmentsGetter.getSegmentByIndex(representation, segment);
+                media.push(segment.media);
+            }
+
+            expect(media).to.deep.equal(['seg1.m4s', 'seg2.m4s', 'seg3.m4s', 'seg4.m4s']);
+        });
+    });
+
     describe('getMediaFinishedInformation', () => {
         it('should calculate the number of available segments correctly', () => {
             const representation = createRepresentationMock();


### PR DESCRIPTION
## Problem

For a `<SegmentList>` that carries a `<SegmentTimeline>`, `TimelineSegmentsGetter` looks up the per-segment `<SegmentURL>` with `sElementCounter`, the index of the `<S>` element, instead of `sElementCounterIncludingRepeats`, the index of the media segment. A few lines below, `segment.index` already uses the latter.

So for an `<S>` with `r > 0`, every repeated segment reuses the `<SegmentURL>` of the first segment of that element, and the later entries are never requested. With `<S t="0" d="90000" r="2"/>` plus a fourth segment and four `SegmentURL` entries, all of `seg1..seg4` come back as `seg1.m4s` and `0-999`.

ISO/IEC 23009-1 says the `SegmentURL` elements are "a consecutive list of Media Segment URLs" (5.3.9.3.1, 5.3.9.5) and that `@r` is a repeat count where "a repeat count of three means there are four contiguous Segments" (5.3.9.6.1, Table 21), so the list is indexed per segment, not per `<S>`. Shaka expands `@r` and pairs `mediaSegments[i]` with `timeline[i]`, and ExoPlayer does the same.

This looks like a regression from the v3 rewrite in #3003: the original 2016 implementation (84af8ef0, "Enable SegmentTimeline within SegmentList") indexed the list with the expanded index. `ListSegmentsGetter` is correct today.

The combination is not common in the wild. I could only produce it with GPAC, either `MP4Box -mpd playlist.m3u8 -segment-timeline` or the dasher filter with `tpl=false:stl`, plus hand-authored MPDs; ffmpeg, Bento4, Shaka Packager and plain `MP4Box -dash` all avoid it. It is still valid, and #4185 took the same view when it enabled the combination.

## Change

Pass the segment counter to `_getMediaUrl` and `_getMediaRange`, and drop `sElementCounter` from the `_onSegmentFound` payload, which no longer needs it.

Three unit tests: media URLs, media ranges, and a sequential walk with `getSegmentByIndex`. All three fail on `development` and pass with the change; the full unit suite is 1907 passing.

One thing worth flagging: #5051 rewrites this same function and keeps the `<S>`-element index (as `blockIndex`), with a comment stating that it indexes `SegmentURL`. Whichever lands second will need adjusting; happy to rebase if that one goes first.

One behaviour note: an MPD that declares fewer `SegmentURL` entries than the timeline expands to will now throw where it previously replayed the first entry. That MPD is already malformed, and the code already throws when there are more `<S>` elements than URLs, but I did not add a guard in case you would rather have one.